### PR TITLE
fix(site): show "View Code" only on the main official host

### DIFF
--- a/change/@acedatacloud-nexior-api-code-main-official.json
+++ b/change/@acedatacloud-nexior-api-code-main-official.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(site): only the bare main official host (studio.acedata.cloud) shows the \"View Code\" affordance; drop the per-site toggle",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/common/ApiCodeButton.vue
+++ b/src/components/common/ApiCodeButton.vue
@@ -27,7 +27,7 @@ import { defineComponent, type PropType } from 'vue';
 import { ElButton, ElTooltip } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import ApiCodeDialog from '@/components/common/ApiCodeDialog.vue';
-import { isApiCodeVisible, isOfficial } from '@/utils';
+import { isMainOfficial } from '@/utils';
 
 type ButtonType = '' | 'default' | 'text' | 'primary' | 'success' | 'warning' | 'info' | 'danger';
 type ButtonSize = '' | 'small' | 'default' | 'large';
@@ -113,11 +113,9 @@ export default defineComponent({
   },
   computed: {
     showViewCode(): boolean {
-      // Default: shown on first-party official sites, hidden on white-label
-      // subsites/tenants (they shouldn't expose our API host/code). A site
-      // owner overrides either way from Site settings via
-      // `Site.branding.hide_api_code` (tri-state, see `isApiCodeVisible`).
-      return isApiCodeVisible(this.$store?.state?.site, isOfficial());
+      // Only the bare main official host (studio.acedata.cloud) exposes the
+      // API host/code; subsites and white-label tenants never show it.
+      return isMainOfficial();
     },
     cleanedBody(): Record<string, unknown> {
       const src = (this.body || {}) as Record<string, unknown>;

--- a/src/components/producer/task/Preview.vue
+++ b/src/components/producer/task/Preview.vue
@@ -135,7 +135,7 @@ import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { saveAs } from 'file-saver';
 import { producerOperator } from '@/operators';
 import ApiCodeDialog from '@/components/common/ApiCodeDialog.vue';
-import { isApiCodeVisible, isOfficial } from '@/utils';
+import { isMainOfficial } from '@/utils';
 
 export default defineComponent({
   name: 'TaskPreview',
@@ -172,7 +172,7 @@ export default defineComponent({
       return this.$store.state.producer?.status?.getApplications === Status.Request;
     },
     showViewCode(): boolean {
-      return isApiCodeVisible(this.$store?.state?.site, isOfficial());
+      return isMainOfficial();
     },
     credential() {
       return this.$store.state.producer.credential;

--- a/src/components/setting/Site.vue
+++ b/src/components/setting/Site.vue
@@ -142,24 +142,12 @@
         <edit-contacts :model-value="contacts" :title="$t('site.title.editContacts')" @confirm="onSaveContacts" />
       </div>
     </section>
-
-    <section class="settings-item">
-      <div class="settings-label">
-        <p class="settings-title">{{ $t('site.field.apiCode') }}</p>
-        <p class="settings-tip">
-          {{ $t('site.message.apiCodeTip') }}
-        </p>
-      </div>
-      <div class="settings-content">
-        <el-switch :model-value="apiCodeVisible" @change="onToggleApiCode" />
-      </div>
-    </section>
   </div>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElButton, ElColorPicker, ElImage, ElSwitch, ElTag } from 'element-plus';
+import { ElButton, ElColorPicker, ElImage, ElTag } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import EditText from '@/components/site/EditText.vue';
 import EditImage from '@/components/site/EditImage.vue';
@@ -169,7 +157,7 @@ import UserChip from '@/components/site/UserChip.vue';
 import AutoTranslateToggle from '@/components/site/AutoTranslateToggle.vue';
 import SectionNotice from '@/components/setting/SectionNotice.vue';
 import { siteOperator } from '@/operators';
-import { getBrandContacts, hasBrandContacts, isApiCodeVisible, isOfficial } from '@/utils';
+import { getBrandContacts, hasBrandContacts } from '@/utils';
 import { contactIcon, contactBrand, contactTypeI18nKey } from '@/utils/contactTypes';
 import { ISiteContact } from '@/models';
 import { DEFAULT_PRIMARY_COLOR, applyAccentColor } from '@/utils/theme';
@@ -201,7 +189,6 @@ export default defineComponent({
     ElButton,
     ElColorPicker,
     ElImage,
-    ElSwitch,
     ElTag,
     FontAwesomeIcon,
     SectionNotice
@@ -241,9 +228,6 @@ export default defineComponent({
     },
     hasContacts(): boolean {
       return hasBrandContacts(this.site);
-    },
-    apiCodeVisible(): boolean {
-      return isApiCodeVisible(this.site, isOfficial());
     }
   },
   methods: {
@@ -269,14 +253,6 @@ export default defineComponent({
         console.debug('getSite for id', this.site?.id);
         this.$store.dispatch('getSite');
       });
-    },
-    onToggleApiCode(value: string | number | boolean) {
-      // Persist the tri-state explicitly (inverted): ON -> show ->
-      // hide_api_code=false; OFF -> hide -> hide_api_code=true. Merge so
-      // other white-label branding keys are preserved.
-      const branding = { ...(this.site?.branding || {}) };
-      branding.hide_api_code = value !== true;
-      this.onSave({ branding });
     },
     onSaveContacts(contacts: ISiteContact[]) {
       // Merge into the existing branding so other white-label keys

--- a/src/components/suno/task/Preview.vue
+++ b/src/components/suno/task/Preview.vue
@@ -260,7 +260,7 @@ import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { saveAs } from 'file-saver';
 import { sunoOperator } from '@/operators';
 import ApiCodeDialog from '@/components/common/ApiCodeDialog.vue';
-import { isApiCodeVisible, isOfficial } from '@/utils';
+import { isMainOfficial } from '@/utils';
 export default defineComponent({
   name: 'TaskPreview',
   components: {
@@ -302,7 +302,7 @@ export default defineComponent({
       return this.$store.state.suno?.status?.getApplications === Status.Request;
     },
     showViewCode(): boolean {
-      return isApiCodeVisible(this.$store?.state?.site, isOfficial());
+      return isMainOfficial();
     },
     credential() {
       return this.$store.state.suno.credential;

--- a/src/i18n/ar/site.json
+++ b/src/i18n/ar/site.json
@@ -43,10 +43,6 @@
     "message": "جهات اتصال الدعم",
     "description": "Field title for the customer-service contacts in site settings"
   },
-  "field.apiCode": {
-    "message": "Show \"View Code\"",
-    "description": "Site settings: toggle whether the per-generation 'View Code' button is shown to end users"
-  },
   "field.markupRatio": {
     "message": "نسبة زيادة موحدة للموقع بأكمله",
     "description": "إعدادات الموقع: النسبة الموحدة لزيادة الأسعار لجميع باقات الشحن في هذا الموقع (كنسبة مئوية)"
@@ -470,10 +466,6 @@
   "message.contactsEmpty": {
     "message": "لم يُضبط",
     "description": "Placeholder shown when no support contact has been filled in"
-  },
-  "message.apiCodeTip": {
-    "message": "When enabled, the 'View Code' button appears next to each generation so users can see the underlying API request. Hidden by default on white-label subsites.",
-    "description": "Help text for the View Code visibility toggle"
   },
   "message.keywordsTip": {
     "message": "كلمات مفتاحية للموقع، موجودة في المعلومات الوصفية للموقع، تستخدم لتحسين SEO للموقع.",

--- a/src/i18n/de/site.json
+++ b/src/i18n/de/site.json
@@ -43,10 +43,6 @@
     "message": "Support-Kontakte",
     "description": "Field title for the customer-service contacts in site settings"
   },
-  "field.apiCode": {
-    "message": "Show \"View Code\"",
-    "description": "Site settings: toggle whether the per-generation 'View Code' button is shown to end users"
-  },
   "field.markupRatio": {
     "message": "Einheitlicher Aufschlag für die gesamte Website",
     "description": "Website-Einstellungen: Der einheitliche Aufschlag für alle Aufladepakete auf dieser Website (Prozentsatz)"
@@ -470,10 +466,6 @@
   "message.contactsEmpty": {
     "message": "Nicht festgelegt",
     "description": "Placeholder shown when no support contact has been filled in"
-  },
-  "message.apiCodeTip": {
-    "message": "When enabled, the 'View Code' button appears next to each generation so users can see the underlying API request. Hidden by default on white-label subsites.",
-    "description": "Help text for the View Code visibility toggle"
   },
   "message.keywordsTip": {
     "message": "Schlüsselwörter der Seite, befinden sich in den Metadaten der Seite und dienen der SEO-Optimierung.",

--- a/src/i18n/el/site.json
+++ b/src/i18n/el/site.json
@@ -43,10 +43,6 @@
     "message": "Στοιχεία υποστήριξης",
     "description": "Field title for the customer-service contacts in site settings"
   },
-  "field.apiCode": {
-    "message": "Show \"View Code\"",
-    "description": "Site settings: toggle whether the per-generation 'View Code' button is shown to end users"
-  },
   "field.markupRatio": {
     "message": "Ενιαία προσαύξηση για όλο τον ιστότοπο",
     "description": "Ρυθμίσεις ιστότοπου: το ποσοστό προσαύξησης που εφαρμόζεται σε όλα τα πακέτα φόρτισης του ιστότοπου (ποσοστό)"
@@ -470,10 +466,6 @@
   "message.contactsEmpty": {
     "message": "Δεν έχει οριστεί",
     "description": "Placeholder shown when no support contact has been filled in"
-  },
-  "message.apiCodeTip": {
-    "message": "When enabled, the 'View Code' button appears next to each generation so users can see the underlying API request. Hidden by default on white-label subsites.",
-    "description": "Help text for the View Code visibility toggle"
   },
   "message.keywordsTip": {
     "message": "Λέξεις-κλειδιά του ιστότοπου, βρίσκονται στα μεταδεδομένα του ιστότοπου, για SEO βελτιστοποίηση.",

--- a/src/i18n/en/site.json
+++ b/src/i18n/en/site.json
@@ -43,10 +43,6 @@
     "message": "Support Contacts",
     "description": "Field title for the customer-service contacts in site settings"
   },
-  "field.apiCode": {
-    "message": "Show \"View Code\"",
-    "description": "Site settings: toggle whether the per-generation 'View Code' button is shown to end users"
-  },
   "field.markupRatio": {
     "message": "Site-wide uniform markup",
     "description": "Site settings: uniform markup percentage applied to all recharge packages on this site"
@@ -470,10 +466,6 @@
   "message.contactsEmpty": {
     "message": "Not set",
     "description": "Placeholder shown when no support contact has been filled in"
-  },
-  "message.apiCodeTip": {
-    "message": "When enabled, the 'View Code' button appears next to each generation so users can see the underlying API request. Hidden by default on white-label subsites.",
-    "description": "Help text for the View Code visibility toggle"
   },
   "message.keywordsTip": {
     "message": "Site keywords, located in the site metadata, used for site SEO optimization.",

--- a/src/i18n/es/site.json
+++ b/src/i18n/es/site.json
@@ -43,10 +43,6 @@
     "message": "Contactos de soporte",
     "description": "Field title for the customer-service contacts in site settings"
   },
-  "field.apiCode": {
-    "message": "Show \"View Code\"",
-    "description": "Site settings: toggle whether the per-generation 'View Code' button is shown to end users"
-  },
   "field.markupRatio": {
     "message": "Recargo uniforme para todo el sitio",
     "description": "Configuración del sitio: proporción de aumento unificada para todos los paquetes de recarga en este sitio (porcentaje)"
@@ -470,10 +466,6 @@
   "message.contactsEmpty": {
     "message": "Sin configurar",
     "description": "Placeholder shown when no support contact has been filled in"
-  },
-  "message.apiCodeTip": {
-    "message": "When enabled, the 'View Code' button appears next to each generation so users can see the underlying API request. Hidden by default on white-label subsites.",
-    "description": "Help text for the View Code visibility toggle"
   },
   "message.keywordsTip": {
     "message": "Palabras clave del sitio, ubicadas en la metainformación del sitio, utilizadas para la optimización SEO.",

--- a/src/i18n/fi/site.json
+++ b/src/i18n/fi/site.json
@@ -43,10 +43,6 @@
     "message": "Tuen yhteystiedot",
     "description": "Field title for the customer-service contacts in site settings"
   },
-  "field.apiCode": {
-    "message": "Show \"View Code\"",
-    "description": "Site settings: toggle whether the per-generation 'View Code' button is shown to end users"
-  },
   "field.markupRatio": {
     "message": "Koko sivuston yhtenäinen hinnankorotus",
     "description": "Sivuston asetukset: Yhdistelee kaikille latauspaketeille yhteisen hintaprosentin (prosentteina)."
@@ -470,10 +466,6 @@
   "message.contactsEmpty": {
     "message": "Ei asetettu",
     "description": "Placeholder shown when no support contact has been filled in"
-  },
-  "message.apiCodeTip": {
-    "message": "When enabled, the 'View Code' button appears next to each generation so users can see the underlying API request. Hidden by default on white-label subsites.",
-    "description": "Help text for the View Code visibility toggle"
   },
   "message.keywordsTip": {
     "message": "Sivuston avainsanat, sijaitsee sivuston metatiedoissa, käytetään sivuston SEO-optimointiin.",

--- a/src/i18n/fr/site.json
+++ b/src/i18n/fr/site.json
@@ -43,10 +43,6 @@
     "message": "Contacts d'assistance",
     "description": "Field title for the customer-service contacts in site settings"
   },
-  "field.apiCode": {
-    "message": "Show \"View Code\"",
-    "description": "Site settings: toggle whether the per-generation 'View Code' button is shown to end users"
-  },
   "field.markupRatio": {
     "message": "Majoration uniforme pour tout le site",
     "description": "Paramètres du site : le taux de majoration appliqué uniformément à tous les forfaits de recharge sur ce site (en pourcentage)"
@@ -470,10 +466,6 @@
   "message.contactsEmpty": {
     "message": "Non défini",
     "description": "Placeholder shown when no support contact has been filled in"
-  },
-  "message.apiCodeTip": {
-    "message": "When enabled, the 'View Code' button appears next to each generation so users can see the underlying API request. Hidden by default on white-label subsites.",
-    "description": "Help text for the View Code visibility toggle"
   },
   "message.keywordsTip": {
     "message": "Mots-clés du site, situés dans les métadonnées du site, utilisés pour l'optimisation SEO.",

--- a/src/i18n/it/site.json
+++ b/src/i18n/it/site.json
@@ -43,10 +43,6 @@
     "message": "Contatti di assistenza",
     "description": "Field title for the customer-service contacts in site settings"
   },
-  "field.apiCode": {
-    "message": "Show \"View Code\"",
-    "description": "Site settings: toggle whether the per-generation 'View Code' button is shown to end users"
-  },
   "field.markupRatio": {
     "message": "Sovrapprezzo uniforme per l'intero sito",
     "description": "Impostazioni del sito: percentuale di sovrapprezzo uniforme per tutti i pacchetti di ricarica su questo sito (percentuale)"
@@ -470,10 +466,6 @@
   "message.contactsEmpty": {
     "message": "Non impostato",
     "description": "Placeholder shown when no support contact has been filled in"
-  },
-  "message.apiCodeTip": {
-    "message": "When enabled, the 'View Code' button appears next to each generation so users can see the underlying API request. Hidden by default on white-label subsites.",
-    "description": "Help text for the View Code visibility toggle"
   },
   "message.keywordsTip": {
     "message": "Parole chiave del sito, presenti nei metadati del sito, utili per l'ottimizzazione SEO.",

--- a/src/i18n/ja/site.json
+++ b/src/i18n/ja/site.json
@@ -43,10 +43,6 @@
     "message": "サポート連絡先",
     "description": "Field title for the customer-service contacts in site settings"
   },
-  "field.apiCode": {
-    "message": "Show \"View Code\"",
-    "description": "Site settings: toggle whether the per-generation 'View Code' button is shown to end users"
-  },
   "field.markupRatio": {
     "message": "サイト全体の一律上乗せ率",
     "description": "サイト設定：このサイトのすべてのチャージプランに統一して加価する割合（パーセント）"
@@ -470,10 +466,6 @@
   "message.contactsEmpty": {
     "message": "未設定",
     "description": "Placeholder shown when no support contact has been filled in"
-  },
-  "message.apiCodeTip": {
-    "message": "When enabled, the 'View Code' button appears next to each generation so users can see the underlying API request. Hidden by default on white-label subsites.",
-    "description": "Help text for the View Code visibility toggle"
   },
   "message.keywordsTip": {
     "message": "サイトのキーワード。サイトのメタ情報にあり、サイトのSEO最適化に使用されます。",

--- a/src/i18n/ko/site.json
+++ b/src/i18n/ko/site.json
@@ -43,10 +43,6 @@
     "message": "고객지원 연락처",
     "description": "Field title for the customer-service contacts in site settings"
   },
-  "field.apiCode": {
-    "message": "Show \"View Code\"",
-    "description": "Site settings: toggle whether the per-generation 'View Code' button is shown to end users"
-  },
   "field.markupRatio": {
     "message": "사이트 전체 공통 가산율",
     "description": "사이트 설정: 본 사이트의 모든 충전 패키지에 대해 통일된 가산 비율(백분율)"
@@ -470,10 +466,6 @@
   "message.contactsEmpty": {
     "message": "설정 안 됨",
     "description": "Placeholder shown when no support contact has been filled in"
-  },
-  "message.apiCodeTip": {
-    "message": "When enabled, the 'View Code' button appears next to each generation so users can see the underlying API request. Hidden by default on white-label subsites.",
-    "description": "Help text for the View Code visibility toggle"
   },
   "message.keywordsTip": {
     "message": "사이트 키워드, 사이트 메타 정보에 위치하며, 사이트 SEO 최적화에 사용됩니다.",

--- a/src/i18n/pl/site.json
+++ b/src/i18n/pl/site.json
@@ -43,10 +43,6 @@
     "message": "Kontakty pomocy",
     "description": "Field title for the customer-service contacts in site settings"
   },
-  "field.apiCode": {
-    "message": "Show \"View Code\"",
-    "description": "Site settings: toggle whether the per-generation 'View Code' button is shown to end users"
-  },
   "field.markupRatio": {
     "message": "Jednolity narzut dla całej witryny",
     "description": "Ustawienia witryny: procentowy narzut stosowany do wszystkich usług w tej witrynie."
@@ -470,10 +466,6 @@
   "message.contactsEmpty": {
     "message": "Nie ustawiono",
     "description": "Placeholder shown when no support contact has been filled in"
-  },
-  "message.apiCodeTip": {
-    "message": "When enabled, the 'View Code' button appears next to each generation so users can see the underlying API request. Hidden by default on white-label subsites.",
-    "description": "Help text for the View Code visibility toggle"
   },
   "message.keywordsTip": {
     "message": "Słowa kluczowe strony, znajdujące się w metadanych strony, używane do optymalizacji SEO.",

--- a/src/i18n/pt/site.json
+++ b/src/i18n/pt/site.json
@@ -43,10 +43,6 @@
     "message": "Contatos de suporte",
     "description": "Field title for the customer-service contacts in site settings"
   },
-  "field.apiCode": {
-    "message": "Show \"View Code\"",
-    "description": "Site settings: toggle whether the per-generation 'View Code' button is shown to end users"
-  },
   "field.markupRatio": {
     "message": "Acréscimo uniforme em todo o site",
     "description": "Configuração do site: proporção de aumento unificada para todos os pacotes de recarga deste site (percentagem)"
@@ -470,10 +466,6 @@
   "message.contactsEmpty": {
     "message": "Não definido",
     "description": "Placeholder shown when no support contact has been filled in"
-  },
-  "message.apiCodeTip": {
-    "message": "When enabled, the 'View Code' button appears next to each generation so users can see the underlying API request. Hidden by default on white-label subsites.",
-    "description": "Help text for the View Code visibility toggle"
   },
   "message.keywordsTip": {
     "message": "Palavras-chave do site, localizadas nas metainformações do site, usadas para otimização de SEO.",

--- a/src/i18n/ru/site.json
+++ b/src/i18n/ru/site.json
@@ -43,10 +43,6 @@
     "message": "Контакты поддержки",
     "description": "Field title for the customer-service contacts in site settings"
   },
-  "field.apiCode": {
-    "message": "Show \"View Code\"",
-    "description": "Site settings: toggle whether the per-generation 'View Code' button is shown to end users"
-  },
   "field.markupRatio": {
     "message": "Единая наценка для всего сайта",
     "description": "Настройки сайта: процент наценки для всех тарифных планов на пополнение на данном сайте (в процентах)"
@@ -470,10 +466,6 @@
   "message.contactsEmpty": {
     "message": "Не задано",
     "description": "Placeholder shown when no support contact has been filled in"
-  },
-  "message.apiCodeTip": {
-    "message": "When enabled, the 'View Code' button appears next to each generation so users can see the underlying API request. Hidden by default on white-label subsites.",
-    "description": "Help text for the View Code visibility toggle"
   },
   "message.keywordsTip": {
     "message": "Ключевые слова сайта, находятся в метаданных сайта, используются для SEO-оптимизации сайта.",

--- a/src/i18n/sr/site.json
+++ b/src/i18n/sr/site.json
@@ -43,10 +43,6 @@
     "message": "Контакти подршке",
     "description": "Field title for the customer-service contacts in site settings"
   },
-  "field.apiCode": {
-    "message": "Show \"View Code\"",
-    "description": "Site settings: toggle whether the per-generation 'View Code' button is shown to end users"
-  },
   "field.markupRatio": {
     "message": "Јединствено увећање цене за цео сајт",
     "description": "Podešavanje sajta: Proporcija povećanja za sve pakete dopune na ovom sajtu (procenat)"
@@ -470,10 +466,6 @@
   "message.contactsEmpty": {
     "message": "Није постављено",
     "description": "Placeholder shown when no support contact has been filled in"
-  },
-  "message.apiCodeTip": {
-    "message": "When enabled, the 'View Code' button appears next to each generation so users can see the underlying API request. Hidden by default on white-label subsites.",
-    "description": "Help text for the View Code visibility toggle"
   },
   "message.keywordsTip": {
     "message": "Кључне речи сајта, налазе се у мета информацијама сајта, користе се за SEO оптимизацију.",

--- a/src/i18n/sv/site.json
+++ b/src/i18n/sv/site.json
@@ -43,10 +43,6 @@
     "message": "Supportkontakter",
     "description": "Field title for the customer-service contacts in site settings"
   },
-  "field.apiCode": {
-    "message": "Show \"View Code\"",
-    "description": "Site settings: toggle whether the per-generation 'View Code' button is shown to end users"
-  },
   "field.markupRatio": {
     "message": "Enhetligt påslag för hela webbplatsen",
     "description": "Inställningar för webbplatsen: den enhetliga påslagsprocenten (i procent) för alla insättningspaket på denna webbplats."
@@ -470,10 +466,6 @@
   "message.contactsEmpty": {
     "message": "Inte angivet",
     "description": "Placeholder shown when no support contact has been filled in"
-  },
-  "message.apiCodeTip": {
-    "message": "When enabled, the 'View Code' button appears next to each generation so users can see the underlying API request. Hidden by default on white-label subsites.",
-    "description": "Help text for the View Code visibility toggle"
   },
   "message.keywordsTip": {
     "message": "Webbplatsens nyckelord, finns i webbplatsens metadata och används för SEO-optimering.",

--- a/src/i18n/uk/site.json
+++ b/src/i18n/uk/site.json
@@ -43,10 +43,6 @@
     "message": "Контакти підтримки",
     "description": "Field title for the customer-service contacts in site settings"
   },
-  "field.apiCode": {
-    "message": "Show \"View Code\"",
-    "description": "Site settings: toggle whether the per-generation 'View Code' button is shown to end users"
-  },
   "field.markupRatio": {
     "message": "Єдина націнка для всього сайту",
     "description": "Налаштування сайту: відсоток націнки для всіх пакетів поповнення на цьому сайті (у відсотках)"
@@ -470,10 +466,6 @@
   "message.contactsEmpty": {
     "message": "Не задано",
     "description": "Placeholder shown when no support contact has been filled in"
-  },
-  "message.apiCodeTip": {
-    "message": "When enabled, the 'View Code' button appears next to each generation so users can see the underlying API request. Hidden by default on white-label subsites.",
-    "description": "Help text for the View Code visibility toggle"
   },
   "message.keywordsTip": {
     "message": "Ключові слова сайту, розташовані у метаданих сайту, використовуються для SEO-оптимізації.",

--- a/src/i18n/zh-CN/site.json
+++ b/src/i18n/zh-CN/site.json
@@ -43,10 +43,6 @@
     "message": "客服联系方式",
     "description": "站点设置中『客服联系方式』的字段标题"
   },
-  "field.apiCode": {
-    "message": "显示『查看代码』",
-    "description": "站点设置：控制每次生成结果旁的『查看代码』按钮是否对用户展示"
-  },
   "field.markupRatio": {
     "message": "全站统一加价比例",
     "description": "站点设置：对本站所有充值套餐统一加价的比例（百分比）"
@@ -470,10 +466,6 @@
   "message.contactsEmpty": {
     "message": "暂未设置",
     "description": "未填写任何客服联系方式时的占位文案"
-  },
-  "message.apiCodeTip": {
-    "message": "开启后，每次生成结果旁会显示『查看代码』按钮，用户可查看对应的 API 请求。白标子站默认隐藏。",
-    "description": "『查看代码』显示开关的提示文案"
   },
   "message.keywordsTip": {
     "message": "站点关键词，位于站点元信息中，用于站点 SEO 优化。",

--- a/src/i18n/zh-TW/site.json
+++ b/src/i18n/zh-TW/site.json
@@ -43,10 +43,6 @@
     "message": "客服聯絡方式",
     "description": "Field title for the customer-service contacts in site settings"
   },
-  "field.apiCode": {
-    "message": "Show \"View Code\"",
-    "description": "Site settings: toggle whether the per-generation 'View Code' button is shown to end users"
-  },
   "field.markupRatio": {
     "message": "全站統一加價比例",
     "description": "站點設置：對本站所有充值套餐統一加價的比例（百分比）"
@@ -470,10 +466,6 @@
   "message.contactsEmpty": {
     "message": "尚未設定",
     "description": "Placeholder shown when no support contact has been filled in"
-  },
-  "message.apiCodeTip": {
-    "message": "When enabled, the 'View Code' button appears next to each generation so users can see the underlying API request. Hidden by default on white-label subsites.",
-    "description": "Help text for the View Code visibility toggle"
   },
   "message.keywordsTip": {
     "message": "站點關鍵詞，位於站點元信息中，用於站點 SEO 優化。",

--- a/src/models/site.ts
+++ b/src/models/site.ts
@@ -140,10 +140,6 @@ export interface ISiteBranding {
   company?: string;
   copyright?: string;
   hide_powered_by?: boolean;
-  // Tri-state for the "View Code" affordance: `true` force-hides, `false`
-  // force-shows (opt-in), unset defaults to shown on official hosts and
-  // hidden on white-label subsites. See `isApiCodeVisible` in `utils/site`.
-  hide_api_code?: boolean;
   links?: ISiteBrandingLinks;
   contacts?: ISiteContact[];
 }

--- a/src/utils/site.test.ts
+++ b/src/utils/site.test.ts
@@ -7,7 +7,6 @@ import {
   getApplicationCallerOrderDiscountRate,
   applyMarkup,
   isBrandingHidden,
-  isApiCodeVisible,
   getBrandSupportUrl,
   getBrandContacts,
   hasBrandContacts
@@ -146,32 +145,6 @@ describe('isBrandingHidden', () => {
     expect(isBrandingHidden({ branding: { hide_powered_by: true } } as never, 'powered_by')).toBe(true);
     expect(isBrandingHidden({ branding: { hide_powered_by: false } } as never, 'powered_by')).toBe(false);
     expect(isBrandingHidden({ branding: { hide_powered_by: 1 } } as never, 'powered_by')).toBe(false);
-  });
-});
-
-describe('isApiCodeVisible', () => {
-  it('defaults to the official flag when the site-config flag is unset', () => {
-    // Sub-sites (official=false) hide by default; the main site (official=true) shows.
-    expect(isApiCodeVisible(null, false)).toBe(false);
-    expect(isApiCodeVisible(undefined, true)).toBe(true);
-    expect(isApiCodeVisible({} as never, false)).toBe(false);
-    expect(isApiCodeVisible({ branding: {} } as never, true)).toBe(true);
-  });
-
-  it('force-hides on explicit true regardless of official', () => {
-    expect(isApiCodeVisible({ branding: { hide_api_code: true } } as never, true)).toBe(false);
-    expect(isApiCodeVisible({ branding: { hide_api_code: true } } as never, false)).toBe(false);
-  });
-
-  it('force-shows on explicit false (subsite opt-in) regardless of official', () => {
-    expect(isApiCodeVisible({ branding: { hide_api_code: false } } as never, false)).toBe(true);
-    expect(isApiCodeVisible({ branding: { hide_api_code: false } } as never, true)).toBe(true);
-  });
-
-  it('ignores truthy/falsy coercions and only honors real booleans', () => {
-    // A non-boolean flag falls through to the official default.
-    expect(isApiCodeVisible({ branding: { hide_api_code: 1 } } as never, false)).toBe(false);
-    expect(isApiCodeVisible({ branding: { hide_api_code: 0 } } as never, true)).toBe(true);
   });
 });
 

--- a/src/utils/site.ts
+++ b/src/utils/site.ts
@@ -76,23 +76,6 @@ export const isBrandingHidden = (site: ISite | null | undefined, key: 'powered_b
 };
 
 /**
- * Whether the per-generation "View Code" affordance (Nexior ApiCodeButton)
- * should render. ``branding.hide_api_code`` is a tri-state:
- *   - ``true``  → force-hidden (any site).
- *   - ``false`` → force-shown  (explicit site-config opt-in, e.g. a subsite).
- *   - unset     → default: shown on first-party official hosts, hidden on
- *     white-label subsites/tenants so they don't expose api.acedata.cloud.
- * ``official`` is injected so callers (and tests) stay independent of the
- * host-reading ``isOfficial()``.
- */
-export const isApiCodeVisible = (site: ISite | null | undefined, official: boolean): boolean => {
-  const flag = site?.branding?.hide_api_code;
-  if (flag === true) return false;
-  if (flag === false) return true;
-  return official;
-};
-
-/**
  * Resolve the reseller's support URL: `branding.links.support` first, then
  * the legacy `metadata.support_url`. Returns '' when neither is set so
  * callers can hide the entry instead of leaking our own domain.


### PR DESCRIPTION
## 背景

「查看代码 / View Code」入口会暴露 `api.acedata.cloud` 底层 API 请求。按最新要求，只在**主站官方域名**（`studio.acedata.cloud`，`isMainOfficial()`）展示，其余一律不显示——**不需要**站点配置开关。

## 改动

- `ApiCodeButton` + Suno / Producer 预览下拉的「查看代码」全部改为 `showViewCode = isMainOfficial()`。
- 移除上一版加的冗余逻辑：
  - `Site.vue` 里的站点配置开关（section + `el-switch` + `apiCodeVisible` computed + `onToggleApiCode` + `ElSwitch` 引入）。
  - `isApiCodeVisible` 辅助函数及其单测。
  - `ISiteBranding.hide_api_code` 字段与 tri-state 注释。
  - 全部 18 个语言的 `field.apiCode` / `message.apiCodeTip` 文案。

净变更 **+17 / −228**，纯收敛。

## 测试

- `vitest run src/utils/site.test.ts` — 25 通过。
- `vue-tsc -b --force` exit 0；eslint 干净；`check_i18n_coverage.py` 通过。

## 🤖 对抗评审

改动为纯删除 + 单点收敛（三处 `showViewCode` 统一为 `isMainOfficial()`），无新增分支逻辑。保留的 `apiCodeVisible` 仅是 Suno/Producer 里既有的**弹窗开合状态**（与本功能无关）。**VERDICT: CLEAN**
