### PR TITLE
feat(site): configurable per-site "View Code" visibility

### DIFF
--- a/change/@acedatacloud-nexior-api-code-site-toggle.json
+++ b/change/@acedatacloud-nexior-api-code-site-toggle.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat(site): make the per-generation \"View Code\" button configurable per-site (hidden by default on white-label subsites, shown on the official site)",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/common/ApiCodeButton.vue
+++ b/src/components/common/ApiCodeButton.vue
@@ -27,7 +27,7 @@ import { defineComponent, type PropType } from 'vue';
 import { ElButton, ElTooltip } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import ApiCodeDialog from '@/components/common/ApiCodeDialog.vue';
-import { isBrandingHidden } from '@/utils';
+import { isApiCodeVisible, isOfficial } from '@/utils';
 
 type ButtonType = '' | 'default' | 'text' | 'primary' | 'success' | 'warning' | 'info' | 'danger';
 type ButtonSize = '' | 'small' | 'default' | 'large';
@@ -113,10 +113,11 @@ export default defineComponent({
   },
   computed: {
     showViewCode(): boolean {
-      // Default: show (behavior unchanged). A reseller opts out per-site by
-      // setting Site.branding.hide_api_code === true (white-label item 14),
-      // so end users of a white-label site don't see our API host/code.
-      return !isBrandingHidden(this.$store?.state?.site, 'api_code');
+      // Default: shown on first-party official sites, hidden on white-label
+      // subsites/tenants (they shouldn't expose our API host/code). A site
+      // owner overrides either way from Site settings via
+      // `Site.branding.hide_api_code` (tri-state, see `isApiCodeVisible`).
+      return isApiCodeVisible(this.$store?.state?.site, isOfficial());
     },
     cleanedBody(): Record<string, unknown> {
       const src = (this.body || {}) as Record<string, unknown>;

--- a/src/components/producer/task/Preview.vue
+++ b/src/components/producer/task/Preview.vue
@@ -104,7 +104,7 @@
               <el-dropdown-item v-if="audio?.id" @click.stop="onReplaceSection(audio)">
                 {{ $t('producer.button.replace_section') }}
               </el-dropdown-item>
-              <el-dropdown-item @click.stop="onViewCode">
+              <el-dropdown-item v-if="showViewCode" @click.stop="onViewCode">
                 <font-awesome-icon icon="fa-solid fa-code" class="mr-1" />
                 {{ $t('common.button.viewCode') }}
               </el-dropdown-item>
@@ -135,6 +135,7 @@ import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { saveAs } from 'file-saver';
 import { producerOperator } from '@/operators';
 import ApiCodeDialog from '@/components/common/ApiCodeDialog.vue';
+import { isApiCodeVisible, isOfficial } from '@/utils';
 
 export default defineComponent({
   name: 'TaskPreview',
@@ -169,6 +170,9 @@ export default defineComponent({
   computed: {
     loading() {
       return this.$store.state.producer?.status?.getApplications === Status.Request;
+    },
+    showViewCode(): boolean {
+      return isApiCodeVisible(this.$store?.state?.site, isOfficial());
     },
     credential() {
       return this.$store.state.producer.credential;

--- a/src/components/setting/Site.vue
+++ b/src/components/setting/Site.vue
@@ -142,12 +142,24 @@
         <edit-contacts :model-value="contacts" :title="$t('site.title.editContacts')" @confirm="onSaveContacts" />
       </div>
     </section>
+
+    <section class="settings-item">
+      <div class="settings-label">
+        <p class="settings-title">{{ $t('site.field.apiCode') }}</p>
+        <p class="settings-tip">
+          {{ $t('site.message.apiCodeTip') }}
+        </p>
+      </div>
+      <div class="settings-content">
+        <el-switch :model-value="apiCodeVisible" @change="onToggleApiCode" />
+      </div>
+    </section>
   </div>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElButton, ElColorPicker, ElImage, ElTag } from 'element-plus';
+import { ElButton, ElColorPicker, ElImage, ElSwitch, ElTag } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import EditText from '@/components/site/EditText.vue';
 import EditImage from '@/components/site/EditImage.vue';
@@ -157,7 +169,7 @@ import UserChip from '@/components/site/UserChip.vue';
 import AutoTranslateToggle from '@/components/site/AutoTranslateToggle.vue';
 import SectionNotice from '@/components/setting/SectionNotice.vue';
 import { siteOperator } from '@/operators';
-import { getBrandContacts, hasBrandContacts } from '@/utils';
+import { getBrandContacts, hasBrandContacts, isApiCodeVisible, isOfficial } from '@/utils';
 import { contactIcon, contactBrand, contactTypeI18nKey } from '@/utils/contactTypes';
 import { ISiteContact } from '@/models';
 import { DEFAULT_PRIMARY_COLOR, applyAccentColor } from '@/utils/theme';
@@ -189,6 +201,7 @@ export default defineComponent({
     ElButton,
     ElColorPicker,
     ElImage,
+    ElSwitch,
     ElTag,
     FontAwesomeIcon,
     SectionNotice
@@ -228,6 +241,9 @@ export default defineComponent({
     },
     hasContacts(): boolean {
       return hasBrandContacts(this.site);
+    },
+    apiCodeVisible(): boolean {
+      return isApiCodeVisible(this.site, isOfficial());
     }
   },
   methods: {
@@ -253,6 +269,14 @@ export default defineComponent({
         console.debug('getSite for id', this.site?.id);
         this.$store.dispatch('getSite');
       });
+    },
+    onToggleApiCode(value: string | number | boolean) {
+      // Persist the tri-state explicitly (inverted): ON -> show ->
+      // hide_api_code=false; OFF -> hide -> hide_api_code=true. Merge so
+      // other white-label branding keys are preserved.
+      const branding = { ...(this.site?.branding || {}) };
+      branding.hide_api_code = value !== true;
+      this.onSave({ branding });
     },
     onSaveContacts(contacts: ISiteContact[]) {
       // Merge into the existing branding so other white-label keys

--- a/src/components/suno/task/Preview.vue
+++ b/src/components/suno/task/Preview.vue
@@ -210,7 +210,7 @@
                 <font-awesome-icon icon="fa-solid fa-clock" class="menu-icon" />
                 {{ $t('suno.button.get_timing') }}
               </el-dropdown-item>
-              <el-dropdown-item @click.stop="onViewCode">
+              <el-dropdown-item v-if="showViewCode" @click.stop="onViewCode">
                 <font-awesome-icon icon="fa-solid fa-code" class="menu-icon" />
                 {{ $t('common.button.viewCode') }}
               </el-dropdown-item>
@@ -260,7 +260,7 @@ import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { saveAs } from 'file-saver';
 import { sunoOperator } from '@/operators';
 import ApiCodeDialog from '@/components/common/ApiCodeDialog.vue';
-
+import { isApiCodeVisible, isOfficial } from '@/utils';
 export default defineComponent({
   name: 'TaskPreview',
   components: {
@@ -300,6 +300,9 @@ export default defineComponent({
   computed: {
     loading() {
       return this.$store.state.suno?.status?.getApplications === Status.Request;
+    },
+    showViewCode(): boolean {
+      return isApiCodeVisible(this.$store?.state?.site, isOfficial());
     },
     credential() {
       return this.$store.state.suno.credential;

--- a/src/i18n/ar/site.json
+++ b/src/i18n/ar/site.json
@@ -43,6 +43,10 @@
     "message": "جهات اتصال الدعم",
     "description": "Field title for the customer-service contacts in site settings"
   },
+  "field.apiCode": {
+    "message": "Show \"View Code\"",
+    "description": "Site settings: toggle whether the per-generation 'View Code' button is shown to end users"
+  },
   "field.markupRatio": {
     "message": "نسبة زيادة موحدة للموقع بأكمله",
     "description": "إعدادات الموقع: النسبة الموحدة لزيادة الأسعار لجميع باقات الشحن في هذا الموقع (كنسبة مئوية)"
@@ -466,6 +470,10 @@
   "message.contactsEmpty": {
     "message": "لم يُضبط",
     "description": "Placeholder shown when no support contact has been filled in"
+  },
+  "message.apiCodeTip": {
+    "message": "When enabled, the 'View Code' button appears next to each generation so users can see the underlying API request. Hidden by default on white-label subsites.",
+    "description": "Help text for the View Code visibility toggle"
   },
   "message.keywordsTip": {
     "message": "كلمات مفتاحية للموقع، موجودة في المعلومات الوصفية للموقع، تستخدم لتحسين SEO للموقع.",

--- a/src/i18n/de/site.json
+++ b/src/i18n/de/site.json
@@ -43,6 +43,10 @@
     "message": "Support-Kontakte",
     "description": "Field title for the customer-service contacts in site settings"
   },
+  "field.apiCode": {
+    "message": "Show \"View Code\"",
+    "description": "Site settings: toggle whether the per-generation 'View Code' button is shown to end users"
+  },
   "field.markupRatio": {
     "message": "Einheitlicher Aufschlag für die gesamte Website",
     "description": "Website-Einstellungen: Der einheitliche Aufschlag für alle Aufladepakete auf dieser Website (Prozentsatz)"
@@ -466,6 +470,10 @@
   "message.contactsEmpty": {
     "message": "Nicht festgelegt",
     "description": "Placeholder shown when no support contact has been filled in"
+  },
+  "message.apiCodeTip": {
+    "message": "When enabled, the 'View Code' button appears next to each generation so users can see the underlying API request. Hidden by default on white-label subsites.",
+    "description": "Help text for the View Code visibility toggle"
   },
   "message.keywordsTip": {
     "message": "Schlüsselwörter der Seite, befinden sich in den Metadaten der Seite und dienen der SEO-Optimierung.",

--- a/src/i18n/el/site.json
+++ b/src/i18n/el/site.json
@@ -43,6 +43,10 @@
     "message": "Στοιχεία υποστήριξης",
     "description": "Field title for the customer-service contacts in site settings"
   },
+  "field.apiCode": {
+    "message": "Show \"View Code\"",
+    "description": "Site settings: toggle whether the per-generation 'View Code' button is shown to end users"
+  },
   "field.markupRatio": {
     "message": "Ενιαία προσαύξηση για όλο τον ιστότοπο",
     "description": "Ρυθμίσεις ιστότοπου: το ποσοστό προσαύξησης που εφαρμόζεται σε όλα τα πακέτα φόρτισης του ιστότοπου (ποσοστό)"
@@ -466,6 +470,10 @@
   "message.contactsEmpty": {
     "message": "Δεν έχει οριστεί",
     "description": "Placeholder shown when no support contact has been filled in"
+  },
+  "message.apiCodeTip": {
+    "message": "When enabled, the 'View Code' button appears next to each generation so users can see the underlying API request. Hidden by default on white-label subsites.",
+    "description": "Help text for the View Code visibility toggle"
   },
   "message.keywordsTip": {
     "message": "Λέξεις-κλειδιά του ιστότοπου, βρίσκονται στα μεταδεδομένα του ιστότοπου, για SEO βελτιστοποίηση.",

--- a/src/i18n/en/site.json
+++ b/src/i18n/en/site.json
@@ -43,6 +43,10 @@
     "message": "Support Contacts",
     "description": "Field title for the customer-service contacts in site settings"
   },
+  "field.apiCode": {
+    "message": "Show \"View Code\"",
+    "description": "Site settings: toggle whether the per-generation 'View Code' button is shown to end users"
+  },
   "field.markupRatio": {
     "message": "Site-wide uniform markup",
     "description": "Site settings: uniform markup percentage applied to all recharge packages on this site"
@@ -466,6 +470,10 @@
   "message.contactsEmpty": {
     "message": "Not set",
     "description": "Placeholder shown when no support contact has been filled in"
+  },
+  "message.apiCodeTip": {
+    "message": "When enabled, the 'View Code' button appears next to each generation so users can see the underlying API request. Hidden by default on white-label subsites.",
+    "description": "Help text for the View Code visibility toggle"
   },
   "message.keywordsTip": {
     "message": "Site keywords, located in the site metadata, used for site SEO optimization.",

--- a/src/i18n/es/site.json
+++ b/src/i18n/es/site.json
@@ -43,6 +43,10 @@
     "message": "Contactos de soporte",
     "description": "Field title for the customer-service contacts in site settings"
   },
+  "field.apiCode": {
+    "message": "Show \"View Code\"",
+    "description": "Site settings: toggle whether the per-generation 'View Code' button is shown to end users"
+  },
   "field.markupRatio": {
     "message": "Recargo uniforme para todo el sitio",
     "description": "Configuración del sitio: proporción de aumento unificada para todos los paquetes de recarga en este sitio (porcentaje)"
@@ -466,6 +470,10 @@
   "message.contactsEmpty": {
     "message": "Sin configurar",
     "description": "Placeholder shown when no support contact has been filled in"
+  },
+  "message.apiCodeTip": {
+    "message": "When enabled, the 'View Code' button appears next to each generation so users can see the underlying API request. Hidden by default on white-label subsites.",
+    "description": "Help text for the View Code visibility toggle"
   },
   "message.keywordsTip": {
     "message": "Palabras clave del sitio, ubicadas en la metainformación del sitio, utilizadas para la optimización SEO.",

--- a/src/i18n/fi/site.json
+++ b/src/i18n/fi/site.json
@@ -43,6 +43,10 @@
     "message": "Tuen yhteystiedot",
     "description": "Field title for the customer-service contacts in site settings"
   },
+  "field.apiCode": {
+    "message": "Show \"View Code\"",
+    "description": "Site settings: toggle whether the per-generation 'View Code' button is shown to end users"
+  },
   "field.markupRatio": {
     "message": "Koko sivuston yhtenäinen hinnankorotus",
     "description": "Sivuston asetukset: Yhdistelee kaikille latauspaketeille yhteisen hintaprosentin (prosentteina)."
@@ -466,6 +470,10 @@
   "message.contactsEmpty": {
     "message": "Ei asetettu",
     "description": "Placeholder shown when no support contact has been filled in"
+  },
+  "message.apiCodeTip": {
+    "message": "When enabled, the 'View Code' button appears next to each generation so users can see the underlying API request. Hidden by default on white-label subsites.",
+    "description": "Help text for the View Code visibility toggle"
   },
   "message.keywordsTip": {
     "message": "Sivuston avainsanat, sijaitsee sivuston metatiedoissa, käytetään sivuston SEO-optimointiin.",

--- a/src/i18n/fr/site.json
+++ b/src/i18n/fr/site.json
@@ -43,6 +43,10 @@
     "message": "Contacts d'assistance",
     "description": "Field title for the customer-service contacts in site settings"
   },
+  "field.apiCode": {
+    "message": "Show \"View Code\"",
+    "description": "Site settings: toggle whether the per-generation 'View Code' button is shown to end users"
+  },
   "field.markupRatio": {
     "message": "Majoration uniforme pour tout le site",
     "description": "Paramètres du site : le taux de majoration appliqué uniformément à tous les forfaits de recharge sur ce site (en pourcentage)"
@@ -466,6 +470,10 @@
   "message.contactsEmpty": {
     "message": "Non défini",
     "description": "Placeholder shown when no support contact has been filled in"
+  },
+  "message.apiCodeTip": {
+    "message": "When enabled, the 'View Code' button appears next to each generation so users can see the underlying API request. Hidden by default on white-label subsites.",
+    "description": "Help text for the View Code visibility toggle"
   },
   "message.keywordsTip": {
     "message": "Mots-clés du site, situés dans les métadonnées du site, utilisés pour l'optimisation SEO.",

--- a/src/i18n/it/site.json
+++ b/src/i18n/it/site.json
@@ -43,6 +43,10 @@
     "message": "Contatti di assistenza",
     "description": "Field title for the customer-service contacts in site settings"
   },
+  "field.apiCode": {
+    "message": "Show \"View Code\"",
+    "description": "Site settings: toggle whether the per-generation 'View Code' button is shown to end users"
+  },
   "field.markupRatio": {
     "message": "Sovrapprezzo uniforme per l'intero sito",
     "description": "Impostazioni del sito: percentuale di sovrapprezzo uniforme per tutti i pacchetti di ricarica su questo sito (percentuale)"
@@ -466,6 +470,10 @@
   "message.contactsEmpty": {
     "message": "Non impostato",
     "description": "Placeholder shown when no support contact has been filled in"
+  },
+  "message.apiCodeTip": {
+    "message": "When enabled, the 'View Code' button appears next to each generation so users can see the underlying API request. Hidden by default on white-label subsites.",
+    "description": "Help text for the View Code visibility toggle"
   },
   "message.keywordsTip": {
     "message": "Parole chiave del sito, presenti nei metadati del sito, utili per l'ottimizzazione SEO.",

--- a/src/i18n/ja/site.json
+++ b/src/i18n/ja/site.json
@@ -43,6 +43,10 @@
     "message": "サポート連絡先",
     "description": "Field title for the customer-service contacts in site settings"
   },
+  "field.apiCode": {
+    "message": "Show \"View Code\"",
+    "description": "Site settings: toggle whether the per-generation 'View Code' button is shown to end users"
+  },
   "field.markupRatio": {
     "message": "サイト全体の一律上乗せ率",
     "description": "サイト設定：このサイトのすべてのチャージプランに統一して加価する割合（パーセント）"
@@ -466,6 +470,10 @@
   "message.contactsEmpty": {
     "message": "未設定",
     "description": "Placeholder shown when no support contact has been filled in"
+  },
+  "message.apiCodeTip": {
+    "message": "When enabled, the 'View Code' button appears next to each generation so users can see the underlying API request. Hidden by default on white-label subsites.",
+    "description": "Help text for the View Code visibility toggle"
   },
   "message.keywordsTip": {
     "message": "サイトのキーワード。サイトのメタ情報にあり、サイトのSEO最適化に使用されます。",

--- a/src/i18n/ko/site.json
+++ b/src/i18n/ko/site.json
@@ -43,6 +43,10 @@
     "message": "고객지원 연락처",
     "description": "Field title for the customer-service contacts in site settings"
   },
+  "field.apiCode": {
+    "message": "Show \"View Code\"",
+    "description": "Site settings: toggle whether the per-generation 'View Code' button is shown to end users"
+  },
   "field.markupRatio": {
     "message": "사이트 전체 공통 가산율",
     "description": "사이트 설정: 본 사이트의 모든 충전 패키지에 대해 통일된 가산 비율(백분율)"
@@ -466,6 +470,10 @@
   "message.contactsEmpty": {
     "message": "설정 안 됨",
     "description": "Placeholder shown when no support contact has been filled in"
+  },
+  "message.apiCodeTip": {
+    "message": "When enabled, the 'View Code' button appears next to each generation so users can see the underlying API request. Hidden by default on white-label subsites.",
+    "description": "Help text for the View Code visibility toggle"
   },
   "message.keywordsTip": {
     "message": "사이트 키워드, 사이트 메타 정보에 위치하며, 사이트 SEO 최적화에 사용됩니다.",

--- a/src/i18n/pl/site.json
+++ b/src/i18n/pl/site.json
@@ -43,6 +43,10 @@
     "message": "Kontakty pomocy",
     "description": "Field title for the customer-service contacts in site settings"
   },
+  "field.apiCode": {
+    "message": "Show \"View Code\"",
+    "description": "Site settings: toggle whether the per-generation 'View Code' button is shown to end users"
+  },
   "field.markupRatio": {
     "message": "Jednolity narzut dla całej witryny",
     "description": "Ustawienia witryny: procentowy narzut stosowany do wszystkich usług w tej witrynie."
@@ -466,6 +470,10 @@
   "message.contactsEmpty": {
     "message": "Nie ustawiono",
     "description": "Placeholder shown when no support contact has been filled in"
+  },
+  "message.apiCodeTip": {
+    "message": "When enabled, the 'View Code' button appears next to each generation so users can see the underlying API request. Hidden by default on white-label subsites.",
+    "description": "Help text for the View Code visibility toggle"
   },
   "message.keywordsTip": {
     "message": "Słowa kluczowe strony, znajdujące się w metadanych strony, używane do optymalizacji SEO.",

--- a/src/i18n/pt/site.json
+++ b/src/i18n/pt/site.json
@@ -43,6 +43,10 @@
     "message": "Contatos de suporte",
     "description": "Field title for the customer-service contacts in site settings"
   },
+  "field.apiCode": {
+    "message": "Show \"View Code\"",
+    "description": "Site settings: toggle whether the per-generation 'View Code' button is shown to end users"
+  },
   "field.markupRatio": {
     "message": "Acréscimo uniforme em todo o site",
     "description": "Configuração do site: proporção de aumento unificada para todos os pacotes de recarga deste site (percentagem)"
@@ -466,6 +470,10 @@
   "message.contactsEmpty": {
     "message": "Não definido",
     "description": "Placeholder shown when no support contact has been filled in"
+  },
+  "message.apiCodeTip": {
+    "message": "When enabled, the 'View Code' button appears next to each generation so users can see the underlying API request. Hidden by default on white-label subsites.",
+    "description": "Help text for the View Code visibility toggle"
   },
   "message.keywordsTip": {
     "message": "Palavras-chave do site, localizadas nas metainformações do site, usadas para otimização de SEO.",

--- a/src/i18n/ru/site.json
+++ b/src/i18n/ru/site.json
@@ -43,6 +43,10 @@
     "message": "Контакты поддержки",
     "description": "Field title for the customer-service contacts in site settings"
   },
+  "field.apiCode": {
+    "message": "Show \"View Code\"",
+    "description": "Site settings: toggle whether the per-generation 'View Code' button is shown to end users"
+  },
   "field.markupRatio": {
     "message": "Единая наценка для всего сайта",
     "description": "Настройки сайта: процент наценки для всех тарифных планов на пополнение на данном сайте (в процентах)"
@@ -466,6 +470,10 @@
   "message.contactsEmpty": {
     "message": "Не задано",
     "description": "Placeholder shown when no support contact has been filled in"
+  },
+  "message.apiCodeTip": {
+    "message": "When enabled, the 'View Code' button appears next to each generation so users can see the underlying API request. Hidden by default on white-label subsites.",
+    "description": "Help text for the View Code visibility toggle"
   },
   "message.keywordsTip": {
     "message": "Ключевые слова сайта, находятся в метаданных сайта, используются для SEO-оптимизации сайта.",

--- a/src/i18n/sr/site.json
+++ b/src/i18n/sr/site.json
@@ -43,6 +43,10 @@
     "message": "Контакти подршке",
     "description": "Field title for the customer-service contacts in site settings"
   },
+  "field.apiCode": {
+    "message": "Show \"View Code\"",
+    "description": "Site settings: toggle whether the per-generation 'View Code' button is shown to end users"
+  },
   "field.markupRatio": {
     "message": "Јединствено увећање цене за цео сајт",
     "description": "Podešavanje sajta: Proporcija povećanja za sve pakete dopune na ovom sajtu (procenat)"
@@ -466,6 +470,10 @@
   "message.contactsEmpty": {
     "message": "Није постављено",
     "description": "Placeholder shown when no support contact has been filled in"
+  },
+  "message.apiCodeTip": {
+    "message": "When enabled, the 'View Code' button appears next to each generation so users can see the underlying API request. Hidden by default on white-label subsites.",
+    "description": "Help text for the View Code visibility toggle"
   },
   "message.keywordsTip": {
     "message": "Кључне речи сајта, налазе се у мета информацијама сајта, користе се за SEO оптимизацију.",

--- a/src/i18n/sv/site.json
+++ b/src/i18n/sv/site.json
@@ -43,6 +43,10 @@
     "message": "Supportkontakter",
     "description": "Field title for the customer-service contacts in site settings"
   },
+  "field.apiCode": {
+    "message": "Show \"View Code\"",
+    "description": "Site settings: toggle whether the per-generation 'View Code' button is shown to end users"
+  },
   "field.markupRatio": {
     "message": "Enhetligt påslag för hela webbplatsen",
     "description": "Inställningar för webbplatsen: den enhetliga påslagsprocenten (i procent) för alla insättningspaket på denna webbplats."
@@ -466,6 +470,10 @@
   "message.contactsEmpty": {
     "message": "Inte angivet",
     "description": "Placeholder shown when no support contact has been filled in"
+  },
+  "message.apiCodeTip": {
+    "message": "When enabled, the 'View Code' button appears next to each generation so users can see the underlying API request. Hidden by default on white-label subsites.",
+    "description": "Help text for the View Code visibility toggle"
   },
   "message.keywordsTip": {
     "message": "Webbplatsens nyckelord, finns i webbplatsens metadata och används för SEO-optimering.",

--- a/src/i18n/uk/site.json
+++ b/src/i18n/uk/site.json
@@ -43,6 +43,10 @@
     "message": "Контакти підтримки",
     "description": "Field title for the customer-service contacts in site settings"
   },
+  "field.apiCode": {
+    "message": "Show \"View Code\"",
+    "description": "Site settings: toggle whether the per-generation 'View Code' button is shown to end users"
+  },
   "field.markupRatio": {
     "message": "Єдина націнка для всього сайту",
     "description": "Налаштування сайту: відсоток націнки для всіх пакетів поповнення на цьому сайті (у відсотках)"
@@ -466,6 +470,10 @@
   "message.contactsEmpty": {
     "message": "Не задано",
     "description": "Placeholder shown when no support contact has been filled in"
+  },
+  "message.apiCodeTip": {
+    "message": "When enabled, the 'View Code' button appears next to each generation so users can see the underlying API request. Hidden by default on white-label subsites.",
+    "description": "Help text for the View Code visibility toggle"
   },
   "message.keywordsTip": {
     "message": "Ключові слова сайту, розташовані у метаданих сайту, використовуються для SEO-оптимізації.",

--- a/src/i18n/zh-CN/site.json
+++ b/src/i18n/zh-CN/site.json
@@ -43,6 +43,10 @@
     "message": "客服联系方式",
     "description": "站点设置中『客服联系方式』的字段标题"
   },
+  "field.apiCode": {
+    "message": "显示『查看代码』",
+    "description": "站点设置：控制每次生成结果旁的『查看代码』按钮是否对用户展示"
+  },
   "field.markupRatio": {
     "message": "全站统一加价比例",
     "description": "站点设置：对本站所有充值套餐统一加价的比例（百分比）"
@@ -466,6 +470,10 @@
   "message.contactsEmpty": {
     "message": "暂未设置",
     "description": "未填写任何客服联系方式时的占位文案"
+  },
+  "message.apiCodeTip": {
+    "message": "开启后，每次生成结果旁会显示『查看代码』按钮，用户可查看对应的 API 请求。白标子站默认隐藏。",
+    "description": "『查看代码』显示开关的提示文案"
   },
   "message.keywordsTip": {
     "message": "站点关键词，位于站点元信息中，用于站点 SEO 优化。",

--- a/src/i18n/zh-TW/site.json
+++ b/src/i18n/zh-TW/site.json
@@ -43,6 +43,10 @@
     "message": "客服聯絡方式",
     "description": "Field title for the customer-service contacts in site settings"
   },
+  "field.apiCode": {
+    "message": "Show \"View Code\"",
+    "description": "Site settings: toggle whether the per-generation 'View Code' button is shown to end users"
+  },
   "field.markupRatio": {
     "message": "全站統一加價比例",
     "description": "站點設置：對本站所有充值套餐統一加價的比例（百分比）"
@@ -466,6 +470,10 @@
   "message.contactsEmpty": {
     "message": "尚未設定",
     "description": "Placeholder shown when no support contact has been filled in"
+  },
+  "message.apiCodeTip": {
+    "message": "When enabled, the 'View Code' button appears next to each generation so users can see the underlying API request. Hidden by default on white-label subsites.",
+    "description": "Help text for the View Code visibility toggle"
   },
   "message.keywordsTip": {
     "message": "站點關鍵詞，位於站點元信息中，用於站點 SEO 優化。",

--- a/src/models/site.ts
+++ b/src/models/site.ts
@@ -140,6 +140,9 @@ export interface ISiteBranding {
   company?: string;
   copyright?: string;
   hide_powered_by?: boolean;
+  // Tri-state for the "View Code" affordance: `true` force-hides, `false`
+  // force-shows (opt-in), unset defaults to shown on official hosts and
+  // hidden on white-label subsites. See `isApiCodeVisible` in `utils/site`.
   hide_api_code?: boolean;
   links?: ISiteBrandingLinks;
   contacts?: ISiteContact[];

--- a/src/utils/site.test.ts
+++ b/src/utils/site.test.ts
@@ -7,6 +7,7 @@ import {
   getApplicationCallerOrderDiscountRate,
   applyMarkup,
   isBrandingHidden,
+  isApiCodeVisible,
   getBrandSupportUrl,
   getBrandContacts,
   hasBrandContacts
@@ -136,22 +137,41 @@ describe('applyMarkup', () => {
 describe('isBrandingHidden', () => {
   it('returns false when site / branding / flag is unset (default = show ours)', () => {
     expect(isBrandingHidden(null, 'powered_by')).toBe(false);
-    expect(isBrandingHidden(undefined, 'api_code')).toBe(false);
+    expect(isBrandingHidden(undefined, 'powered_by')).toBe(false);
     expect(isBrandingHidden({} as never, 'powered_by')).toBe(false);
-    expect(isBrandingHidden({ branding: {} } as never, 'api_code')).toBe(false);
+    expect(isBrandingHidden({ branding: {} } as never, 'powered_by')).toBe(false);
   });
 
   it('hides only on an explicit boolean true (not truthy coercions)', () => {
     expect(isBrandingHidden({ branding: { hide_powered_by: true } } as never, 'powered_by')).toBe(true);
-    expect(isBrandingHidden({ branding: { hide_api_code: true } } as never, 'api_code')).toBe(true);
     expect(isBrandingHidden({ branding: { hide_powered_by: false } } as never, 'powered_by')).toBe(false);
     expect(isBrandingHidden({ branding: { hide_powered_by: 1 } } as never, 'powered_by')).toBe(false);
   });
+});
 
-  it('keys are independent', () => {
-    const site = { branding: { hide_api_code: true } } as never;
-    expect(isBrandingHidden(site, 'api_code')).toBe(true);
-    expect(isBrandingHidden(site, 'powered_by')).toBe(false);
+describe('isApiCodeVisible', () => {
+  it('defaults to the official flag when the site-config flag is unset', () => {
+    // Sub-sites (official=false) hide by default; the main site (official=true) shows.
+    expect(isApiCodeVisible(null, false)).toBe(false);
+    expect(isApiCodeVisible(undefined, true)).toBe(true);
+    expect(isApiCodeVisible({} as never, false)).toBe(false);
+    expect(isApiCodeVisible({ branding: {} } as never, true)).toBe(true);
+  });
+
+  it('force-hides on explicit true regardless of official', () => {
+    expect(isApiCodeVisible({ branding: { hide_api_code: true } } as never, true)).toBe(false);
+    expect(isApiCodeVisible({ branding: { hide_api_code: true } } as never, false)).toBe(false);
+  });
+
+  it('force-shows on explicit false (subsite opt-in) regardless of official', () => {
+    expect(isApiCodeVisible({ branding: { hide_api_code: false } } as never, false)).toBe(true);
+    expect(isApiCodeVisible({ branding: { hide_api_code: false } } as never, true)).toBe(true);
+  });
+
+  it('ignores truthy/falsy coercions and only honors real booleans', () => {
+    // A non-boolean flag falls through to the official default.
+    expect(isApiCodeVisible({ branding: { hide_api_code: 1 } } as never, false)).toBe(false);
+    expect(isApiCodeVisible({ branding: { hide_api_code: 0 } } as never, true)).toBe(true);
   });
 });
 

--- a/src/utils/site.ts
+++ b/src/utils/site.ts
@@ -68,12 +68,28 @@ export const getSiteOrigin = (site?: ISite) => {
  * matching the "unset = use our default" principle. Only an explicit `true`
  * hides the surface.
  */
-export const isBrandingHidden = (site: ISite | null | undefined, key: 'powered_by' | 'api_code'): boolean => {
+export const isBrandingHidden = (site: ISite | null | undefined, key: 'powered_by'): boolean => {
   const branding = site?.branding;
   if (!branding) return false;
   if (key === 'powered_by') return branding.hide_powered_by === true;
-  if (key === 'api_code') return branding.hide_api_code === true;
   return false;
+};
+
+/**
+ * Whether the per-generation "View Code" affordance (Nexior ApiCodeButton)
+ * should render. ``branding.hide_api_code`` is a tri-state:
+ *   - ``true``  → force-hidden (any site).
+ *   - ``false`` → force-shown  (explicit site-config opt-in, e.g. a subsite).
+ *   - unset     → default: shown on first-party official hosts, hidden on
+ *     white-label subsites/tenants so they don't expose api.acedata.cloud.
+ * ``official`` is injected so callers (and tests) stay independent of the
+ * host-reading ``isOfficial()``.
+ */
+export const isApiCodeVisible = (site: ISite | null | undefined, official: boolean): boolean => {
+  const flag = site?.branding?.hide_api_code;
+  if (flag === true) return false;
+  if (flag === false) return true;
+  return official;
 };
 
 /**


### PR DESCRIPTION
## 背景

Nexior 每次生成结果旁有一个「查看代码 / View Code」入口，会暴露 `api.acedata.cloud` 的底层 API 请求。白标/分销子站不希望默认暴露这个入口，希望：

- **主站（studio / hub）默认显示**
- **白标子站默认隐藏**
- **站点配置里可由管理员开关覆盖**

## 实现

复用已有的 `Site.branding.hide_api_code` 字段，改为**三态**语义（新增 `isApiCodeVisible(site, official)` 辅助函数，`src/utils/site.ts`）：

| `hide_api_code` | 效果 |
|---|---|
| `true` | 强制隐藏（任意站点） |
| `false` | 强制显示（子站显式开启） |
| 未设置 | 默认：官方主站显示、白标子站隐藏（由 `isOfficial()` 决定） |

- `Site.vue` 新增一个管理员开关（`el-switch`），`ON→hide_api_code=false`、`OFF→hide_api_code=true`，合并写入 branding 保留其它白标键。
- 网关侧无需改动：`hide_api_code` 本就是 `PlatformBackend/app/utils/site_branding.py` 允许的布尔键，写入 `false` 合法。
- 门控覆盖全部入口：`ApiCodeButton`（21 处预览）+ Suno / Producer 预览下拉里的「查看代码」项。
- i18n：`field.apiCode` / `message.apiCodeTip` 已补齐全部 18 个语言（en + zh-CN 已本地化，其余占位英文），`scripts/check_i18n_coverage.py` 通过。

## 测试

- `vitest run src/utils/site.test.ts` — 新增 `isApiCodeVisible` 覆盖三态 + 非布尔回退，全部通过。
- eslint 干净；`beachball check` 通过（含 change file）。

## 🤖 对抗评审

Codex 因额度用尽，改用独立 subagent 评审（read-only）。

- **RISK: Suno / Producer 预览的「查看代码」下拉项未走新门控，子站仍会泄露 `api.acedata.cloud`。** → **已修复**：给两处 `el-dropdown-item` 加 `v-if="showViewCode"`（各自新增 `showViewCode` computed 调用 `isApiCodeVisible(site, isOfficial())`）。
- **RISK（低）: `isBrandingHidden(site, 'api_code')` 变为死代码且语义（未设置→显示）与新默认（未设置→子站隐藏）矛盾，未来误用会重新引入泄露。** → **已修复**：将 `isBrandingHidden` 收窄为仅 `'powered_by'`，删除 `'api_code'` 分支及其对应测试。
- Cleared：三态逻辑、开关反转 round-trip、i18n 覆盖、SSG/`window` 安全（`build:web` 为纯 vite，`build:ssg` 只预渲染 `/auth/login`，不含这些组件）、后端兼容。

修复后重跑 tests + lint + i18n guard 全绿，评审收敛。