### PR TITLE
Show durable browser execution states

### DIFF
--- a/change/@acedatacloud-nexior-browser-execution-status.json
+++ b/change/@acedatacloud-nexior-browser-execution-status.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Show durable BrowserDevice execution states in chat and scheduled task history.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/chat/BrowserToolActivity.test.ts
+++ b/src/components/chat/BrowserToolActivity.test.ts
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import type { IBrowserToolExecutionState, IChatMessageContentItem } from '@/models';
+import BrowserToolActivity from './BrowserToolActivity.vue';
+
+const STATES: IBrowserToolExecutionState[] = [
+  'choose_device',
+  'device_offline',
+  'awaiting_device',
+  'awaiting_local_approval',
+  'takeover_required',
+  'executing',
+  'completed',
+  'denied',
+  'expired',
+  'cancel_too_late'
+];
+
+function mountActivity(item: IChatMessageContentItem) {
+  return mount(BrowserToolActivity, {
+    props: { item },
+    global: {
+      mocks: { $t: (key: string) => key },
+      stubs: { FontAwesomeIcon: true }
+    }
+  });
+}
+
+describe('BrowserToolActivity', () => {
+  it.each(STATES)('renders durable state %s without cloud approval controls', (executionState) => {
+    const wrapper = mountActivity({
+      type: 'tool_use',
+      execution: 'browser',
+      execution_state: executionState,
+      tool_display_name: 'Read browser tab'
+    });
+
+    expect(wrapper.text()).toContain(`chat.browserTool.state.${executionState}`);
+    expect(wrapper.find('button').exists()).toBe(false);
+    expect(wrapper.emitted()).toEqual({});
+  });
+
+  it('shows only the sanitized origin from persisted content', () => {
+    const wrapper = mountActivity({
+      type: 'tool_use',
+      execution: 'browser',
+      execution_state: 'executing',
+      origin: 'https://user:secret@example.com/private?token=hidden#fragment'
+    });
+
+    expect(wrapper.text()).toContain('https://example.com');
+    expect(wrapper.text()).not.toContain('secret');
+    expect(wrapper.text()).not.toContain('private');
+  });
+});

