### PR TITLE
feat(about): site support contacts + official-only first-party trio

### DIFF
--- a/change/@acedatacloud-nexior-4ed8af9d-78e3-41ee-a967-e522cdaddada.json
+++ b/change/@acedatacloud-nexior-4ed8af9d-78e3-41ee-a967-e522cdaddada.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(about): site support contacts + official-only first-party trio",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/setting/About.vue
+++ b/src/components/setting/About.vue
@@ -1,50 +1,85 @@
 <template>
   <div class="settings-list">
-    <section v-if="!brandingHidden" class="settings-item">
+    <!--
+      The first-party attribution + one-click build trio (Nexior source,
+      Ace Data Cloud API, Build-your-own) is shown only on our own
+      first-party official builds: the bare official web host, plus the
+      native (Capacitor) / desktop (Electron) shells whose window.host is
+      a useless "localhost"/"bundle" but which always run against studio.
+      Web subsites and white-label tenants get their contacts block only.
+    -->
+    <template v-if="isFirstPartyOfficial">
+      <section class="settings-item">
+        <div class="settings-label">
+          <p class="settings-title">{{ $t('common.settings.poweredBy') }}</p>
+          <p class="settings-tip">{{ $t('common.settings.poweredByTip') }}</p>
+        </div>
+        <div class="settings-content">
+          <a href="https://github.com/AceDataCloud/Nexior" target="_blank" rel="noopener noreferrer" class="about-link">
+            <font-awesome-icon :icon="faGithub" class="icon" />
+            <span>Nexior</span>
+          </a>
+        </div>
+      </section>
+      <section class="settings-item">
+        <div class="settings-label">
+          <p class="settings-title">{{ $t('common.settings.apiService') }}</p>
+          <p class="settings-tip">{{ $t('common.settings.apiServiceTip') }}</p>
+        </div>
+        <div class="settings-content">
+          <a href="https://platform.acedata.cloud" target="_blank" rel="noopener noreferrer" class="about-link">
+            <font-awesome-icon :icon="faCloud" class="icon" />
+            <span>Ace Data Cloud</span>
+          </a>
+        </div>
+      </section>
+      <section class="settings-item">
+        <div class="settings-label">
+          <p class="settings-title">{{ $t('common.settings.buildYourOwn') }}</p>
+          <p class="settings-tip">{{ $t('common.settings.buildYourOwnTip') }}</p>
+        </div>
+        <div class="settings-content">
+          <!--
+            One-click subsite create: ask the parent dialog (Setting.vue)
+            to switch to the Subsites tab with the create form open.
+          -->
+          <el-button type="primary" @click="onBuildOneClick">
+            <font-awesome-icon :icon="faRocket" class="mr-1" />
+            {{ $t('common.settings.buildNow') }}
+          </el-button>
+        </div>
+      </section>
+    </template>
+
+    <!--
+      Customer-service contacts the site owner filled in
+      (Site.branding.contacts). Rendered whenever at least one channel is
+      set, so the official main host can also surface them if configured.
+    -->
+    <section v-if="hasContacts" class="settings-item contacts-item">
       <div class="settings-label">
-        <p class="settings-title">{{ $t('common.settings.poweredBy') }}</p>
-        <p class="settings-tip">{{ $t('common.settings.poweredByTip') }}</p>
+        <p class="settings-title">{{ $t('common.settings.contactSupport') }}</p>
+        <p class="settings-tip">{{ $t('common.settings.contactSupportTip') }}</p>
       </div>
-      <div class="settings-content">
-        <a href="https://github.com/AceDataCloud/Nexior" target="_blank" rel="noopener noreferrer" class="about-link">
-          <font-awesome-icon :icon="faGithub" class="icon" />
-          <span>Nexior</span>
-        </a>
-      </div>
-    </section>
-    <section v-if="!brandingHidden" class="settings-item">
-      <div class="settings-label">
-        <p class="settings-title">{{ $t('common.settings.apiService') }}</p>
-        <p class="settings-tip">{{ $t('common.settings.apiServiceTip') }}</p>
-      </div>
-      <div class="settings-content">
-        <a href="https://platform.acedata.cloud" target="_blank" rel="noopener noreferrer" class="about-link">
-          <font-awesome-icon :icon="faCloud" class="icon" />
-          <span>Ace Data Cloud</span>
-        </a>
-      </div>
-    </section>
-    <section v-if="showBuildSection" class="settings-item">
-      <div class="settings-label">
-        <p class="settings-title">{{ $t('common.settings.buildYourOwn') }}</p>
-        <p class="settings-tip">{{ $t('common.settings.buildYourOwnTip') }}</p>
-      </div>
-      <div class="settings-content">
-        <!--
-          On the official main site we offer a true one-click subsite create:
-          ask the parent dialog (Setting.vue) to switch to the Subsites tab
-          with the create form already open. Other hosts (subsites,
-          white-label) keep the original "contact us" CTA since they can't
-          self-spawn further subsites.
-        -->
-        <el-button v-if="isMainOfficialHost" type="primary" @click="onBuildOneClick">
-          <font-awesome-icon :icon="faRocket" class="mr-1" />
-          {{ $t('common.settings.buildNow') }}
-        </el-button>
-        <el-button v-else type="primary" @click="onContact">
-          <font-awesome-icon :icon="faComments" class="mr-1" />
-          {{ $t('common.settings.contactUs') }}
-        </el-button>
+      <div class="settings-content contacts-content">
+        <div v-for="(c, i) in contacts" :key="i" class="contact-entry">
+          <a v-if="contactHref(c)" :href="contactHref(c)" v-bind="linkAttrs(c)" class="about-link">
+            <font-awesome-icon :icon="contactIconFor(c.type)" class="icon" />
+            <span>{{ contactText(c) }}</span>
+          </a>
+          <span v-else class="about-link contact-static">
+            <font-awesome-icon :icon="contactIconFor(c.type)" class="icon" />
+            <span>{{ contactText(c) }}</span>
+          </span>
+          <el-image
+            v-if="c.qr"
+            :src="c.qr"
+            :preview-src-list="[c.qr]"
+            :preview-teleported="true"
+            fit="contain"
+            class="contact-qr"
+          />
+        </div>
       </div>
     </section>
   </div>
@@ -52,18 +87,20 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElButton } from 'element-plus';
+import { ElButton, ElImage } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { faGithub } from '@fortawesome/free-brands-svg-icons';
-import { faCloud, faComments, faRocket } from '@fortawesome/free-solid-svg-icons';
+import { faCloud, faRocket } from '@fortawesome/free-solid-svg-icons';
 import { SETTING_TAB_SUBSITES } from '@/constants';
