### PR TITLE
fix(nexior): pin @acedatacloud scope to public npmjs registry

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -8,3 +8,10 @@
 # CI, Docker, Cloudflare Pages — without needing a `--legacy-peer-deps` flag at
 # every call site.
 legacy-peer-deps=true
+
+# Always resolve @acedatacloud/* from public npmjs. Some contributor machines
+# default their global registry to a corporate mirror/proxy that lags behind and
+# can't serve newly published core versions (e.g. controls.css was missing when a
+# stale mirror only had an old core), leaving Element Plus controls unstyled.
+@acedatacloud:registry=https://registry.npmjs.org/
+

--- a/change/@acedatacloud-nexior-npmrc-scope.json
+++ b/change/@acedatacloud-nexior-npmrc-scope.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Pin @acedatacloud scope to public npmjs so proxied registries can't serve a stale core (missing controls.css)",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
## 问题

近期迁移到共享库 `@acedatacloud/core` 后，部分贡献者本地的 Element Plus 控件（`el-input` / `el-select` / `el-button`）尺寸互相对不上、也和官方默认不一致。

## 根因

`main.ts` 依赖 `@acedatacloud/core/controls.css`（v0.14 的 control adapter 起才有）来统一控件尺寸。但当贡献者机器的**全局 npm registry 指向了滞后的公司代理/镜像**时，该代理没有镜像新发布的 core 版本（本机代理 `npm view` 只能看到旧版），`npm install` 拿不到 lockfile 锁定的 `0.16.0`，node_modules 卡在旧版 → `controls.css` 缺失 → 控件回退成未规范化的尺寸。

CI 与直连 npmjs 的环境不受影响（这也是构建一直通过的原因），纯粹是被代理 registry 的机器踩坑。

## 改动

`.npmrc` 增加一行，把 `@acedatacloud/*` 这个 scope 固定走公共 npmjs：

```
@acedatacloud:registry=https://registry.npmjs.org/
```

`@acedatacloud/core` 是公开发布在 npmjs 上的（latest = 0.16.0），因此把该 scope 锁到公共源是规范做法，不改变 CI/Docker/Cloudflare 行为（它们本就走 npmjs）。

> 注：已装成旧版的机器仍需重装一次 core 才能立即生效；本改动保证之后的 install 不再退回旧版。

## 🤖 对抗评审

单行 registry scope 配置，无代码、无逻辑、无安全面（只把公开包锁到公开源）。**VERDICT: CLEAN**
