### PR TITLE
feat(nexior): app 下载页仅在官方主站展示

### DIFF
--- a/change/@acedatacloud-nexior-9b1cc4ca-9eb2-45d1-b5ff-647d82d7c750.json
+++ b/change/@acedatacloud-nexior-9b1cc4ca-9eb2-45d1-b5ff-647d82d7c750.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat(nexior): show app download page only on official main host",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/common/BottomFooter.vue
+++ b/src/components/common/BottomFooter.vue
@@ -5,8 +5,10 @@
         <el-row>
           <el-col :span="24" class="text-center">
             <p>
-              <a href="/download">{{ $t('common.nav.mobileApp') }}</a>
-              ·
+              <template v-if="isMainOfficialHost">
+                <a href="/download">{{ $t('common.nav.mobileApp') }}</a>
+                ·
+              </template>
               <a href="https://platform.acedata.cloud">{{ $t('common.entity.website') }}</a> ©
               {{ new Date().getFullYear() }}
               {{ $t('common.entity.copyright') }}
@@ -33,6 +35,7 @@ import { defineComponent } from 'vue';
 import { ElContainer, ElRow, ElCol } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { faGithub } from '@fortawesome/free-brands-svg-icons';
+import { isMainOfficial } from '@/utils';
 
 export default defineComponent({
   name: 'BottomFooter',
@@ -47,7 +50,12 @@ export default defineComponent({
       faGithub
     };
   },
-  computed: {},
+  computed: {
+    // The mobile-app download page only exists on the official main host.
+    isMainOfficialHost() {
+      return isMainOfficial();
+    }
+  },
   methods: {}
 });
 </script>

--- a/src/components/common/TopHeader.vue
+++ b/src/components/common/TopHeader.vue
@@ -22,7 +22,12 @@
             index="/headshots"
           ></el-menu-item>
         </el-sub-menu>
-        <el-menu-item v-t="'common.nav.mobileApp'" @route="undefined" @click="onDownload"></el-menu-item>
+        <el-menu-item
+          v-if="isMainOfficialHost"
+          v-t="'common.nav.mobileApp'"
+          @route="undefined"
+          @click="onDownload"
+        ></el-menu-item>
         <el-menu-item
           v-t="'common.nav.apiPlatform'"
           @route="undefined"
@@ -69,7 +74,7 @@
 <script lang="ts">
 import { defineComponent } from 'vue';
 import defaultAvatar from '@/assets/images/avatar.png';
-import { getBaseUrlAuth, withCurrentUserIdAndSite } from '@/utils';
+import { getBaseUrlAuth, withCurrentUserIdAndSite, isMainOfficial } from '@/utils';
 import { ROUTE_CONSOLE_ROOT, ROUTE_DOWNLOAD, ROUTE_INDEX } from '@/router';
 import { ElCol, ElRow, ElDropdown, ElMenu, ElSubMenu, ElMenuItem, ElDropdownItem, ElButton } from 'element-plus';
 import Logo from './Logo.vue';