--- a/src/components/chat/BrowserToolActivity.vue
+++ b/src/components/chat/BrowserToolActivity.vue
@@ -1,0 +1,109 @@
+<template>
+  <div :class="['browser-tool-activity', `state-${state}`]" role="status" aria-live="polite">
+    <div class="activity-icon" aria-hidden="true">
+      <font-awesome-icon :icon="icon" :spin="state === 'executing'" />
+    </div>
+    <div class="activity-copy">
+      <div class="activity-title">{{ title }}</div>
+      <div class="activity-status">{{ $t(`chat.browserTool.state.${state}`) }}</div>
+      <div v-if="origin" class="activity-origin">{{ origin }}</div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, type PropType } from 'vue';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import type { IBrowserToolExecutionState, IChatMessageContentItem } from '@/models';
+import { isBrowserToolExecutionState, sanitizeBrowserOrigin } from '@/utils/browserToolExecution';
+
+const TERMINAL_STATES = new Set<IBrowserToolExecutionState>(['completed', 'denied', 'expired', 'cancel_too_late']);
+
+export default defineComponent({
+  name: 'BrowserToolActivity',
+  components: { FontAwesomeIcon },
+  props: {
+    item: {
+      type: Object as PropType<IChatMessageContentItem>,
+      required: true
+    }
+  },
+  computed: {
+    state(): IBrowserToolExecutionState {
+      return isBrowserToolExecutionState(this.item.execution_state) ? this.item.execution_state : 'awaiting_device';
+    },
+    title(): string {
+      return (
+        this.item.tool_display_name ||
+        this.item.tool_name?.replace(/_/g, ' ') ||
+        (this.$t('chat.browserTool.title') as string)
+      );
+    },
+    origin(): string | undefined {
+      return sanitizeBrowserOrigin(this.item.origin);
+    },
+    icon(): string {
+      if (this.state === 'completed') return 'fa-solid fa-check';
+      if (this.state === 'denied' || this.state === 'expired') return 'fa-solid fa-xmark';
+      if (this.state === 'executing') return 'fa-solid fa-spinner';
+      if (TERMINAL_STATES.has(this.state)) return 'fa-solid fa-triangle-exclamation';
+      return 'fa-solid fa-globe';
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.browser-tool-activity {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  margin: 8px 0;
+  padding: 10px 12px;
+  border: 1px solid var(--el-border-color-lighter);
+  border-radius: 8px;
+  background: var(--el-fill-color-light);
+  color: var(--el-text-color-primary);
+
+  &.state-completed {
+    border-color: var(--el-color-success-light-5);
+  }
+
+  &.state-denied,
+  &.state-expired {
+    border-color: var(--el-color-danger-light-5);
+  }
+}
+
+.activity-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  margin-top: 1px;
+  color: var(--el-text-color-secondary);
+}
+
+.activity-copy {
+  min-width: 0;
+}
+
+.activity-title {
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.4;
+}
+
+.activity-status,
+.activity-origin {
+  margin-top: 2px;
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--el-text-color-secondary);
+}
+
+.activity-origin {
+  overflow-wrap: anywhere;
+}
+</style>

--- a/src/components/chat/Message.browserTool.test.ts
+++ b/src/components/chat/Message.browserTool.test.ts
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+import { shallowMount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import { IChatMessageState } from '@/models';
+import Message from './Message.vue';
+
+describe('Message browser tool rendering', () => {
+  it('uses the read-only browser activity instead of generic tool output', () => {
+    const wrapper = shallowMount(Message, {
+      props: {
+        application: {},
+        message: {
+          role: 'assistant',
+          state: IChatMessageState.ANSWERING,
+          content: [
+            {
+              type: 'tool_use',
+              tool_id: 'browser-call-1',
+              tool_name: 'browser_read',
+              execution: 'browser',
+              execution_state: 'awaiting_local_approval'
+            }
+          ]
+        }
+      },
+      global: {
+        mocks: {
+          $t: (key: string) => key,
+          $store: { state: { chat: {} }, getters: { site: {} } }
+        },
+        directives: { motion: () => undefined }
+      }
+    });
+
+    expect(wrapper.findComponent({ name: 'BrowserToolActivity' }).exists()).toBe(true);
+    expect(wrapper.findComponent({ name: 'ToolActivity' }).exists()).toBe(false);
+  });
+});

--- a/src/components/chat/Message.vue
+++ b/src/components/chat/Message.vue
@@ -63,6 +63,7 @@
               <tool-activity
                 v-if="
                   item.type === 'tool_use' &&
+                  item.execution !== 'browser' &&
                   !(
                     item.tool_name === 'ask_user_question' &&
                     (item.status === 'awaiting_input' || item.status === 'done')
@@ -74,6 +75,7 @@
                 "
                 :item="item"
               />
+              <browser-tool-activity v-if="item.type === 'tool_use' && item.execution === 'browser'" :item="item" />
               <ask-user-question-card
                 v-if="
                   item.type === 'tool_use' &&
@@ -201,6 +203,7 @@ import RestartToGenerate from './RestartToGenerate.vue';
 import EditMessage from './EditMessage.vue';
 import FilePreview from '@/components/common/FilePreview.vue';
 import ToolActivity from './ToolActivity.vue';
+import BrowserToolActivity from './BrowserToolActivity.vue';
 import EntityCard from './EntityCard.vue';
 import ThinkingBlock from './ThinkingBlock.vue';
 import AskUserQuestionCard from './AskUserQuestionCard.vue';
@@ -238,6 +241,7 @@ export default defineComponent({
     MarkdownRenderer,
     FilePreview,
     ToolActivity,
+    BrowserToolActivity,
     EntityCard,
     ThinkingBlock,
     AskUserQuestionCard,

--- a/src/components/site/EditContacts.vue
+++ b/src/components/site/EditContacts.vue
@@ -19,11 +19,7 @@
             {{ $t('common.button.delete') }}
           </el-button>
         </div>
-        <el-input
-          v-model="row.label"
-          class="row-field"
-          :placeholder="$t('common.settings.contactLabelPlaceholder')"
-        />
+        <el-input v-model="row.label" class="row-field" :placeholder="$t('common.settings.contactLabelPlaceholder')" />
         <el-input v-model="row.value" class="row-field" :placeholder="valuePlaceholder(row.type)" />
         <el-input v-model="row.url" class="row-field" placeholder="https://..." />
         <div class="qr-row">
@@ -43,9 +39,7 @@
         </div>
       </div>
     </div>
-    <el-button class="add-btn" :icon="Plus" @click="addRow">{{
-      $t('common.settings.contactAdd')
-    }}</el-button>
+    <el-button class="add-btn" :icon="Plus" @click="addRow">{{ $t('common.settings.contactAdd') }}</el-button>
     <template #footer>
       <span class="dialog-footer">
         <el-button round @click="onCancel">{{ $t('common.button.cancel') }}</el-button>

--- a/src/i18n/ar/chat.json
+++ b/src/i18n/ar/chat.json
@@ -1048,5 +1048,42 @@
   },
   "scheduledTasks.run.reason.billing_gate_failed": {
     "message": "فشل تفويض الفوترة"
+  },
+  "browserTool.title": {
+    "message": "Browser activity",
+    "description": "Fallback title for a BrowserDevice tool activity"
+  },
+  "browserTool.state.choose_device": {
+    "message": "Choose a browser device"
+  },
+  "browserTool.state.device_offline": {
+    "message": "Browser device is offline"
+  },
+  "browserTool.state.awaiting_device": {
+    "message": "Waiting for browser device"
+  },
+  "browserTool.state.awaiting_local_approval": {
+    "message": "Waiting for approval on the browser device"
+  },
+  "browserTool.state.takeover_required": {
+    "message": "Take over on the browser device"
+  },
+  "browserTool.state.executing": {
+    "message": "Executing in browser"
+  },
+  "browserTool.state.completed": {
+    "message": "Completed"
+  },
+  "browserTool.state.denied": {
+    "message": "Denied on the browser device"
+  },
+  "browserTool.state.expired": {
+    "message": "Browser request expired"
+  },
+  "browserTool.state.cancel_too_late": {
+    "message": "Too late to cancel"
+  },
+  "scheduledTasks.run.waiting_for_device": {
+    "message": "Waiting for browser device"
   }
 }

--- a/src/i18n/de/chat.json
+++ b/src/i18n/de/chat.json
@@ -1048,5 +1048,42 @@
   },
   "scheduledTasks.run.reason.billing_gate_failed": {
     "message": "Autorisierung der Abrechnung fehlgeschlagen"
+  },
+  "browserTool.title": {
+    "message": "Browser activity",
+    "description": "Fallback title for a BrowserDevice tool activity"
+  },
+  "browserTool.state.choose_device": {
+    "message": "Choose a browser device"
+  },
+  "browserTool.state.device_offline": {
+    "message": "Browser device is offline"
+  },
+  "browserTool.state.awaiting_device": {
+    "message": "Waiting for browser device"
+  },
+  "browserTool.state.awaiting_local_approval": {
+    "message": "Waiting for approval on the browser device"
+  },
+  "browserTool.state.takeover_required": {
+    "message": "Take over on the browser device"
+  },
+  "browserTool.state.executing": {
+    "message": "Executing in browser"
+  },
+  "browserTool.state.completed": {
+    "message": "Completed"
+  },
+  "browserTool.state.denied": {
+    "message": "Denied on the browser device"
+  },
+  "browserTool.state.expired": {
+    "message": "Browser request expired"
+  },
+  "browserTool.state.cancel_too_late": {
+    "message": "Too late to cancel"
+  },
+  "scheduledTasks.run.waiting_for_device": {
+    "message": "Waiting for browser device"
   }
 }

--- a/src/i18n/el/chat.json
+++ b/src/i18n/el/chat.json
@@ -1048,5 +1048,42 @@
   },
   "scheduledTasks.run.reason.billing_gate_failed": {
     "message": "Η εξουσιοδότηση χρέωσης απέτυχε"
+  },
+  "browserTool.title": {
+    "message": "Browser activity",
+    "description": "Fallback title for a BrowserDevice tool activity"
+  },
+  "browserTool.state.choose_device": {
+    "message": "Choose a browser device"
+  },
+  "browserTool.state.device_offline": {
+    "message": "Browser device is offline"
+  },
+  "browserTool.state.awaiting_device": {
+    "message": "Waiting for browser device"
+  },
+  "browserTool.state.awaiting_local_approval": {
+    "message": "Waiting for approval on the browser device"
+  },
+  "browserTool.state.takeover_required": {
+    "message": "Take over on the browser device"
+  },
+  "browserTool.state.executing": {
+    "message": "Executing in browser"
+  },
+  "browserTool.state.completed": {
+    "message": "Completed"
+  },
+  "browserTool.state.denied": {
+    "message": "Denied on the browser device"
+  },
+  "browserTool.state.expired": {
+    "message": "Browser request expired"
+  },
+  "browserTool.state.cancel_too_late": {
+    "message": "Too late to cancel"
+  },
+  "scheduledTasks.run.waiting_for_device": {
+    "message": "Waiting for browser device"
   }
 }

--- a/src/i18n/en/chat.json
+++ b/src/i18n/en/chat.json
@@ -575,6 +575,40 @@
     "message": "Connector authorization skipped",
     "description": "Resolved banner when the user clicked Skip"
   },
