### PR TITLE
refactor(design): adopt shared control adapter

### DIFF
--- a/change/@acedatacloud-nexior-p1-control-adapter.json
+++ b/change/@acedatacloud-nexior-p1-control-adapter.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Adopt the shared core control adapter and remove duplicate global control rules.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.327.3",
       "license": "MIT",
       "dependencies": {
-        "@acedatacloud/core": "^0.14.0",
+        "@acedatacloud/core": "^0.15.0",
         "@capacitor-community/apple-sign-in": "^7.1.0",
         "@capacitor-community/stripe": "^8.1.1",
         "@capacitor/app": "^8.0.1",
@@ -127,9 +127,9 @@
       }
     },
     "node_modules/@acedatacloud/core": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@acedatacloud/core/-/core-0.14.0.tgz",
-      "integrity": "sha512-ZaTg1yY1mGT2ZPSl6cr0AXRetATzdBbpUZWuXYic3VMooX2DkqEW8ES8Ram+GhP4j/Z8bmBLtdkjcNKtsckItQ==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@acedatacloud/core/-/core-0.15.0.tgz",
+      "integrity": "sha512-0upcnHzayfBE5O8ExWhh8spNpLPcebGNXcJ1pejK8p5TeNXP8OQRAErfEgy5F9aA9uBMwIlMc/T0P/bbSIDW+Q==",
       "license": "UNLICENSED",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "build:ssg": "cross-env VITE_SURFACE=web vite-ssg build"
   },
   "dependencies": {
-    "@acedatacloud/core": "^0.14.0",
+    "@acedatacloud/core": "^0.15.0",
     "@capacitor-community/apple-sign-in": "^7.1.0",
     "@capacitor-community/stripe": "^8.1.1",
     "@capacitor/app": "^8.0.1",

--- a/src/assets/scss/_common.scss
+++ b/src/assets/scss/_common.scss
@@ -100,6 +100,9 @@ html:root {
   /* Glow */
   --app-glow-primary: 0 0 20px rgba(var(--app-brand-rgb), 0.15);
   --app-glow-primary-lg: 0 0 40px rgba(var(--app-brand-rgb), 0.25);
+  --adc-control-card-border: 1px solid var(--app-glass-border);
+  --adc-control-card-shadow: var(--app-shadow-sm);
+  --adc-control-card-shadow-hover: var(--app-shadow-md);
 }
 
 html.surface-android {
@@ -158,25 +161,6 @@ w3m-modal {
   z-index: var(--adc-layer-third-party) !important;
 }
 
-html:root body
-  :where(
-    a[href],
-    button,
-    [role='button'],
-    input,
-    select,
-    textarea,
-    [tabindex]:not([tabindex='-1'])
-  ):not(.el-input__inner, .el-select__input, .el-textarea__inner):focus-visible {
-  outline: var(--adc-focus-outline-width) solid var(--adc-focus-outline-color);
-  outline-offset: var(--adc-focus-outline-offset);
-}
-
-.el-button:focus-visible {
-  outline: var(--adc-focus-outline-width) solid var(--adc-focus-outline-color);
-  outline-offset: var(--adc-focus-outline-offset);
-}
-
 #app {
   width: 100%;
   height: 100%;
@@ -210,37 +194,8 @@ html:root body
 }
 
 .el-button {
-  --el-button-size: var(--adc-control-height);
-  border-radius: var(--el-border-radius-round);
   font-weight: var(--adc-font-weight-medium);
   letter-spacing: var(--adc-letter-spacing);
-  transition:
-    color var(--adc-motion-duration-normal) var(--adc-motion-easing-standard),
-    background-color var(--adc-motion-duration-normal) var(--adc-motion-easing-standard),
-    border-color var(--adc-motion-duration-normal) var(--adc-motion-easing-standard),
-    box-shadow var(--adc-motion-duration-normal) var(--adc-motion-easing-standard);
-
-  &.el-button--small {
-    --el-button-size: var(--adc-control-height-sm);
-  }
-
-  &.el-button--large {
-    --el-button-size: var(--adc-control-height-lg);
-  }
-
-  &:not(.is-link, .is-text, .is-circle, .el-button--small, .el-button--large) {
-    height: var(--adc-control-height);
-  }
-
-  &.is-circle:not(.el-button--small, .el-button--large) {
-    width: var(--adc-control-height);
-    height: var(--adc-control-height);
-  }
-
-  &.is-link,
-  &.is-text {
-    height: auto;
-  }
 }
 
 // Drop the gradient (its 100% stop is `--el-color-primary-light-3`, which makes
@@ -331,26 +286,13 @@ html:root body
 }
 
 .el-card {
-  word-wrap: break-word;
-  border-radius: var(--adc-radius-card);
-  border: var(--adc-border-width) var(--adc-border-style) var(--app-glass-border);
   --el-card-padding: var(--adc-space-5);
-  box-shadow: none;
-  transition:
-    box-shadow var(--adc-motion-duration-normal) var(--adc-motion-easing-standard),
-    transform var(--adc-motion-duration-normal) var(--adc-motion-easing-standard);
+  transition: transform var(--adc-motion-duration-normal) var(--adc-motion-easing-standard);
   // Use the standard Element Plus card background (white in light mode) so
   // console panels (Applications / Orders / Top Up) read as clean white
   // surfaces instead of being tinted by the brand gradient. The dark-mode
   // override below restores the glass effect.
   background: var(--el-card-bg-color);
-  &.is-always-shadow {
-    box-shadow: var(--app-shadow-sm);
-  }
-
-  &.is-hover-shadow:hover {
-    box-shadow: var(--app-shadow-md);
-  }
 }
 
 html.dark .el-card {
@@ -379,35 +321,20 @@ html.dark .el-card {
 }
 
 .el-textarea {
-  border-radius: var(--adc-radius-control);
   .el-textarea__inner {
-    border-radius: var(--adc-radius-control);
     resize: none;
     box-shadow:
       0 0 0 1px var(--adc-color-border) inset,
       var(--app-shadow-xs);
-    transition: box-shadow var(--adc-motion-duration-normal) var(--adc-motion-easing-standard);
-    &:focus {
-      box-shadow:
-        0 0 0 1px var(--el-color-primary) inset,
-        0 0 0 var(--adc-focus-ring-width) var(--adc-focus-ring-color);
-    }
   }
 }
 
 .el-input {
   .el-input__wrapper {
-    border-radius: var(--el-border-radius-base);
     width: 100%;
     box-shadow:
       0 0 0 1px var(--adc-color-border) inset,
       var(--app-shadow-xs);
-    transition: box-shadow var(--adc-motion-duration-normal) var(--adc-motion-easing-standard);
-    &.is-focus {
-      box-shadow:
-        0 0 0 1px var(--el-color-primary) inset,
-        0 0 0 var(--adc-focus-ring-width) var(--adc-focus-ring-color);
-    }
     textarea:focus,
     input:focus {
       outline: none;
@@ -416,7 +343,6 @@ html.dark .el-card {
 }
 
 .el-dialog {
-  --el-dialog-border-radius: var(--adc-radius-dialog);
   .el-dialog__body {
     color: var(--el-text-color-primary);
   }
@@ -478,10 +404,6 @@ html.dark .el-dialog {
   }
 }
 
-.el-message-box {
-  --el-messagebox-border-radius: 1.25rem;
-}
-
 .el-tabs--border-card {
   border-radius: 1rem;
   overflow: hidden;
@@ -497,17 +419,10 @@ html.dark .el-dialog {
 
 .el-select {
   .el-select__wrapper {
-    border-radius: var(--el-border-radius-base);
     width: 100%;
     box-shadow:
       0 0 0 1px var(--el-border-color) inset,
       var(--app-shadow-xs);
-    transition: box-shadow 0.2s ease;
-    &.is-focused {
-      box-shadow:
-        0 0 0 1px var(--el-color-primary) inset,
-        0 0 0 3px var(--el-color-primary-light-8);
-    }
   }
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ import { initTelemetry, setUser, captureError } from './plugins/telemetry';
 import '@acedatacloud/core/styles.css';
 import './assets/scss/style.scss';
 import './assets/css/tailwind.css';
+import '@acedatacloud/core/controls.css';
 import 'mac-scrollbar/dist/mac-scrollbar.css';
 import dayjs from './plugins/dayjs';
 import './plugins/font-awesome';


### PR DESCRIPTION
## Summary
- upgrade core to 0.15.0 and load `controls.css` after app and Tailwind styles
- delete 94 lines of duplicated global control SCSS
- retain Nexior primary glow, dark glass, card hooks, textarea resize, and mobile dialog/drawer layout

## Validation
- full repository ESLint after the separate main lint fix
- Node 22 vue-tsc, Web build, and SSG build
- Beachball patch validation
- shared fixture covers sizes/variants/errors/Select/card/MessageBox states

Local site initialization still redirects anonymous pages to SSO, so authenticated rendered-page review remains required.

## Adversarial review
- `VERDICT: CLEAN`