### PR TITLE
fix(design): remove dormant purple Tailwind theme

### DIFF
--- a/change/@acedatacloud-nexior-p0-tailwind-semantic.json
+++ b/change/@acedatacloud-nexior-p0-tailwind-semantic.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Replace the dormant purple Tailwind theme with runtime semantic design tokens.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/assets/tailwindConfig.test.ts
+++ b/src/assets/tailwindConfig.test.ts
@@ -1,0 +1,33 @@
+import { createRequire } from 'node:module';
+import { describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const config = require('../../tailwind.config.js');
+
+describe('Tailwind design tokens', () => {
+  it('uses the runtime semantic palette instead of a second brand theme', () => {
+    const { colors, boxShadow, keyframes, fontFamily } = config.theme.extend;
+
+    expect(colors.brand).toEqual({
+      DEFAULT: 'var(--adc-color-primary)',
+      hover: 'var(--el-color-primary-dark-2)',
+      subtle: 'var(--adc-color-primary-subtle)'
+    });
+    expect(colors.surface).toEqual({
+      canvas: 'var(--adc-color-surface-page)',
+      DEFAULT: 'var(--adc-color-surface)',
+      overlay: 'var(--adc-color-surface-overlay)'
+    });
+    expect(boxShadow.glow).toBe('var(--app-glow-primary)');
+    expect(boxShadow['glow-lg']).toBe('var(--app-glow-primary-lg)');
+    expect(keyframes.pulseGlow['0%, 100%'].boxShadow).toBe('var(--app-glow-primary)');
+    expect(fontFamily.sans).toEqual(['var(--adc-font-family-sans)']);
+  });
+
+  it('does not retain the legacy purple or blue-dark palette', () => {
+    const serializedTheme = JSON.stringify(config.theme.extend);
+
+    expect(serializedTheme).not.toMatch(/#(?:8b5cf6|7c3aed|6d28d9|5b21b6|4c1d95)/i);
+    expect(serializedTheme).not.toMatch(/#(?:0b0d17|111427|1a1d2e|252840)/i);
+  });
+});

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,40 +5,26 @@ module.exports = {
     extend: {
       colors: {
         brand: {
-          50: '#f5f3ff',
-          100: '#ede9fe',
-          200: '#ddd6fe',
-          300: '#c4b5fd',
-          400: '#a78bfa',
-          500: '#8b5cf6',
-          600: '#7c3aed',
-          700: '#6d28d9',
-          800: '#5b21b6',
-          900: '#4c1d95'
+          DEFAULT: 'var(--adc-color-primary)',
+          hover: 'var(--el-color-primary-dark-2)',
+          subtle: 'var(--adc-color-primary-subtle)'
         },
         surface: {
-          0: '#ffffff',
-          1: '#f8fafc',
-          2: '#f1f5f9',
-          3: '#e2e8f0',
-          dark0: '#0b0d17',
-          dark1: '#111427',
-          dark2: '#1a1d2e',
-          dark3: '#252840'
+          canvas: 'var(--adc-color-surface-page)',
+          DEFAULT: 'var(--adc-color-surface)',
+          overlay: 'var(--adc-color-surface-overlay)'
         }
       },
       fontFamily: {
-        sans: ['Inter', 'ui-sans-serif', 'system-ui', '-apple-system', 'Segoe UI', 'Roboto', 'Helvetica', 'Arial', 'sans-serif'],
-        display: ['Inter', 'ui-sans-serif', 'system-ui', '-apple-system', 'sans-serif']
+        sans: ['var(--adc-font-family-sans)'],
+        display: ['var(--adc-font-family-sans)']
       },
       boxShadow: {
-        glow: '0 0 20px rgba(139, 92, 246, 0.15)',
-        'glow-lg': '0 0 40px rgba(139, 92, 246, 0.25)',
-        'glow-sm': '0 0 10px rgba(139, 92, 246, 0.1)',
-        card: '0 4px 24px rgba(0, 0, 0, 0.06)',
-        'card-hover': '0 8px 32px rgba(0, 0, 0, 0.1)',
-        'card-dark': '0 4px 24px rgba(0, 0, 0, 0.4)',
-        'card-dark-hover': '0 8px 32px rgba(0, 0, 0, 0.5)'
+        glow: 'var(--app-glow-primary)',
+        'glow-lg': 'var(--app-glow-primary-lg)',
+        'glow-sm': '0 0 10px rgba(var(--app-brand-rgb), 0.1)',
+        card: 'var(--app-shadow-md)',
+        'card-hover': 'var(--app-shadow-lg)'
       },
       borderRadius: {
         '2xl': '1rem',
@@ -69,8 +55,8 @@ module.exports = {
           to: { backgroundPosition: '200% 0' }
         },
         pulseGlow: {
-          '0%, 100%': { boxShadow: '0 0 20px rgba(139, 92, 246, 0.15)' },
-          '50%': { boxShadow: '0 0 30px rgba(139, 92, 246, 0.3)' }
+          '0%, 100%': { boxShadow: 'var(--app-glow-primary)' },
+          '50%': { boxShadow: 'var(--app-glow-primary-lg)' }
         }
       },
       backdropBlur: {


### PR DESCRIPTION
## Summary
- replace the unused purple Tailwind brand scale with runtime semantic design tokens
- replace stale blue-purple dark surfaces and fixed purple glows with shared/app CSS variables
- add a regression test that prevents the legacy palette from returning

This closes one P0 global-baseline gap. Focus, elevation, density, icon, and cross-platform quality work remain separate follow-ups.

## Validation
- focused Tailwind contract: 2/2
- ESLint and vue-tsc on Node 22
- Web production build and SSG build
- Beachball patch validation and git diff check

## Adversarial review (reviewer: codex, 1 round)
- VERDICT: CLEAN