@@ -110,6 +115,10 @@ export default defineComponent({
     },
     authenticated() {
       return this.$store.getters?.authenticated;
+    },
+    // The mobile-app download page only exists on the official main host.
+    isMainOfficialHost() {
+      return isMainOfficial();
     },
     // Frameless desktop: make the header a drag handle; macOS needs left inset
     // so the logo clears the traffic lights.

--- a/src/components/user/Center.vue
+++ b/src/components/user/Center.vue
@@ -12,7 +12,7 @@
             <font-awesome-icon icon="fa-solid fa-user" class="mr-2" />
             {{ $t('common.button.login') }}
           </el-dropdown-item>
-          <el-dropdown-item v-if="!isNative" class="py-2" @click="onDownload">
+          <el-dropdown-item v-if="!isNative && isMainOfficialHost" class="py-2" @click="onDownload">
             <font-awesome-icon icon="fa-solid fa-mobile-screen-button" class="mr-2" />
             {{ $t('common.nav.mobileApp') }}
           </el-dropdown-item>
@@ -53,6 +53,7 @@ import DeleteAccountDialog from '@/components/user/DeleteAccountDialog.vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { ROUTE_CONSOLE_ROOT, ROUTE_DISTRIBUTION_INDEX, ROUTE_DOWNLOAD } from '@/router';
 import { isIOS as isIOSSurface, isNative as isNativeSurface } from '@/utils/surface';
+import { isMainOfficial } from '@/utils';
 import { ElDivider } from 'element-plus';
 import { ElDropdownMenu, ElDropdownItem, ElDropdown } from 'element-plus';
 
@@ -85,6 +86,10 @@ export default defineComponent({
     },
     isNative() {
       return isNativeSurface();
+    },
+    // The mobile-app download page only exists on the official main host.
+    isMainOfficialHost() {
+      return isMainOfficial();
     },
     isIOS() {
       return isIOSSurface();

--- a/src/router/download.ts
+++ b/src/router/download.ts
@@ -1,4 +1,5 @@
-import { ROUTE_DOWNLOAD } from './constants';
+import { ROUTE_DOWNLOAD, ROUTE_INDEX } from './constants';
+import { isMainOfficial } from '@/utils';
 
 export default {
   path: '/download',
@@ -7,6 +8,9 @@ export default {
     {
       path: '',
       name: ROUTE_DOWNLOAD,
+      // The mobile-app download page only exists on the official main host;
+      // block direct URL access on subsites / white-label tenants.
+      beforeEnter: () => (isMainOfficial() ? true : { name: ROUTE_INDEX }),
       component: () => import('@/pages/download/Index.vue')
     }
   ]


### PR DESCRIPTION
## 背景

Nexior 的「移动 App 下载页」(`/download`, `ROUTE_DOWNLOAD`) 之前在所有站点（分站 `*.studio.acedata.cloud`、白标自定义域名、原生 App）都会露出入口，但该页面仅对官方主站 `studio.acedata.cloud` 有意义。

## 改动

只在官方主站（`isMainOfficial()` → host === `studio.acedata.cloud`）展示该页面，并封堵直达 URL：

- `TopHeader.vue`：顶部导航 `mobileApp` 菜单项加 `v-if="isMainOfficialHost"`。
- `Center.vue`：用户下拉里的 App 入口从 `!isNative` 收紧为 `!isNative && isMainOfficialHost`。
- `BottomFooter.vue`：页脚 `<a href="/download">` 及其分隔符用 `isMainOfficialHost` 包裹。
- `router/download.ts`:  加 `beforeEnter` 守卫，非主站直达 `/download` 重定向到首页。

采用严格的 `isMainOfficial()`（而非非对称的 `isOfficial()/isSubOfficial()`），该 helper 已做 SSR (`typeof window`) 保护，守卫安全。其它 `onDownload` 匹配项均为各服务的媒体下载按钮，与本页无关。

## 🤖 对抗评审

- **Reviewer:** Codex 命中用量上限，回退 Claude `general-purpose` subagent（read-only）。
- **RISK 1（已修复）:** `BottomFooter.vue` 的 `<a href="/download">` 是未加 host gate 的静态锚点，在分站/白标/原生上仍渲染，点击会整页刷新回同站首页，形成可见死链 → 已用 `isMainOfficialHost` 包裹链接与分隔符。
- 复核确认：`ROUTE_INDEX` 已从 `router/constants.ts` 导出；`@/utils` 已导出 `isMainOfficial`；无重定向环（目标 `ROUTE_INDEX` 未被 gate）；两处 `onDownload` push 入口既有 `v-if` 又有 `beforeEnter` 兜底。
- 二轮复核收敛：`VERDICT: CLEAN`。

vue-tsc 类型检查通过。