-import { isMainOfficial, isBrandingHidden, getBrandSupportUrl } from '@/utils';
-import { ISite } from '@/models';
+import { isMainOfficial, isNative, isDesktop, getBrandContacts, hasBrandContacts } from '@/utils';
+import { contactIcon, contactMeta, contactBrand, contactTypeI18nKey } from '@/utils/contactTypes';
+import { ISite, ISiteContact } from '@/models';
 
 export default defineComponent({
   name: 'AboutSetting',
   components: {
     ElButton,
+    ElImage,
     FontAwesomeIcon
   },
   emits: ['switch-tab'],
@@ -71,7 +108,6 @@ export default defineComponent({
     return {
       faGithub,
       faCloud,
-      faComments,
       faRocket
     };
   },
@@ -79,30 +115,47 @@ export default defineComponent({
     site(): ISite | undefined {
       return this.$store?.state?.site;
     },
-    brandingHidden(): boolean {
-      // White-label master switch (Site.branding.hide_powered_by). Hides the
-      // "Powered by" + "API Service" attribution. Default (unset) = show ours.
-      return isBrandingHidden(this.site, 'powered_by');
+    isFirstPartyOfficial(): boolean {
+      // Bare official web host, OR a native/desktop shell (host is
+      // "localhost"/"bundle" there but the bundle always resolves the
+      // studio Site row — see getSiteOrigin).
+      return isMainOfficial() || isNative() || isDesktop();
     },
-    supportUrl(): string {
-      // Reseller support link first (branding.links.support -> support_url).
-      // Only fall back to our platform when branding is NOT hidden, so a
-      // white-label site never leaks our domain.
-      return getBrandSupportUrl(this.site) || (this.brandingHidden ? '' : 'https://platform.acedata.cloud');
+    contacts(): ISiteContact[] {
+      return getBrandContacts(this.site);
     },
-    isMainOfficialHost(): boolean {
-      return isMainOfficial();
-    },
-    showBuildSection(): boolean {
-      // Official main host shows one-click subsite build; other hosts show a
-      // "contact us" CTA. On a white-label site with no support URL there's
-      // nothing useful to show (and a "contact us" would leak us), so hide it.
-      return this.isMainOfficialHost || !this.brandingHidden || !!this.supportUrl;
+    hasContacts(): boolean {
+      return hasBrandContacts(this.site);
     }
   },
   methods: {
-    onContact() {
-      window.open(this.supportUrl, '_blank', 'noopener,noreferrer');
+    contactIconFor(type: string) {
+      return contactIcon(type);
+    },
+    contactHref(c: ISiteContact): string {
+      // An explicit URL always wins; otherwise derive tel:/mailto: from the
+      // value for phone/email types. Backend validation guarantees url is
+      // http(s) and phone/email values are scheme-safe, so no XSS here.
+      if (c.url) return c.url;
+      const scheme = contactMeta(c.type).scheme;
+      if (c.value && scheme === 'tel') return `tel:${c.value}`;
+      if (c.value && scheme === 'mailto') return `mailto:${c.value}`;
+      return '';
+    },
+    linkAttrs(c: ISiteContact): Record<string, string> {
+      // Only external http(s) links open in a new tab; tel:/mailto: don't.
+      return /^https?:/i.test(this.contactHref(c)) ? { target: '_blank', rel: 'noopener noreferrer' } : {};
+    },
+    contactText(c: ISiteContact): string {
+      if (c.label) return c.label;
+      if (c.value) return c.value;
+      const brand = contactBrand(c.type);
+      if (brand) return brand;
+      const key = contactTypeI18nKey(c.type);
+      return key ? (this.$t(key) as string) : this.capitalize(c.type);
+    },
+    capitalize(s: string): string {
+      return s ? s.charAt(0).toUpperCase() + s.slice(1) : '';
     },
     onBuildOneClick() {
       // Ask the parent settings dialog to swap to the Subsites tab with
@@ -129,6 +182,38 @@ export default defineComponent({
 
   &:hover {
     color: var(--el-color-primary);
+  }
+}
+
+.contacts-content {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.contact-entry {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+
+  .contact-static {
+    cursor: default;
+
+    &:hover {
+      color: var(--el-text-color-regular);
+    }
+
+    span {
+      user-select: text;
+    }
+  }
+
+  .contact-qr {
+    width: 96px;
+    height: 96px;
+    border-radius: 8px;
+    border: 1px solid var(--el-border-color-lighter);
+    cursor: zoom-in;
   }
 }
 </style>

--- a/src/components/setting/Site.vue
+++ b/src/components/setting/Site.vue
@@ -123,19 +123,39 @@
         />
       </div>
     </section>
+
+    <section class="settings-item">
+      <div class="settings-label">
+        <p class="settings-title">{{ $t('site.field.contacts') }}</p>
+        <p class="settings-tip">
+          {{ $t('site.message.contactsTip') }}
+        </p>
+      </div>
+      <div class="settings-content">
+        <div v-if="hasContacts" class="contacts-summary">
+          <el-tag v-for="(c, i) in contacts" :key="i" size="small" round>{{ contactSummary(c) }}</el-tag>
+        </div>
+        <span v-else class="settings-value">{{ $t('site.message.contactsEmpty') }}</span>
+        <edit-contacts :model-value="contacts" :title="$t('site.title.editContacts')" @confirm="onSaveContacts" />
+      </div>
+    </section>
   </div>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElButton, ElColorPicker, ElImage } from 'element-plus';
+import { ElButton, ElColorPicker, ElImage, ElTag } from 'element-plus';
 import EditText from '@/components/site/EditText.vue';
 import EditImage from '@/components/site/EditImage.vue';
 import EditUsers from '@/components/site/EditUsers.vue';
+import EditContacts from '@/components/site/EditContacts.vue';
 import UserChip from '@/components/site/UserChip.vue';
 import AutoTranslateToggle from '@/components/site/AutoTranslateToggle.vue';
 import SectionNotice from '@/components/setting/SectionNotice.vue';
 import { siteOperator } from '@/operators';
+import { getBrandContacts, hasBrandContacts } from '@/utils';
+import { contactBrand, contactTypeI18nKey } from '@/utils/contactTypes';
+import { ISiteContact } from '@/models';
 import { DEFAULT_PRIMARY_COLOR, applyAccentColor } from '@/utils/theme';
 
 // A small curated palette to make picking a "good" colour easy. The picker
@@ -159,11 +179,13 @@ export default defineComponent({
     EditText,
     EditImage,
     EditUsers,
+    EditContacts,
     UserChip,
     AutoTranslateToggle,
     ElButton,
     ElColorPicker,
     ElImage,
+    ElTag,
     SectionNotice
   },
   data() {
@@ -195,9 +217,25 @@ export default defineComponent({
     hasCustomPrimaryColor(): boolean {
       const c = this.storedPrimaryColor;
       return !!c && c.toLowerCase() !== DEFAULT_PRIMARY_COLOR.toLowerCase();
+    },
+    contacts(): ISiteContact[] {
+      return getBrandContacts(this.site);
+    },
+    hasContacts(): boolean {
+      return hasBrandContacts(this.site);
     }
   },
   methods: {
+    contactSummary(c: ISiteContact): string {
+      // Short chip label: prefer the owner's label, then the value, then a
+      // brand/type name.
+      if (c.label) return c.label;
+      if (c.value) return c.value;
+      const brand = contactBrand(c.type);
+      if (brand) return brand;
+      const key = contactTypeI18nKey(c.type);
+      return key ? (this.$t(key) as string) : c.type;
+    },
     onSave(data: any) {
       const payload = {
         ...this.site,
@@ -207,6 +245,18 @@ export default defineComponent({
         console.debug('getSite for id', this.site?.id);
         this.$store.dispatch('getSite');
       });
+    },
+    onSaveContacts(contacts: ISiteContact[]) {
+      // Merge into the existing branding so other white-label keys
+      // (company / links / hide_*) are preserved. Drop the key entirely
+      // when cleared so ``Site.branding`` stays tidy.
+      const branding = { ...(this.site?.branding || {}) };
+      if (Array.isArray(contacts) && contacts.length > 0) {
+        branding.contacts = contacts;
+      } else {
+        delete branding.contacts;
+      }
+      this.onSave({ branding });
     },
     onTranslationChanged() {
       // Toggle endpoints mutate the row server-side; refresh so the

--- a/src/components/site/EditContacts.vue
+++ b/src/components/site/EditContacts.vue
@@ -1,0 +1,290 @@
+<template>
+  <el-dialog v-model="editing" :title="title" width="560px" class="edit-contacts-dialog" append-to-body>
+    <p class="hint">{{ $t('common.settings.contactEditorHint') }}</p>
+    <div class="rows">
+      <div v-for="(row, idx) in rows" :key="idx" class="contact-row">
+        <div class="row-head">
+          <el-select
+            v-model="row.type"
+            filterable
+            allow-create
+            default-first-option
+            class="type-select"
+            :placeholder="$t('common.settings.contactType')"
+          >
+            <el-option v-for="opt in typeOptions" :key="opt.value" :label="opt.label" :value="opt.value" />
+          </el-select>
+          <el-button link type="danger" :icon="Delete" @click="removeRow(idx)">
+            {{ $t('common.button.delete') }}
+          </el-button>
+        </div>
+        <el-input v-model="row.label" class="row-field" :placeholder="$t('common.settings.contactLabelPlaceholder')" />
+        <el-input v-model="row.value" class="row-field" :placeholder="valuePlaceholder(row.type)" />
+        <el-input v-model="row.url" class="row-field" placeholder="https://..." />
+        <div class="qr-row">
+          <span class="qr-label">{{ $t('common.settings.contactQr') }}</span>
+          <el-image v-if="row.qr" :src="row.qr" class="qr-thumb" fit="contain" />
+          <edit-image
+            :model-value="row.qr"
+            :title="$t('common.settings.contactQr')"
+            :tip="$t('common.settings.contactQrTip')"
+            :width="200"
+            :height="200"
+            @confirm="row.qr = $event"
+          />
+          <el-button v-if="row.qr" link type="danger" @click="row.qr = ''">
+            {{ $t('common.button.delete') }}
+          </el-button>
+        </div>
+      </div>
+    </div>
+    <el-button class="add-btn" :icon="Plus" @click="addRow">{{ $t('common.settings.contactAdd') }}</el-button>
+    <template #footer>
+      <span class="dialog-footer">
+        <el-button round @click="onCancel">{{ $t('common.button.cancel') }}</el-button>
+        <el-button round type="primary" @click="onConfirm">{{ $t('common.button.confirm') }}</el-button>
+      </span>
+    </template>
+  </el-dialog>
+  <span class="edit" @click="onOpen">
+    <el-icon class="icon">
+      <edit />
+    </el-icon>
+  </span>
+</template>
+
+<script lang="ts">
+import { defineComponent, PropType } from 'vue';
+import { ElDialog, ElInput, ElButton, ElIcon, ElImage, ElSelect, ElOption, ElMessage } from 'element-plus';
+import { Edit, Plus, Delete } from '@element-plus/icons-vue';
+import EditImage from '@/components/site/EditImage.vue';
+import { contactBrand, contactTypeI18nKey, CONTACT_TYPE_PRESETS } from '@/utils/contactTypes';
+import { ISiteContact } from '@/models';
+
+// Client-side mirrors of the backend validators in
+// ``PlatformBackend/app/utils/site_branding.py``. They give the site owner an
+// inline error instead of a silent 400 — the backend stays the source of truth.
+const TYPE_RE = /^[a-z][a-z0-9_-]{0,31}$/;
+const HTTP_URL_RE = /^https?:\/\/[^\s/?#]+/i; // require a non-empty host after //
+const EMAIL_RE = /^[^@\s]+@[^@\s]+\.[^@\s]+$/;
+const PHONE_RE = /^[+()\-.\s0-9]{3,40}$/;
+const MAX_URL_LEN = 2048;
+const MAX_EMAIL_LEN = 254;
+const MAX_VALUE_LEN = 200;
+const MAX_LABEL_LEN = 100;
+const MAX_CONTACTS = 30;
+
+interface ContactRow {
+  type: string;
+  label: string;
+  value: string;
+  url: string;
+  qr: string;
+}
+
+export default defineComponent({
+  name: 'EditContacts',
+  components: {
+    ElDialog,
+    ElInput,
+    ElButton,
+    ElIcon,
+    ElImage,
+    ElSelect,
+    ElOption,
+    Edit,
+    EditImage
+  },
+  props: {
+    modelValue: {
+      type: Array as PropType<ISiteContact[]>,
+      default: () => []
+    },
+    title: {
+      type: String,
+      required: true
+    }
+  },
+  emits: ['confirm', 'cancel'],
+  data() {
+    return {
+      Plus,
+      Delete,
+      editing: false,
+      rows: this.toRows(this.modelValue)
+    };
+  },
+  computed: {
+    typeOptions(): { value: string; label: string }[] {
+      return CONTACT_TYPE_PRESETS.map((value) => ({ value, label: this.typeLabel(value) }));
+    }
+  },
+  methods: {
+    toRows(list?: ISiteContact[]): ContactRow[] {
+      return (list || []).map((c) => ({
+        type: c.type || '',
+        label: c.label || '',
+        value: c.value || '',
+        url: c.url || '',
+        qr: c.qr || ''
+      }));
+    },
+    typeLabel(slug: string): string {
+      const brand = contactBrand(slug);
+      if (brand) return brand;
+      const key = contactTypeI18nKey(slug);
+      return key ? (this.$t(key) as string) : slug;
+    },
+    valuePlaceholder(type: string): string {
+      const t = (type || '').trim().toLowerCase();
+      if (t === 'phone') return '+86 400-000-0000';
+      if (t === 'email') return 'support@example.com';
+      return this.$t('common.settings.contactValuePlaceholder');
+    },
+    onOpen() {
+      // Re-seed from the latest saved value each time so a cancelled edit
+      // never lingers in the form.
+      this.rows = this.toRows(this.modelValue);
+      this.editing = true;
+    },
+    onCancel() {
+      this.editing = false;
+      this.$emit('cancel');
+    },
+    addRow() {
+      this.rows.push({ type: '', label: '', value: '', url: '', qr: '' });
+    },
+    removeRow(idx: number) {
+      this.rows.splice(idx, 1);
+    },
+    isBlankRow(r: ContactRow): boolean {
+      return !r.type.trim() && !r.label.trim() && !r.value.trim() && !r.url.trim() && !r.qr.trim();
+    },
+    validate(): string {
+      const filled = this.rows.filter((r: ContactRow) => !this.isBlankRow(r));
+      if (filled.length > MAX_CONTACTS) {
+        return this.$t('common.settings.contactTooMany', { max: MAX_CONTACTS });
+      }
+      const badUrl = (v: string) => !HTTP_URL_RE.test(v) || v.length > MAX_URL_LEN;
+      for (const r of filled) {
+        const type = r.type.trim().toLowerCase();
+        if (!TYPE_RE.test(type)) return this.$t('common.settings.contactInvalidType');
+        const value = r.value.trim();
+        const url = r.url.trim();
+        const qr = r.qr.trim();
+        if (!value && !url && !qr) return this.$t('common.settings.contactRowNeedsValue');
+        if (r.label.trim().length > MAX_LABEL_LEN) return this.$t('common.settings.contactInvalidValue');
+        if (url && badUrl(url)) return this.$t('common.settings.contactInvalidUrl', { field: this.typeLabel(type) });
+        if (qr && badUrl(qr)) {
+          return this.$t('common.settings.contactInvalidUrl', { field: this.$t('common.settings.contactQr') });
+        }
+        if (value) {
+          if (type === 'phone' && !PHONE_RE.test(value)) return this.$t('common.settings.contactInvalidPhone');
+          if (type === 'email' && (!EMAIL_RE.test(value) || value.length > MAX_EMAIL_LEN)) {
+            return this.$t('common.settings.contactInvalidEmail');
+          }
+          if (type !== 'phone' && type !== 'email' && value.length > MAX_VALUE_LEN) {
+            return this.$t('common.settings.contactInvalidValue');
+          }
+        }
+      }
+      return '';
+    },
+    buildContacts(): ISiteContact[] {
+      return this.rows
+        .filter((r: ContactRow) => !this.isBlankRow(r))
+        .map((r: ContactRow) => {
+          const contact: ISiteContact = { type: r.type.trim().toLowerCase() };
+          if (r.label.trim()) contact.label = r.label.trim();
+          if (r.value.trim()) contact.value = r.value.trim();
+          if (r.url.trim()) contact.url = r.url.trim();
+          if (r.qr.trim()) contact.qr = r.qr.trim();
+          return contact;
+        });
+    },
+    onConfirm() {
+      const error = this.validate();
+      if (error) {
+        ElMessage.error(error);
+        return;
+      }
+      this.$emit('confirm', this.buildContacts());
+      this.editing = false;
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.edit {
+  cursor: pointer;
+  margin-left: 5px;
+  position: relative;
+  top: 2px;
+  .icon {
+    font-size: 14px;
+  }
+}
+
+.hint {
+  margin: 0 0 12px;
+  font-size: 13px;
+  color: var(--el-text-color-secondary);
+}
+
+.rows {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  max-height: 52vh;
+  overflow-y: auto;
+}
+
+.contact-row {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+  border: 1px solid var(--el-border-color-lighter);
+  border-radius: 10px;
+
+  .row-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+
+    .type-select {
+      flex: 1;
+    }
+  }
+
+  .qr-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+
+    .qr-label {
+      font-size: 13px;
+      color: var(--el-text-color-regular);
+    }
+
+    .qr-thumb {
+      width: 56px;
+      height: 56px;
+      border-radius: 8px;
+      border: 1px solid var(--el-border-color-lighter);
+    }
+  }
+}
+
+.add-btn {
+  margin-top: 12px;
+}
+
+.dialog-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+}
+</style>

--- a/src/i18n/ar/common.json
+++ b/src/i18n/ar/common.json
@@ -1300,6 +1300,86 @@
     "message": "اتصل بالدعم",
     "description": "نص زر الاتصال بالدعم"
   },
+  "settings.contactSupport": {
+    "message": "التواصل مع الدعم",
+    "description": "Section title on the About page listing the site owner's customer-service channels"
+  },
+  "settings.contactSupportTip": {
+    "message": "تواصل مع فريق الدعم عبر أي من القنوات أدناه.",
+    "description": "Subtitle under the support contacts section on the About page"
+  },
+  "settings.contactInvalidUrl": {
+    "message": "يجب أن يكون {field} رابط http(s) صالحًا",
+    "description": "Validation error shown when a contact URL is not a valid http(s) link"
+  },
+  "settings.contactInvalidPhone": {
+    "message": "يرجى إدخال رقم هاتف صالح",
+    "description": "Validation error shown when the phone number is invalid"
+  },
+  "settings.contactInvalidEmail": {
+    "message": "يرجى إدخال بريد إلكتروني صالح",
+    "description": "Validation error shown when the email address is invalid"
+  },
+  "settings.contactType": {
+    "message": "النوع",
+    "description": "Placeholder for the contact type picker in the editor"
+  },
+  "settings.contactType_phone": {
+    "message": "الهاتف",
+    "description": "Display name for the phone contact type"
+  },
+  "settings.contactType_email": {
+    "message": "البريد الإلكتروني",
+    "description": "Display name for the email contact type"
+  },
+  "settings.contactType_website": {
+    "message": "الموقع الإلكتروني",
+    "description": "Display name for the website contact type"
+  },
+  "settings.contactType_wechat": {
+    "message": "WeChat",
+    "description": "Display name for the WeChat contact type"
+  },
+  "settings.contactLabelPlaceholder": {
+    "message": "تسمية (اختياري)، مثل: المبيعات",
+    "description": "Placeholder for the optional contact label input"
+  },
+  "settings.contactValuePlaceholder": {
+    "message": "الحساب / نص العرض",
+    "description": "Placeholder for the generic contact value input"
+  },
+  "settings.contactQr": {
+    "message": "رمز QR",
+    "description": "Label for a contact's QR-code image"
+  },
+  "settings.contactQrTip": {
+    "message": "ارفع رمز QR يمكن للمستخدمين مسحه ضوئيًا لإضافتك.",
+    "description": "Tip for the contact QR-code uploader"
+  },
+  "settings.contactAdd": {
+    "message": "إضافة جهة اتصال",
+    "description": "Button to add another contact entry"
+  },
+  "settings.contactEditorHint": {
+    "message": "اختر نوعًا لكل قناة واملأ قيمة أو رابطًا أو رمز QR على الأقل. يمكنك إضافة عدة عناصر.",
+    "description": "Hint at the top of the contacts editor dialog"
+  },
+  "settings.contactInvalidType": {
+    "message": "يمكن أن يحتوي النوع على أحرف صغيرة وأرقام و'-' و'_' فقط",
+    "description": "Validation error for an invalid contact type slug"
+  },
+  "settings.contactRowNeedsValue": {
+    "message": "تحتاج كل جهة اتصال إلى قيمة أو رابط أو رمز QR على الأقل",
+    "description": "Validation error when a contact row has no value/url/qr"
+  },
+  "settings.contactInvalidValue": {
+    "message": "أحد حقول جهة الاتصال غير صالح أو طويل جدًا",
+    "description": "Validation error when a contact value/label is invalid or too long"
+  },
+  "settings.contactTooMany": {
+    "message": "يمكنك إضافة {max} جهات اتصال كحد أقصى",
+    "description": "Validation error when too many contacts are added"
+  },
   "message.viewOnGithub": {
     "message": "عرض على GitHub",
     "description": "نص رابط لعرض المشروع على GitHub"

--- a/src/i18n/ar/site.json
+++ b/src/i18n/ar/site.json
@@ -39,6 +39,10 @@
     "message": "معرفات مديري الموقع",
     "description": "عرض في مربع التحرير"
   },
+  "field.contacts": {
+    "message": "جهات اتصال الدعم",
+    "description": "Field title for the customer-service contacts in site settings"
+  },
   "field.markupRatio": {
     "message": "نسبة زيادة موحدة للموقع بأكمله",
     "description": "إعدادات الموقع: النسبة الموحدة لزيادة الأسعار لجميع باقات الشحن في هذا الموقع (كنسبة مئوية)"
@@ -234,6 +238,10 @@
   "title.editAdmins": {
     "message": "تحرير المدراء",
     "description": "عرض في مربع التحرير"
+  },
+  "title.editContacts": {
+    "message": "تحرير جهات اتصال الدعم",
+    "description": "Title of the edit-support-contacts dialog"
   },
   "title.featuresConfig": {
     "message": "إعدادات الميزات",
@@ -442,6 +450,14 @@
   "message.adminsTip2": {
     "message": "يمكنك إضافة أو حذف معرفات المديرين هنا، يمكنك زيارة https://auth.acedata.cloud لرؤية معرفات المستخدمين",
     "description": "تنبيه مديري الموقع"
+  },
+  "message.contactsTip": {
+    "message": "أدخل جهات اتصال خدمة العملاء (Discord وX وWeChat والهاتف والبريد). تظهر في صفحة \"حول\" ليتواصل معك المستخدمون.",
+    "description": "Tip for the support-contacts field"
+  },
+  "message.contactsEmpty": {
+    "message": "لم يُضبط",
+    "description": "Placeholder shown when no support contact has been filled in"
   },
   "message.keywordsTip": {
     "message": "كلمات مفتاحية للموقع، موجودة في المعلومات الوصفية للموقع، تستخدم لتحسين SEO للموقع.",

--- a/src/i18n/de/common.json
+++ b/src/i18n/de/common.json
@@ -1300,6 +1300,86 @@
     "message": "Kontaktieren Sie den Support",
     "description": "Text des Buttons zum Kontaktieren des Supports"
   },
+  "settings.contactSupport": {
+    "message": "Support kontaktieren",
+    "description": "Section title on the About page listing the site owner's customer-service channels"
+  },
+  "settings.contactSupportTip": {
+    "message": "Erreichen Sie unser Support-Team über einen der folgenden Kanäle.",
+    "description": "Subtitle under the support contacts section on the About page"
+  },
+  "settings.contactInvalidUrl": {
+    "message": "{field} muss ein gültiger http(s)-Link sein",
+    "description": "Validation error shown when a contact URL is not a valid http(s) link"
+  },
+  "settings.contactInvalidPhone": {
+    "message": "Bitte eine gültige Telefonnummer eingeben",
+    "description": "Validation error shown when the phone number is invalid"
+  },
+  "settings.contactInvalidEmail": {
+    "message": "Bitte eine gültige E-Mail-Adresse eingeben",
+    "description": "Validation error shown when the email address is invalid"
+  },
+  "settings.contactType": {
+    "message": "Typ",
+    "description": "Placeholder for the contact type picker in the editor"
+  },
+  "settings.contactType_phone": {
+    "message": "Telefon",
+    "description": "Display name for the phone contact type"
+  },
+  "settings.contactType_email": {
+    "message": "E-Mail",
+    "description": "Display name for the email contact type"
+  },
+  "settings.contactType_website": {
+    "message": "Website",
+    "description": "Display name for the website contact type"
+  },
+  "settings.contactType_wechat": {
+    "message": "WeChat",
+    "description": "Display name for the WeChat contact type"
+  },
+  "settings.contactLabelPlaceholder": {
+    "message": "Bezeichnung (optional), z. B. Vertrieb",
+    "description": "Placeholder for the optional contact label input"
+  },
+  "settings.contactValuePlaceholder": {
+    "message": "Konto / Anzeigetext",
+    "description": "Placeholder for the generic contact value input"
+  },
+  "settings.contactQr": {
+    "message": "QR-Code",
+    "description": "Label for a contact's QR-code image"
+  },
+  "settings.contactQrTip": {
+    "message": "Laden Sie einen QR-Code hoch, den Nutzer scannen können.",
+    "description": "Tip for the contact QR-code uploader"
+  },
+  "settings.contactAdd": {
+    "message": "Kontakt hinzufügen",
+    "description": "Button to add another contact entry"
+  },
+  "settings.contactEditorHint": {
+    "message": "Wählen Sie je Kanal einen Typ und geben Sie mindestens Wert, Link oder QR an. Beliebig viele möglich.",
+    "description": "Hint at the top of the contacts editor dialog"
+  },
+  "settings.contactInvalidType": {
+    "message": "Der Typ darf nur Kleinbuchstaben, Ziffern, '-' und '_' enthalten",
+    "description": "Validation error for an invalid contact type slug"
+  },
+  "settings.contactRowNeedsValue": {
+    "message": "Jeder Kontakt braucht mindestens Wert, Link oder QR-Code",
+    "description": "Validation error when a contact row has no value/url/qr"
+  },
+  "settings.contactInvalidValue": {
+    "message": "Ein Kontaktfeld ist ungültig oder zu lang",
+    "description": "Validation error when a contact value/label is invalid or too long"
+  },
+  "settings.contactTooMany": {
+    "message": "Sie können höchstens {max} Kontakte hinzufügen",
+    "description": "Validation error when too many contacts are added"
+  },
   "message.viewOnGithub": {
     "message": "Auf GitHub ansehen",
     "description": "Text des Links, um das Projekt auf GitHub anzusehen"

--- a/src/i18n/de/site.json
+++ b/src/i18n/de/site.json
@@ -39,6 +39,10 @@
     "message": "Seiten-Admin-ID",
     "description": "Anzeige im Bearbeitungsfeld"
   },
+  "field.contacts": {
+    "message": "Support-Kontakte",
+    "description": "Field title for the customer-service contacts in site settings"
+  },
   "field.markupRatio": {
     "message": "Einheitlicher Aufschlag für die gesamte Website",
     "description": "Website-Einstellungen: Der einheitliche Aufschlag für alle Aufladepakete auf dieser Website (Prozentsatz)"
@@ -234,6 +238,10 @@
   "title.editAdmins": {
     "message": "Admins bearbeiten",
     "description": "Anzeige im Bearbeitungsfeld"
+  },
+  "title.editContacts": {
+    "message": "Support-Kontakte bearbeiten",
+    "description": "Title of the edit-support-contacts dialog"
   },
   "title.featuresConfig": {
     "message": "Funktionskonfiguration",
@@ -442,6 +450,14 @@
   "message.adminsTip2": {
     "message": "Hier können Administrator-IDs hinzugefügt oder entfernt werden. Benutzer-IDs können unter https://auth.acedata.cloud eingesehen werden.",
     "description": "Hinweis zu den Administratoren der Seite"
+  },
+  "message.contactsTip": {
+    "message": "Geben Sie Ihre Kundendienst-Kontakte an (Discord, X, WeChat, Telefon, E-Mail). Sie erscheinen auf der Info-Seite, damit Nutzer Sie erreichen.",
+    "description": "Tip for the support-contacts field"
+  },
+  "message.contactsEmpty": {
+    "message": "Nicht festgelegt",
+    "description": "Placeholder shown when no support contact has been filled in"
   },
   "message.keywordsTip": {
     "message": "Schlüsselwörter der Seite, befinden sich in den Metadaten der Seite und dienen der SEO-Optimierung.",

--- a/src/i18n/el/common.json
+++ b/src/i18n/el/common.json
@@ -1300,6 +1300,86 @@
     "message": "Επικοινωνήστε με την υποστήριξη",
     "description": "Κείμενο του κουμπιού για επικοινωνία με την υποστήριξη"
   },
+  "settings.contactSupport": {
+    "message": "Επικοινωνία με υποστήριξη",
+    "description": "Section title on the About page listing the site owner's customer-service channels"
+  },
+  "settings.contactSupportTip": {
+    "message": "Επικοινωνήστε με την ομάδα υποστήριξης μέσω οποιουδήποτε από τα παρακάτω κανάλια.",
+    "description": "Subtitle under the support contacts section on the About page"
+  },
+  "settings.contactInvalidUrl": {
+    "message": "Το {field} πρέπει να είναι έγκυρος σύνδεσμος http(s)",
+    "description": "Validation error shown when a contact URL is not a valid http(s) link"
+  },
+  "settings.contactInvalidPhone": {
+    "message": "Εισαγάγετε έγκυρο αριθμό τηλεφώνου",
+    "description": "Validation error shown when the phone number is invalid"
+  },
+  "settings.contactInvalidEmail": {
+    "message": "Εισαγάγετε έγκυρη διεύθυνση email",
+    "description": "Validation error shown when the email address is invalid"
+  },
+  "settings.contactType": {
+    "message": "Τύπος",
+    "description": "Placeholder for the contact type picker in the editor"
+  },
+  "settings.contactType_phone": {
+    "message": "Τηλέφωνο",
+    "description": "Display name for the phone contact type"
+  },
+  "settings.contactType_email": {
+    "message": "Email",
+    "description": "Display name for the email contact type"
+  },
+  "settings.contactType_website": {
+    "message": "Ιστότοπος",
+    "description": "Display name for the website contact type"
+  },
+  "settings.contactType_wechat": {
+    "message": "WeChat",
+    "description": "Display name for the WeChat contact type"
+  },
+  "settings.contactLabelPlaceholder": {
+    "message": "Label (optional), e.g. Sales",
+    "description": "Placeholder for the optional contact label input"
+  },
+  "settings.contactValuePlaceholder": {
+    "message": "Account / display text",
+    "description": "Placeholder for the generic contact value input"
+  },
+  "settings.contactQr": {
+    "message": "Κωδικός QR",
+    "description": "Label for a contact's QR-code image"
+  },
+  "settings.contactQrTip": {
+    "message": "Upload a QR code users can scan to add you.",
+    "description": "Tip for the contact QR-code uploader"
+  },
+  "settings.contactAdd": {
+    "message": "Προσθήκη επαφής",
+    "description": "Button to add another contact entry"
+  },
+  "settings.contactEditorHint": {
+    "message": "Pick a type for each channel and fill in at least a value, link or QR. Add as many as you like.",
+    "description": "Hint at the top of the contacts editor dialog"
+  },
+  "settings.contactInvalidType": {
+    "message": "Type may only contain lowercase letters, digits, '-' and '_'",
+    "description": "Validation error for an invalid contact type slug"
+  },
+  "settings.contactRowNeedsValue": {
+    "message": "Each contact needs at least a value, link or QR code",
+    "description": "Validation error when a contact row has no value/url/qr"
+  },
+  "settings.contactInvalidValue": {
+    "message": "A contact field is invalid or too long",
+    "description": "Validation error when a contact value/label is invalid or too long"
+  },
+  "settings.contactTooMany": {
+    "message": "You can add at most {max} contacts",
+    "description": "Validation error when too many contacts are added"
+  },
   "message.viewOnGithub": {
     "message": "Δείτε στο GitHub",
     "description": "Κείμενο συνδέσμου για να δείτε το έργο στο GitHub"

--- a/src/i18n/el/site.json
+++ b/src/i18n/el/site.json
@@ -39,6 +39,10 @@
     "message": "ID Διαχειριστών Ιστοσελίδας",
     "description": "展示在编辑框的标题"
   },
+  "field.contacts": {
+    "message": "Στοιχεία υποστήριξης",
+    "description": "Field title for the customer-service contacts in site settings"
+  },
   "field.markupRatio": {
     "message": "Ενιαία προσαύξηση για όλο τον ιστότοπο",
     "description": "Ρυθμίσεις ιστότοπου: το ποσοστό προσαύξησης που εφαρμόζεται σε όλα τα πακέτα φόρτισης του ιστότοπου (ποσοστό)"
@@ -234,6 +238,10 @@
   "title.editAdmins": {
     "message": "Επεξεργασία Διαχειριστών",
     "description": "展示在编辑框的标题"
+  },
+  "title.editContacts": {
+    "message": "Επεξεργασία στοιχείων υποστήριξης",
+    "description": "Title of the edit-support-contacts dialog"
   },
   "title.featuresConfig": {
     "message": "Ρύθμιση Λειτουργιών",
@@ -442,6 +450,14 @@
   "message.adminsTip2": {
     "message": "Μπορείτε να προσθέσετε ή να αφαιρέσετε ID διαχειριστών εδώ. Μπορείτε να δείτε τα ID χρηστών στο https://auth.acedata.cloud",
     "description": "Προτροπή για τους διαχειριστές του ιστότοπου"
+  },
+  "message.contactsTip": {
+    "message": "Συμπληρώστε τα στοιχεία εξυπηρέτησης (Discord, X, WeChat, τηλέφωνο, email). Εμφανίζονται στη σελίδα «Σχετικά» για να επικοινωνούν οι χρήστες.",
+    "description": "Tip for the support-contacts field"
+  },
+  "message.contactsEmpty": {
+    "message": "Δεν έχει οριστεί",
+    "description": "Placeholder shown when no support contact has been filled in"
   },
   "message.keywordsTip": {
     "message": "Λέξεις-κλειδιά του ιστότοπου, βρίσκονται στα μεταδεδομένα του ιστότοπου, για SEO βελτιστοποίηση.",

--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -1280,6 +1280,86 @@
     "message": "Contact Support",
     "description": "Text for the contact support button"
   },
+  "settings.contactSupport": {
+    "message": "Contact Support",
+    "description": "Section title on the About page listing the site owner's customer-service channels"
+  },
+  "settings.contactSupportTip": {
+    "message": "Reach our support team through any of the channels below.",
+    "description": "Subtitle under the support contacts section on the About page"
+  },
+  "settings.contactInvalidUrl": {
+    "message": "{field} must be a valid http(s) link",
+    "description": "Validation error shown when a contact URL is not a valid http(s) link"
+  },
+  "settings.contactInvalidPhone": {
+    "message": "Please enter a valid phone number",
+    "description": "Validation error shown when the phone number is invalid"
+  },
+  "settings.contactInvalidEmail": {
+    "message": "Please enter a valid email address",
+    "description": "Validation error shown when the email address is invalid"
+  },
+  "settings.contactType": {
+    "message": "Type",
+    "description": "Placeholder for the contact type picker in the editor"
+  },
+  "settings.contactType_phone": {
+    "message": "Phone",
+    "description": "Display name for the phone contact type"
+  },
+  "settings.contactType_email": {
+    "message": "Email",
+    "description": "Display name for the email contact type"
+  },
+  "settings.contactType_website": {
+    "message": "Website",
+    "description": "Display name for the website contact type"
+  },
+  "settings.contactType_wechat": {
+    "message": "WeChat",
+    "description": "Display name for the WeChat contact type"
+  },
+  "settings.contactLabelPlaceholder": {
+    "message": "Label (optional), e.g. Sales",
+    "description": "Placeholder for the optional contact label input"
+  },
+  "settings.contactValuePlaceholder": {
+    "message": "Account / display text",
+    "description": "Placeholder for the generic contact value input"
+  },
+  "settings.contactQr": {
+    "message": "QR code",
+    "description": "Label for a contact's QR-code image"
+  },
+  "settings.contactQrTip": {
+    "message": "Upload a QR code users can scan to add you.",
+    "description": "Tip for the contact QR-code uploader"
+  },
+  "settings.contactAdd": {
+    "message": "Add contact",
+    "description": "Button to add another contact entry"
+  },
+  "settings.contactEditorHint": {
+    "message": "Pick a type for each channel and fill in at least a value, link or QR. Add as many as you like.",
+    "description": "Hint at the top of the contacts editor dialog"
+  },
+  "settings.contactInvalidType": {
+    "message": "Type may only contain lowercase letters, digits, '-' and '_'",
+    "description": "Validation error for an invalid contact type slug"
+  },
+  "settings.contactRowNeedsValue": {
+    "message": "Each contact needs at least a value, link or QR code",
+    "description": "Validation error when a contact row has no value/url/qr"
+  },
+  "settings.contactInvalidValue": {
+    "message": "A contact field is invalid or too long",
+    "description": "Validation error when a contact value/label is invalid or too long"
+  },
+  "settings.contactTooMany": {
+    "message": "You can add at most {max} contacts",
+    "description": "Validation error when too many contacts are added"
+  },
   "message.viewOnGithub": {
     "message": "View on GitHub",
     "description": "Link text to view the project on GitHub"

--- a/src/i18n/en/site.json
+++ b/src/i18n/en/site.json
@@ -39,6 +39,10 @@
     "message": "Site Admin IDs",
     "description": "Displayed as the title in the editing box"
   },
+  "field.contacts": {
+    "message": "Support Contacts",
+    "description": "Field title for the customer-service contacts in site settings"
+  },
   "field.markupRatio": {
     "message": "Site-wide uniform markup",
     "description": "Site settings: uniform markup percentage applied to all recharge packages on this site"
@@ -234,6 +238,10 @@
   "title.editAdmins": {
     "message": "Edit Admins",
     "description": "Displayed as the title in the editing box"
+  },
+  "title.editContacts": {
+    "message": "Edit Support Contacts",
+    "description": "Title of the edit-support-contacts dialog"
   },
   "title.featuresConfig": {
     "message": "Features Configuration",
@@ -442,6 +450,14 @@
   "message.adminsTip2": {
     "message": "You can add or remove admin IDs here. You can view user IDs at https://auth.acedata.cloud",
     "description": "Tip for site admins"
+  },
+  "message.contactsTip": {
+    "message": "Fill in your customer-service contacts (Discord, X, WeChat, phone, email). They are shown on the About page so users can reach you.",
+    "description": "Tip for the support-contacts field"
+  },
+  "message.contactsEmpty": {
+    "message": "Not set",
+    "description": "Placeholder shown when no support contact has been filled in"
   },
   "message.keywordsTip": {
     "message": "Site keywords, located in the site metadata, used for site SEO optimization.",

--- a/src/i18n/es/common.json
+++ b/src/i18n/es/common.json
@@ -1300,6 +1300,86 @@
     "message": "Contactar soporte",
     "description": "Texto del botón para contactar soporte"
   },
+  "settings.contactSupport": {
+    "message": "Contactar soporte",
+    "description": "Section title on the About page listing the site owner's customer-service channels"
+  },
+  "settings.contactSupportTip": {
+    "message": "Comunícate con nuestro equipo de soporte por cualquiera de los canales siguientes.",
+    "description": "Subtitle under the support contacts section on the About page"
+  },
+  "settings.contactInvalidUrl": {
+    "message": "{field} debe ser un enlace http(s) válido",
+    "description": "Validation error shown when a contact URL is not a valid http(s) link"
+  },
+  "settings.contactInvalidPhone": {
+    "message": "Introduce un número de teléfono válido",
+    "description": "Validation error shown when the phone number is invalid"
+  },
+  "settings.contactInvalidEmail": {
+    "message": "Introduce un correo electrónico válido",
+    "description": "Validation error shown when the email address is invalid"
+  },
+  "settings.contactType": {
+    "message": "Tipo",
+    "description": "Placeholder for the contact type picker in the editor"
+  },
+  "settings.contactType_phone": {
+    "message": "Teléfono",
+    "description": "Display name for the phone contact type"
+  },
+  "settings.contactType_email": {
+    "message": "Correo electrónico",
+    "description": "Display name for the email contact type"
+  },
+  "settings.contactType_website": {
+    "message": "Sitio web",
+    "description": "Display name for the website contact type"
+  },
+  "settings.contactType_wechat": {
+    "message": "WeChat",
+    "description": "Display name for the WeChat contact type"
+  },
+  "settings.contactLabelPlaceholder": {
+    "message": "Etiqueta (opcional), p. ej. Ventas",
+    "description": "Placeholder for the optional contact label input"
+  },
+  "settings.contactValuePlaceholder": {
+    "message": "Cuenta / texto mostrado",
+    "description": "Placeholder for the generic contact value input"
+  },
+  "settings.contactQr": {
+    "message": "Código QR",
+    "description": "Label for a contact's QR-code image"
+  },
+  "settings.contactQrTip": {
+    "message": "Sube un código QR que los usuarios puedan escanear.",
+    "description": "Tip for the contact QR-code uploader"
+  },
+  "settings.contactAdd": {
+    "message": "Añadir contacto",
+    "description": "Button to add another contact entry"
+  },
+  "settings.contactEditorHint": {
+    "message": "Elige un tipo por canal y completa al menos un valor, enlace o QR. Añade los que quieras.",
+    "description": "Hint at the top of the contacts editor dialog"
+  },
+  "settings.contactInvalidType": {
+    "message": "El tipo solo puede contener minúsculas, dígitos, '-' y '_'",
+    "description": "Validation error for an invalid contact type slug"
+  },
+  "settings.contactRowNeedsValue": {
+    "message": "Cada contacto necesita al menos un valor, enlace o código QR",
+    "description": "Validation error when a contact row has no value/url/qr"
+  },
+  "settings.contactInvalidValue": {
+    "message": "Un campo de contacto no es válido o es demasiado largo",
+    "description": "Validation error when a contact value/label is invalid or too long"
+  },
+  "settings.contactTooMany": {
+    "message": "Puedes añadir como máximo {max} contactos",
+    "description": "Validation error when too many contacts are added"
+  },
   "message.viewOnGithub": {
     "message": "Ver en GitHub",
     "description": "Texto del enlace para ver el proyecto en GitHub"

--- a/src/i18n/es/site.json
+++ b/src/i18n/es/site.json
@@ -39,6 +39,10 @@
     "message": "ID de administradores del sitio",
     "description": "Texto que se muestra en el cuadro de edición"
   },
+  "field.contacts": {
+    "message": "Contactos de soporte",
+    "description": "Field title for the customer-service contacts in site settings"
+  },
   "field.markupRatio": {
     "message": "Recargo uniforme para todo el sitio",
     "description": "Configuración del sitio: proporción de aumento unificada para todos los paquetes de recarga en este sitio (porcentaje)"
@@ -234,6 +238,10 @@
   "title.editAdmins": {
     "message": "Editar administradores",
     "description": "Texto que se muestra en el cuadro de edición"
+  },
+  "title.editContacts": {
+    "message": "Editar contactos de soporte",
+    "description": "Title of the edit-support-contacts dialog"
   },
   "title.featuresConfig": {
     "message": "Configuración de funciones",
@@ -442,6 +450,14 @@
   "message.adminsTip2": {
     "message": "Puede agregar o eliminar ID de administradores aquí. Puede ver los ID de usuario en https://auth.acedata.cloud",
     "description": "Sugerencia para los administradores del sitio"
+  },
+  "message.contactsTip": {
+    "message": "Completa tus contactos de atención (Discord, X, WeChat, teléfono, correo). Se muestran en la página Acerca de para que los usuarios te contacten.",
+    "description": "Tip for the support-contacts field"
+  },
+  "message.contactsEmpty": {
+    "message": "Sin configurar",
+    "description": "Placeholder shown when no support contact has been filled in"
   },
   "message.keywordsTip": {
     "message": "Palabras clave del sitio, ubicadas en la metainformación del sitio, utilizadas para la optimización SEO.",

--- a/src/i18n/fi/common.json
+++ b/src/i18n/fi/common.json
@@ -1300,6 +1300,86 @@
     "message": "Ota yhteyttä asiakaspalveluun",
     "description": "Asiakaspalveluun ottamisen painikkeen teksti"
   },
+  "settings.contactSupport": {
+    "message": "Ota yhteyttä tukeen",
+    "description": "Section title on the About page listing the site owner's customer-service channels"
+  },
+  "settings.contactSupportTip": {
+    "message": "Tavoita tukitiimimme minkä tahansa alla olevan kanavan kautta.",
+    "description": "Subtitle under the support contacts section on the About page"
+  },
+  "settings.contactInvalidUrl": {
+    "message": "{field} on oltava kelvollinen http(s)-linkki",
+    "description": "Validation error shown when a contact URL is not a valid http(s) link"
+  },
+  "settings.contactInvalidPhone": {
+    "message": "Anna kelvollinen puhelinnumero",
+    "description": "Validation error shown when the phone number is invalid"
+  },
+  "settings.contactInvalidEmail": {
+    "message": "Anna kelvollinen sähköpostiosoite",
+    "description": "Validation error shown when the email address is invalid"
+  },
+  "settings.contactType": {
+    "message": "Tyyppi",
+    "description": "Placeholder for the contact type picker in the editor"
+  },
+  "settings.contactType_phone": {
+    "message": "Puhelin",
+    "description": "Display name for the phone contact type"
+  },
+  "settings.contactType_email": {
+    "message": "Sähköposti",
+    "description": "Display name for the email contact type"
+  },
+  "settings.contactType_website": {
+    "message": "Verkkosivusto",
+    "description": "Display name for the website contact type"
+  },
+  "settings.contactType_wechat": {
+    "message": "WeChat",
+    "description": "Display name for the WeChat contact type"
+  },
+  "settings.contactLabelPlaceholder": {
+    "message": "Label (optional), e.g. Sales",
+    "description": "Placeholder for the optional contact label input"
+  },
+  "settings.contactValuePlaceholder": {
+    "message": "Account / display text",
+    "description": "Placeholder for the generic contact value input"
+  },
+  "settings.contactQr": {
+    "message": "QR-koodi",
+    "description": "Label for a contact's QR-code image"
+  },
+  "settings.contactQrTip": {
+    "message": "Upload a QR code users can scan to add you.",
+    "description": "Tip for the contact QR-code uploader"
+  },
+  "settings.contactAdd": {
+    "message": "Lisää yhteystieto",
+    "description": "Button to add another contact entry"
+  },
+  "settings.contactEditorHint": {
+    "message": "Pick a type for each channel and fill in at least a value, link or QR. Add as many as you like.",
+    "description": "Hint at the top of the contacts editor dialog"
+  },
+  "settings.contactInvalidType": {
+    "message": "Type may only contain lowercase letters, digits, '-' and '_'",
+    "description": "Validation error for an invalid contact type slug"
+  },
+  "settings.contactRowNeedsValue": {
+    "message": "Each contact needs at least a value, link or QR code",
+    "description": "Validation error when a contact row has no value/url/qr"
+  },
+  "settings.contactInvalidValue": {
+    "message": "A contact field is invalid or too long",
+    "description": "Validation error when a contact value/label is invalid or too long"
+  },
+  "settings.contactTooMany": {
+    "message": "You can add at most {max} contacts",
+    "description": "Validation error when too many contacts are added"
+  },
   "message.viewOnGithub": {
     "message": "Katso GitHubissa",
     "description": "Linkkiteksti projektin katsomiseen GitHubissa"

--- a/src/i18n/fi/site.json
+++ b/src/i18n/fi/site.json
@@ -39,6 +39,10 @@
     "message": "Sivuston ylläpitäjätunnus",
     "description": "Näytetään muokkausruudun otsikkona"
   },
+  "field.contacts": {
+    "message": "Tuen yhteystiedot",
+    "description": "Field title for the customer-service contacts in site settings"
+  },
   "field.markupRatio": {
     "message": "Koko sivuston yhtenäinen hinnankorotus",
     "description": "Sivuston asetukset: Yhdistelee kaikille latauspaketeille yhteisen hintaprosentin (prosentteina)."
@@ -234,6 +238,10 @@
   "title.editAdmins": {
     "message": "Muokkaa ylläpitäjiä",
     "description": "Näytetään muokkausruudun otsikkona"
+  },
+  "title.editContacts": {
+    "message": "Muokkaa tuen yhteystietoja",
+    "description": "Title of the edit-support-contacts dialog"
   },
   "title.featuresConfig": {
     "message": "Ominaisuuksien asetukset",
@@ -442,6 +450,14 @@
   "message.adminsTip2": {
     "message": "Voit lisätä tai poistaa ylläpitäjän ID:tä täältä, voit tarkistaa käyttäjä ID:t https://auth.acedata.cloud",
     "description": "Sivuston ylläpitäjien ohje"
+  },
+  "message.contactsTip": {
+    "message": "Täytä asiakaspalvelun yhteystiedot (Discord, X, WeChat, puhelin, sähköposti). Ne näkyvät Tietoja-sivulla, jotta käyttäjät tavoittavat sinut.",
+    "description": "Tip for the support-contacts field"
+  },
+  "message.contactsEmpty": {
+    "message": "Ei asetettu",
+    "description": "Placeholder shown when no support contact has been filled in"
   },
   "message.keywordsTip": {
     "message": "Sivuston avainsanat, sijaitsee sivuston metatiedoissa, käytetään sivuston SEO-optimointiin.",

--- a/src/i18n/fr/common.json
+++ b/src/i18n/fr/common.json
@@ -1300,6 +1300,86 @@
     "message": "Contacter le support",
     "description": "Texte du bouton pour contacter le support"
   },
+  "settings.contactSupport": {
+    "message": "Contacter le support",
+    "description": "Section title on the About page listing the site owner's customer-service channels"
+  },
+  "settings.contactSupportTip": {
+    "message": "Contactez notre équipe d'assistance via l'un des canaux ci-dessous.",
+    "description": "Subtitle under the support contacts section on the About page"
+  },
+  "settings.contactInvalidUrl": {
+    "message": "{field} doit être un lien http(s) valide",
+    "description": "Validation error shown when a contact URL is not a valid http(s) link"
+  },
+  "settings.contactInvalidPhone": {
+    "message": "Veuillez saisir un numéro de téléphone valide",
+    "description": "Validation error shown when the phone number is invalid"
+  },
+  "settings.contactInvalidEmail": {
+    "message": "Veuillez saisir une adresse e-mail valide",
+    "description": "Validation error shown when the email address is invalid"
+  },
+  "settings.contactType": {
+    "message": "Type",
+    "description": "Placeholder for the contact type picker in the editor"
+  },
+  "settings.contactType_phone": {
+    "message": "Téléphone",
+    "description": "Display name for the phone contact type"
+  },
+  "settings.contactType_email": {
+    "message": "E-mail",
+    "description": "Display name for the email contact type"
+  },
+  "settings.contactType_website": {
+    "message": "Site web",
+    "description": "Display name for the website contact type"
+  },
+  "settings.contactType_wechat": {
+    "message": "WeChat",
+    "description": "Display name for the WeChat contact type"
+  },
+  "settings.contactLabelPlaceholder": {
+    "message": "Libellé (facultatif), ex. Ventes",
+    "description": "Placeholder for the optional contact label input"
+  },
+  "settings.contactValuePlaceholder": {
+    "message": "Compte / texte affiché",
+    "description": "Placeholder for the generic contact value input"
+  },
+  "settings.contactQr": {
+    "message": "QR code",
+    "description": "Label for a contact's QR-code image"
+  },
+  "settings.contactQrTip": {
+    "message": "Téléversez un QR code que les utilisateurs peuvent scanner.",
+    "description": "Tip for the contact QR-code uploader"
+  },
+  "settings.contactAdd": {
+    "message": "Ajouter un contact",
+    "description": "Button to add another contact entry"
+  },
+  "settings.contactEditorHint": {
+    "message": "Choisissez un type par canal et renseignez au moins une valeur, un lien ou un QR. Ajoutez-en autant que voulu.",
+    "description": "Hint at the top of the contacts editor dialog"
+  },
+  "settings.contactInvalidType": {
+    "message": "Le type ne peut contenir que des minuscules, chiffres, '-' et '_'",
+    "description": "Validation error for an invalid contact type slug"
+  },
+  "settings.contactRowNeedsValue": {
+    "message": "Chaque contact nécessite au moins une valeur, un lien ou un QR code",
+    "description": "Validation error when a contact row has no value/url/qr"
+  },
+  "settings.contactInvalidValue": {
+    "message": "Un champ de contact est invalide ou trop long",
+    "description": "Validation error when a contact value/label is invalid or too long"
+  },
+  "settings.contactTooMany": {
+    "message": "Vous pouvez ajouter au maximum {max} contacts",
+    "description": "Validation error when too many contacts are added"
+  },
   "message.viewOnGithub": {
     "message": "Voir sur GitHub",
     "description": "Texte du lien pour voir le projet sur GitHub"

--- a/src/i18n/fr/site.json
+++ b/src/i18n/fr/site.json
@@ -39,6 +39,10 @@
     "message": "ID des administrateurs du site",
     "description": "Affiché comme titre dans la zone d'édition"
   },
+  "field.contacts": {
+    "message": "Contacts d'assistance",
+    "description": "Field title for the customer-service contacts in site settings"
+  },
   "field.markupRatio": {
     "message": "Majoration uniforme pour tout le site",
     "description": "Paramètres du site : le taux de majoration appliqué uniformément à tous les forfaits de recharge sur ce site (en pourcentage)"
@@ -234,6 +238,10 @@
   "title.editAdmins": {
     "message": "Modifier les administrateurs",
     "description": "Affiché comme titre dans la zone d'édition"
+  },
+  "title.editContacts": {
+    "message": "Modifier les contacts d'assistance",
+    "description": "Title of the edit-support-contacts dialog"
   },
   "title.featuresConfig": {
     "message": "Configuration des fonctionnalités",
@@ -442,6 +450,14 @@
   "message.adminsTip2": {
     "message": "Vous pouvez ajouter ou supprimer des ID d'administrateurs ici. Vous pouvez consulter les ID d'utilisateur sur https://auth.acedata.cloud",
     "description": "Alerte pour les administrateurs du site"
+  },
+  "message.contactsTip": {
+    "message": "Renseignez vos contacts de service client (Discord, X, WeChat, téléphone, e-mail). Ils apparaissent sur la page À propos pour que les utilisateurs vous joignent.",
+    "description": "Tip for the support-contacts field"
+  },
+  "message.contactsEmpty": {
+    "message": "Non défini",
+    "description": "Placeholder shown when no support contact has been filled in"
   },
   "message.keywordsTip": {
     "message": "Mots-clés du site, situés dans les métadonnées du site, utilisés pour l'optimisation SEO.",

--- a/src/i18n/it/common.json
+++ b/src/i18n/it/common.json
@@ -1300,6 +1300,86 @@
     "message": "Contatta il supporto",
     "description": "Testo del pulsante per contattare il supporto"
   },
+  "settings.contactSupport": {
+    "message": "Contatta l'assistenza",
+    "description": "Section title on the About page listing the site owner's customer-service channels"
+  },
+  "settings.contactSupportTip": {
+    "message": "Contatta il nostro team di assistenza tramite uno dei canali seguenti.",
+    "description": "Subtitle under the support contacts section on the About page"
+  },
+  "settings.contactInvalidUrl": {
+    "message": "{field} deve essere un link http(s) valido",
+    "description": "Validation error shown when a contact URL is not a valid http(s) link"
+  },
+  "settings.contactInvalidPhone": {
+    "message": "Inserisci un numero di telefono valido",
+    "description": "Validation error shown when the phone number is invalid"
+  },
+  "settings.contactInvalidEmail": {
+    "message": "Inserisci un indirizzo email valido",
+    "description": "Validation error shown when the email address is invalid"
+  },
+  "settings.contactType": {
+    "message": "Tipo",
+    "description": "Placeholder for the contact type picker in the editor"
+  },
+  "settings.contactType_phone": {
+    "message": "Telefono",
+    "description": "Display name for the phone contact type"
+  },
+  "settings.contactType_email": {
+    "message": "Email",
+    "description": "Display name for the email contact type"
+  },
+  "settings.contactType_website": {
+    "message": "Sito web",
+    "description": "Display name for the website contact type"
+  },
+  "settings.contactType_wechat": {
+    "message": "WeChat",
+    "description": "Display name for the WeChat contact type"
+  },
+  "settings.contactLabelPlaceholder": {
+    "message": "Etichetta (facoltativa), es. Vendite",
+    "description": "Placeholder for the optional contact label input"
+  },
+  "settings.contactValuePlaceholder": {
+    "message": "Account / testo visualizzato",
+    "description": "Placeholder for the generic contact value input"
+  },
+  "settings.contactQr": {
+    "message": "QR code",
+    "description": "Label for a contact's QR-code image"
+  },
+  "settings.contactQrTip": {
+    "message": "Carica un QR code che gli utenti possono scansionare.",
+    "description": "Tip for the contact QR-code uploader"
+  },
+  "settings.contactAdd": {
+    "message": "Aggiungi contatto",
+    "description": "Button to add another contact entry"
+  },
+  "settings.contactEditorHint": {
+    "message": "Scegli un tipo per canale e inserisci almeno un valore, link o QR. Aggiungine quanti vuoi.",
+    "description": "Hint at the top of the contacts editor dialog"
+  },
+  "settings.contactInvalidType": {
+    "message": "Il tipo può contenere solo minuscole, cifre, '-' e '_'",
+    "description": "Validation error for an invalid contact type slug"
+  },
+  "settings.contactRowNeedsValue": {
+    "message": "Ogni contatto richiede almeno un valore, link o QR code",
+    "description": "Validation error when a contact row has no value/url/qr"
+  },
+  "settings.contactInvalidValue": {
+    "message": "Un campo del contatto non è valido o è troppo lungo",
+    "description": "Validation error when a contact value/label is invalid or too long"
+  },
+  "settings.contactTooMany": {
+    "message": "Puoi aggiungere al massimo {max} contatti",
+    "description": "Validation error when too many contacts are added"
+  },
   "message.viewOnGithub": {
     "message": "Visualizza su GitHub",
     "description": "Testo del link per visualizzare il progetto su GitHub"

--- a/src/i18n/it/site.json
+++ b/src/i18n/it/site.json
@@ -39,6 +39,10 @@
     "message": "ID amministratori del sito",
     "description": "Mostrato nel campo di modifica del titolo"
   },
+  "field.contacts": {
+    "message": "Contatti di assistenza",
+    "description": "Field title for the customer-service contacts in site settings"
+  },
   "field.markupRatio": {
     "message": "Sovrapprezzo uniforme per l'intero sito",
     "description": "Impostazioni del sito: percentuale di sovrapprezzo uniforme per tutti i pacchetti di ricarica su questo sito (percentuale)"
@@ -234,6 +238,10 @@
   "title.editAdmins": {
     "message": "Modifica amministratori",
     "description": "Mostrato nel campo di modifica del titolo"
+  },
+  "title.editContacts": {
+    "message": "Modifica contatti di assistenza",
+    "description": "Title of the edit-support-contacts dialog"
   },
   "title.featuresConfig": {
     "message": "Configurazione funzionalità",
@@ -442,6 +450,14 @@
   "message.adminsTip2": {
     "message": "Puoi aggiungere o rimuovere ID amministratori qui. Puoi visualizzare gli ID utente su https://auth.acedata.cloud",
     "description": "Messaggio di avviso per gli amministratori del sito"
+  },
+  "message.contactsTip": {
+    "message": "Inserisci i contatti del servizio clienti (Discord, X, WeChat, telefono, email). Compaiono nella pagina Informazioni così gli utenti possono contattarti.",
+    "description": "Tip for the support-contacts field"
+  },
+  "message.contactsEmpty": {
+    "message": "Non impostato",
+    "description": "Placeholder shown when no support contact has been filled in"
   },
   "message.keywordsTip": {
     "message": "Parole chiave del sito, presenti nei metadati del sito, utili per l'ottimizzazione SEO.",

--- a/src/i18n/ja/common.json
+++ b/src/i18n/ja/common.json
@@ -1300,6 +1300,86 @@
     "message": "カスタマーサポートに連絡",
     "description": "カスタマーサポートボタンのテキスト"
   },
+  "settings.contactSupport": {
+    "message": "サポートに問い合わせ",
+    "description": "Section title on the About page listing the site owner's customer-service channels"
+  },
+  "settings.contactSupportTip": {
+    "message": "以下のいずれかのチャネルからサポートチームにご連絡ください。",
+    "description": "Subtitle under the support contacts section on the About page"
+  },
+  "settings.contactInvalidUrl": {
+    "message": "{field} は有効な http(s) リンクである必要があります",
+    "description": "Validation error shown when a contact URL is not a valid http(s) link"
+  },
+  "settings.contactInvalidPhone": {
+    "message": "有効な電話番号を入力してください",
+    "description": "Validation error shown when the phone number is invalid"
+  },
+  "settings.contactInvalidEmail": {
+    "message": "有効なメールアドレスを入力してください",
+    "description": "Validation error shown when the email address is invalid"
+  },
+  "settings.contactType": {
+    "message": "種類",
+    "description": "Placeholder for the contact type picker in the editor"
+  },
+  "settings.contactType_phone": {
+    "message": "電話",
+    "description": "Display name for the phone contact type"
+  },
+  "settings.contactType_email": {
+    "message": "メール",
+    "description": "Display name for the email contact type"
+  },
+  "settings.contactType_website": {
+    "message": "ウェブサイト",
+    "description": "Display name for the website contact type"
+  },
+  "settings.contactType_wechat": {
+    "message": "WeChat",
+    "description": "Display name for the WeChat contact type"
+  },
+  "settings.contactLabelPlaceholder": {
+    "message": "ラベル（任意）例：営業",
+    "description": "Placeholder for the optional contact label input"
+  },
+  "settings.contactValuePlaceholder": {
+    "message": "アカウント / 表示テキスト",
+    "description": "Placeholder for the generic contact value input"
+  },
+  "settings.contactQr": {
+    "message": "QRコード",
+    "description": "Label for a contact's QR-code image"
+  },
+  "settings.contactQrTip": {
+    "message": "QRコードをアップロードすると、ユーザーはスキャンして追加できます。",
+    "description": "Tip for the contact QR-code uploader"
+  },
+  "settings.contactAdd": {
+    "message": "連絡先を追加",
+    "description": "Button to add another contact entry"
+  },
+  "settings.contactEditorHint": {
+    "message": "各チャネルの種類を選び、値・リンク・QRのいずれかを入力してください。複数追加できます。",
+    "description": "Hint at the top of the contacts editor dialog"
+  },
+  "settings.contactInvalidType": {
+    "message": "種類は英小文字・数字・- ・_ のみ使用できます",
+    "description": "Validation error for an invalid contact type slug"
+  },
+  "settings.contactRowNeedsValue": {
+    "message": "各連絡先には値・リンク・QRのいずれかが必要です",
+    "description": "Validation error when a contact row has no value/url/qr"
+  },
+  "settings.contactInvalidValue": {
+    "message": "連絡先の入力が無効か長すぎます",
+    "description": "Validation error when a contact value/label is invalid or too long"
+  },
+  "settings.contactTooMany": {
+    "message": "連絡先は最大 {max} 件まで追加できます",
+    "description": "Validation error when too many contacts are added"
+  },
   "message.viewOnGithub": {
     "message": "GitHubで見る",
     "description": "GitHubでプロジェクトを表示するリンクテキスト"

--- a/src/i18n/ja/site.json
+++ b/src/i18n/ja/site.json
@@ -39,6 +39,10 @@
     "message": "サイト管理者ID",
     "description": "編集ボックスに表示されるタイトル"
   },
+  "field.contacts": {
+    "message": "サポート連絡先",
+    "description": "Field title for the customer-service contacts in site settings"
+  },
   "field.markupRatio": {
     "message": "サイト全体の一律上乗せ率",
     "description": "サイト設定：このサイトのすべてのチャージプランに統一して加価する割合（パーセント）"
@@ -234,6 +238,10 @@
   "title.editAdmins": {
     "message": "管理者を編集",
     "description": "編集ボックスに表示されるタイトル"
+  },
+  "title.editContacts": {
+    "message": "サポート連絡先を編集",
+    "description": "Title of the edit-support-contacts dialog"
   },
   "title.featuresConfig": {
     "message": "機能設定",
@@ -442,6 +450,14 @@
   "message.adminsTip2": {
     "message": "ここで管理者IDを追加または削除できます。ユーザーIDは https://auth.acedata.cloud で確認できます。",
     "description": "サイト管理者に関するヒント"
+  },
+  "message.contactsTip": {
+    "message": "カスタマーサポートの連絡先（Discord、X、WeChat、電話、メール）を入力してください。「概要」ページに表示され、ユーザーが連絡できます。",
+    "description": "Tip for the support-contacts field"
+  },
+  "message.contactsEmpty": {
+    "message": "未設定",
+    "description": "Placeholder shown when no support contact has been filled in"
   },
   "message.keywordsTip": {
     "message": "サイトのキーワード。サイトのメタ情報にあり、サイトのSEO最適化に使用されます。",

--- a/src/i18n/ko/common.json
+++ b/src/i18n/ko/common.json
@@ -1300,6 +1300,86 @@
     "message": "고객 지원 문의",
     "description": "고객 지원 문의 버튼 텍스트"
   },
+  "settings.contactSupport": {
+    "message": "고객지원 문의",
+    "description": "Section title on the About page listing the site owner's customer-service channels"
+  },
+  "settings.contactSupportTip": {
+    "message": "아래 채널 중 하나를 통해 고객지원팀에 문의하세요.",
+    "description": "Subtitle under the support contacts section on the About page"
+  },
+  "settings.contactInvalidUrl": {
+    "message": "{field}은(는) 유효한 http(s) 링크여야 합니다",
+    "description": "Validation error shown when a contact URL is not a valid http(s) link"
+  },
+  "settings.contactInvalidPhone": {
+    "message": "유효한 전화번호를 입력하세요",
+    "description": "Validation error shown when the phone number is invalid"
+  },
+  "settings.contactInvalidEmail": {
+    "message": "유효한 이메일 주소를 입력하세요",
+    "description": "Validation error shown when the email address is invalid"
+  },
+  "settings.contactType": {
+    "message": "유형",
+    "description": "Placeholder for the contact type picker in the editor"
+  },
+  "settings.contactType_phone": {
+    "message": "전화",
+    "description": "Display name for the phone contact type"
+  },
+  "settings.contactType_email": {
+    "message": "이메일",
+    "description": "Display name for the email contact type"
+  },
+  "settings.contactType_website": {
+    "message": "웹사이트",
+    "description": "Display name for the website contact type"
+  },
+  "settings.contactType_wechat": {
+    "message": "위챗",
+    "description": "Display name for the WeChat contact type"
+  },
+  "settings.contactLabelPlaceholder": {
+    "message": "라벨(선택), 예: 영업",
+    "description": "Placeholder for the optional contact label input"
+  },
+  "settings.contactValuePlaceholder": {
+    "message": "계정 / 표시 텍스트",
+    "description": "Placeholder for the generic contact value input"
+  },
+  "settings.contactQr": {
+    "message": "QR 코드",
+    "description": "Label for a contact's QR-code image"
+  },
+  "settings.contactQrTip": {
+    "message": "QR 코드를 업로드하면 사용자가 스캔하여 추가할 수 있습니다.",
+    "description": "Tip for the contact QR-code uploader"
+  },
+  "settings.contactAdd": {
+    "message": "연락처 추가",
+    "description": "Button to add another contact entry"
+  },
+  "settings.contactEditorHint": {
+    "message": "각 채널의 유형을 고르고 값·링크·QR 중 하나 이상을 입력하세요. 여러 개 추가할 수 있습니다.",
+    "description": "Hint at the top of the contacts editor dialog"
+  },
+  "settings.contactInvalidType": {
+    "message": "유형은 소문자, 숫자, '-', '_'만 사용할 수 있습니다",
+    "description": "Validation error for an invalid contact type slug"
+  },
+  "settings.contactRowNeedsValue": {
+    "message": "각 연락처에는 값·링크·QR 중 하나 이상이 필요합니다",
+    "description": "Validation error when a contact row has no value/url/qr"
+  },
+  "settings.contactInvalidValue": {
+    "message": "연락처 입력이 잘못되었거나 너무 깁니다",
+    "description": "Validation error when a contact value/label is invalid or too long"
+  },
+  "settings.contactTooMany": {
+    "message": "연락처는 최대 {max}개까지 추가할 수 있습니다",
+    "description": "Validation error when too many contacts are added"
+  },
   "message.viewOnGithub": {
     "message": "GitHub에서 보기",
     "description": "GitHub에서 프로젝트를 보는 링크 텍스트"

--- a/src/i18n/ko/site.json
+++ b/src/i18n/ko/site.json
@@ -39,6 +39,10 @@
     "message": "사이트 관리자 ID",
     "description": "편집 상자에 표시되는 제목"
   },
+  "field.contacts": {
+    "message": "고객지원 연락처",
+    "description": "Field title for the customer-service contacts in site settings"
+  },
   "field.markupRatio": {
     "message": "사이트 전체 공통 가산율",
     "description": "사이트 설정: 본 사이트의 모든 충전 패키지에 대해 통일된 가산 비율(백분율)"
@@ -234,6 +238,10 @@
   "title.editAdmins": {
     "message": "관리자 편집",
     "description": "편집 상자에 표시되는 제목"
+  },
+  "title.editContacts": {
+    "message": "고객지원 연락처 편집",
+    "description": "Title of the edit-support-contacts dialog"
   },
   "title.featuresConfig": {
     "message": "기능 설정",
@@ -442,6 +450,14 @@
   "message.adminsTip2": {
     "message": "여기에서 관리자 ID를 추가하거나 삭제할 수 있으며, https://auth.acedata.cloud에서 사용자 ID를 확인할 수 있습니다.",
     "description": "사이트 관리자에 대한 안내"
+  },
+  "message.contactsTip": {
+    "message": "고객지원 연락처(Discord, X, 위챗, 전화, 이메일)를 입력하세요. 정보 페이지에 표시되어 사용자가 연락할 수 있습니다.",
+    "description": "Tip for the support-contacts field"
+  },
+  "message.contactsEmpty": {
+    "message": "설정 안 됨",
+    "description": "Placeholder shown when no support contact has been filled in"
   },
   "message.keywordsTip": {
     "message": "사이트 키워드, 사이트 메타 정보에 위치하며, 사이트 SEO 최적화에 사용됩니다.",

--- a/src/i18n/pl/common.json
+++ b/src/i18n/pl/common.json
@@ -1300,6 +1300,86 @@
     "message": "Skontaktuj się z nami",
     "description": "Tekst przycisku do kontaktu z obsługą klienta"
   },
+  "settings.contactSupport": {
+    "message": "Kontakt z pomocą",
+    "description": "Section title on the About page listing the site owner's customer-service channels"
+  },
+  "settings.contactSupportTip": {
+    "message": "Skontaktuj się z naszym zespołem pomocy przez dowolny z poniższych kanałów.",
+    "description": "Subtitle under the support contacts section on the About page"
+  },
+  "settings.contactInvalidUrl": {
+    "message": "{field} musi być prawidłowym linkiem http(s)",
+    "description": "Validation error shown when a contact URL is not a valid http(s) link"
+  },
+  "settings.contactInvalidPhone": {
+    "message": "Podaj prawidłowy numer telefonu",
+    "description": "Validation error shown when the phone number is invalid"
+  },
+  "settings.contactInvalidEmail": {
+    "message": "Podaj prawidłowy adres e-mail",
+    "description": "Validation error shown when the email address is invalid"
+  },
+  "settings.contactType": {
+    "message": "Typ",
+    "description": "Placeholder for the contact type picker in the editor"
+  },
+  "settings.contactType_phone": {
+    "message": "Telefon",
+    "description": "Display name for the phone contact type"
+  },
+  "settings.contactType_email": {
+    "message": "E-mail",
+    "description": "Display name for the email contact type"
+  },
+  "settings.contactType_website": {
+    "message": "Strona internetowa",
+    "description": "Display name for the website contact type"
+  },
+  "settings.contactType_wechat": {
+    "message": "WeChat",
+    "description": "Display name for the WeChat contact type"
+  },
+  "settings.contactLabelPlaceholder": {
+    "message": "Label (optional), e.g. Sales",
+    "description": "Placeholder for the optional contact label input"
+  },
+  "settings.contactValuePlaceholder": {
+    "message": "Account / display text",
+    "description": "Placeholder for the generic contact value input"
+  },
+  "settings.contactQr": {
+    "message": "Kod QR",
+    "description": "Label for a contact's QR-code image"
+  },
+  "settings.contactQrTip": {
+    "message": "Upload a QR code users can scan to add you.",
+    "description": "Tip for the contact QR-code uploader"
+  },
+  "settings.contactAdd": {
+    "message": "Dodaj kontakt",
+    "description": "Button to add another contact entry"
+  },
+  "settings.contactEditorHint": {
+    "message": "Pick a type for each channel and fill in at least a value, link or QR. Add as many as you like.",
+    "description": "Hint at the top of the contacts editor dialog"
+  },
+  "settings.contactInvalidType": {
+    "message": "Type may only contain lowercase letters, digits, '-' and '_'",
+    "description": "Validation error for an invalid contact type slug"
+  },
+  "settings.contactRowNeedsValue": {
+    "message": "Each contact needs at least a value, link or QR code",
+    "description": "Validation error when a contact row has no value/url/qr"
+  },
+  "settings.contactInvalidValue": {
+    "message": "A contact field is invalid or too long",
+    "description": "Validation error when a contact value/label is invalid or too long"
+  },
+  "settings.contactTooMany": {
+    "message": "You can add at most {max} contacts",
+    "description": "Validation error when too many contacts are added"
+  },
   "message.viewOnGithub": {
     "message": "Zobacz na GitHubie",
     "description": "Tekst linku do przeglądania projektu na GitHubie"

--- a/src/i18n/pl/site.json
+++ b/src/i18n/pl/site.json
@@ -39,6 +39,10 @@
     "message": "ID administratorów witryny",
     "description": "Wyświetlane w tytule edytora"
   },
+  "field.contacts": {
+    "message": "Kontakty pomocy",
+    "description": "Field title for the customer-service contacts in site settings"
+  },
   "field.markupRatio": {
     "message": "Jednolity narzut dla całej witryny",
     "description": "Ustawienia witryny: procentowy narzut stosowany do wszystkich usług w tej witrynie."
@@ -234,6 +238,10 @@
   "title.editAdmins": {
     "message": "Edytuj administratorów",
     "description": "Wyświetlane w tytule edytora"
+  },
+  "title.editContacts": {
+    "message": "Edytuj kontakty pomocy",
+    "description": "Title of the edit-support-contacts dialog"
   },
   "title.featuresConfig": {
     "message": "Konfiguracja funkcji",
@@ -442,6 +450,14 @@
   "message.adminsTip2": {
     "message": "Możesz dodać lub usunąć ID administratorów tutaj. Możesz sprawdzić ID użytkowników na https://auth.acedata.cloud",
     "description": "Wskazówki dotyczące administratorów strony"
+  },
+  "message.contactsTip": {
+    "message": "Podaj kontakty obsługi klienta (Discord, X, WeChat, telefon, e-mail). Pojawią się na stronie O nas, aby użytkownicy mogli się z Tobą skontaktować.",
+    "description": "Tip for the support-contacts field"
+  },
+  "message.contactsEmpty": {
+    "message": "Nie ustawiono",
+    "description": "Placeholder shown when no support contact has been filled in"
   },
   "message.keywordsTip": {
     "message": "Słowa kluczowe strony, znajdujące się w metadanych strony, używane do optymalizacji SEO.",

--- a/src/i18n/pt/common.json
+++ b/src/i18n/pt/common.json
@@ -1300,6 +1300,86 @@
     "message": "Fale Conosco",
     "description": "Texto do botão para entrar em contato com o suporte"
   },
+  "settings.contactSupport": {
+    "message": "Contatar suporte",
+    "description": "Section title on the About page listing the site owner's customer-service channels"
+  },
+  "settings.contactSupportTip": {
+    "message": "Fale com nossa equipe de suporte por qualquer um dos canais abaixo.",
+    "description": "Subtitle under the support contacts section on the About page"
+  },
+  "settings.contactInvalidUrl": {
+    "message": "{field} deve ser um link http(s) válido",
+    "description": "Validation error shown when a contact URL is not a valid http(s) link"
+  },
+  "settings.contactInvalidPhone": {
+    "message": "Insira um número de telefone válido",
+    "description": "Validation error shown when the phone number is invalid"
+  },
+  "settings.contactInvalidEmail": {
+    "message": "Insira um endereço de e-mail válido",
+    "description": "Validation error shown when the email address is invalid"
+  },
+  "settings.contactType": {
+    "message": "Tipo",
+    "description": "Placeholder for the contact type picker in the editor"
+  },
+  "settings.contactType_phone": {
+    "message": "Telefone",
+    "description": "Display name for the phone contact type"
+  },
+  "settings.contactType_email": {
+    "message": "E-mail",
+    "description": "Display name for the email contact type"
+  },
+  "settings.contactType_website": {
+    "message": "Site",
+    "description": "Display name for the website contact type"
+  },
+  "settings.contactType_wechat": {
+    "message": "WeChat",
+    "description": "Display name for the WeChat contact type"
+  },
+  "settings.contactLabelPlaceholder": {
+    "message": "Rótulo (opcional), ex.: Vendas",
+    "description": "Placeholder for the optional contact label input"
+  },
+  "settings.contactValuePlaceholder": {
+    "message": "Conta / texto exibido",
+    "description": "Placeholder for the generic contact value input"
+  },
+  "settings.contactQr": {
+    "message": "QR code",
+    "description": "Label for a contact's QR-code image"
+  },
+  "settings.contactQrTip": {
+    "message": "Envie um QR code que os usuários possam escanear.",
+    "description": "Tip for the contact QR-code uploader"
+  },
+  "settings.contactAdd": {
+    "message": "Adicionar contato",
+    "description": "Button to add another contact entry"
+  },
+  "settings.contactEditorHint": {
+    "message": "Escolha um tipo por canal e preencha ao menos um valor, link ou QR. Adicione quantos quiser.",
+    "description": "Hint at the top of the contacts editor dialog"
+  },
+  "settings.contactInvalidType": {
+    "message": "O tipo só pode conter minúsculas, dígitos, '-' e '_'",
+    "description": "Validation error for an invalid contact type slug"
+  },
+  "settings.contactRowNeedsValue": {
+    "message": "Cada contato precisa de ao menos um valor, link ou QR code",
+    "description": "Validation error when a contact row has no value/url/qr"
+  },
+  "settings.contactInvalidValue": {
+    "message": "Um campo de contato é inválido ou muito longo",
+    "description": "Validation error when a contact value/label is invalid or too long"
+  },
+  "settings.contactTooMany": {
+    "message": "Você pode adicionar no máximo {max} contatos",
+    "description": "Validation error when too many contacts are added"
+  },
   "message.viewOnGithub": {
     "message": "Ver no GitHub",
     "description": "Texto do link para visualizar o projeto no GitHub"

--- a/src/i18n/pt/site.json
+++ b/src/i18n/pt/site.json
@@ -39,6 +39,10 @@
     "message": "ID dos administradores do site",
     "description": "Exibido como o título na caixa de edição"
   },
+  "field.contacts": {
+    "message": "Contatos de suporte",
+    "description": "Field title for the customer-service contacts in site settings"
+  },
   "field.markupRatio": {
     "message": "Acréscimo uniforme em todo o site",
     "description": "Configuração do site: proporção de aumento unificada para todos os pacotes de recarga deste site (percentagem)"
@@ -234,6 +238,10 @@
   "title.editAdmins": {
     "message": "Editar administradores",
     "description": "Exibido como o título na caixa de edição"
+  },
+  "title.editContacts": {
+    "message": "Editar contatos de suporte",
+    "description": "Title of the edit-support-contacts dialog"
   },
   "title.featuresConfig": {
     "message": "Configuração de funcionalidades",
@@ -442,6 +450,14 @@
   "message.adminsTip2": {
     "message": "Você pode adicionar ou remover IDs de administradores aqui. Veja os IDs de usuários em https://auth.acedata.cloud",
     "description": "Mensagem de dica para os administradores do site"
+  },
+  "message.contactsTip": {
+    "message": "Preencha seus contatos de atendimento (Discord, X, WeChat, telefone, e-mail). Eles aparecem na página Sobre para os usuários falarem com você.",
+    "description": "Tip for the support-contacts field"
+  },
+  "message.contactsEmpty": {
+    "message": "Não definido",
+    "description": "Placeholder shown when no support contact has been filled in"
   },
   "message.keywordsTip": {
     "message": "Palavras-chave do site, localizadas nas metainformações do site, usadas para otimização de SEO.",

--- a/src/i18n/ru/common.json
+++ b/src/i18n/ru/common.json
@@ -1300,6 +1300,86 @@
     "message": "Связаться с поддержкой",
     "description": "Текст кнопки для связи с поддержкой"
   },
+  "settings.contactSupport": {
+    "message": "Связаться с поддержкой",
+    "description": "Section title on the About page listing the site owner's customer-service channels"
+  },
+  "settings.contactSupportTip": {
+    "message": "Свяжитесь с нашей службой поддержки любым из указанных ниже способов.",
+    "description": "Subtitle under the support contacts section on the About page"
+  },
+  "settings.contactInvalidUrl": {
+    "message": "{field} должен быть корректной ссылкой http(s)",
+    "description": "Validation error shown when a contact URL is not a valid http(s) link"
+  },
+  "settings.contactInvalidPhone": {
+    "message": "Введите корректный номер телефона",
+    "description": "Validation error shown when the phone number is invalid"
+  },
+  "settings.contactInvalidEmail": {
+    "message": "Введите корректный адрес эл. почты",
+    "description": "Validation error shown when the email address is invalid"
+  },
+  "settings.contactType": {
+    "message": "Тип",
+    "description": "Placeholder for the contact type picker in the editor"
+  },
+  "settings.contactType_phone": {
+    "message": "Телефон",
+    "description": "Display name for the phone contact type"
+  },
+  "settings.contactType_email": {
+    "message": "Эл. почта",
+    "description": "Display name for the email contact type"
+  },
+  "settings.contactType_website": {
+    "message": "Веб-сайт",
+    "description": "Display name for the website contact type"
+  },
+  "settings.contactType_wechat": {
+    "message": "WeChat",
+    "description": "Display name for the WeChat contact type"
+  },
+  "settings.contactLabelPlaceholder": {
+    "message": "Метка (необязательно), напр. Продажи",
+    "description": "Placeholder for the optional contact label input"
+  },
+  "settings.contactValuePlaceholder": {
+    "message": "Аккаунт / отображаемый текст",
+    "description": "Placeholder for the generic contact value input"
+  },
+  "settings.contactQr": {
+    "message": "QR-код",
+    "description": "Label for a contact's QR-code image"
+  },
+  "settings.contactQrTip": {
+    "message": "Загрузите QR-код, который пользователи смогут отсканировать.",
+    "description": "Tip for the contact QR-code uploader"
+  },
+  "settings.contactAdd": {
+    "message": "Добавить контакт",
+    "description": "Button to add another contact entry"
+  },
+  "settings.contactEditorHint": {
+    "message": "Выберите тип для каждого канала и укажите хотя бы значение, ссылку или QR. Можно добавить несколько.",
+    "description": "Hint at the top of the contacts editor dialog"
+  },
+  "settings.contactInvalidType": {
+    "message": "Тип может содержать только строчные буквы, цифры, '-' и '_'",
+    "description": "Validation error for an invalid contact type slug"
+  },
+  "settings.contactRowNeedsValue": {
+    "message": "Для каждого контакта нужно хотя бы значение, ссылка или QR-код",
+    "description": "Validation error when a contact row has no value/url/qr"
+  },
+  "settings.contactInvalidValue": {
+    "message": "Поле контакта недействительно или слишком длинное",
+    "description": "Validation error when a contact value/label is invalid or too long"
+  },
+  "settings.contactTooMany": {
+    "message": "Можно добавить не более {max} контактов",
+    "description": "Validation error when too many contacts are added"
+  },
   "message.viewOnGithub": {
     "message": "Посмотреть на GitHub",
     "description": "Текст ссылки для просмотра проекта на GitHub"

--- a/src/i18n/ru/site.json
+++ b/src/i18n/ru/site.json
@@ -39,6 +39,10 @@
     "message": "ID администраторов сайта",
     "description": "展示在编辑框的标题"
   },
+  "field.contacts": {
+    "message": "Контакты поддержки",
+    "description": "Field title for the customer-service contacts in site settings"
+  },
   "field.markupRatio": {
     "message": "Единая наценка для всего сайта",
     "description": "Настройки сайта: процент наценки для всех тарифных планов на пополнение на данном сайте (в процентах)"
@@ -234,6 +238,10 @@
   "title.editAdmins": {
     "message": "Редактировать администраторов",
     "description": "展示在编辑框的标题"
+  },
+  "title.editContacts": {
+    "message": "Изменить контакты поддержки",
+    "description": "Title of the edit-support-contacts dialog"
   },
   "title.featuresConfig": {
     "message": "Настройки функций",
@@ -442,6 +450,14 @@
   "message.adminsTip2": {
     "message": "Здесь можно добавлять или удалять ID администраторов. Вы можете посмотреть ID пользователей на https://auth.acedata.cloud",
     "description": "站点管理员的提示"
+  },
+  "message.contactsTip": {
+    "message": "Укажите контакты службы поддержки (Discord, X, WeChat, телефон, эл. почта). Они показываются на странице «О нас», чтобы пользователи могли связаться с вами.",
+    "description": "Tip for the support-contacts field"
+  },
+  "message.contactsEmpty": {
+    "message": "Не задано",
+    "description": "Placeholder shown when no support contact has been filled in"
   },
   "message.keywordsTip": {
     "message": "Ключевые слова сайта, находятся в метаданных сайта, используются для SEO-оптимизации сайта.",

--- a/src/i18n/sr/common.json
+++ b/src/i18n/sr/common.json
@@ -1300,6 +1300,86 @@
     "message": "Kontaktirajte podršku",
     "description": "Tekst dugmeta za kontaktiranje podrške"
   },
+  "settings.contactSupport": {
+    "message": "Контакт подршке",
+    "description": "Section title on the About page listing the site owner's customer-service channels"
+  },
+  "settings.contactSupportTip": {
+    "message": "Обратите се нашем тиму подршке путем било ког од доле наведених канала.",
+    "description": "Subtitle under the support contacts section on the About page"
+  },
+  "settings.contactInvalidUrl": {
+    "message": "{field} мора бити важећи http(s) линк",
+    "description": "Validation error shown when a contact URL is not a valid http(s) link"
+  },
+  "settings.contactInvalidPhone": {
+    "message": "Унесите важећи број телефона",
+    "description": "Validation error shown when the phone number is invalid"
+  },
+  "settings.contactInvalidEmail": {
+    "message": "Унесите важећу имејл адресу",
+    "description": "Validation error shown when the email address is invalid"
+  },
+  "settings.contactType": {
+    "message": "Тип",
+    "description": "Placeholder for the contact type picker in the editor"
+  },
+  "settings.contactType_phone": {
+    "message": "Телефон",
+    "description": "Display name for the phone contact type"
+  },
+  "settings.contactType_email": {
+    "message": "Имејл",
+    "description": "Display name for the email contact type"
+  },
+  "settings.contactType_website": {
+    "message": "Веб-сајт",
+    "description": "Display name for the website contact type"
+  },
+  "settings.contactType_wechat": {
+    "message": "WeChat",
+    "description": "Display name for the WeChat contact type"
+  },
+  "settings.contactLabelPlaceholder": {
+    "message": "Label (optional), e.g. Sales",
+    "description": "Placeholder for the optional contact label input"
+  },
+  "settings.contactValuePlaceholder": {
+    "message": "Account / display text",
+    "description": "Placeholder for the generic contact value input"
+  },
+  "settings.contactQr": {
+    "message": "QR код",
+    "description": "Label for a contact's QR-code image"
+  },
+  "settings.contactQrTip": {
+    "message": "Upload a QR code users can scan to add you.",
+    "description": "Tip for the contact QR-code uploader"
+  },
+  "settings.contactAdd": {
+    "message": "Додај контакт",
+    "description": "Button to add another contact entry"
+  },
+  "settings.contactEditorHint": {
+    "message": "Pick a type for each channel and fill in at least a value, link or QR. Add as many as you like.",
+    "description": "Hint at the top of the contacts editor dialog"
+  },
+  "settings.contactInvalidType": {
+    "message": "Type may only contain lowercase letters, digits, '-' and '_'",
+    "description": "Validation error for an invalid contact type slug"
+  },
+  "settings.contactRowNeedsValue": {
+    "message": "Each contact needs at least a value, link or QR code",
+    "description": "Validation error when a contact row has no value/url/qr"
+  },
+  "settings.contactInvalidValue": {
+    "message": "A contact field is invalid or too long",
+    "description": "Validation error when a contact value/label is invalid or too long"
+  },
+  "settings.contactTooMany": {
+    "message": "You can add at most {max} contacts",
+    "description": "Validation error when too many contacts are added"
+  },
   "message.viewOnGithub": {
     "message": "Pogledajte na GitHub-u",
     "description": "Tekst linka za pregled projekta na GitHub-u"

--- a/src/i18n/sr/site.json
+++ b/src/i18n/sr/site.json
@@ -39,6 +39,10 @@
     "message": "ID administratora sajta",
     "description": "Prikazuje se kao naslov u okviru za uređivanje"
   },
+  "field.contacts": {
+    "message": "Контакти подршке",
+    "description": "Field title for the customer-service contacts in site settings"
+  },
   "field.markupRatio": {
     "message": "Јединствено увећање цене за цео сајт",
     "description": "Podešavanje sajta: Proporcija povećanja za sve pakete dopune na ovom sajtu (procenat)"
@@ -234,6 +238,10 @@
   "title.editAdmins": {
     "message": "Uredi administratore",
     "description": "Prikazuje se kao naslov u okviru za uređivanje"
+  },
+  "title.editContacts": {
+    "message": "Уреди контакте подршке",
+    "description": "Title of the edit-support-contacts dialog"
   },
   "title.featuresConfig": {
     "message": "Podešavanja funkcija",
@@ -442,6 +450,14 @@
   "message.adminsTip2": {
     "message": "Можете додавати или уклањати ID администраторов овде, можете посетити https://auth.acedata.cloud за преглед ID корисника",
     "description": "Упутство о администраторима сајта"
+  },
+  "message.contactsTip": {
+    "message": "Унесите контакте корисничке подршке (Discord, X, WeChat, телефон, имејл). Приказују се на страници „О нама“ како би вас корисници контактирали.",
+    "description": "Tip for the support-contacts field"
+  },
+  "message.contactsEmpty": {
+    "message": "Није постављено",
+    "description": "Placeholder shown when no support contact has been filled in"
   },
   "message.keywordsTip": {
     "message": "Кључне речи сајта, налазе се у мета информацијама сајта, користе се за SEO оптимизацију.",

--- a/src/i18n/sv/common.json
+++ b/src/i18n/sv/common.json
@@ -1300,6 +1300,86 @@
     "message": "Kontakta support",
     "description": "Texten för knappen för att kontakta support"
   },
+  "settings.contactSupport": {
+    "message": "Kontakta support",
+    "description": "Section title on the About page listing the site owner's customer-service channels"
+  },
+  "settings.contactSupportTip": {
+    "message": "Nå vårt supportteam via någon av kanalerna nedan.",
+    "description": "Subtitle under the support contacts section on the About page"
+  },
+  "settings.contactInvalidUrl": {
+    "message": "{field} måste vara en giltig http(s)-länk",
+    "description": "Validation error shown when a contact URL is not a valid http(s) link"
+  },
+  "settings.contactInvalidPhone": {
+    "message": "Ange ett giltigt telefonnummer",
+    "description": "Validation error shown when the phone number is invalid"
+  },
+  "settings.contactInvalidEmail": {
+    "message": "Ange en giltig e-postadress",
+    "description": "Validation error shown when the email address is invalid"
+  },
+  "settings.contactType": {
+    "message": "Typ",
+    "description": "Placeholder for the contact type picker in the editor"
+  },
+  "settings.contactType_phone": {
+    "message": "Telefon",
+    "description": "Display name for the phone contact type"
+  },
+  "settings.contactType_email": {
+    "message": "E-post",
+    "description": "Display name for the email contact type"
+  },
+  "settings.contactType_website": {
+    "message": "Webbplats",
+    "description": "Display name for the website contact type"
+  },
+  "settings.contactType_wechat": {
+    "message": "WeChat",
+    "description": "Display name for the WeChat contact type"
+  },
+  "settings.contactLabelPlaceholder": {
+    "message": "Label (optional), e.g. Sales",
+    "description": "Placeholder for the optional contact label input"
+  },
+  "settings.contactValuePlaceholder": {
+    "message": "Account / display text",
+    "description": "Placeholder for the generic contact value input"
+  },
+  "settings.contactQr": {
+    "message": "QR-kod",
+    "description": "Label for a contact's QR-code image"
+  },
+  "settings.contactQrTip": {
+    "message": "Upload a QR code users can scan to add you.",
+    "description": "Tip for the contact QR-code uploader"
+  },
+  "settings.contactAdd": {
+    "message": "Lägg till kontakt",
+    "description": "Button to add another contact entry"
+  },
+  "settings.contactEditorHint": {
+    "message": "Pick a type for each channel and fill in at least a value, link or QR. Add as many as you like.",
+    "description": "Hint at the top of the contacts editor dialog"
+  },
+  "settings.contactInvalidType": {
+    "message": "Type may only contain lowercase letters, digits, '-' and '_'",
+    "description": "Validation error for an invalid contact type slug"
+  },
+  "settings.contactRowNeedsValue": {
+    "message": "Each contact needs at least a value, link or QR code",
+    "description": "Validation error when a contact row has no value/url/qr"
+  },
+  "settings.contactInvalidValue": {
+    "message": "A contact field is invalid or too long",
+    "description": "Validation error when a contact value/label is invalid or too long"
+  },
+  "settings.contactTooMany": {
+    "message": "You can add at most {max} contacts",
+    "description": "Validation error when too many contacts are added"
+  },
   "message.viewOnGithub": {
     "message": "Visa på GitHub",
     "description": "Texten för länken för att se projektet på GitHub"

--- a/src/i18n/sv/site.json
+++ b/src/i18n/sv/site.json
@@ -39,6 +39,10 @@
     "message": "Webbplatsens administratörs-ID",
     "description": "Visas som titeln i redigeringsrutan"
   },
+  "field.contacts": {
+    "message": "Supportkontakter",
+    "description": "Field title for the customer-service contacts in site settings"
+  },
   "field.markupRatio": {
     "message": "Enhetligt påslag för hela webbplatsen",
     "description": "Inställningar för webbplatsen: den enhetliga påslagsprocenten (i procent) för alla insättningspaket på denna webbplats."
@@ -234,6 +238,10 @@
   "title.editAdmins": {
     "message": "Redigera administratörer",
     "description": "Visas som titeln i redigeringsrutan"
+  },
+  "title.editContacts": {
+    "message": "Redigera supportkontakter",
+    "description": "Title of the edit-support-contacts dialog"
   },
   "title.featuresConfig": {
     "message": "Funktioner konfiguration",
@@ -442,6 +450,14 @@
   "message.adminsTip2": {
     "message": "Kan här lägga till eller ta bort administratörs-ID. Du kan se användar-ID på https://auth.acedata.cloud",
     "description": "Tips om webbplatsens administratörer"
+  },
+  "message.contactsTip": {
+    "message": "Fyll i dina kundtjänstkontakter (Discord, X, WeChat, telefon, e-post). De visas på Om-sidan så att användare kan nå dig.",
+    "description": "Tip for the support-contacts field"
+  },
+  "message.contactsEmpty": {
+    "message": "Inte angivet",
+    "description": "Placeholder shown when no support contact has been filled in"
   },
   "message.keywordsTip": {
     "message": "Webbplatsens nyckelord, finns i webbplatsens metadata och används för SEO-optimering.",

--- a/src/i18n/uk/common.json
+++ b/src/i18n/uk/common.json
@@ -1300,6 +1300,86 @@
     "message": "Зв'язатися з підтримкою",
     "description": "Текст кнопки для зв'язку з підтримкою"
   },
+  "settings.contactSupport": {
+    "message": "Звʼязатися з підтримкою",
+    "description": "Section title on the About page listing the site owner's customer-service channels"
+  },
+  "settings.contactSupportTip": {
+    "message": "Звʼяжіться з нашою службою підтримки будь-яким із наведених нижче каналів.",
+    "description": "Subtitle under the support contacts section on the About page"
+  },
+  "settings.contactInvalidUrl": {
+    "message": "{field} має бути дійсним посиланням http(s)",
+    "description": "Validation error shown when a contact URL is not a valid http(s) link"
+  },
+  "settings.contactInvalidPhone": {
+    "message": "Введіть дійсний номер телефону",
+    "description": "Validation error shown when the phone number is invalid"
+  },
+  "settings.contactInvalidEmail": {
+    "message": "Введіть дійсну адресу електронної пошти",
+    "description": "Validation error shown when the email address is invalid"
+  },
+  "settings.contactType": {
+    "message": "Тип",
+    "description": "Placeholder for the contact type picker in the editor"
+  },
+  "settings.contactType_phone": {
+    "message": "Телефон",
+    "description": "Display name for the phone contact type"
+  },
+  "settings.contactType_email": {
+    "message": "Електронна пошта",
+    "description": "Display name for the email contact type"
+  },
+  "settings.contactType_website": {
+    "message": "Вебсайт",
+    "description": "Display name for the website contact type"
+  },
+  "settings.contactType_wechat": {
+    "message": "WeChat",
+    "description": "Display name for the WeChat contact type"
+  },
+  "settings.contactLabelPlaceholder": {
+    "message": "Label (optional), e.g. Sales",
+    "description": "Placeholder for the optional contact label input"
+  },
+  "settings.contactValuePlaceholder": {
+    "message": "Account / display text",
+    "description": "Placeholder for the generic contact value input"
+  },
+  "settings.contactQr": {
+    "message": "QR-код",
+    "description": "Label for a contact's QR-code image"
+  },
+  "settings.contactQrTip": {
+    "message": "Upload a QR code users can scan to add you.",
+    "description": "Tip for the contact QR-code uploader"
+  },
+  "settings.contactAdd": {
+    "message": "Додати контакт",
+    "description": "Button to add another contact entry"
+  },
+  "settings.contactEditorHint": {
+    "message": "Pick a type for each channel and fill in at least a value, link or QR. Add as many as you like.",
+    "description": "Hint at the top of the contacts editor dialog"
+  },
+  "settings.contactInvalidType": {
+    "message": "Type may only contain lowercase letters, digits, '-' and '_'",
+    "description": "Validation error for an invalid contact type slug"
+  },
+  "settings.contactRowNeedsValue": {
+    "message": "Each contact needs at least a value, link or QR code",
+    "description": "Validation error when a contact row has no value/url/qr"
+  },
+  "settings.contactInvalidValue": {
+    "message": "A contact field is invalid or too long",
+    "description": "Validation error when a contact value/label is invalid or too long"
+  },
+  "settings.contactTooMany": {
+    "message": "You can add at most {max} contacts",
+    "description": "Validation error when too many contacts are added"
+  },
   "message.viewOnGithub": {
     "message": "Переглянути на GitHub",
     "description": "Текст посилання для перегляду проекту на GitHub"

--- a/src/i18n/uk/site.json
+++ b/src/i18n/uk/site.json
@@ -39,6 +39,10 @@
     "message": "ID адміністраторів сайту",
     "description": "展示在编辑框的标题"
   },
+  "field.contacts": {
+    "message": "Контакти підтримки",
+    "description": "Field title for the customer-service contacts in site settings"
+  },
   "field.markupRatio": {
     "message": "Єдина націнка для всього сайту",
     "description": "Налаштування сайту: відсоток націнки для всіх пакетів поповнення на цьому сайті (у відсотках)"
@@ -234,6 +238,10 @@
   "title.editAdmins": {
     "message": "Редагувати адміністраторів",
     "description": "展示在编辑框的标题"
+  },
+  "title.editContacts": {
+    "message": "Редагувати контакти підтримки",
+    "description": "Title of the edit-support-contacts dialog"
   },
   "title.featuresConfig": {
     "message": "Налаштування функцій",
@@ -442,6 +450,14 @@
   "message.adminsTip2": {
     "message": "Тут можна додавати або видаляти ID адміністраторів, можна переглянути ID користувачів на https://auth.acedata.cloud",
     "description": "Підказка для адміністраторів сайту"
+  },
+  "message.contactsTip": {
+    "message": "Вкажіть контакти служби підтримки (Discord, X, WeChat, телефон, е-пошта). Вони показуються на сторінці «Про нас», щоб користувачі могли звʼязатися з вами.",
+    "description": "Tip for the support-contacts field"
+  },
+  "message.contactsEmpty": {
+    "message": "Не задано",
+    "description": "Placeholder shown when no support contact has been filled in"
   },
   "message.keywordsTip": {
     "message": "Ключові слова сайту, розташовані у метаданих сайту, використовуються для SEO-оптимізації.",

--- a/src/i18n/zh-CN/common.json
+++ b/src/i18n/zh-CN/common.json
@@ -1300,6 +1300,86 @@
     "message": "联系客服",
     "description": "联系客服按钮的文本"
   },
+  "settings.contactSupport": {
+    "message": "联系客服",
+    "description": "关于页面中展示站长客服渠道的栏目标题"
+  },
+  "settings.contactSupportTip": {
+    "message": "可通过以下任一方式联系我们的客服。",
+    "description": "关于页面客服栏目下方的副标题"
+  },
+  "settings.contactInvalidUrl": {
+    "message": "{field} 需要是有效的 http(s) 链接",
+    "description": "联系方式链接无效时的校验错误提示"
+  },
+  "settings.contactInvalidPhone": {
+    "message": "请输入有效的电话号码",
+    "description": "电话号码无效时的校验错误提示"
+  },
+  "settings.contactInvalidEmail": {
+    "message": "请输入有效的邮箱地址",
+    "description": "邮箱地址无效时的校验错误提示"
+  },
+  "settings.contactType": {
+    "message": "类型",
+    "description": "Placeholder for the contact type picker in the editor"
+  },
+  "settings.contactType_phone": {
+    "message": "电话",
+    "description": "Display name for the phone contact type"
+  },
+  "settings.contactType_email": {
+    "message": "邮箱",
+    "description": "Display name for the email contact type"
+  },
+  "settings.contactType_website": {
+    "message": "网站",
+    "description": "Display name for the website contact type"
+  },
+  "settings.contactType_wechat": {
+    "message": "微信",
+    "description": "Display name for the WeChat contact type"
+  },
+  "settings.contactLabelPlaceholder": {
+    "message": "备注（可选），如：售前",
+    "description": "Placeholder for the optional contact label input"
+  },
+  "settings.contactValuePlaceholder": {
+    "message": "账号 / 展示文本",
+    "description": "Placeholder for the generic contact value input"
+  },
+  "settings.contactQr": {
+    "message": "二维码",
+    "description": "Label for a contact's QR-code image"
+  },
+  "settings.contactQrTip": {
+    "message": "上传一张二维码，用户扫码即可添加你。",
+    "description": "Tip for the contact QR-code uploader"
+  },
+  "settings.contactAdd": {
+    "message": "添加联系方式",
+    "description": "Button to add another contact entry"
+  },
+  "settings.contactEditorHint": {
+    "message": "为每个渠道选择类型，并至少填写 值 / 链接 / 二维码 之一；可添加多条。",
+    "description": "Hint at the top of the contacts editor dialog"
+  },
+  "settings.contactInvalidType": {
+    "message": "类型只能包含小写字母、数字、- 和 _",
+    "description": "Validation error for an invalid contact type slug"
+  },
+  "settings.contactRowNeedsValue": {
+    "message": "每条联系方式至少填写 值、链接 或 二维码 之一",
+    "description": "Validation error when a contact row has no value/url/qr"
+  },
+  "settings.contactInvalidValue": {
+    "message": "联系方式内容无效或过长",
+    "description": "Validation error when a contact value/label is invalid or too long"
+  },
+  "settings.contactTooMany": {
+    "message": "最多可添加 {max} 条联系方式",
+    "description": "Validation error when too many contacts are added"
+  },
   "message.viewOnGithub": {
     "message": "在 GitHub 上查看",
     "description": "在GitHub上查看项目的链接文本"

--- a/src/i18n/zh-CN/site.json
+++ b/src/i18n/zh-CN/site.json
@@ -39,6 +39,10 @@
     "message": "站点管理员 ID",
     "description": "展示在编辑框的标题"
   },
+  "field.contacts": {
+    "message": "客服联系方式",
+    "description": "站点设置中『客服联系方式』的字段标题"
+  },
   "field.markupRatio": {
     "message": "全站统一加价比例",
     "description": "站点设置：对本站所有充值套餐统一加价的比例（百分比）"
@@ -234,6 +238,10 @@
   "title.editAdmins": {
     "message": "编辑管理员",
     "description": "展示在编辑框的标题"
+  },
+  "title.editContacts": {
+    "message": "编辑客服联系方式",
+    "description": "编辑客服联系方式弹窗的标题"
   },
   "title.featuresConfig": {
     "message": "功能配置",
@@ -442,6 +450,14 @@
   "message.adminsTip2": {
     "message": "可在此处增删管理员 ID，可到 https://auth.acedata.cloud 查看用户 ID",
     "description": "站点管理员的提示"
+  },
+  "message.contactsTip": {
+    "message": "填写客服联系方式（Discord、X、微信、电话、邮箱），将展示在『关于』页面中，方便用户联系你。",
+    "description": "客服联系方式字段的提示"
+  },
+  "message.contactsEmpty": {
+    "message": "暂未设置",
+    "description": "未填写任何客服联系方式时的占位文案"
   },
   "message.keywordsTip": {
     "message": "站点关键词，位于站点元信息中，用于站点 SEO 优化。",

--- a/src/i18n/zh-TW/common.json
+++ b/src/i18n/zh-TW/common.json
@@ -1300,6 +1300,86 @@
     "message": "聯繫客服",
     "description": "聯繫客服按鈕的文本"
   },
+  "settings.contactSupport": {
+    "message": "聯絡客服",
+    "description": "Section title on the About page listing the site owner's customer-service channels"
+  },
+  "settings.contactSupportTip": {
+    "message": "可透過以下任一方式聯絡我們的客服。",
+    "description": "Subtitle under the support contacts section on the About page"
+  },
+  "settings.contactInvalidUrl": {
+    "message": "{field} 需要是有效的 http(s) 連結",
+    "description": "Validation error shown when a contact URL is not a valid http(s) link"
+  },
+  "settings.contactInvalidPhone": {
+    "message": "請輸入有效的電話號碼",
+    "description": "Validation error shown when the phone number is invalid"
+  },
+  "settings.contactInvalidEmail": {
+    "message": "請輸入有效的郵箱地址",
+    "description": "Validation error shown when the email address is invalid"
+  },
+  "settings.contactType": {
+    "message": "類型",
+    "description": "Placeholder for the contact type picker in the editor"
+  },
+  "settings.contactType_phone": {
+    "message": "電話",
+    "description": "Display name for the phone contact type"
+  },
+  "settings.contactType_email": {
+    "message": "郵箱",
+    "description": "Display name for the email contact type"
+  },
+  "settings.contactType_website": {
+    "message": "網站",
+    "description": "Display name for the website contact type"
+  },
+  "settings.contactType_wechat": {
+    "message": "微信",
+    "description": "Display name for the WeChat contact type"
+  },
+  "settings.contactLabelPlaceholder": {
+    "message": "備註（可選），如：售前",
+    "description": "Placeholder for the optional contact label input"
+  },
+  "settings.contactValuePlaceholder": {
+    "message": "帳號 / 顯示文字",
+    "description": "Placeholder for the generic contact value input"
+  },
+  "settings.contactQr": {
+    "message": "二維碼",
+    "description": "Label for a contact's QR-code image"
+  },
+  "settings.contactQrTip": {
+    "message": "上傳一張二維碼，使用者掃碼即可加你。",
+    "description": "Tip for the contact QR-code uploader"
+  },
+  "settings.contactAdd": {
+    "message": "新增聯絡方式",
+    "description": "Button to add another contact entry"
+  },
+  "settings.contactEditorHint": {
+    "message": "為每個管道選擇類型，並至少填寫 值 / 連結 / 二維碼 之一；可新增多條。",
+    "description": "Hint at the top of the contacts editor dialog"
+  },
+  "settings.contactInvalidType": {
+    "message": "類型只能包含小寫字母、數字、- 和 _",
+    "description": "Validation error for an invalid contact type slug"
+  },
+  "settings.contactRowNeedsValue": {
+    "message": "每條聯絡方式至少填寫 值、連結 或 二維碼 之一",
+    "description": "Validation error when a contact row has no value/url/qr"
+  },
+  "settings.contactInvalidValue": {
+    "message": "聯絡方式內容無效或過長",
+    "description": "Validation error when a contact value/label is invalid or too long"
+  },
+  "settings.contactTooMany": {
+    "message": "最多可新增 {max} 條聯絡方式",
+    "description": "Validation error when too many contacts are added"
+  },
   "message.viewOnGithub": {
     "message": "在 GitHub 上查看",
     "description": "在GitHub上查看專案的連結文本"

--- a/src/i18n/zh-TW/site.json
+++ b/src/i18n/zh-TW/site.json
@@ -39,6 +39,10 @@
     "message": "站點管理員 ID",
     "description": "展示在編輯框的標題"
   },
+  "field.contacts": {
+    "message": "客服聯絡方式",
+    "description": "Field title for the customer-service contacts in site settings"
+  },
   "field.markupRatio": {
     "message": "全站統一加價比例",
     "description": "站點設置：對本站所有充值套餐統一加價的比例（百分比）"
@@ -234,6 +238,10 @@
   "title.editAdmins": {
     "message": "編輯管理員",
     "description": "展示在編輯框的標題"
+  },
+  "title.editContacts": {
+    "message": "編輯客服聯絡方式",
+    "description": "Title of the edit-support-contacts dialog"
   },
   "title.featuresConfig": {
     "message": "功能配置",
@@ -442,6 +450,14 @@
   "message.adminsTip2": {
     "message": "可在此處增刪管理員 ID，可到 https://auth.acedata.cloud 查看用戶 ID",
     "description": "站點管理員的提示"
+  },
+  "message.contactsTip": {
+    "message": "填寫客服聯絡方式（Discord、X、微信、電話、郵箱），將顯示在「關於」頁面中，方便使用者聯絡你。",
+    "description": "Tip for the support-contacts field"
+  },
+  "message.contactsEmpty": {
+    "message": "尚未設定",
+    "description": "Placeholder shown when no support contact has been filled in"
   },
   "message.keywordsTip": {
     "message": "站點關鍵詞，位於站點元信息中，用於站點 SEO 優化。",

--- a/src/models/site.ts
+++ b/src/models/site.ts
@@ -116,12 +116,28 @@ export interface ISiteBrandingLinks {
   privacy?: string;
 }
 
+// One customer-service entry shown on the About page (an ordered list
+// lives at ``Site.branding.contacts``). ``type`` is a short slug
+// (discord / x / wechat / telegram / phone / email / website / any
+// custom channel) that drives the icon + link scheme; each item must
+// carry at least one of ``value`` / ``url`` / ``qr``. This shape scales
+// to multiple phones/emails, a QR on any channel, and new channel types
+// with no schema change. Backend validator: ``app/utils/site_branding.py``.
+export interface ISiteContact {
+  type: string;
+  label?: string;
+  value?: string;
+  url?: string;
+  qr?: string;
+}
+
 export interface ISiteBranding {
   company?: string;
   copyright?: string;
   hide_powered_by?: boolean;
   hide_api_code?: boolean;
   links?: ISiteBrandingLinks;
+  contacts?: ISiteContact[];
 }
 
 export interface ISite {

--- a/src/utils/contactTypes.ts
+++ b/src/utils/contactTypes.ts
@@ -1,0 +1,76 @@
+// Shared metadata for site support-contact channels (Site.branding.contacts).
+// Maps a contact `type` slug to its icon, link scheme and a locale-independent
+// brand name, plus the preset list the editor offers. Adding a channel here is
+// the only change needed to give a new `type` a nice icon everywhere.
+import type { IconDefinition } from '@fortawesome/fontawesome-svg-core';
+import {
+  faDiscord,
+  faXTwitter,
+  faWeixin,
+  faTelegram,
+  faWhatsapp,
+  faFacebook,
+  faInstagram,
+  faYoutube,
+  faLinkedin,
+  faGithub,
+  faQq,
+  faLine,
+  faTiktok
+} from '@fortawesome/free-brands-svg-icons';
+import { faPhone, faEnvelope, faGlobe, faLink } from '@fortawesome/free-solid-svg-icons';
+
+// How the entry's `value` becomes an href when no explicit `url` is set.
+export type ContactScheme = 'tel' | 'mailto' | 'text';
+
+interface ContactTypeMeta {
+  icon: IconDefinition;
+  // Scheme used to build a link from `value` (ignored when `url` is present).
+  scheme: ContactScheme;
+  // Locale-independent display name for known brands ('' = derive/translate).
+  brand?: string;
+}
+
+const TYPES: Record<string, ContactTypeMeta> = {
+  discord: { icon: faDiscord, scheme: 'text', brand: 'Discord' },
+  x: { icon: faXTwitter, scheme: 'text', brand: 'X' },
+  twitter: { icon: faXTwitter, scheme: 'text', brand: 'X' },
+  wechat: { icon: faWeixin, scheme: 'text' },
+  telegram: { icon: faTelegram, scheme: 'text', brand: 'Telegram' },
+  whatsapp: { icon: faWhatsapp, scheme: 'text', brand: 'WhatsApp' },
+  facebook: { icon: faFacebook, scheme: 'text', brand: 'Facebook' },
+  instagram: { icon: faInstagram, scheme: 'text', brand: 'Instagram' },
+  youtube: { icon: faYoutube, scheme: 'text', brand: 'YouTube' },
+  tiktok: { icon: faTiktok, scheme: 'text', brand: 'TikTok' },
+  linkedin: { icon: faLinkedin, scheme: 'text', brand: 'LinkedIn' },
+  github: { icon: faGithub, scheme: 'text', brand: 'GitHub' },
+  qq: { icon: faQq, scheme: 'text', brand: 'QQ' },
+  line: { icon: faLine, scheme: 'text', brand: 'LINE' },
+  phone: { icon: faPhone, scheme: 'tel' },
+  email: { icon: faEnvelope, scheme: 'mailto' },
+  website: { icon: faGlobe, scheme: 'text' }
+};
+
+const DEFAULT_META: ContactTypeMeta = { icon: faLink, scheme: 'text' };
+
+const normalize = (type?: string): string => (type || '').trim().toLowerCase();
+
+export const contactMeta = (type?: string): ContactTypeMeta => TYPES[normalize(type)] || DEFAULT_META;
+
+export const contactIcon = (type?: string): IconDefinition => contactMeta(type).icon;
+
+// Locale-independent brand name for known channels ('' when the caller should
+// translate — phone/email/website — or fall back to the raw/capitalized slug).
+export const contactBrand = (type?: string): string => contactMeta(type).brand || '';
+
+// Channels whose display name is translatable via an i18n key
+// `common.settings.contactType_<type>`. Returns that key, or '' when the type
+// has no localized name (caller should fall back to brand / capitalized slug).
+const I18N_TYPES = new Set(['phone', 'email', 'website', 'wechat']);
+export const contactTypeI18nKey = (type?: string): string => {
+  const t = normalize(type);
+  return I18N_TYPES.has(t) ? `common.settings.contactType_${t}` : '';
+};
+
+// Presets offered in the editor's type picker (order = list order there).
+export const CONTACT_TYPE_PRESETS = ['wechat', 'phone', 'email', 'discord', 'x', 'telegram', 'whatsapp', 'website'];

--- a/src/utils/site.test.ts
+++ b/src/utils/site.test.ts
@@ -7,7 +7,9 @@ import {
   getApplicationCallerOrderDiscountRate,
   applyMarkup,
   isBrandingHidden,
-  getBrandSupportUrl
+  getBrandSupportUrl,
+  getBrandContacts,
+  hasBrandContacts
 } from './site';
 
 /**
@@ -164,5 +166,36 @@ describe('getBrandSupportUrl', () => {
     expect(getBrandSupportUrl({ metadata: { support_url: 'https://b.com' } } as never)).toBe('https://b.com');
     expect(getBrandSupportUrl({} as never)).toBe('');
     expect(getBrandSupportUrl(null)).toBe('');
+  });
+});
+
+describe('getBrandContacts', () => {
+  it('returns [] when site / branding / contacts is unset or malformed', () => {
+    expect(getBrandContacts(null)).toEqual([]);
+    expect(getBrandContacts(undefined)).toEqual([]);
+    expect(getBrandContacts({} as never)).toEqual([]);
+    expect(getBrandContacts({ branding: {} } as never)).toEqual([]);
+    // non-array (legacy dict shape / garbage) is ignored
+    expect(getBrandContacts({ branding: { contacts: { discord: 'x' } } } as never)).toEqual([]);
+  });
+
+  it('returns the configured contacts list', () => {
+    const contacts = [
+      { type: 'discord', url: 'https://discord.gg/x' },
+      { type: 'email', value: 'a@b.co' }
+    ];
+    expect(getBrandContacts({ branding: { contacts } } as never)).toEqual(contacts);
+  });
+});
+
+describe('hasBrandContacts', () => {
+  it('is false when the list is missing or empty', () => {
+    expect(hasBrandContacts(null)).toBe(false);
+    expect(hasBrandContacts({ branding: { contacts: [] } } as never)).toBe(false);
+    expect(hasBrandContacts({ branding: { contacts: {} } } as never)).toBe(false);
+  });
+
+  it('is true when at least one entry is present', () => {
+    expect(hasBrandContacts({ branding: { contacts: [{ type: 'phone', value: '12345' }] } } as never)).toBe(true);
   });
 });

--- a/src/utils/site.ts
+++ b/src/utils/site.ts
@@ -1,4 +1,4 @@
-import { IApplication, ISite } from '@/models';
+import { IApplication, ISite, ISiteContact } from '@/models';
 import { v4 as uuid } from 'uuid';
 import { BASE_HOST_HUB } from '@/constants/endpoint';
 import { isNative, isDesktop } from './surface';
@@ -83,6 +83,23 @@ export const isBrandingHidden = (site: ISite | null | undefined, key: 'powered_b
  */
 export const getBrandSupportUrl = (site?: ISite | null): string => {
   return site?.branding?.links?.support || site?.metadata?.support_url || '';
+};
+
+/**
+ * Ordered list of customer-service entries the site owner configured
+ * (`branding.contacts`, PlatformBackend). Returns `[]` when unset / malformed
+ * so callers can treat "no contacts" uniformly.
+ */
+export const getBrandContacts = (site?: ISite | null): ISiteContact[] => {
+  const contacts = site?.branding?.contacts;
+  return Array.isArray(contacts) ? contacts : [];
+};
+
+/**
+ * True when the site owner filled in at least one contact entry.
+ */
+export const hasBrandContacts = (site?: ISite | null): boolean => {
+  return getBrandContacts(site).length > 0;
 };
 
 // Site-wide markup ceiling, mirroring PlatformBackend


### PR DESCRIPTION
## Summary
Lets a site owner publish customer-service contacts on the **关于 (About)** tab, edited in **站点设置 (Site Settings)**. Companion to PlatformBackend https://github.com/AceDataCloud/PlatformBackend/pull/967.

**Extensible list design** (replaces the earlier fixed `{discord,x,wechat,phone,email}` shape): contacts are an **ordered list** of `{ type, label?, value?, url?, qr? }`. So you can add **multiple phones/emails**, put a **QR on any channel** (Discord, Telegram, …), and use **new channel types** with no code change. `src/utils/contactTypes.ts` maps a `type` slug → icon + link scheme (discord/x/wechat/telegram/whatsapp/facebook/instagram/youtube/tiktok/linkedin/github/qq/line/phone/email/website + a generic-link fallback for anything custom).

About tab behavior:
- The three first-party items (Nexior open-source, Ace Data Cloud API, one-click 搭建同款) render **only on our own official builds** — `isMainOfficial() || isNative() || isDesktop()`.
- The **联系客服 / Contact Support** block renders whenever ≥1 contact is configured, on any site. Each entry: icon + (label→value→brand/type name); external URLs open in a new tab; `phone`→`tel:`, `email`→`mailto:`; a QR thumbnail (click to zoom) on any entry.

Editing: `EditContacts.vue` is now a repeatable-row editor (type picker with presets + free custom slug, label, value, link, QR upload; add/remove rows), with client validation mirroring the backend. Saves the array into `branding.contacts`, preserving other branding keys.

## Validation
- `eslint` clean; `vue-tsc -b` clean; `vitest run src/utils/site.test.ts` — 26 passed.
- `python3 scripts/check_i18n_coverage.py` — OK (all 18 locales; deprecated per-channel keys removed, new list-editor keys added).

## 🤖 对抗评审 (reviewer: general-purpose subagent, 1 round)
- Cleared (no RISK): **XSS** — `contactHref` only yields `c.url` (backend http(s)) or `tel:`/`mailto:` gated on scheme reachable **only** for literal `phone`/`email` types (regex-validated values); custom types → static span, no href; `el-image :src` is http(s). Front/back validation parity tight (client lowercases+regex-checks type, enforces 30-cap & length/url/phone/email). Legacy dict-shaped data degrades to `[]` (no crash). i18n `{max}`/`{field}` present in all locales; no component references a removed key.
- `VERDICT: CLEAN`
