### PR TITLE
polish(contacts): icons on summary chips + smaller editor inputs/buttons

### DIFF
--- a/change/@acedatacloud-nexior-0d4d4f83-2a75-4ede-a5fa-ed5861af1a8f.json
+++ b/change/@acedatacloud-nexior-0d4d4f83-2a75-4ede-a5fa-ed5861af1a8f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "polish(contacts): icons on summary chips + smaller editor inputs/buttons",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/setting/Site.vue
+++ b/src/components/setting/Site.vue
@@ -133,7 +133,10 @@
       </div>
       <div class="settings-content">
         <div v-if="hasContacts" class="contacts-summary">
-          <el-tag v-for="(c, i) in contacts" :key="i" size="small" round>{{ contactSummary(c) }}</el-tag>
+          <el-tag v-for="(c, i) in contacts" :key="i" size="small" round class="contact-chip">
+            <font-awesome-icon :icon="contactIconFor(c.type)" class="chip-icon" />
+            {{ contactSummary(c) }}
+          </el-tag>
         </div>
         <span v-else class="settings-value">{{ $t('site.message.contactsEmpty') }}</span>
         <edit-contacts :model-value="contacts" :title="$t('site.title.editContacts')" @confirm="onSaveContacts" />
@@ -145,6 +148,7 @@
 <script lang="ts">
 import { defineComponent } from 'vue';
 import { ElButton, ElColorPicker, ElImage, ElTag } from 'element-plus';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import EditText from '@/components/site/EditText.vue';
 import EditImage from '@/components/site/EditImage.vue';
 import EditUsers from '@/components/site/EditUsers.vue';
@@ -154,7 +158,7 @@ import AutoTranslateToggle from '@/components/site/AutoTranslateToggle.vue';
 import SectionNotice from '@/components/setting/SectionNotice.vue';
 import { siteOperator } from '@/operators';
 import { getBrandContacts, hasBrandContacts } from '@/utils';
-import { contactBrand, contactTypeI18nKey } from '@/utils/contactTypes';
+import { contactIcon, contactBrand, contactTypeI18nKey } from '@/utils/contactTypes';
 import { ISiteContact } from '@/models';
 import { DEFAULT_PRIMARY_COLOR, applyAccentColor } from '@/utils/theme';
 
@@ -186,6 +190,7 @@ export default defineComponent({
     ElColorPicker,
     ElImage,
     ElTag,
+    FontAwesomeIcon,
     SectionNotice
   },
   data() {
@@ -226,6 +231,9 @@ export default defineComponent({
     }
   },
   methods: {
+    contactIconFor(type: string) {
+      return contactIcon(type);
+    },
     contactSummary(c: ISiteContact): string {
       // Short chip label: prefer the owner's label, then the value, then a
       // brand/type name.
@@ -321,6 +329,23 @@ export default defineComponent({
 
 .admins-chip {
   max-width: 100%;
+}
+
+.contacts-summary {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 6px;
+  max-width: 100%;
+
+  .contact-chip {
+    max-width: 100%;
+
+    .chip-icon {
+      margin-right: 5px;
+      font-size: 11px;
+    }
+  }
 }
 
 .primary-color-content {

--- a/src/components/site/EditContacts.vue
+++ b/src/components/site/EditContacts.vue
@@ -10,18 +10,24 @@
             filterable
             allow-create
             default-first-option
+            size="small"
             class="type-select"
             :placeholder="$t('common.settings.contactType')"
           >
             <el-option v-for="opt in typeOptions" :key="opt.value" :label="opt.label" :value="opt.value" />
           </el-select>
-          <el-button link type="danger" :icon="Delete" @click="removeRow(idx)">
+          <el-button link type="danger" size="small" :icon="Delete" @click="removeRow(idx)">
             {{ $t('common.button.delete') }}
           </el-button>
         </div>
-        <el-input v-model="row.label" class="row-field" :placeholder="$t('common.settings.contactLabelPlaceholder')" />
-        <el-input v-model="row.value" class="row-field" :placeholder="valuePlaceholder(row.type)" />
-        <el-input v-model="row.url" class="row-field" placeholder="https://..." />
+        <el-input
+          v-model="row.label"
+          size="small"
+          class="row-field"
+          :placeholder="$t('common.settings.contactLabelPlaceholder')"
+        />
+        <el-input v-model="row.value" size="small" class="row-field" :placeholder="valuePlaceholder(row.type)" />
+        <el-input v-model="row.url" size="small" class="row-field" placeholder="https://..." />
         <div class="qr-row">
           <span class="qr-label">{{ $t('common.settings.contactQr') }}</span>
           <el-image v-if="row.qr" :src="row.qr" class="qr-thumb" fit="contain" />
@@ -33,17 +39,19 @@
             :height="200"
             @confirm="row.qr = $event"
           />
-          <el-button v-if="row.qr" link type="danger" @click="row.qr = ''">
+          <el-button v-if="row.qr" link type="danger" size="small" @click="row.qr = ''">
             {{ $t('common.button.delete') }}
           </el-button>
         </div>
       </div>
     </div>
-    <el-button class="add-btn" :icon="Plus" @click="addRow">{{ $t('common.settings.contactAdd') }}</el-button>
+    <el-button class="add-btn" size="small" :icon="Plus" @click="addRow">{{
+      $t('common.settings.contactAdd')
+    }}</el-button>
     <template #footer>
       <span class="dialog-footer">
-        <el-button round @click="onCancel">{{ $t('common.button.cancel') }}</el-button>
-        <el-button round type="primary" @click="onConfirm">{{ $t('common.button.confirm') }}</el-button>
+        <el-button round size="small" @click="onCancel">{{ $t('common.button.cancel') }}</el-button>
+        <el-button round size="small" type="primary" @click="onConfirm">{{ $t('common.button.confirm') }}</el-button>
       </span>
     </template>
   </el-dialog>


### PR DESCRIPTION
## Summary
Small UI polish for the Site Settings → Support Contacts feature (both requested):
1. **Icons on the summary chips** — each chip in the Site Settings row now shows the channel icon (via `contactTypes.ts`) before the label, matching the About page and the editor rows.
2. **Smaller editor controls** — the `EditContacts` dialog's type select, text inputs, delete buttons, "Add contact", and Cancel/Confirm are now `size="small"` (one step down from default).

## Validation
- `eslint` clean; `vue-tsc -b` clean.

## 🤖 对抗评审
Trivial, cosmetic change (Element Plus `size="small"` attributes + a chip icon rendered from a static FontAwesome IconDefinition + scoped styles). No logic, data, or security surface touched. `VERDICT: CLEAN`
