### PR TITLE
feat: adopt semantic icons in scheduled tasks

### DIFF
--- a/change/@acedatacloud-nexior-p2-icon-wave-1.json
+++ b/change/@acedatacloud-nexior-p2-icon-wave-1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Migrate scheduled-task actions to the shared semantic Lucide icon entries.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.327.6",
       "license": "MIT",
       "dependencies": {
-        "@acedatacloud/core": "^0.15.0",
+        "@acedatacloud/core": "^0.16.0",
         "@capacitor-community/apple-sign-in": "^7.1.0",
         "@capacitor-community/stripe": "^8.1.1",
         "@capacitor/app": "^8.0.1",
@@ -31,6 +31,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.2.1",
         "@fortawesome/vue-fontawesome": "^3.0.2",
         "@icon-park/vue-next": "^1.3.6",
+        "@lucide/vue": "1.23.0",
         "@mdit/plugin-katex": "^0.23.1",
         "@skjnldsv/vue-plyr": "^7.5.0",
         "@solana/wallet-adapter-base": "^0.9.27",
@@ -127,14 +128,15 @@
       }
     },
     "node_modules/@acedatacloud/core": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@acedatacloud/core/-/core-0.15.0.tgz",
-      "integrity": "sha512-0upcnHzayfBE5O8ExWhh8spNpLPcebGNXcJ1pejK8p5TeNXP8OQRAErfEgy5F9aA9uBMwIlMc/T0P/bbSIDW+Q==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@acedatacloud/core/-/core-0.16.0.tgz",
+      "integrity": "sha512-V7KDz7DYrbshUiVg5Q/e8VBH//1pTUtXwNHFlRVP2MWUJejnT0fjx1sXrc0J3n+1vQm5wvomyjCSu4LaQzBkYA==",
       "license": "UNLICENSED",
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
+        "@lucide/vue": ">=1.23.0 <2",
         "aegis-web-sdk": "*",
         "axios": ">=1.0.0 <2",
         "element-plus": ">=2.10.4 <3",
@@ -2978,6 +2980,15 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
+    "node_modules/@lucide/vue": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@lucide/vue/-/vue-1.23.0.tgz",
+      "integrity": "sha512-9SIYeY5K+R1iv8F8JUKMGSL7Pck/86BJ8djtZz/lnYsoHtKFUj1H2z6+PvKnC/8blZ8tqTDeDXAoTKobuX80hg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "vue": ">=3.0.1"
       }
     },
     "node_modules/@malept/cross-spawn-promise": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "build:ssg": "cross-env VITE_SURFACE=web vite-ssg build"
   },
   "dependencies": {
-    "@acedatacloud/core": "^0.15.0",
+    "@acedatacloud/core": "^0.16.0",
     "@capacitor-community/apple-sign-in": "^7.1.0",
     "@capacitor-community/stripe": "^8.1.1",
     "@capacitor/app": "^8.0.1",
@@ -63,6 +63,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.2.1",
     "@fortawesome/vue-fontawesome": "^3.0.2",
     "@icon-park/vue-next": "^1.3.6",
+    "@lucide/vue": "1.23.0",
     "@mdit/plugin-katex": "^0.23.1",
     "@skjnldsv/vue-plyr": "^7.5.0",
     "@solana/wallet-adapter-base": "^0.9.27",

--- a/src/pages/chat/ScheduledTasks.vue
+++ b/src/pages/chat/ScheduledTasks.vue
@@ -4,7 +4,7 @@
       <div class="header">
         <h2 class="title">{{ $t('chat.scheduledTasks.title') }}</h2>
         <el-button type="primary" round :disabled="saving" @click="openCreate">
-          <font-awesome-icon icon="fa-solid fa-plus" class="icon" />
+          <add-icon :size="16" class="icon" aria-hidden="true" />
           {{ $t('chat.scheduledTasks.create') }}
         </el-button>
       </div>
@@ -29,13 +29,19 @@
                   </el-button>
                 </el-tooltip>
                 <el-tooltip :content="$t('common.button.edit')" placement="top">
-                  <el-button text class="icon-action" @click="openEdit(task)">
-                    <font-awesome-icon icon="fa-solid fa-pen" />
+                  <el-button text class="icon-action" :aria-label="$t('common.button.edit')" @click="openEdit(task)">
+                    <edit-icon :size="16" aria-hidden="true" />
                   </el-button>
                 </el-tooltip>
                 <el-tooltip :content="$t('common.button.delete')" placement="top">
-                  <el-button text type="danger" class="icon-action" @click="confirmDelete(task)">
-                    <font-awesome-icon icon="fa-solid fa-trash" />
+                  <el-button
+                    text
+                    type="danger"
+                    class="icon-action"
+                    :aria-label="$t('common.button.delete')"
+                    @click="confirmDelete(task)"
+                  >
+                    <delete-icon :size="16" aria-hidden="true" />
                   </el-button>
                 </el-tooltip>
               </div>
@@ -59,7 +65,7 @@
             </div>
             <div class="task-footer">
               <span class="run-count">
-                <font-awesome-icon icon="fa-solid fa-arrows-rotate" class="footer-icon" />
+                <refresh-icon :size="16" class="footer-icon" aria-hidden="true" />
                 {{ $t('chat.scheduledTasks.runCount', { count: task.run_count }) }}
               </span>
               <span v-if="task.last_error" class="error-hint">{{ task.last_error }}</span>
@@ -313,6 +319,10 @@ import {
   ElMessageBox
 } from 'element-plus';
 import { Pagination } from '@acedatacloud/core/components';
+import { AddIcon } from '@acedatacloud/core/icons/add';
+import { DeleteIcon } from '@acedatacloud/core/icons/delete';
+import { EditIcon } from '@acedatacloud/core/icons/edit';
+import { RefreshIcon } from '@acedatacloud/core/icons/refresh';
 import {
   scheduledTasksOperator,
   IScheduledTask,
@@ -353,6 +363,10 @@ export default defineComponent({
   name: 'ScheduledTasks',
   components: {
     FontAwesomeIcon,
+    AddIcon,
+    DeleteIcon,
+    EditIcon,
+    RefreshIcon,
     ElButton,
     ElCard,
     ElSkeleton,


### PR DESCRIPTION
## Summary

- upgrade `@acedatacloud/core` to `^0.16.0` and pin `@lucide/vue` to `1.23.0`
- migrate four static Scheduled Tasks actions to explicit semantic icon subpaths: add, edit, delete, and refresh
- keep play, clock, brain, chevron, dynamic, and brand icons on Font Awesome until their semantics enter a reviewed wave
- add the required Beachball change file

## Accessibility

- mark decorative Lucide SVGs hidden from assistive technology
- preserve localized labels on the edit and delete icon-only controls

## Validation

- ESLint (`src`)
- `vue-tsc -b`
- Vite Web build
- Vite SSG build
- `beachball check --no-fetch`
- `git diff --check`

## 🤖 对抗评审

Reviewed semantic mapping, mixed Font Awesome/Lucide registration, accessibility, SSR/SSG behavior, dependency resolution, lockfile integrity, and the scoped migration boundary.

`VERDICT: CLEAN`