### PR TITLE
fix(nexior): use Element Plus native control sizes

### DIFF
--- a/change/@acedatacloud-nexior-native-control-size.json
+++ b/change/@acedatacloud-nexior-native-control-size.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Use Element Plus native control sizes (drop --el-component-size override) so el-input/el-select/el-button align",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.327.10",
       "license": "MIT",
       "dependencies": {
-        "@acedatacloud/core": "^0.16.0",
+        "@acedatacloud/core": "^0.17.0",
         "@capacitor-community/apple-sign-in": "^7.1.0",
         "@capacitor-community/stripe": "^8.1.1",
         "@capacitor/app": "^8.0.1",
@@ -128,9 +128,9 @@
       }
     },
     "node_modules/@acedatacloud/core": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@acedatacloud/core/-/core-0.16.0.tgz",
-      "integrity": "sha512-V7KDz7DYrbshUiVg5Q/e8VBH//1pTUtXwNHFlRVP2MWUJejnT0fjx1sXrc0J3n+1vQm5wvomyjCSu4LaQzBkYA==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@acedatacloud/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-QHMd3fx5UM32wsdCFCh+nQpZV+17JC0wJSZvznYDIipycWsqki/FCNI5P74KJFRi9Qsc+LMfwO+L91sfSryT+Q==",
       "license": "UNLICENSED",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "build:ssg": "cross-env VITE_SURFACE=web vite-ssg build"
   },
   "dependencies": {
-    "@acedatacloud/core": "^0.16.0",
+    "@acedatacloud/core": "^0.17.0",
     "@capacitor-community/apple-sign-in": "^7.1.0",
     "@capacitor-community/stripe": "^8.1.1",
     "@capacitor/app": "^8.0.1",

--- a/src/assets/scss/_common.scss
+++ b/src/assets/scss/_common.scss
@@ -46,9 +46,6 @@ html:root {
   --el-border-radius-base: var(--adc-radius-control);
   --el-border-radius-small: var(--adc-radius-small);
   --el-border-radius-round: var(--adc-radius-full);
-  --el-component-size-small: var(--adc-control-height-sm);
-  --el-component-size: var(--adc-control-height);
-  --el-component-size-large: var(--adc-control-height-lg);
 
   --app-safe-area-top: env(safe-area-inset-top, 0px);
   --app-safe-area-bottom: env(safe-area-inset-bottom, 0px);


### PR DESCRIPTION
## 问题（P0）

settings 弹窗等处 Element Plus 控件尺寸不一致：`el-input`/`el-button`=40px 但 `el-select`=32px。

## 根因

本 App 的 `_common.scss` 把 `--el-component-size` 映射成 `--adc-control-height`(40/32/48)，比 EP 原生(32/24/40)大一档。input/button 跟着变 40，但 `el-select__wrapper` 用 EP 写死的 min-height（不读该变量），停在 32 → 错乱。

## 改动

- 删除 `_common.scss` 里的 `--el-component-size* : var(--adc-control-height*)` 覆盖 → 控件回到 Element Plus 原生尺寸，input/select/button 全部一致（保留 `--el-border-radius-*` 圆角与颜色 token）。
- `@acedatacloud/core` 依赖提到 `^0.17.0`（core 同步删除了 button 的尺寸覆盖，见 CommonFrontend#22）。

尺寸完全交回 Element Plus；适配器只保留 border-radius + 颜色 + focus。

## 对抗评审

纯删除尺寸覆盖 + 依赖 bump，回归 EP 原生尺寸，无逻辑变更。VERDICT: CLEAN