+  "browserTool.title": {
+    "message": "Browser activity",
+    "description": "Fallback title for a BrowserDevice tool activity"
+  },
+  "browserTool.state.choose_device": {
+    "message": "Choose a browser device"
+  },
+  "browserTool.state.device_offline": {
+    "message": "Browser device is offline"
+  },
+  "browserTool.state.awaiting_device": {
+    "message": "Waiting for browser device"
+  },
+  "browserTool.state.awaiting_local_approval": {
+    "message": "Waiting for approval on the browser device"
+  },
+  "browserTool.state.takeover_required": {
+    "message": "Take over on the browser device"
+  },
+  "browserTool.state.executing": {
+    "message": "Executing in browser"
+  },
+  "browserTool.state.completed": {
+    "message": "Completed"
+  },
+  "browserTool.state.denied": {
+    "message": "Denied on the browser device"
+  },
+  "browserTool.state.expired": {
+    "message": "Browser request expired"
+  },
+  "browserTool.state.cancel_too_late": {
+    "message": "Too late to cancel"
+  },
   "scheduledTasks.navTitle": {
     "message": "Scheduled Tasks"
   },
@@ -691,6 +725,9 @@
   },
   "scheduledTasks.run.needs_user_input": {
     "message": "Needs action"
+  },
+  "scheduledTasks.run.waiting_for_device": {
+    "message": "Waiting for browser device"
   },
   "scheduledTasks.scheduleType.daily": {
     "message": "Daily"

--- a/src/i18n/es/chat.json
+++ b/src/i18n/es/chat.json
@@ -1048,5 +1048,42 @@
   },
   "scheduledTasks.run.reason.billing_gate_failed": {
     "message": "Error de autorización de facturación"
+  },
+  "browserTool.title": {
+    "message": "Browser activity",
+    "description": "Fallback title for a BrowserDevice tool activity"
+  },
+  "browserTool.state.choose_device": {
+    "message": "Choose a browser device"
+  },
+  "browserTool.state.device_offline": {
+    "message": "Browser device is offline"
+  },
+  "browserTool.state.awaiting_device": {
+    "message": "Waiting for browser device"
+  },
+  "browserTool.state.awaiting_local_approval": {
+    "message": "Waiting for approval on the browser device"
+  },
+  "browserTool.state.takeover_required": {
+    "message": "Take over on the browser device"
+  },
+  "browserTool.state.executing": {
+    "message": "Executing in browser"
+  },
+  "browserTool.state.completed": {
+    "message": "Completed"
+  },
+  "browserTool.state.denied": {
+    "message": "Denied on the browser device"
+  },
+  "browserTool.state.expired": {
+    "message": "Browser request expired"
+  },
+  "browserTool.state.cancel_too_late": {
+    "message": "Too late to cancel"
+  },
+  "scheduledTasks.run.waiting_for_device": {
+    "message": "Waiting for browser device"
   }
 }

--- a/src/i18n/fi/chat.json
+++ b/src/i18n/fi/chat.json
@@ -1048,5 +1048,42 @@
   },
   "scheduledTasks.run.reason.billing_gate_failed": {
     "message": "Laskutuksen valtuutus epäonnistui"
+  },
+  "browserTool.title": {
+    "message": "Browser activity",
+    "description": "Fallback title for a BrowserDevice tool activity"
+  },
+  "browserTool.state.choose_device": {
+    "message": "Choose a browser device"
+  },
+  "browserTool.state.device_offline": {
+    "message": "Browser device is offline"
+  },
+  "browserTool.state.awaiting_device": {
+    "message": "Waiting for browser device"
+  },
+  "browserTool.state.awaiting_local_approval": {
+    "message": "Waiting for approval on the browser device"
+  },
+  "browserTool.state.takeover_required": {
+    "message": "Take over on the browser device"
+  },
+  "browserTool.state.executing": {
+    "message": "Executing in browser"
+  },
+  "browserTool.state.completed": {
+    "message": "Completed"
+  },
+  "browserTool.state.denied": {
+    "message": "Denied on the browser device"
+  },
+  "browserTool.state.expired": {
+    "message": "Browser request expired"
+  },
+  "browserTool.state.cancel_too_late": {
+    "message": "Too late to cancel"
+  },
+  "scheduledTasks.run.waiting_for_device": {
+    "message": "Waiting for browser device"
   }
 }

--- a/src/i18n/fr/chat.json
+++ b/src/i18n/fr/chat.json
@@ -1048,5 +1048,42 @@
   },
   "scheduledTasks.run.reason.billing_gate_failed": {
     "message": "Échec de l’autorisation de facturation"
+  },
+  "browserTool.title": {
+    "message": "Browser activity",
+    "description": "Fallback title for a BrowserDevice tool activity"
+  },
+  "browserTool.state.choose_device": {
+    "message": "Choose a browser device"
+  },
+  "browserTool.state.device_offline": {
+    "message": "Browser device is offline"
+  },
+  "browserTool.state.awaiting_device": {
+    "message": "Waiting for browser device"
+  },
+  "browserTool.state.awaiting_local_approval": {
+    "message": "Waiting for approval on the browser device"
+  },
+  "browserTool.state.takeover_required": {
+    "message": "Take over on the browser device"
+  },
+  "browserTool.state.executing": {
+    "message": "Executing in browser"
+  },
+  "browserTool.state.completed": {
+    "message": "Completed"
+  },
+  "browserTool.state.denied": {
+    "message": "Denied on the browser device"
+  },
+  "browserTool.state.expired": {
+    "message": "Browser request expired"
+  },
+  "browserTool.state.cancel_too_late": {
+    "message": "Too late to cancel"
+  },
+  "scheduledTasks.run.waiting_for_device": {
+    "message": "Waiting for browser device"
   }
 }

--- a/src/i18n/it/chat.json
+++ b/src/i18n/it/chat.json
@@ -1048,5 +1048,42 @@
   },
   "scheduledTasks.run.reason.billing_gate_failed": {
     "message": "Autorizzazione alla fatturazione non riuscita"
+  },
+  "browserTool.title": {
+    "message": "Browser activity",
+    "description": "Fallback title for a BrowserDevice tool activity"
+  },
+  "browserTool.state.choose_device": {
+    "message": "Choose a browser device"
+  },
+  "browserTool.state.device_offline": {
+    "message": "Browser device is offline"
+  },
+  "browserTool.state.awaiting_device": {
+    "message": "Waiting for browser device"
+  },
+  "browserTool.state.awaiting_local_approval": {
+    "message": "Waiting for approval on the browser device"
+  },
+  "browserTool.state.takeover_required": {
+    "message": "Take over on the browser device"
+  },
+  "browserTool.state.executing": {
+    "message": "Executing in browser"
+  },
+  "browserTool.state.completed": {
+    "message": "Completed"
+  },
+  "browserTool.state.denied": {
+    "message": "Denied on the browser device"
+  },
+  "browserTool.state.expired": {
+    "message": "Browser request expired"
+  },
+  "browserTool.state.cancel_too_late": {
+    "message": "Too late to cancel"
+  },
+  "scheduledTasks.run.waiting_for_device": {
+    "message": "Waiting for browser device"
   }
 }

