### PR TITLE
fix(chat): localize scheduled task errors

### DIFF
--- a/change/@acedatacloud-nexior-scheduled-task-error-localization.json
+++ b/change/@acedatacloud-nexior-scheduled-task-error-localization.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Localize the latest error code shown on scheduled task cards",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/i18n/ar/chat.json
+++ b/src/i18n/ar/chat.json
@@ -1045,5 +1045,8 @@
   "artifacts.hiddenBadge": {
     "message": "Hidden",
     "description": "Badge shown on artifacts that are currently hidden"
+  },
+  "scheduledTasks.run.reason.billing_gate_failed": {
+    "message": "فشل تفويض الفوترة"
   }
 }

--- a/src/i18n/de/chat.json
+++ b/src/i18n/de/chat.json
@@ -1045,5 +1045,8 @@
   "artifacts.hiddenBadge": {
     "message": "Hidden",
     "description": "Badge shown on artifacts that are currently hidden"
+  },
+  "scheduledTasks.run.reason.billing_gate_failed": {
+    "message": "Autorisierung der Abrechnung fehlgeschlagen"
   }
 }

--- a/src/i18n/el/chat.json
+++ b/src/i18n/el/chat.json
@@ -1045,5 +1045,8 @@
   "artifacts.hiddenBadge": {
     "message": "Hidden",
     "description": "Badge shown on artifacts that are currently hidden"
+  },
+  "scheduledTasks.run.reason.billing_gate_failed": {
+    "message": "Η εξουσιοδότηση χρέωσης απέτυχε"
   }
 }

--- a/src/i18n/en/chat.json
+++ b/src/i18n/en/chat.json
@@ -677,6 +677,9 @@
   "scheduledTasks.run.reason.balance_insufficient": {
     "message": "Insufficient balance"
   },
+  "scheduledTasks.run.reason.billing_gate_failed": {
+    "message": "Billing authorization failed"
+  },
   "scheduledTasks.run.reason.unauthorized": {
     "message": "Unauthorized"
   },

--- a/src/i18n/es/chat.json
+++ b/src/i18n/es/chat.json
@@ -1045,5 +1045,8 @@
   "artifacts.hiddenBadge": {
     "message": "Hidden",
     "description": "Badge shown on artifacts that are currently hidden"
+  },
+  "scheduledTasks.run.reason.billing_gate_failed": {
+    "message": "Error de autorización de facturación"
   }
 }

--- a/src/i18n/fi/chat.json
+++ b/src/i18n/fi/chat.json
@@ -1045,5 +1045,8 @@
   "artifacts.hiddenBadge": {
     "message": "Hidden",
     "description": "Badge shown on artifacts that are currently hidden"
+  },
+  "scheduledTasks.run.reason.billing_gate_failed": {
+    "message": "Laskutuksen valtuutus epäonnistui"
   }
 }

--- a/src/i18n/fr/chat.json
+++ b/src/i18n/fr/chat.json
@@ -1045,5 +1045,8 @@
   "artifacts.hiddenBadge": {
     "message": "Hidden",
     "description": "Badge shown on artifacts that are currently hidden"
+  },
+  "scheduledTasks.run.reason.billing_gate_failed": {
+    "message": "Échec de l’autorisation de facturation"
   }
 }

--- a/src/i18n/it/chat.json
+++ b/src/i18n/it/chat.json
@@ -1045,5 +1045,8 @@
   "artifacts.hiddenBadge": {
     "message": "Hidden",
     "description": "Badge shown on artifacts that are currently hidden"
+  },
+  "scheduledTasks.run.reason.billing_gate_failed": {
+    "message": "Autorizzazione alla fatturazione non riuscita"
   }
 }

--- a/src/i18n/ja/chat.json
+++ b/src/i18n/ja/chat.json
@@ -1045,5 +1045,8 @@
   "artifacts.hiddenBadge": {
     "message": "Hidden",
     "description": "Badge shown on artifacts that are currently hidden"
+  },
+  "scheduledTasks.run.reason.billing_gate_failed": {
+    "message": "請求認証に失敗しました"
   }
 }

--- a/src/i18n/ko/chat.json
+++ b/src/i18n/ko/chat.json
@@ -1045,5 +1045,8 @@
   "artifacts.hiddenBadge": {
     "message": "Hidden",
     "description": "Badge shown on artifacts that are currently hidden"
+  },
+  "scheduledTasks.run.reason.billing_gate_failed": {
+    "message": "결제 인증에 실패했습니다"
   }
 }

--- a/src/i18n/pl/chat.json
+++ b/src/i18n/pl/chat.json
@@ -1045,5 +1045,8 @@
   "artifacts.hiddenBadge": {
     "message": "Hidden",
     "description": "Badge shown on artifacts that are currently hidden"
+  },
+  "scheduledTasks.run.reason.billing_gate_failed": {
+    "message": "Autoryzacja rozliczeń nie powiodła się"
   }
 }

