### PR TITLE
fix(chat): remove square focus outline on composer textarea

### DIFF
--- a/change/@acedatacloud-nexior-chat-composer-focus-outline.json
+++ b/change/@acedatacloud-nexior-chat-composer-focus-outline.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(chat): remove square focus outline on the composer textarea (shared-adapter :focus-visible rule)",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/chat/Composer.vue
+++ b/src/components/chat/Composer.vue
@@ -387,7 +387,11 @@ textarea.input {
   font-family: var(--el-font-family);
   padding-top: 6px;
 }
-textarea.input:focus {
+/* The composer wrapper shows focus via its own :focus-within border, so the
+   native textarea must not also get the shared-adapter :focus-visible outline
+   (@acedatacloud/core controls.css). Match html:root body to beat its specificity. */
+html:root body textarea.input:focus,
+html:root body textarea.input:focus-visible {
   outline: none;
 }
 .composer {


### PR DESCRIPTION
## Problem

The chat composer input box showed an ugly 2px square **focus outline** (`solid #277186`) whenever it was focused — regression visible on production (`studio.acedata.cloud/chatgpt/conversations`).

## Root cause

The shared control adapter `@acedatacloud/core/src/controls.css` (adopted in #1283) applies a global `:focus-visible` outline:

```css
html:root body :where(a[href], button, [role='button'], input, select, textarea, [tabindex]:not([tabindex='-1']))
  :not(.el-input__inner, .el-select__input, .el-select__wrapper, .el-textarea__inner):focus-visible { outline: ... }
```

It only excludes **Element Plus** input internals. The chat composer uses a **raw `<textarea class="input">`**, so it isn't excluded and gets the outline. The composer's own `textarea.input:focus { outline: none }` (specificity `0,2,1`, `:focus`) loses to the adapter rule (`0,2,2`, `:focus-visible`).

## Fix

Cancel the outline for the composer textarea with an `html:root body` override (specificity `0,2,3` > `0,2,2`). The composer wrapper already shows focus via its `:focus-within` border, so keyboard focus stays visible — no a11y regression.

Verified on the live page by injecting the rule: computed `outline` went from `solid 2px rgb(39,113,134)` → `none`.

## 🤖 对抗评审

Single-file, Nexior-scoped CSS override; behavior confirmed live; wrapper retains a `:focus-within` focus affordance so a11y is preserved. Root cause (adapter not excluding native text inputs) noted for a possible future `@acedatacloud/core` improvement, but the Nexior-owned composer is correctly fixed here. **VERDICT: CLEAN**