--- a/src/i18n/ja/chat.json
+++ b/src/i18n/ja/chat.json
@@ -1048,5 +1048,42 @@
   },
   "scheduledTasks.run.reason.billing_gate_failed": {
     "message": "請求認証に失敗しました"
+  },
+  "browserTool.title": {
+    "message": "Browser activity",
+    "description": "Fallback title for a BrowserDevice tool activity"
+  },
+  "browserTool.state.choose_device": {
+    "message": "Choose a browser device"
+  },
+  "browserTool.state.device_offline": {
+    "message": "Browser device is offline"
+  },
+  "browserTool.state.awaiting_device": {
+    "message": "Waiting for browser device"
+  },
+  "browserTool.state.awaiting_local_approval": {
+    "message": "Waiting for approval on the browser device"
+  },
+  "browserTool.state.takeover_required": {
+    "message": "Take over on the browser device"
+  },
+  "browserTool.state.executing": {
+    "message": "Executing in browser"
+  },
+  "browserTool.state.completed": {
+    "message": "Completed"
+  },
+  "browserTool.state.denied": {
+    "message": "Denied on the browser device"
+  },
+  "browserTool.state.expired": {
+    "message": "Browser request expired"
+  },
+  "browserTool.state.cancel_too_late": {
+    "message": "Too late to cancel"
+  },
+  "scheduledTasks.run.waiting_for_device": {
+    "message": "Waiting for browser device"
   }
 }

--- a/src/i18n/ko/chat.json
+++ b/src/i18n/ko/chat.json
@@ -1048,5 +1048,42 @@
   },
   "scheduledTasks.run.reason.billing_gate_failed": {
     "message": "결제 인증에 실패했습니다"
+  },
+  "browserTool.title": {
+    "message": "Browser activity",
+    "description": "Fallback title for a BrowserDevice tool activity"
+  },
+  "browserTool.state.choose_device": {
+    "message": "Choose a browser device"
+  },
+  "browserTool.state.device_offline": {
+    "message": "Browser device is offline"
+  },
+  "browserTool.state.awaiting_device": {
+    "message": "Waiting for browser device"
+  },
+  "browserTool.state.awaiting_local_approval": {
+    "message": "Waiting for approval on the browser device"
+  },
+  "browserTool.state.takeover_required": {
+    "message": "Take over on the browser device"
+  },
+  "browserTool.state.executing": {
+    "message": "Executing in browser"
+  },
+  "browserTool.state.completed": {
+    "message": "Completed"
+  },
+  "browserTool.state.denied": {
+    "message": "Denied on the browser device"
+  },
+  "browserTool.state.expired": {
+    "message": "Browser request expired"
+  },
+  "browserTool.state.cancel_too_late": {
+    "message": "Too late to cancel"
+  },
+  "scheduledTasks.run.waiting_for_device": {
+    "message": "Waiting for browser device"
   }
 }

--- a/src/i18n/pl/chat.json
+++ b/src/i18n/pl/chat.json
@@ -1048,5 +1048,42 @@
   },
   "scheduledTasks.run.reason.billing_gate_failed": {
     "message": "Autoryzacja rozliczeń nie powiodła się"
+  },
+  "browserTool.title": {
+    "message": "Browser activity",
+    "description": "Fallback title for a BrowserDevice tool activity"
+  },
+  "browserTool.state.choose_device": {
+    "message": "Choose a browser device"
+  },
+  "browserTool.state.device_offline": {
+    "message": "Browser device is offline"
+  },
+  "browserTool.state.awaiting_device": {
+    "message": "Waiting for browser device"
+  },
+  "browserTool.state.awaiting_local_approval": {
+    "message": "Waiting for approval on the browser device"
+  },
+  "browserTool.state.takeover_required": {
+    "message": "Take over on the browser device"
+  },
+  "browserTool.state.executing": {
+    "message": "Executing in browser"
+  },
+  "browserTool.state.completed": {
+    "message": "Completed"
+  },
+  "browserTool.state.denied": {
+    "message": "Denied on the browser device"
+  },
+  "browserTool.state.expired": {
+    "message": "Browser request expired"
+  },
+  "browserTool.state.cancel_too_late": {
+    "message": "Too late to cancel"
+  },
+  "scheduledTasks.run.waiting_for_device": {
+    "message": "Waiting for browser device"
   }
 }

--- a/src/i18n/pt/chat.json
+++ b/src/i18n/pt/chat.json
@@ -1048,5 +1048,42 @@
   },
   "scheduledTasks.run.reason.billing_gate_failed": {
     "message": "Falha na autorização de faturamento"
+  },
+  "browserTool.title": {
+    "message": "Browser activity",
+    "description": "Fallback title for a BrowserDevice tool activity"
+  },
+  "browserTool.state.choose_device": {
+    "message": "Choose a browser device"
+  },
+  "browserTool.state.device_offline": {
+    "message": "Browser device is offline"
+  },
+  "browserTool.state.awaiting_device": {
+    "message": "Waiting for browser device"
+  },
+  "browserTool.state.awaiting_local_approval": {
+    "message": "Waiting for approval on the browser device"
+  },
+  "browserTool.state.takeover_required": {
+    "message": "Take over on the browser device"
+  },
+  "browserTool.state.executing": {
+    "message": "Executing in browser"
+  },
+  "browserTool.state.completed": {
+    "message": "Completed"
+  },
+  "browserTool.state.denied": {
+    "message": "Denied on the browser device"
+  },
+  "browserTool.state.expired": {
+    "message": "Browser request expired"
+  },
+  "browserTool.state.cancel_too_late": {
+    "message": "Too late to cancel"
+  },
+  "scheduledTasks.run.waiting_for_device": {
+    "message": "Waiting for browser device"
   }
 }

--- a/src/i18n/ru/chat.json
+++ b/src/i18n/ru/chat.json
@@ -1048,5 +1048,42 @@
   },
   "scheduledTasks.run.reason.billing_gate_failed": {
     "message": "Не удалось авторизовать оплату"
+  },
+  "browserTool.title": {
+    "message": "Browser activity",
+    "description": "Fallback title for a BrowserDevice tool activity"
+  },
+  "browserTool.state.choose_device": {
+    "message": "Choose a browser device"
+  },
+  "browserTool.state.device_offline": {
+    "message": "Browser device is offline"
+  },
+  "browserTool.state.awaiting_device": {
+    "message": "Waiting for browser device"
+  },
+  "browserTool.state.awaiting_local_approval": {
+    "message": "Waiting for approval on the browser device"
+  },
+  "browserTool.state.takeover_required": {
+    "message": "Take over on the browser device"
+  },
+  "browserTool.state.executing": {
+    "message": "Executing in browser"
+  },
+  "browserTool.state.completed": {
+    "message": "Completed"
+  },
+  "browserTool.state.denied": {
+    "message": "Denied on the browser device"
+  },
+  "browserTool.state.expired": {
+    "message": "Browser request expired"
+  },
+  "browserTool.state.cancel_too_late": {
+    "message": "Too late to cancel"
+  },
+  "scheduledTasks.run.waiting_for_device": {
+    "message": "Waiting for browser device"
   }
 }