--- a/src/i18n/pt/chat.json
+++ b/src/i18n/pt/chat.json
@@ -1045,5 +1045,8 @@
   "artifacts.hiddenBadge": {
     "message": "Hidden",
     "description": "Badge shown on artifacts that are currently hidden"
+  },
+  "scheduledTasks.run.reason.billing_gate_failed": {
+    "message": "Falha na autorização de faturamento"
   }
 }

--- a/src/i18n/ru/chat.json
+++ b/src/i18n/ru/chat.json
@@ -1045,5 +1045,8 @@
   "artifacts.hiddenBadge": {
     "message": "Hidden",
     "description": "Badge shown on artifacts that are currently hidden"
+  },
+  "scheduledTasks.run.reason.billing_gate_failed": {
+    "message": "Не удалось авторизовать оплату"
   }
 }

--- a/src/i18n/sr/chat.json
+++ b/src/i18n/sr/chat.json
@@ -1045,5 +1045,8 @@
   "artifacts.hiddenBadge": {
     "message": "Hidden",
     "description": "Badge shown on artifacts that are currently hidden"
+  },
+  "scheduledTasks.run.reason.billing_gate_failed": {
+    "message": "Ауторизација наплате није успела"
   }
 }

--- a/src/i18n/sv/chat.json
+++ b/src/i18n/sv/chat.json
@@ -1045,5 +1045,8 @@
   "artifacts.hiddenBadge": {
     "message": "Hidden",
     "description": "Badge shown on artifacts that are currently hidden"
+  },
+  "scheduledTasks.run.reason.billing_gate_failed": {
+    "message": "Faktureringsauktoriseringen misslyckades"
   }
 }

--- a/src/i18n/uk/chat.json
+++ b/src/i18n/uk/chat.json
@@ -1045,5 +1045,8 @@
   "artifacts.hiddenBadge": {
     "message": "Hidden",
     "description": "Badge shown on artifacts that are currently hidden"
+  },
+  "scheduledTasks.run.reason.billing_gate_failed": {
+    "message": "Не вдалося авторизувати оплату"
   }
 }

--- a/src/i18n/zh-CN/chat.json
+++ b/src/i18n/zh-CN/chat.json
@@ -707,6 +707,10 @@
     "message": "余额不足",
     "description": "账户余额不足"
   },
+  "scheduledTasks.run.reason.billing_gate_failed": {
+    "message": "计费授权失败",
+    "description": "凭证无效或余额不足导致计费授权失败"
+  },
   "scheduledTasks.run.reason.unauthorized": {
     "message": "未授权",
     "description": "凭证未授权"

--- a/src/i18n/zh-TW/chat.json
+++ b/src/i18n/zh-TW/chat.json
@@ -1045,5 +1045,8 @@
   "artifacts.hiddenBadge": {
     "message": "Hidden",
     "description": "Badge shown on artifacts that are currently hidden"
+  },
+  "scheduledTasks.run.reason.billing_gate_failed": {
+    "message": "計費授權失敗"
   }
 }

