### PR TITLE
fix(site): center service-override dropdown hover highlight

### DIFF
--- a/change/@acedatacloud-nexior-52d15dac-1412-417f-9a52-4e7d317c42d0.json
+++ b/change/@acedatacloud-nexior-52d15dac-1412-417f-9a52-4e7d317c42d0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(site): vertically center service-override dropdown hover",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/setting/SiteServices.vue
+++ b/src/components/setting/SiteServices.vue
@@ -823,8 +823,12 @@ export default defineComponent({
 }
 
 :global(.service-catalog-select-popper .el-select-dropdown__item) {
+  display: flex;
+  align-items: center;
   height: auto;
   min-height: 34px;
+  padding-top: 4px;
+  padding-bottom: 4px;
   line-height: 1.4;
 }
 


### PR DESCRIPTION
## Summary
- The service catalog `<el-select>` dropdown in the site services override dialog overrode `.el-select-dropdown__item` with `height: auto; min-height: 34px; line-height: 1.4`, which removed Element Plus's default vertical centering (its default relies on `line-height: 34px`). Content sat top-aligned inside the row, so the hover highlight looked vertically off-center.
- Fix: make the item a flex container with `align-items: center` and symmetric top/bottom padding so content and the hover highlight are vertically centered.

## Validation
- lint-staged (ESLint + prettier) passed on commit

## 🤖 对抗评审
Trivial CSS-only change (single dropdown item rule). VERDICT: CLEAN.