--- a/src/i18n/sr/chat.json
+++ b/src/i18n/sr/chat.json
@@ -1048,5 +1048,42 @@
   },
   "scheduledTasks.run.reason.billing_gate_failed": {
     "message": "Ауторизација наплате није успела"
+  },
+  "browserTool.title": {
+    "message": "Browser activity",
+    "description": "Fallback title for a BrowserDevice tool activity"
+  },
+  "browserTool.state.choose_device": {
+    "message": "Choose a browser device"
+  },
+  "browserTool.state.device_offline": {
+    "message": "Browser device is offline"
+  },
+  "browserTool.state.awaiting_device": {
+    "message": "Waiting for browser device"
+  },
+  "browserTool.state.awaiting_local_approval": {
+    "message": "Waiting for approval on the browser device"
+  },
+  "browserTool.state.takeover_required": {
+    "message": "Take over on the browser device"
+  },
+  "browserTool.state.executing": {
+    "message": "Executing in browser"
+  },
+  "browserTool.state.completed": {
+    "message": "Completed"
+  },
+  "browserTool.state.denied": {
+    "message": "Denied on the browser device"
+  },
+  "browserTool.state.expired": {
+    "message": "Browser request expired"
+  },
+  "browserTool.state.cancel_too_late": {
+    "message": "Too late to cancel"
+  },
+  "scheduledTasks.run.waiting_for_device": {
+    "message": "Waiting for browser device"
   }
 }

--- a/src/i18n/sv/chat.json
+++ b/src/i18n/sv/chat.json
@@ -1048,5 +1048,42 @@
   },
   "scheduledTasks.run.reason.billing_gate_failed": {
     "message": "Faktureringsauktoriseringen misslyckades"
+  },
+  "browserTool.title": {
+    "message": "Browser activity",
+    "description": "Fallback title for a BrowserDevice tool activity"
+  },
+  "browserTool.state.choose_device": {
+    "message": "Choose a browser device"
+  },
+  "browserTool.state.device_offline": {
+    "message": "Browser device is offline"
+  },
+  "browserTool.state.awaiting_device": {
+    "message": "Waiting for browser device"
+  },
+  "browserTool.state.awaiting_local_approval": {
+    "message": "Waiting for approval on the browser device"
+  },
+  "browserTool.state.takeover_required": {
+    "message": "Take over on the browser device"
+  },
+  "browserTool.state.executing": {
+    "message": "Executing in browser"
+  },
+  "browserTool.state.completed": {
+    "message": "Completed"
+  },
+  "browserTool.state.denied": {
+    "message": "Denied on the browser device"
+  },
+  "browserTool.state.expired": {
+    "message": "Browser request expired"
+  },
+  "browserTool.state.cancel_too_late": {
+    "message": "Too late to cancel"
+  },
+  "scheduledTasks.run.waiting_for_device": {
+    "message": "Waiting for browser device"
   }
 }

--- a/src/i18n/uk/chat.json
+++ b/src/i18n/uk/chat.json
@@ -1048,5 +1048,42 @@
   },
   "scheduledTasks.run.reason.billing_gate_failed": {
     "message": "Не вдалося авторизувати оплату"
+  },
+  "browserTool.title": {
+    "message": "Browser activity",
+    "description": "Fallback title for a BrowserDevice tool activity"
+  },
+  "browserTool.state.choose_device": {
+    "message": "Choose a browser device"
+  },
+  "browserTool.state.device_offline": {
+    "message": "Browser device is offline"
+  },
+  "browserTool.state.awaiting_device": {
+    "message": "Waiting for browser device"
+  },
+  "browserTool.state.awaiting_local_approval": {
+    "message": "Waiting for approval on the browser device"
+  },
+  "browserTool.state.takeover_required": {
+    "message": "Take over on the browser device"
+  },
+  "browserTool.state.executing": {
+    "message": "Executing in browser"
+  },
+  "browserTool.state.completed": {
+    "message": "Completed"
+  },
+  "browserTool.state.denied": {
+    "message": "Denied on the browser device"
+  },
+  "browserTool.state.expired": {
+    "message": "Browser request expired"
+  },
+  "browserTool.state.cancel_too_late": {
+    "message": "Too late to cancel"
+  },
+  "scheduledTasks.run.waiting_for_device": {
+    "message": "Waiting for browser device"
   }
 }

--- a/src/i18n/zh-CN/chat.json
+++ b/src/i18n/zh-CN/chat.json
@@ -575,6 +575,50 @@
     "message": "已跳过连接器授权",
     "description": "用户跳过授权后的卡片底部说明"
   },
