### PR TITLE
fix(auth): float native/desktop login popup over the app

### DIFF
--- a/change/@acedatacloud-nexior-native-login-floating-modal.json
+++ b/change/@acedatacloud-nexior-native-login-floating-modal.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(auth): present native/desktop login as a floating popup over the app instead of a full-screen page",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/common/AuthPanel.vue
+++ b/src/components/common/AuthPanel.vue
@@ -1,14 +1,22 @@
 <template>
-  <div v-if="isInAppLogin" class="auth-native">
-    <div v-if="useBrowser" class="auth-native__loading">
-      <p>{{ $t('common.status.loading') }}</p>
-    </div>
-    <iframe v-else ref="iframe" class="auth-native__iframe" :src="iframeUrl" frameborder="0" referrerpolicy="origin" />
-  </div>
-  <div v-else class="auth-frame-modal" role="dialog" aria-modal="true">
+  <!-- Every surface (web iframe mode, native, desktop) renders the same
+       floating popup: a centered card over a dimmed/blurred backdrop so the
+       chat page stays visible behind it. `isInAppLogin` still drives the
+       functional differences (URL params, in-app OAuth) below. -->
+  <div class="auth-frame-modal" role="dialog" aria-modal="true">
     <div class="auth-frame-modal__panel">
       <button class="auth-frame-modal__close" type="button" aria-label="Close" @click="closeWebLogin">×</button>
-      <iframe ref="iframe" class="auth-frame-modal__iframe" :src="iframeUrl" frameborder="0" referrerpolicy="origin" />
+      <div v-if="useBrowser" class="auth-frame-modal__loading">
+        <p>{{ $t('common.status.loading') }}</p>
+      </div>
+      <iframe
+        v-else
+        ref="iframe"
+        class="auth-frame-modal__iframe"
+        :src="iframeUrl"
+        frameborder="0"
+        referrerpolicy="origin"
+      />
     </div>
   </div>
   <el-dialog v-model="showQR" width="400px" :show-close="true">
@@ -305,13 +313,15 @@ export default defineComponent({
   z-index: 9999;
   display: grid;
   place-items: center;
+  // Keep the card clear of the notch / home indicator on native devices.
+  padding: max(12px, env(safe-area-inset-top)) 12px max(12px, env(safe-area-inset-bottom));
   background: rgba(15, 23, 42, 0.62);
   backdrop-filter: blur(8px);
 
   &__panel {
     position: relative;
     width: min(400px, calc(100vw - 24px));
-    height: min(720px, calc(100vh - 24px));
+    height: min(720px, 100%);
   }
 
   &__iframe {
@@ -321,6 +331,23 @@ export default defineComponent({
     border-radius: 18px;
     background: transparent;
     box-shadow: 0 24px 80px rgba(15, 23, 42, 0.28);
+  }
+
+  &__loading {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    border-radius: 18px;
+    background: #ffffff;
+    color: #666;
+    font-size: 16px;
+
+    @media (prefers-color-scheme: dark) {
+      background: #1a1a1a;
+      color: #bbb;
+    }
   }
 
   &__close {
@@ -337,34 +364,6 @@ export default defineComponent({
     font-size: 24px;
     line-height: 32px;
     cursor: pointer;
-  }
-}
-
-.auth-native {
-  position: fixed;
-  inset: 0;
-  z-index: 9999;
-  background: #ffffff;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-
-  &__iframe {
-    width: 100%;
-    height: 100%;
-    border: none;
-  }
-
-  &__loading {
-    text-align: center;
-    color: #666;
-    font-size: 16px;
-  }
-}
-
-@media (prefers-color-scheme: dark) {
-  .auth-native {
-    background: #1a1a1a;
   }
 }
 </style>


### PR DESCRIPTION
## 背景

iOS / Android / Windows / macOS 上，内嵌的 AuthFrontend 登录 iframe 之前用 `.auth-native` 渲染 —— **不透明的全屏白页**，盖住整个 app，看不到背后的 chat 页面。用户反馈「感觉像跳出了 app」，不够友好。

Web 端的 `iframe` 登录模式早就用的是 `.auth-frame-modal`：**居中浮窗卡片 + 半透明模糊背景**，背后页面可见，右上角带关闭按钮。

## 改动

让 native / desktop 也复用 `.auth-frame-modal` 这个浮窗样式，四端登录呈现统一：

- 居中卡片，四周留白，圆角 + 阴影
- 半透明模糊背景，背后 chat 页面可见
- 右上角关闭按钮（配合已启用的 guest browsing，登录可关闭）
- `useBrowser` 加载态（native 点第三方登录、in-app 浏览器打开时）移入卡片内
- 移动端加了 `env(safe-area-inset-*)` 内边距，避开刘海 / home 指示条

`isInAppLogin` 计算属性**保留**，继续负责功能差异（iframe URL 参数、native OAuth 的 postMessage 处理），只有**呈现层**变了。删除了不再使用的 `.auth-native` 样式。

## 验证

- `vue-tsc -b --force`（CI 类型检查门禁）通过
- `eslint` 通过
- `vitest run`：389 tests passed
- 无任何测试 / 代码残留引用 `.auth-native`

## 🤖 对抗评审

独立评审（subagent）逐项核对 5 个风险点，结论 **VERDICT: CLEAN**：

1. **postMessage 握手的 `$refs.iframe`** — iframe 仅在 `useBrowser===true`（native OAuth、握手已完成后）才卸载，后续走 Capacitor Browser + deep link（App.vue `exchangeSsoCode`），不依赖 iframe postMessage；消息监听有 `iframe?.contentWindow` 可选链兜底。与旧 `.auth-native` 挂载语义一致，无回归。
2. **新增关闭按钮是否造成强制登录被困** — 路由守卫在打开弹窗时已把 guest 导向安全页，可关闭符合 guest-browsing 语义；OAuth 回调在 App.vue，中途关闭不影响 token 交换。
3. **CSS** — `padding` 三值简写合法，`height: min(720px,100%)` 在桌面等价旧 `calc(100vh-24px)`，移动端正确收缩避让安全区。
4. **无 `.auth-native` 残留引用**（grep 全仓库为空）。
5. **beachball change file** 格式正确。

评审附带一个**既有**（非本 PR 引入）提示：`mounted` 的 `message` 监听未在 `beforeUnmount` 移除，反复开关面板会泄漏监听器 —— 属既有问题、超出本 PR 范围，留作后续跟进。