--- a/src/pages/chat/ScheduledTasks.test.ts
+++ b/src/pages/chat/ScheduledTasks.test.ts
@@ -31,8 +31,12 @@ const editedTask: IScheduledTask = {
 const mountComponent = () =>
   shallowMount(ScheduledTasks, {
     global: {
+      stubs: {
+        ElCard: { template: '<div><slot /></div>' }
+      },
       mocks: {
-        $t: (key: string) => key,
+        $t: (key: string) => (key === 'chat.scheduledTasks.run.reason.internal_error' ? 'Internal error' : key),
+        $te: (key: string) => key === 'chat.scheduledTasks.run.reason.internal_error',
         $store: {
           state: {
             chat: { credential: null },
@@ -44,6 +48,15 @@ const mountComponent = () =>
   });
 
 describe('chat/ScheduledTasks', () => {
+  it('localizes the latest task error code', async () => {
+    const wrapper = mountComponent();
+
+    await wrapper.setData({ tasks: [{ ...editedTask, last_error: 'internal_error' }] });
+
+    expect(wrapper.find('.error-hint').text()).toBe('Internal error');
+    expect(wrapper.text()).not.toContain('internal_error');
+  });
+
   it('opens a fresh form when New is clicked after editing a task', async () => {
     const wrapper = mountComponent();
     const vm = wrapper.vm as unknown as {

--- a/src/pages/chat/ScheduledTasks.test.ts
+++ b/src/pages/chat/ScheduledTasks.test.ts
@@ -28,6 +28,11 @@ const editedTask: IScheduledTask = {
   updated_at: 1
 };
 
+const errorMessages: Record<string, string> = {
+  'chat.scheduledTasks.run.reason.internal_error': 'Internal error',
+  'chat.scheduledTasks.run.reason.billing_gate_failed': 'Billing authorization failed'
+};
+
 const mountComponent = () =>
   shallowMount(ScheduledTasks, {
     global: {
@@ -35,8 +40,8 @@ const mountComponent = () =>
         ElCard: { template: '<div><slot /></div>' }
       },
       mocks: {
-        $t: (key: string) => (key === 'chat.scheduledTasks.run.reason.internal_error' ? 'Internal error' : key),
-        $te: (key: string) => key === 'chat.scheduledTasks.run.reason.internal_error',
+        $t: (key: string) => errorMessages[key] ?? key,
+        $te: (key: string) => key in errorMessages,
         $store: {
           state: {
             chat: { credential: null },
@@ -48,13 +53,16 @@ const mountComponent = () =>
   });
 
 describe('chat/ScheduledTasks', () => {
-  it('localizes the latest task error code', async () => {
+  it.each([
+    ['internal_error', 'Internal error'],
+    ['billing_gate_failed', 'Billing authorization failed']
+  ])('localizes the latest task error code %s', async (errorCode, expected) => {
     const wrapper = mountComponent();
 
-    await wrapper.setData({ tasks: [{ ...editedTask, last_error: 'internal_error' }] });
+    await wrapper.setData({ tasks: [{ ...editedTask, last_error: errorCode }] });
 
-    expect(wrapper.find('.error-hint').text()).toBe('Internal error');
-    expect(wrapper.text()).not.toContain('internal_error');
+    expect(wrapper.find('.error-hint').text()).toBe(expected);
+    expect(wrapper.text()).not.toContain(errorCode);
   });
 
   it('opens a fresh form when New is clicked after editing a task', async () => {

--- a/src/pages/chat/ScheduledTasks.vue
+++ b/src/pages/chat/ScheduledTasks.vue
@@ -68,7 +68,7 @@
                 <refresh-icon :size="16" class="footer-icon" aria-hidden="true" />
                 {{ $t('chat.scheduledTasks.runCount', { count: task.run_count }) }}
               </span>
-              <span v-if="task.last_error" class="error-hint">{{ task.last_error }}</span>
+              <span v-if="task.last_error" class="error-hint">{{ errorCodeText(task.last_error) }}</span>
               <span class="open-hint">
                 {{ $t('chat.scheduledTasks.viewRuns') }}
                 <font-awesome-icon icon="fa-solid fa-chevron-right" />
@@ -814,6 +814,9 @@ export default defineComponent({
       if (run.error_message) return run.error_message;
       const code = run.error_code;
       if (!code) return '';
+      return this.errorCodeText(code);
+    },
+    errorCodeText(code: string) {
       const key = `chat.scheduledTasks.run.reason.${code}`;
       return (this as any).$te(key) ? (this.$t(key) as string) : code.replace(/_/g, ' ');
     },


### PR DESCRIPTION
## Summary
- localize the latest error code shown on scheduled task cards
- reuse the run-history error-code translator and preserve readable fallback text
- localize the missing `billing_gate_failed` backend code in all 18 supported locales
- cover both `internal_error` and `billing_gate_failed` card rendering

## Root cause and enum audit
The task card rendered `task.last_error` directly, bypassing the translation path used by run history. The backend currently emits 13 distinct failure codes: 8 failed `TerminalReason` values, 4 classified runtime errors, and `billing_gate_failed`. The frontend had 13 reason keys but used `unknown` instead of `billing_gate_failed`, leaving actual coverage at 12/13. This PR now covers all 13 emitted failure codes; the legacy `unknown` fallback remains available.

## Validation
- `npm run test -- --run src/pages/chat/ScheduledTasks.test.ts` (4 passed)
- `python3 scripts/check_i18n_coverage.py` (17 locales x 44 namespaces)
- explicit 18-locale value check (0 English placeholders outside `en`)
- `npx eslint src/pages/chat/ScheduledTasks.vue src/pages/chat/ScheduledTasks.test.ts`
- `npx prettier --check src/pages/chat/ScheduledTasks.test.ts src/i18n/*/chat.json change/@acedatacloud-nexior-scheduled-task-error-localization.json`
- `npx vue-tsc -b`
- `npm run verify`

## 🤖 对抗评审 (reviewer: codex, 2 rounds)
- RISK: non-English locales shipped an English billing error -> fixed with native-language messages in all 16 non-English backfilled locales
- Re-review: `VERDICT: CLEAN`
- Confirmed the flat i18n loader produces the expected keys and vue-i18n legacy `$te`/`$t` resolves them correctly.