+  "browserTool.title": {
+    "message": "浏览器活动",
+    "description": "BrowserDevice 工具活动的默认标题"
+  },
+  "browserTool.state.choose_device": {
+    "message": "请选择浏览器设备",
+    "description": "尚未选择浏览器设备"
+  },
+  "browserTool.state.device_offline": {
+    "message": "浏览器设备已离线",
+    "description": "所选浏览器设备不在线"
+  },
+  "browserTool.state.awaiting_device": {
+    "message": "正在等待浏览器设备",
+    "description": "等待浏览器设备接收任务"
+  },
+  "browserTool.state.awaiting_local_approval": {
+    "message": "请在浏览器设备上批准",
+    "description": "等待本地浏览器设备批准操作"
+  },
+  "browserTool.state.takeover_required": {
+    "message": "请在浏览器设备上接管",
+    "description": "需要用户在本地浏览器设备上接管操作"
+  },
+  "browserTool.state.executing": {
+    "message": "正在浏览器中执行",
+    "description": "浏览器设备正在执行工具"
+  },
+  "browserTool.state.completed": {
+    "message": "已完成",
+    "description": "浏览器工具执行完成"
+  },
+  "browserTool.state.denied": {
+    "message": "已在浏览器设备上拒绝",
+    "description": "用户在本地浏览器设备上拒绝操作"
+  },
+  "browserTool.state.expired": {
+    "message": "浏览器请求已过期",
+    "description": "浏览器工具执行请求已过期"
+  },
+  "browserTool.state.cancel_too_late": {
+    "message": "已无法取消",
+    "description": "操作已产生副作用，取消请求过晚"
+  },
   "scheduledTasks.navTitle": {
     "message": "定时任务",
     "description": "侧边栏定时任务入口"
@@ -726,6 +770,10 @@
   "scheduledTasks.run.needs_user_input": {
     "message": "需要操作",
     "description": "需要用户操作状态"
+  },
+  "scheduledTasks.run.waiting_for_device": {
+    "message": "等待浏览器设备",
+    "description": "定时任务正在等待浏览器设备上线"
   },
   "scheduledTasks.scheduleType.daily": {
     "message": "每天",

--- a/src/i18n/zh-TW/chat.json
+++ b/src/i18n/zh-TW/chat.json
@@ -1048,5 +1048,42 @@
   },
   "scheduledTasks.run.reason.billing_gate_failed": {
     "message": "計費授權失敗"
+  },
+  "browserTool.title": {
+    "message": "Browser activity",
+    "description": "Fallback title for a BrowserDevice tool activity"
+  },
+  "browserTool.state.choose_device": {
+    "message": "Choose a browser device"
+  },
+  "browserTool.state.device_offline": {
+    "message": "Browser device is offline"
+  },
+  "browserTool.state.awaiting_device": {
+    "message": "Waiting for browser device"
+  },
+  "browserTool.state.awaiting_local_approval": {
+    "message": "Waiting for approval on the browser device"
+  },
+  "browserTool.state.takeover_required": {
+    "message": "Take over on the browser device"
+  },
+  "browserTool.state.executing": {
+    "message": "Executing in browser"
+  },
+  "browserTool.state.completed": {
+    "message": "Completed"
+  },
+  "browserTool.state.denied": {
+    "message": "Denied on the browser device"
+  },
+  "browserTool.state.expired": {
+    "message": "Browser request expired"
+  },
+  "browserTool.state.cancel_too_late": {
+    "message": "Too late to cancel"
+  },
+  "scheduledTasks.run.waiting_for_device": {
+    "message": "Waiting for browser device"
   }
 }

--- a/src/models/chat.ts
+++ b/src/models/chat.ts
@@ -87,6 +87,20 @@ export enum IChatMessageState {
   FAILED = 'failed'
 }
 
