### PR TITLE
feat(site): add disable-recharge toggle to site config

### DIFF
--- a/change/@acedatacloud-nexior-f48460fa-8b5b-4976-a46f-a7299cbb1cba.json
+++ b/change/@acedatacloud-nexior-f48460fa-8b5b-4976-a46f-a7299cbb1cba.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(site): add site-config toggle to disable recharge, hiding all top-up entries and guarding pay pages",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/application/Info.vue
+++ b/src/components/application/Info.vue
@@ -64,7 +64,7 @@ import { ElButton, ElIcon } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { Check } from '@element-plus/icons-vue';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
-import { isIOS } from '@/utils';
+import { isIOS, isRechargeDisabled } from '@/utils';
 
 export default defineComponent({
   name: 'ApplicationInfo',
@@ -96,6 +96,9 @@ export default defineComponent({
     // products). Keyed on scope (always present) rather than packages, which
     // isn't serialized in every view.
     showPayment(): boolean {
+      if (isRechargeDisabled(this.$store.getters.site)) {
+        return false;
+      }
       if (!isIOS()) {
         return true;
       }

--- a/src/components/chat/Message.vue
+++ b/src/components/chat/Message.vue
@@ -219,7 +219,7 @@ import {
   ERROR_CODE_BUSY
 } from '@/constants';
 import { ROUTE_CONSOLE_APPLICATION_EXTRA } from '@/router';
-import { isIOS } from '@/utils';
+import { isIOS, isRechargeDisabled } from '@/utils';
 
 interface IData {
   copied: boolean;
@@ -358,6 +358,10 @@ export default defineComponent({
       // Payment flows live on the web, not inside the iOS bundle. Hide the
       // in-chat "Top Up" entry on iOS so it never routes to a payment page
       // that renders empty there (matches showPayment in the console pages).
+      // Also hidden when the site admin disabled recharge entirely.
+      if (isRechargeDisabled(this.$store.getters.site)) {
+        return false;
+      }
       return !isIOS() && this.message.role === ROLE_ASSISTANT && this.message.error?.code === ERROR_CODE_USED_UP;
     }
   },

--- a/src/components/setting/SiteServices.vue
+++ b/src/components/setting/SiteServices.vue
@@ -22,6 +22,22 @@
       </div>
     </section>
 
+    <section class="default-price-section">
+      <div>
+        <p class="settings-title">{{ $t('site.field.disableRecharge') }}</p>
+        <p class="settings-tip">{{ $t('site.message.disableRechargeTip') }}</p>
+      </div>
+      <el-switch
+        :model-value="disableRecharge"
+        inline-prompt
+        :loading="disableRechargeSaving"
+        :disabled="disableRechargeSaving || !siteId"
+        :active-text="$t('site.button.enabled')"
+        :inactive-text="$t('site.button.disabled')"
+        @update:model-value="onToggleDisableRecharge($event as boolean)"
+      />
+    </section>
+
     <div class="header">
       <div>
         <p class="settings-title">{{ $t('site.services.title') }}</p>
@@ -240,7 +256,7 @@ import { serviceOperator, siteOperator, siteServiceOverrideOperator } from '@/op
 import type { IService, ISite, ISiteServiceOverride } from '@/models';
 import SectionNotice from '@/components/setting/SectionNotice.vue';
 import AutoTranslateToggle from '@/components/site/AutoTranslateToggle.vue';
-import { getSiteMarkupRatio, MARKUP_RATIO_MAX } from '@/utils';
+import { getSiteMarkupRatio, isRechargeDisabled, MARKUP_RATIO_MAX } from '@/utils';
 
 // Pre-fetch the whole catalog once so each override row can show the
 // service title/alias without an N+1 per-row GET. If a tenant ever
@@ -308,6 +324,7 @@ export default defineComponent({
       siteMarkupConfirmedPercent: 0,
       siteMarkupSaving: false,
       pendingSiteMarkupPercent: undefined as number | undefined,
+      disableRechargeSaving: false,
       loading: false,
       catalogLoading: false,
       submitting: false,
@@ -327,6 +344,9 @@ export default defineComponent({
     },
     siteId(): string | undefined {
       return this.site?.id;
+    },
+    disableRecharge(): boolean {
+      return isRechargeDisabled(this.site);
     },
     // Site-wide default a blank per-service markup inherits.
     siteDefaultRatio(): number {
@@ -395,6 +415,25 @@ export default defineComponent({
   methods: {
     onResize() {
       this.mobile = window.innerWidth < 768;
+    },
+    async onToggleDisableRecharge(enabled: boolean): Promise<void> {
+      if (!this.siteId || this.disableRechargeSaving) return;
+      this.disableRechargeSaving = true;
+      try {
+        const metadata = (this.site.metadata || {}) as Record<string, unknown>;
+        await siteOperator.update(this.siteId, {
+          ...this.site,
+          metadata: {
+            ...metadata,
+            disable_recharge: enabled
+          }
+        });
+        await this.$store.dispatch('getSite');
+      } catch {
+        ElMessage.error(this.$t('site.services.message.saveFailed'));
+      } finally {
+        this.disableRechargeSaving = false;
+      }
     },
     async onSaveSiteMarkup(percent: number | undefined): Promise<void> {
       if (!this.siteId) return;

--- a/src/i18n/ar/site.json
+++ b/src/i18n/ar/site.json
@@ -55,6 +55,14 @@
     "message": "مثال: السعر الرسمي {from} → سعر البيع الخاص بك {to}",
     "description": "مثال حي أسفل إعداد نسبة الزيادة، {from} هو السعر الرسمي الأصلي، و{to} هو السعر بعد الزيادة"
   },
+  "field.disableRecharge": {
+    "message": "تعطيل إعادة الشحن",
+    "description": "Site settings: when on, hide all recharge/top-up entries on this site"
+  },
+  "message.disableRechargeTip": {
+    "message": "عند التفعيل، يتم إخفاء جميع أزرار إعادة الشحن في هذا الموقع ولا يمكن للمستخدمين إعادة شحن رصيدهم.",
+    "description": "Help text for the disable-recharge toggle"
+  },
   "field.distributionDefaultInviterId": {
     "message": "معرف المدعو الافتراضي",
     "description": "عرض في مربع التحرير"

--- a/src/i18n/de/site.json
+++ b/src/i18n/de/site.json
@@ -55,6 +55,14 @@
     "message": "Beispiel: offizieller Preis {from} → dein Verkaufspreis {to}",
     "description": "Echtzeitbeispiel unter dem Aufschlagsquote-Einstellungsfeld, {from} ist der offizielle Preis, {to} ist der Preis nach Aufschlag"
   },
+  "field.disableRecharge": {
+    "message": "Aufladen deaktivieren",
+    "description": "Site settings: when on, hide all recharge/top-up entries on this site"
+  },
+  "message.disableRechargeTip": {
+    "message": "Wenn aktiviert, werden alle Auflade-Schaltflächen auf dieser Website ausgeblendet und Benutzer können ihr Guthaben nicht mehr aufladen.",
+    "description": "Help text for the disable-recharge toggle"
+  },
   "field.distributionDefaultInviterId": {
     "message": "Standard-Einladungs-ID",
     "description": "Anzeige im Bearbeitungsfeld"

--- a/src/i18n/el/site.json
+++ b/src/i18n/el/site.json
@@ -55,6 +55,14 @@
     "message": "Παράδειγμα: επίσημη τιμή {from} → τιμή πώλησής σας {to}",
     "description": "Ρεαλιστικό παράδειγμα κάτω από την ρύθμιση ποσοστού προσαύξησης, όπου {from} είναι η επίσημη τιμή και {to} είναι η τιμή πώλησης μετά την προσαύξηση"
   },
+  "field.disableRecharge": {
+    "message": "Απενεργοποίηση επαναφόρτισης",
+    "description": "Site settings: when on, hide all recharge/top-up entries on this site"
+  },
+  "message.disableRechargeTip": {
+    "message": "Όταν είναι ενεργοποιημένο, όλα τα κουμπιά επαναφόρτισης αποκρύπτονται σε αυτόν τον ιστότοπο και οι χρήστες δεν μπορούν πλέον να ανανεώσουν το υπόλοιπό τους.",
+    "description": "Help text for the disable-recharge toggle"
+  },
   "field.distributionDefaultInviterId": {
     "message": "ID Προεπιλεγμένου Προσκαλέσματος",
     "description": "展示在编辑框的标题"

--- a/src/i18n/en/site.json
+++ b/src/i18n/en/site.json
@@ -55,6 +55,14 @@
     "message": "For example, if the official price is $20 and you enter 10, your price is $22.",
     "description": "Fixed example under the markup setting"
   },
+  "field.disableRecharge": {
+    "message": "Disable recharge",
+    "description": "Site settings: when on, hide all recharge/top-up entries on this site"
+  },
+  "message.disableRechargeTip": {
+    "message": "When enabled, all recharge/top-up buttons are hidden on this site and users can no longer top up their balance.",
+    "description": "Help text for the disable-recharge toggle"
+  },
   "field.distributionDefaultInviterId": {
     "message": "Default Inviter ID",
     "description": "Displayed as the title in the editing box"

--- a/src/i18n/es/site.json
+++ b/src/i18n/es/site.json
@@ -55,6 +55,14 @@
     "message": "Ejemplo: precio oficial {from} → tu precio {to}",
     "description": "Ejemplo en tiempo real debajo de la configuración de proporción de aumento, {from} es el precio original oficial, {to} es el precio después del aumento"
   },
+  "field.disableRecharge": {
+    "message": "Desactivar recarga",
+    "description": "Site settings: when on, hide all recharge/top-up entries on this site"
+  },
+  "message.disableRechargeTip": {
+    "message": "Cuando está activado, todos los botones de recarga se ocultan en este sitio y los usuarios ya no pueden recargar su saldo.",
+    "description": "Help text for the disable-recharge toggle"
+  },
   "field.distributionDefaultInviterId": {
     "message": "ID del invitador por defecto",
     "description": "Texto que se muestra en el cuadro de edición"

--- a/src/i18n/fi/site.json
+++ b/src/i18n/fi/site.json
@@ -55,6 +55,14 @@
     "message": "Esimerkki: Virallinen hinta {from} → Sinun myyntihintasi {to}",
     "description": "Hintaprosentti-asetuksen alla oleva reaaliaikainen esimerkki, jossa {from} on virallinen alkuperäinen hinta ja {to} on korotettu myyntihinta."
   },
+  "field.disableRecharge": {
+    "message": "Poista lataus käytöstä",
+    "description": "Site settings: when on, hide all recharge/top-up entries on this site"
+  },
+  "message.disableRechargeTip": {
+    "message": "Kun tämä on käytössä, kaikki latauspainikkeet piilotetaan tällä sivustolla eivätkä käyttäjät voi enää ladata saldoaan.",
+    "description": "Help text for the disable-recharge toggle"
+  },
   "field.distributionDefaultInviterId": {
     "message": "Oletus kutsuja ID",
     "description": "Näytetään muokkausruudun otsikkona"

--- a/src/i18n/fr/site.json
+++ b/src/i18n/fr/site.json
@@ -55,6 +55,14 @@
     "message": "Exemple : prix officiel {from} → votre prix {to}",
     "description": "Exemple en temps réel sous l'option de taux de majoration, {from} est le prix officiel, {to} est le prix après majoration"
   },
+  "field.disableRecharge": {
+    "message": "Désactiver la recharge",
+    "description": "Site settings: when on, hide all recharge/top-up entries on this site"
+  },
+  "message.disableRechargeTip": {
+    "message": "Lorsqu'elle est activée, tous les boutons de recharge sont masqués sur ce site et les utilisateurs ne peuvent plus recharger leur solde.",
+    "description": "Help text for the disable-recharge toggle"
+  },
   "field.distributionDefaultInviterId": {
     "message": "ID de l'inviteur par défaut",
     "description": "Affiché comme titre dans la zone d'édition"

--- a/src/i18n/it/site.json
+++ b/src/i18n/it/site.json
@@ -55,6 +55,14 @@
     "message": "Esempio: prezzo ufficiale {from} → tuo prezzo {to}",
     "description": "Esempio in tempo reale sotto l'impostazione della percentuale di sovrapprezzo, {from} è il prezzo ufficiale, {to} è il prezzo dopo il sovrapprezzo"
   },
+  "field.disableRecharge": {
+    "message": "Disattiva ricarica",
+    "description": "Site settings: when on, hide all recharge/top-up entries on this site"
+  },
+  "message.disableRechargeTip": {
+    "message": "Se attivato, tutti i pulsanti di ricarica vengono nascosti su questo sito e gli utenti non possono più ricaricare il loro saldo.",
+    "description": "Help text for the disable-recharge toggle"
+  },
   "field.distributionDefaultInviterId": {
     "message": "ID invitante predefinito",
     "description": "Mostrato nel campo di modifica del titolo"

--- a/src/i18n/ja/site.json
+++ b/src/i18n/ja/site.json
@@ -55,6 +55,14 @@
     "message": "例：公式価格 {from} → あなたの販売価格 {to}",
     "description": "加価率設定項目の下にあるリアルタイムの例で、{from} は公式の元の価格、{to} は加価後の販売価格です"
   },
+  "field.disableRecharge": {
+    "message": "チャージを無効化",
+    "description": "Site settings: when on, hide all recharge/top-up entries on this site"
+  },
+  "message.disableRechargeTip": {
+    "message": "有効にすると、このサイトのすべてのチャージボタンが非表示になり、ユーザーは残高をチャージできなくなります。",
+    "description": "Help text for the disable-recharge toggle"
+  },
   "field.distributionDefaultInviterId": {
     "message": "デフォルト招待者ID",
     "description": "編集ボックスに表示されるタイトル"

--- a/src/i18n/ko/site.json
+++ b/src/i18n/ko/site.json
@@ -55,6 +55,14 @@
     "message": "예시: 공식 가격 {from} → 당신의 판매가 {to}",
     "description": "가산 비율 설정 항목 아래의 실시간 예시로, {from}은 공식 원가이고, {to}는 가산된 판매가입니다."
   },
+  "field.disableRecharge": {
+    "message": "충전 비활성화",
+    "description": "Site settings: when on, hide all recharge/top-up entries on this site"
+  },
+  "message.disableRechargeTip": {
+    "message": "활성화하면 이 사이트의 모든 충전 버튼이 숨겨지고 사용자가 잔액을 충전할 수 없습니다.",
+    "description": "Help text for the disable-recharge toggle"
+  },
   "field.distributionDefaultInviterId": {
     "message": "기본 초대자 ID",
     "description": "편집 상자에 표시되는 제목"

--- a/src/i18n/pl/site.json
+++ b/src/i18n/pl/site.json
@@ -55,6 +55,14 @@
     "message": "Przykład: cena oficjalna {from} → Twoja cena {to}",
     "description": "Bieżący przykład pod polem ustawienia procentu narzutu, gdzie {from} to cena oficjalna, a {to} to cena po dodaniu narzutu."
   },
+  "field.disableRecharge": {
+    "message": "Wyłącz doładowanie",
+    "description": "Site settings: when on, hide all recharge/top-up entries on this site"
+  },
+  "message.disableRechargeTip": {
+    "message": "Po włączeniu wszystkie przyciski doładowania są ukryte w tej witrynie, a użytkownicy nie mogą już doładować salda.",
+    "description": "Help text for the disable-recharge toggle"
+  },
   "field.distributionDefaultInviterId": {
     "message": "ID domyślnego zapraszającego",
     "description": "Wyświetlane w tytule edytora"

--- a/src/i18n/pt/site.json
+++ b/src/i18n/pt/site.json
@@ -55,6 +55,14 @@
     "message": "Exemplo: preço oficial {from} → seu preço {to}",
     "description": "Exemplo em tempo real abaixo da configuração da proporção de aumento, {from} é o preço original oficial, {to} é o preço após o aumento"
   },
+  "field.disableRecharge": {
+    "message": "Desativar recarga",
+    "description": "Site settings: when on, hide all recharge/top-up entries on this site"
+  },
+  "message.disableRechargeTip": {
+    "message": "Quando ativado, todos os botões de recarga ficam ocultos neste site e os usuários não podem mais recarregar o saldo.",
+    "description": "Help text for the disable-recharge toggle"
+  },
   "field.distributionDefaultInviterId": {
     "message": "ID do convidador padrão",
     "description": "Exibido como o título na caixa de edição"

--- a/src/i18n/ru/site.json
+++ b/src/i18n/ru/site.json
@@ -55,6 +55,14 @@
     "message": "Пример: официальная цена {from} → ваша цена {to}",
     "description": "Реальный пример под настройкой процента наценки, {from} — официальная цена, {to} — цена с наценкой"
   },
+  "field.disableRecharge": {
+    "message": "Отключить пополнение",
+    "description": "Site settings: when on, hide all recharge/top-up entries on this site"
+  },
+  "message.disableRechargeTip": {
+    "message": "Когда включено, все кнопки пополнения скрыты на этом сайте, и пользователи больше не могут пополнять баланс.",
+    "description": "Help text for the disable-recharge toggle"
+  },
   "field.distributionDefaultInviterId": {
     "message": "ID приглашенного по умолчанию",
     "description": "展示在编辑框的标题"

--- a/src/i18n/sr/site.json
+++ b/src/i18n/sr/site.json
@@ -55,6 +55,14 @@
     "message": "Primer: zvanična cena {from} → tvoja prodajna cena {to}",
     "description": "Real-time primer ispod podešavanja proporcije povećanja, {from} je zvanična cena, {to} je cena nakon povećanja"
   },
+  "field.disableRecharge": {
+    "message": "Onemogući dopunu",
+    "description": "Site settings: when on, hide all recharge/top-up entries on this site"
+  },
+  "message.disableRechargeTip": {
+    "message": "Kada je omogućeno, sva dugmad za dopunu su skrivena na ovom sajtu i korisnici više ne mogu da dopune svoj saldo.",
+    "description": "Help text for the disable-recharge toggle"
+  },
   "field.distributionDefaultInviterId": {
     "message": "ID podrazumevanog pozivaoca",
     "description": "Prikazuje se kao naslov u okviru za uređivanje"

--- a/src/i18n/sv/site.json
+++ b/src/i18n/sv/site.json
@@ -55,6 +55,14 @@
     "message": "Exempel: officiellt pris {from} → ditt försäljningspris {to}",
     "description": "Ett realtids exempel under inställningen för påslagprocent, där {from} är det officiella priset och {to} är försäljningspriset efter påslag."
   },
+  "field.disableRecharge": {
+    "message": "Inaktivera påfyllning",
+    "description": "Site settings: when on, hide all recharge/top-up entries on this site"
+  },
+  "message.disableRechargeTip": {
+    "message": "När det är aktiverat döljs alla påfyllningsknappar på den här webbplatsen och användare kan inte längre fylla på sitt saldo.",
+    "description": "Help text for the disable-recharge toggle"
+  },
   "field.distributionDefaultInviterId": {
     "message": "Standardinbjudar-ID",
     "description": "Visas som titeln i redigeringsrutan"

--- a/src/i18n/uk/site.json
+++ b/src/i18n/uk/site.json
@@ -55,6 +55,14 @@
     "message": "Приклад: офіційна ціна {from} → ваша ціна {to}",
     "description": "Реальний приклад під налаштуванням коефіцієнта націнки, {from} — офіційна ціна, {to} — ціна після націнки"
   },
+  "field.disableRecharge": {
+    "message": "Вимкнути поповнення",
+    "description": "Site settings: when on, hide all recharge/top-up entries on this site"
+  },
+  "message.disableRechargeTip": {
+    "message": "Коли ввімкнено, усі кнопки поповнення приховані на цьому сайті, і користувачі більше не можуть поповнювати баланс.",
+    "description": "Help text for the disable-recharge toggle"
+  },
   "field.distributionDefaultInviterId": {
     "message": "ID запрошувача за замовчуванням",
     "description": "展示在编辑框的标题"

--- a/src/i18n/zh-CN/site.json
+++ b/src/i18n/zh-CN/site.json
@@ -55,6 +55,14 @@
     "message": "例如原价 ￥20，填写 10，则售价为 ￥22。",
     "description": "加价比例设置项下方的固定示例"
   },
+  "field.disableRecharge": {
+    "message": "禁用充值",
+    "description": "站点设置：开启后隐藏本站所有充值/购买入口"
+  },
+  "message.disableRechargeTip": {
+    "message": "开启后，本站将隐藏所有充值/购买按钮，用户无法自行充值额度。",
+    "description": "禁用充值开关的说明文字"
+  },
   "field.distributionDefaultInviterId": {
     "message": "默认邀请人 ID",
     "description": "展示在编辑框的标题"

--- a/src/i18n/zh-TW/site.json
+++ b/src/i18n/zh-TW/site.json
@@ -55,6 +55,14 @@
     "message": "示例：官方價 {from} → 你的售價 {to}",
     "description": "加價比例設置項下方的實時示例，{from} 是官方原價，{to} 是加價後的售價"
   },
+  "field.disableRecharge": {
+    "message": "停用儲值",
+    "description": "Site settings: when on, hide all recharge/top-up entries on this site"
+  },
+  "message.disableRechargeTip": {
+    "message": "啟用後，本站將隱藏所有儲值/購買按鈕，使用者無法自行儲值額度。",
+    "description": "Help text for the disable-recharge toggle"
+  },
   "field.distributionDefaultInviterId": {
     "message": "默認邀請人 ID",
     "description": "展示在編輯框的標題"

--- a/src/models/site.ts
+++ b/src/models/site.ts
@@ -100,6 +100,11 @@ export interface ISiteMetadata {
   support_url?: string;
   icp?: string;
   proxy_cname?: string;
+  // When true, hide every top-up / recharge entry on the site so end
+  // users can't buy more credit. Default (unset / not exactly `true`)
+  // keeps recharge enabled. Read via `isRechargeDisabled` in
+  // `src/utils/site.ts`.
+  disable_recharge?: boolean;
   [key: string]: unknown;
 }
 

--- a/src/pages/console/application/Extra.vue
+++ b/src/pages/console/application/Extra.vue
@@ -130,11 +130,11 @@ import {
   ElRadioButton,
   ElTag
 } from 'element-plus';
-import { ROUTE_CONSOLE_APPLICATION_SUBSCRIBE, ROUTE_CONSOLE_ORDER_DETAIL } from '@/router';
+import { ROUTE_CONSOLE_APPLICATION_SUBSCRIBE, ROUTE_CONSOLE_ORDER_DETAIL, ROUTE_CONSOLE_APPLICATION_LIST } from '@/router';
 import Price from '@/components/common/Price.vue';
 import { applicationOperator, orderOperator } from '@/operators';
 import { getPriceString, applyMarkup, getApplicationMarkupRatio, getApplicationCallerOrderDiscountRate } from '@/utils';
-import { isIOS } from '@/utils';
+import { isIOS, isRechargeDisabled } from '@/utils';
 import { track } from '@/plugins/telemetry';
 import ServiceEstimation from '@/components/service/Estimation.vue';
 
@@ -262,6 +262,12 @@ export default defineComponent({
     }
   },
   mounted() {
+    // Site admin disabled recharge: block the direct/bookmarked top-up page
+    // too, not just the entry buttons.
+    if (isRechargeDisabled(this.$store.getters.site)) {
+      this.$router.replace({ name: ROUTE_CONSOLE_APPLICATION_LIST });
+      return;
+    }
     this.onFetchApplication();
   },
   methods: {

--- a/src/pages/console/application/List.vue
+++ b/src/pages/console/application/List.vue
@@ -288,7 +288,7 @@ import {
   ElMessage
 } from 'element-plus';
 import { ROUTE_CONSOLE_APPLICATION_EXTRA, ROUTE_CONSOLE_USAGE_LIST } from '@/router/constants';
-import { isIOS } from '@/utils';
+import { isIOS, isRechargeDisabled } from '@/utils';
 import {
   IApplication,
   IApplicationListResponse,
@@ -367,6 +367,9 @@ export default defineComponent({
     // the mapped consumable packages), so its top-up entry is shown on every
     // surface. The card itself is still gated on having a global application.
     showGlobalPayment(): boolean {
+      if (isRechargeDisabled(this.$store.getters.site)) {
+        return false;
+      }
       return true;
     }
   },
@@ -385,6 +388,9 @@ export default defineComponent({
     // A per-service app row shows "Buy More" on every surface, but on iOS
     // only when it has an Apple-buyable package (apple_product_id mapped).
     rowCanPay(application: IApplication): boolean {
+      if (isRechargeDisabled(this.$store.getters.site)) {
+        return false;
+      }
       if (!isIOS()) {
         return true;
       }

--- a/src/pages/console/application/Subscribe.vue
+++ b/src/pages/console/application/Subscribe.vue
@@ -93,10 +93,10 @@ import { IService, IApplication, IApplicationType, IOrderDetailResponse, IPackag
 import { ElRow, ElCol, ElCard, ElSkeleton, ElMessage, ElButton, ElTag, ElEmpty } from 'element-plus';
 import { applicationOperator, orderOperator, serviceOperator } from '@/operators';
 import { getPriceString, applyMarkup, getApplicationMarkupRatio } from '@/utils';
-import { isIOS } from '@/utils';
+import { isIOS, isRechargeDisabled } from '@/utils';
 import { track } from '@/plugins/telemetry';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { ROUTE_CONSOLE_APPLICATION_EXTRA, ROUTE_CONSOLE_ORDER_DETAIL } from '@/router';
+import { ROUTE_CONSOLE_APPLICATION_EXTRA, ROUTE_CONSOLE_ORDER_DETAIL, ROUTE_CONSOLE_APPLICATION_LIST } from '@/router';
 
 interface ISubscription {
   name: string;
@@ -220,6 +220,12 @@ export default defineComponent({
     }
   },
   async mounted() {
+    // Site admin disabled recharge: block the direct/bookmarked subscribe
+    // page too, not just the entry buttons.
+    if (isRechargeDisabled(this.$store.getters.site)) {
+      this.$router.replace({ name: ROUTE_CONSOLE_APPLICATION_LIST });
+      return;
+    }
     await this.onInitialize();
   },
   methods: {

--- a/src/utils/site.ts
+++ b/src/utils/site.ts
@@ -109,6 +109,16 @@ export const MARKUP_RATIO_MIN = 0;
 export const MARKUP_RATIO_MAX = 5;
 
 /**
+ * White-label switch to hide every top-up / recharge entry. Reads
+ * `site.metadata.disable_recharge` (PlatformBackend passes unknown
+ * `metadata` keys through verbatim). Default — unset or not exactly
+ * `true` — is `false`, i.e. recharge stays enabled.
+ */
+export const isRechargeDisabled = (site?: ISite | null): boolean => {
+  return site?.metadata?.disable_recharge === true;
+};
+
+/**
  * Read the site-wide markup ratio from `site.metadata.pricing.markup_ratio`
  * defensively. Mirrors the backend `extract_markup_ratio`: any missing /
  * malformed / out-of-range value collapses to 0, values above the ceiling are


### PR DESCRIPTION
## 什么
在 Nexior 的 **Settings → 站点配置 → 服务/定价** 标签页新增一个「禁用充值」开关。开启后，本站所有充值 / 购买入口都会被隐藏，用户无法自行充值额度。

## 为什么
站长（白标站点管理员）有时希望关闭 C 端自助充值（例如线下结算、内部使用、赠送额度模式），此前没有统一开关。

## 怎么做
- 存储：`site.metadata.disable_recharge: boolean`（PlatformBackend 对未知 `metadata` 键原样透传，`validate_metadata` 仅校验 `pricing` 子对象，无需后端改动）。
- 新增中央 helper `isRechargeDisabled(site)`（`src/utils/site.ts`），默认 `false`（未设置 / 非严格 `true` 时充值保持开启）。
- 开关 UI 放在 `SiteServices` 设置页（与统一加价比例同属定价/商务配置），仅管理员可见。
- 隐藏的入口按钮：
  - `components/application/Info.vue` → `showPayment`（同时覆盖 `Status.vue` 弹窗）
  - `components/chat/Message.vue` → `showBuyMore`（聊天内额度用尽提示）
  - `pages/console/application/List.vue` → `showGlobalPayment` + `rowCanPay`（全局钱包卡片 + 每个应用行 + 移动端卡片）
- 深链兜底：`Extra.vue` / `Subscribe.vue` 两个购买页在 `mounted` 时检查开关，开启则 `replace` 回应用列表，防止书签 / 直接 URL 绕过。
- i18n：仅新增 `zh-CN` 与 `en` 的 `site.field.disableRecharge` / `site.message.disableRechargeTip`。

## 🤖 对抗评审
- **Reviewer:** Codex 已达用量上限，回退到 Claude `general-purpose` 子代理。
- **Round 1 — RISK（已修复）:**
  1. `RISK` diff 曾基于落后的主 checkout，误删了已合并的 contacts 功能（`getBrandContacts` / `hasBrandContacts` / `ISiteContact` / 相关 i18n），会导致 `About.vue`、`Site.vue`、`site.test.ts` 编译失败 → **修复：** 丢弃 worktree 中被覆盖的文件，基于最新 `origin/main` 重新应用改动，仅保留 `disable_recharge` 增量。
  2. `RISK` 购买页 `Extra.vue` / `Subscribe.vue` 可被深链绕过，与提示语「用户无法自行充值」矛盾 → **修复：** 两个页面 `mounted` 增加 `isRechargeDisabled` 守卫，重定向回应用列表。
- **Round 2 — VERDICT: CLEAN.**