### PR TITLE
style: format application extras imports

### DIFF
--- a/change/@acedatacloud-nexior-application-extra-format.json
+++ b/change/@acedatacloud-nexior-application-extra-format.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Format the application extras route imports so the repository lint gate passes.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/pages/console/application/Extra.vue
+++ b/src/pages/console/application/Extra.vue
@@ -130,7 +130,11 @@ import {
   ElRadioButton,
   ElTag
 } from 'element-plus';
-import { ROUTE_CONSOLE_APPLICATION_SUBSCRIBE, ROUTE_CONSOLE_ORDER_DETAIL, ROUTE_CONSOLE_APPLICATION_LIST } from '@/router';
+import {
+  ROUTE_CONSOLE_APPLICATION_SUBSCRIBE,
+  ROUTE_CONSOLE_ORDER_DETAIL,
+  ROUTE_CONSOLE_APPLICATION_LIST
+} from '@/router';
 import Price from '@/components/common/Price.vue';
 import { applicationOperator, orderOperator } from '@/operators';
 import { getPriceString, applyMarkup, getApplicationMarkupRatio, getApplicationCallerOrderDiscountRate } from '@/utils';


### PR DESCRIPTION
## Summary
- format the existing application extras route import so the repository-wide Prettier gate passes
- add the required patch change record

This is isolated from the P1 control-adapter work and makes no behavior change.

## Validation
- focused ESLint
- Prettier
- Beachball `check --no-fetch`
- `git diff --check`

## Adversarial review
- `VERDICT: CLEAN`