+export type IChatToolExecution = 'client' | 'server' | 'browser';
+
+export type IBrowserToolExecutionState =
+  | 'choose_device'
+  | 'device_offline'
+  | 'awaiting_device'
+  | 'awaiting_local_approval'
+  | 'takeover_required'
+  | 'executing'
+  | 'completed'
+  | 'denied'
+  | 'expired'
+  | 'cancel_too_late';
+
 export interface IChatMessageContentItem {
   type: string;
   text?: string;
@@ -102,6 +116,10 @@ export interface IChatMessageContentItem {
   tool_id?: string;
   tool_name?: string;
   tool_display_name?: string;
+  execution?: IChatToolExecution;
+  execution_state?: IBrowserToolExecutionState;
+  execution_sequence?: number;
+  origin?: string;
   input?: Record<string, unknown>;
   output?: string;
   is_error?: boolean;
@@ -329,8 +347,12 @@ export interface IChatConversationResponse {
   tool_id?: string;
   tool_name?: string;
   tool_display_name?: string;
-  // 'client' ⇒ desktop runs this tool locally; worker pauses awaiting tool_results.
-  execution?: 'client' | 'server';
+  // 'client' runs in the desktop bridge; 'browser' is observed here but runs
+  // on the selected BrowserDevice, never in this chat client.
+  execution?: IChatToolExecution;
+  execution_state?: IBrowserToolExecutionState;
+  execution_sequence?: number;
+  origin?: string;
   input?: Record<string, unknown>;
   output?: string;
   is_error?: boolean;

--- a/src/operators/chat.test.ts
+++ b/src/operators/chat.test.ts
@@ -57,6 +57,57 @@ describe('chatOperator.chatConversation SSE forwarding', () => {
     expect(argText).toBe('{"command":"echo hi"}');
   });
 
+  it('forwards browser execution state with a sanitized origin', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValue(
+          sseResponse([
+            'data: {"type":"browser_execution","tool_id":"call_browser","tool_name":"browser.read","browser_state":"executing","execution_sequence":7,"origin":"https://user:secret@example.com/private?token=hidden#fragment"}\n',
+            'data: [DONE]\n'
+          ])
+        )
+    );
+
+    const events: IChatConversationResponse[] = [];
+    await chatOperator.chatConversation({ model: 'gpt-5.5', message: 'read the page' } as never, {
+      token: 't',
+      stream: (response) => events.push(response)
+    });
+
+    expect(events[0]).toMatchObject({
+      execution: 'browser',
+      execution_state: 'executing',
+      execution_sequence: 7,
+      origin: 'https://example.com'
+    });
+    expect(events[0]).not.toHaveProperty('browser_state');
+  });
+
+  it('drops unsafe browser origins at the operator boundary', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValue(
+          sseResponse([
+            'data: {"type":"browser_execution","tool_id":"call_browser","execution":"browser","state":"denied","origin":"javascript:alert(1)"}\n',
+            'data: [DONE]\n'
+          ])
+        )
+    );
+
+    const events: IChatConversationResponse[] = [];
+    await chatOperator.chatConversation({ model: 'gpt-5.5', message: 'click' } as never, {
+      token: 't',
+      stream: (response) => events.push(response)
+    });
+
+    expect(events[0]).toMatchObject({ execution: 'browser', execution_state: 'denied' });
+    expect(events[0].origin).toBeUndefined();
+  });
+
   it('normalizes streaming 413 request_entity_too_large errors for localized UI copy', async () => {
     vi.stubGlobal(
       'fetch',

--- a/src/operators/chat.ts
+++ b/src/operators/chat.ts
@@ -12,6 +12,7 @@ import {
 } from '@/models';
 import { BASE_URL_API, ERROR_CODE_API_ERROR, ERROR_CODE_CONTENT_TOO_LARGE } from '@/constants';
 import { currentSiteOrigin } from '@/utils';
+import { isBrowserToolExecutionState, sanitizeBrowserOrigin } from '@/utils/browserToolExecution';
 
 /**
  * Headers carrying the calling Site's bare host. Shared with
@@ -89,6 +90,10 @@ class ChatOperator {
               }
               try {
                 const json = JSON.parse(subValue);
+                const browserState =
+                  json.execution_state ??
+                  json.browser_state ??
+                  (json.execution === 'browser' || json.type === 'browser_execution' ? json.state : undefined);
                 if (json.delta_answer) {
                   finalAnswer += json.delta_answer;
                 }
@@ -115,7 +120,11 @@ class ChatOperator {
                     tool_id: json.tool_id,
                     tool_name: json.tool_name,
                     tool_display_name: json.tool_display_name,
-                    execution: json.execution,
+                    execution: json.type === 'browser_execution' ? 'browser' : json.execution,
+                    execution_state: isBrowserToolExecutionState(browserState) ? browserState : undefined,
+                    execution_sequence:
+                      typeof json.execution_sequence === 'number' ? json.execution_sequence : undefined,
+                    origin: sanitizeBrowserOrigin(json.origin),
                     input: json.input,
                     // Streamed tool-call arguments text (`tool_progress`); without
                     // this the running tool block renders empty while the model

--- a/src/operators/scheduledTasks.ts
+++ b/src/operators/scheduledTasks.ts
@@ -37,7 +37,7 @@ export interface IScheduledTask {
 export interface IScheduledRun {
   id: string;
   task_id: string;
-  status: 'queued' | 'running' | 'success' | 'failed' | 'needs_user_input';
+  status: 'queued' | 'running' | 'success' | 'failed' | 'needs_user_input' | 'waiting_for_device';
   scheduled_at: number;
   llm_started_at?: number;
   llm_finished_at?: number;

--- a/src/pages/chat/Conversation.vue
+++ b/src/pages/chat/Conversation.vue
@@ -108,6 +108,7 @@ import {
   type IConsentReturn
 } from '@/components/chat/consentReturn';
 import { hasLoadedConversationMessages } from '@/components/chat/conversationRestore';
+import { reduceBrowserToolExecution } from '@/utils/browserToolExecution';
 import { chatOperator, agentOperator } from '@/operators';
 import { ElTooltip, ElButton } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
@@ -1197,6 +1198,10 @@ export default defineComponent({
       // Track content parts for tool-calling interleaving
       const contentParts: IChatMessageContentItem[] = [];
       const toolMap = new Map<string, IChatMessageContentItem>();
+      const pendingBrowserUpdates = new Map<
+        string,
+        Pick<IChatMessageContentItem, 'execution_state' | 'execution_sequence' | 'origin'>
+      >();
       let currentText = '';
       // The aichat2 operator emits `response.answer` as the full
       // accumulated text since the start of the turn. Whenever we flush
@@ -1213,6 +1218,19 @@ export default defineComponent({
           stream: (response: IChatConversationResponse) => {
             console.debug('stream response', response);
             const lastMessage = this.messages[targetIndex];
+            const browserToolItem = response.tool_id ? toolMap.get(response.tool_id) : undefined;
+            if (response.tool_id && response.execution === 'browser' && response.execution_state && !browserToolItem) {
+              const pending = pendingBrowserUpdates.get(response.tool_id) ?? {};
+              pendingBrowserUpdates.set(response.tool_id, reduceBrowserToolExecution(pending, response));
+            }
+            if (
+              browserToolItem &&
+              response.execution_state &&
+              (response.execution === 'browser' || browserToolItem.execution === 'browser')
+            ) {
+              browserToolItem.execution = 'browser';
+              Object.assign(browserToolItem, reduceBrowserToolExecution(browserToolItem, response));
+            }
 
             // Handle tool-calling events
             if (response.type === 'thinking' && response.content) {
@@ -1231,6 +1249,15 @@ export default defineComponent({
               if (toolItem) {
                 if (response.tool_name) toolItem.tool_name = response.tool_name;
                 if (response.tool_display_name) toolItem.tool_display_name = response.tool_display_name;
+                if (response.execution) toolItem.execution = response.execution;
+                if (response.execution === 'browser') {
+                  Object.assign(toolItem, reduceBrowserToolExecution(toolItem, response));
+                  const pending = pendingBrowserUpdates.get(response.tool_id);
+                  if (pending) {
+                    Object.assign(toolItem, reduceBrowserToolExecution(toolItem, pending));
+                    pendingBrowserUpdates.delete(response.tool_id);
+                  }
+                }
                 if (response.input && Object.keys(response.input).length > 0) {
                   toolItem.input = response.input;
                 }
@@ -1246,6 +1273,8 @@ export default defineComponent({
                   tool_id: response.tool_id,
                   tool_name: response.tool_name,
                   tool_display_name: response.tool_display_name,
+                  execution: response.execution,
+                  ...(response.execution === 'browser' ? reduceBrowserToolExecution({}, response) : {}),
                   input: response.input,
                   status: 'running'
                 };

--- a/src/pages/chat/ScheduledTasks.test.ts
+++ b/src/pages/chat/ScheduledTasks.test.ts
@@ -37,7 +37,9 @@ const mountComponent = () =>
   shallowMount(ScheduledTasks, {
     global: {
       stubs: {
-        ElCard: { template: '<div><slot /></div>' }
+        ElCard: { template: '<div><slot /></div>' },
+        ElDrawer: { template: '<div><slot /></div>' },
+        ElTag: { template: '<span><slot /></span>' }
       },
       mocks: {
         $t: (key: string) => errorMessages[key] ?? key,
@@ -132,5 +134,23 @@ describe('chat/ScheduledTasks', () => {
     expect(vm.editingTask).toMatchObject({ id: editedTask.id });
     expect(vm.form).toMatchObject({ name: 'Existing task' });
     expect(vm.showCreateDialog).toBe(true);
+  });
+
+  it('shows scheduled runs that are waiting for a browser device', async () => {
+    const wrapper = mountComponent();
+    await wrapper.setData({
+      selectedTask: editedTask,
+      showRunHistory: true,
+      runs: [
+        {
+          id: 'run-1',
+          task_id: editedTask.id,
+          status: 'waiting_for_device',
+          scheduled_at: 1
+        }
+      ]
+    });
+
+    expect(wrapper.text()).toContain('chat.scheduledTasks.run.waiting_for_device');
   });
 });

--- a/src/utils/browserToolExecution.test.ts
+++ b/src/utils/browserToolExecution.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import {
+  BROWSER_TOOL_EXECUTION_STATES,
+  isBrowserToolExecutionState,
+  reduceBrowserToolExecution,
+  sanitizeBrowserOrigin
+} from './browserToolExecution';
+
+describe('reduceBrowserToolExecution', () => {
+  it('advances through durable browser execution phases without regressing', () => {
+    expect(
+      reduceBrowserToolExecution(
+        { execution_state: 'executing', origin: 'https://example.com' },
+        { execution_state: 'awaiting_device', origin: 'https://example.com/late-event?secret=1' }
+      )
+    ).toEqual({ execution_state: 'executing', origin: 'https://example.com' });
+  });
+
+  it.each(['completed', 'denied', 'expired', 'cancel_too_late'] as const)(
+    'keeps terminal state %s immutable',
+    (executionState) => {
+      expect(
+        reduceBrowserToolExecution(
+          { execution_state: executionState, origin: 'https://original.example' },
+          { execution_state: 'executing', origin: 'https://example.com/path' }
+        )
+      ).toEqual({ execution_state: executionState, origin: 'https://original.example' });
+    }
+  );
+
+  it('allows state changes within a pre-execution phase', () => {
+    expect(
+      reduceBrowserToolExecution(
+        { execution_state: 'device_offline' },
+        { execution_state: 'awaiting_device', origin: 'https://example.com/path' }
+      )
+    ).toEqual({ execution_state: 'awaiting_device', origin: 'https://example.com' });
+  });
+
+  it('rejects peer-state regressions without a newer forward transition', () => {
+    expect(
+      reduceBrowserToolExecution(
+        { execution_state: 'awaiting_device' },
+        { execution_state: 'device_offline', origin: 'https://late.example' }
+      )
+    ).toEqual({ execution_state: 'awaiting_device' });
+    expect(
+      reduceBrowserToolExecution(
+        { execution_state: 'takeover_required' },
+        { execution_state: 'awaiting_local_approval' }
+      )
+    ).toEqual({ execution_state: 'takeover_required' });
+  });
+
+  it('rejects stale sequence updates and accepts newer forward transitions', () => {
+    expect(
+      reduceBrowserToolExecution(
+        { execution_state: 'awaiting_device', execution_sequence: 4, origin: 'https://original.example' },
+        { execution_state: 'executing', execution_sequence: 3, origin: 'https://stale.example' }
+      )
+    ).toEqual({
+      execution_state: 'awaiting_device',
+      execution_sequence: 4,
+      origin: 'https://original.example'
+    });
+    expect(
+      reduceBrowserToolExecution(
+        { execution_state: 'awaiting_device', execution_sequence: 4 },
+        { execution_state: 'executing', execution_sequence: 5 }
+      )
+    ).toEqual({ execution_state: 'executing', execution_sequence: 5 });
+  });
+});
+
+describe('isBrowserToolExecutionState', () => {
+  it.each(BROWSER_TOOL_EXECUTION_STATES)('accepts durable state %s', (state) => {
+    expect(isBrowserToolExecutionState(state)).toBe(true);
+  });
+
+  it.each(['failed', 'running', '', null])('rejects unsupported state %s', (state) => {
+    expect(isBrowserToolExecutionState(state)).toBe(false);
+  });
+});
+
+describe('sanitizeBrowserOrigin', () => {
+  it('keeps only the HTTP origin', () => {
+    expect(sanitizeBrowserOrigin('https://user:password@Example.com:8443/private?q=secret#fragment')).toBe(
+      'https://example.com:8443'
+    );
+  });
+
+  it.each(['javascript:alert(1)', 'data:text/html,secret', 'not a URL', ''])('rejects unsafe origin %s', (origin) => {
+    expect(sanitizeBrowserOrigin(origin)).toBeUndefined();
+  });
+});

--- a/src/utils/browserToolExecution.ts
+++ b/src/utils/browserToolExecution.ts
@@ -1,0 +1,83 @@
+import type { IBrowserToolExecutionState, IChatMessageContentItem } from '@/models';
+
+export const BROWSER_TOOL_EXECUTION_STATES: readonly IBrowserToolExecutionState[] = [
+  'choose_device',
+  'device_offline',
+  'awaiting_device',
+  'awaiting_local_approval',
+  'takeover_required',
+  'executing',
+  'completed',
+  'denied',
+  'expired',
+  'cancel_too_late'
+];
+
+const TERMINAL_STATES = new Set<IBrowserToolExecutionState>(['completed', 'denied', 'expired', 'cancel_too_late']);
+const ALLOWED_TRANSITIONS: Record<IBrowserToolExecutionState, ReadonlySet<IBrowserToolExecutionState>> = {
+  choose_device: new Set([
+    'device_offline',
+    'awaiting_device',
+    'awaiting_local_approval',
+    'takeover_required',
+    'executing',
+    ...TERMINAL_STATES
+  ]),
+  device_offline: new Set([
+    'awaiting_device',
+    'awaiting_local_approval',
+    'takeover_required',
+    'executing',
+    ...TERMINAL_STATES
+  ]),
+  awaiting_device: new Set(['awaiting_local_approval', 'takeover_required', 'executing', ...TERMINAL_STATES]),
+  awaiting_local_approval: new Set(['takeover_required', 'executing', ...TERMINAL_STATES]),
+  takeover_required: new Set(['executing', ...TERMINAL_STATES]),
+  executing: new Set(TERMINAL_STATES),
+  completed: new Set(),
+  denied: new Set(),
+  expired: new Set(),
+  cancel_too_late: new Set()
+};
+
+export interface IBrowserToolExecutionUpdate {
+  execution_state?: IBrowserToolExecutionState;
+  execution_sequence?: number;
+  origin?: unknown;
+}
+
+export function isBrowserToolExecutionState(value: unknown): value is IBrowserToolExecutionState {
+  return typeof value === 'string' && BROWSER_TOOL_EXECUTION_STATES.includes(value as IBrowserToolExecutionState);
+}
+
+export function sanitizeBrowserOrigin(value: unknown): string | undefined {
+  if (typeof value !== 'string' || value.length > 2048) return undefined;
+  try {
+    const url = new URL(value);
+    if (url.protocol !== 'https:' && url.protocol !== 'http:') return undefined;
+    return url.origin === 'null' ? undefined : url.origin;
+  } catch {
+    return undefined;
+  }
+}
+
+export function reduceBrowserToolExecution(
+  current: Pick<IChatMessageContentItem, 'execution_state' | 'execution_sequence' | 'origin'>,
+  update: IBrowserToolExecutionUpdate
+): Pick<IChatMessageContentItem, 'execution_state' | 'execution_sequence' | 'origin'> {
+  const next = { ...current };
+  const currentState = current.execution_state;
+  const nextState = update.execution_state;
+  const currentSequence = current.execution_sequence;
+  const nextSequence = update.execution_sequence;
+  if (currentState && TERMINAL_STATES.has(currentState)) return next;
+  if (nextSequence !== undefined && currentSequence !== undefined && nextSequence <= currentSequence) return next;
+  if (nextState && currentState && nextState !== currentState && !ALLOWED_TRANSITIONS[currentState].has(nextState)) {
+    return next;
+  }
+  if (nextState) next.execution_state = nextState;
+  if (nextSequence !== undefined) next.execution_sequence = nextSequence;
+  const sanitizedOrigin = sanitizeBrowserOrigin(update.origin);
+  if (sanitizedOrigin) next.origin = sanitizedOrigin;
+  return next;
+}


### PR DESCRIPTION
Adds read-only chat rendering for durable BrowserDevice execution states without creating an executor or cloud approval control. Includes strict state/origin normalization, browser_execution normalization, early-event buffering, explicit transition and optional sequence fencing, immutable terminal origin attribution, dedicated activity card, scheduled waiting_for_device copy, all locales, tests, and Beachball metadata. Browser blocks never enter desktop local-tool execution. Validation: full 425-test suite passed before final review fixes; focused 46 tests, ESLint, i18n guard, web/SSG/mobile/electron builds, Prettier, and diff checks passed.