### PR TITLE
feat(kling): reference-video upload for kling-video-o1 (Omni video edit)

### DIFF
--- a/change/@acedatacloud-nexior-kling-o1-reference-video.json
+++ b/change/@acedatacloud-nexior-kling-o1-reference-video.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add reference-video uploader for kling-video-o1 (Omni video editing)",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/kling/ConfigPanel.vue
+++ b/src/components/kling/ConfigPanel.vue
@@ -4,6 +4,7 @@
       <prompt-input class="mb-4" @open-inspiration="inspirationOpen = true" />
       <model-selector class="mb-4" />
       <ratio-selector class="mb-4" />
+      <reference-video v-if="capabilities.referenceVideo" class="mb-2" />
       <start-image class="mb-2" />
       <end-image class="mb-2" />
       <duration-selector class="mb-4" />
@@ -45,6 +46,7 @@ import DurationSelector from './config/DurationSelector.vue';
 import RatioSelector from './config/RatioSelector.vue';
 import StartImage from './config/StartImage.vue';
 import EndImage from './config/EndImage.vue';
+import ReferenceVideo from './config/ReferenceVideo.vue';
 import Consumption from '../common/Consumption.vue';
 import CfgScaleSelector from './config/CfgScaleSelector.vue';
 import GenerateAudioSelector from './config/GenerateAudioSelector.vue';
@@ -54,6 +56,7 @@ import NegativePromptInput from './config/NegativePromptInput.vue';
 import InspirationDrawer from './inspiration/InspirationDrawer.vue';
 import SummaryChip from './SummaryChip.vue';
 import { getConsumption } from '@/utils';
+import { getKlingCapabilities } from '@/utils/kling/capabilities';
 
 export default defineComponent({
   name: 'ConfigPanel',
@@ -73,7 +76,8 @@ export default defineComponent({
     CameraControlSelector,
     InspirationDrawer,
     SummaryChip,
-    EndImage
+    EndImage,
+    ReferenceVideo
   },
   emits: ['generate'],
   data() {
@@ -84,6 +88,9 @@ export default defineComponent({
   computed: {
     config() {
       return this.$store.state.kling?.config;
+    },
+    capabilities() {
+      return getKlingCapabilities(this.config?.model, this.config?.mode, this.config?.duration);
     },
     consumption() {
       return getConsumption(this.config, this.service?.cost);

--- a/src/components/kling/config/ReferenceVideo.vue
+++ b/src/components/kling/config/ReferenceVideo.vue
@@ -1,0 +1,149 @@
+<template>
+  <div class="relative">
+    <div class="flex justify-between">
+      <div class="flex justify-start items-center">
+        <span class="text-sm font-bold">{{ $t('kling.name.referenceVideo') }}</span>
+        <info-icon :content="$t('kling.description.referenceVideo')" />
+      </div>
+    </div>
+    <el-upload
+      v-model:file-list="fileList"
+      accept=".mp4,.mov"
+      name="file"
+      class="value"
+      :show-file-list="true"
+      :limit="1"
+      :multiple="false"
+      :action="uploadUrl"
+      :before-upload="beforeUpload"
+      :on-exceed="onExceed"
+      :on-error="onError"
+      :on-success="onSuccess"
+      :headers="headers"
+    >
+      <template #file="{ file }">
+        <file-preview
+          v-if="file.percentage !== undefined"
+          :url="file.url || (file.response as any)?.file_url"
+          :name="file.name"
+          :percentage="file.percentage"
+          @remove="onRemove(file)"
+        />
+      </template>
+      <el-button round type="primary" size="small" class="btn btn-upload">
+        <font-awesome-icon icon="fa-solid fa-upload" class="icon mr-1" />
+        {{ $t('kling.button.uploadReferenceVideo') }}
+      </el-button>
+    </el-upload>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElButton, ElUpload, ElMessage, UploadFiles, UploadFile } from 'element-plus';
+import { getBaseUrlPlatform, uploadTrackerMixin } from '@/utils';
+import InfoIcon from '@/components/common/InfoIcon.vue';
+import FilePreview from '@/components/common/FilePreview.vue';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import { IKlingReferenceVideo } from '@/models';
+import { KLING_VIDEO_TOKEN, stripKlingVideoToken } from '@/utils/kling/capabilities';
+
+interface IData {
+  fileList: UploadFiles;
+  uploadUrl: string;
+}
+
+export default defineComponent({
+  name: 'ReferenceVideo',
+  components: {
+    ElUpload,
+    ElButton,
+    InfoIcon,
+    FilePreview,
+    FontAwesomeIcon
+  },
+  mixins: [uploadTrackerMixin],
+  data(): IData {
+    return {
+      fileList: [],
+      uploadUrl: getBaseUrlPlatform() + '/api/v1/files/'
+    };
+  },
+  computed: {
+    headers() {
+      return {
+        Authorization: `Bearer ${this.$store.state.token.access}`
+      };
+    },
+    urls(): string[] {
+      // @ts-ignore
+      return this.fileList.map((file: UploadFile) => file?.response?.file_url);
+    }
+  },
+  methods: {
+    onExceed() {
+      ElMessage.warning(this.$t('kling.message.referenceVideoExceed'));
+    },
+    onError() {
+      ElMessage.error(this.$t('kling.message.referenceVideoError'));
+    },
+    beforeUpload(file: File) {
+      const isMP4orMOV = file.type === 'video/mp4' || file.type === 'video/quicktime';
+      const isLt200M = file.size / 1024 / 1024 < 200;
+      if (!isMP4orMOV) {
+        ElMessage.error(this.$t('kling.message.referenceVideoTypeFailed'));
+        return false;
+      }
+      if (!isLt200M) {
+        ElMessage.error(this.$t('kling.message.referenceVideoSizeExceed'));
+        return false;
+      }
+      return true;
+    },
+    ensurePromptToken(add: boolean) {
+      const config = this.$store.state.kling?.config;
+      const prompt = config?.prompt || '';
+      const has = prompt.includes(KLING_VIDEO_TOKEN);
+      let next: string;
+      if (add && !has) {
+        next = prompt ? `${prompt} ${KLING_VIDEO_TOKEN}` : KLING_VIDEO_TOKEN;
+      } else if (!add && has) {
+        next = stripKlingVideoToken(prompt);
+      } else {
+        return;
+      }
+      this.$store.commit('kling/setConfig', { ...config, prompt: next });
+    },
+    onRemove(file: UploadFile) {
+      this.fileList.splice(this.fileList.indexOf(file), 1);
+      this.$store.commit('kling/setConfig', {
+        ...this.$store.state.kling?.config,
+        video_list: undefined
+      });
+      this.ensurePromptToken(false);
+    },
+    onSetVideoList() {
+      const url = this.urls?.[0];
+      const video_list: IKlingReferenceVideo[] | undefined = url
+        ? [{ video_url: url, refer_type: 'base', keep_original_sound: 'no' }]
+        : undefined;
+      this.$store.commit('kling/setConfig', {
+        ...this.$store.state.kling?.config,
+        video_list
+      });
+      this.ensurePromptToken(!!url);
+    },
+    async onSuccess() {
+      this.onSetVideoList();
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.btn.btn-upload {
+  position: absolute;
+  top: 5px;
+  right: 0;
+}
+</style>

--- a/src/i18n/ar/kling.json
+++ b/src/i18n/ar/kling.json
@@ -770,5 +770,33 @@
   "message.uploadAudioError": {
     "message": "فشل رفع الصوت، يرجى المحاولة مرة أخرى.",
     "description": "Talking Photo audio upload error"
+  },
+  "name.referenceVideo": {
+    "message": "Reference Video",
+    "description": "Form field label: reference/editable video for Omni video editing"
+  },
+  "description.referenceVideo": {
+    "message": "Only for kling-video-o1. Upload one MP4/MOV (720-2160px, 3-10s, <=200MB) to edit or reference an existing video. The prompt automatically cites it as <<<video_1>>>; keep that token to describe the edit (e.g. 'turn <<<video_1>>> into anime').",
+    "description": "Help text for the reference video uploader"
+  },
+  "button.uploadReferenceVideo": {
+    "message": "Upload Video",
+    "description": "Button to upload the reference video"
+  },
+  "message.referenceVideoExceed": {
+    "message": "You can upload a maximum of 1 reference video",
+    "description": "Error when more than one reference video is uploaded"
+  },
+  "message.referenceVideoError": {
+    "message": "Reference video upload failed, please try again later",
+    "description": "Error when the reference video upload fails"
+  },
+  "message.referenceVideoTypeFailed": {
+    "message": "Uploaded file must be in MP4 or MOV format!",
+    "description": "Error when the reference video is not MP4/MOV"
+  },
+  "message.referenceVideoSizeExceed": {
+    "message": "Uploaded file size cannot exceed 200MB!",
+    "description": "Error when the reference video exceeds 200MB"
   }
 }

--- a/src/i18n/de/kling.json
+++ b/src/i18n/de/kling.json
@@ -770,5 +770,33 @@
   "message.uploadAudioError": {
     "message": "Audio-Upload fehlgeschlagen, bitte erneut versuchen.",
     "description": "Talking Photo audio upload error"
+  },
+  "name.referenceVideo": {
+    "message": "Reference Video",
+    "description": "Form field label: reference/editable video for Omni video editing"
+  },
+  "description.referenceVideo": {
+    "message": "Only for kling-video-o1. Upload one MP4/MOV (720-2160px, 3-10s, <=200MB) to edit or reference an existing video. The prompt automatically cites it as <<<video_1>>>; keep that token to describe the edit (e.g. 'turn <<<video_1>>> into anime').",
+    "description": "Help text for the reference video uploader"
+  },
+  "button.uploadReferenceVideo": {
+    "message": "Upload Video",
+    "description": "Button to upload the reference video"
+  },
+  "message.referenceVideoExceed": {
+    "message": "You can upload a maximum of 1 reference video",
+    "description": "Error when more than one reference video is uploaded"
+  },
+  "message.referenceVideoError": {
+    "message": "Reference video upload failed, please try again later",
+    "description": "Error when the reference video upload fails"
+  },
+  "message.referenceVideoTypeFailed": {
+    "message": "Uploaded file must be in MP4 or MOV format!",
+    "description": "Error when the reference video is not MP4/MOV"
+  },
+  "message.referenceVideoSizeExceed": {
+    "message": "Uploaded file size cannot exceed 200MB!",
+    "description": "Error when the reference video exceeds 200MB"
   }
 }

--- a/src/i18n/el/kling.json
+++ b/src/i18n/el/kling.json
@@ -770,5 +770,33 @@
   "message.uploadAudioError": {
     "message": "Η μεταφόρτωση ήχου απέτυχε, δοκιμάστε ξανά.",
     "description": "Talking Photo audio upload error"
+  },
+  "name.referenceVideo": {
+    "message": "Reference Video",
+    "description": "Form field label: reference/editable video for Omni video editing"
+  },
+  "description.referenceVideo": {
+    "message": "Only for kling-video-o1. Upload one MP4/MOV (720-2160px, 3-10s, <=200MB) to edit or reference an existing video. The prompt automatically cites it as <<<video_1>>>; keep that token to describe the edit (e.g. 'turn <<<video_1>>> into anime').",
+    "description": "Help text for the reference video uploader"
+  },
+  "button.uploadReferenceVideo": {
+    "message": "Upload Video",
+    "description": "Button to upload the reference video"
+  },
+  "message.referenceVideoExceed": {
+    "message": "You can upload a maximum of 1 reference video",
+    "description": "Error when more than one reference video is uploaded"
+  },
+  "message.referenceVideoError": {
+    "message": "Reference video upload failed, please try again later",
+    "description": "Error when the reference video upload fails"
+  },
+  "message.referenceVideoTypeFailed": {
+    "message": "Uploaded file must be in MP4 or MOV format!",
+    "description": "Error when the reference video is not MP4/MOV"
+  },
+  "message.referenceVideoSizeExceed": {
+    "message": "Uploaded file size cannot exceed 200MB!",
+    "description": "Error when the reference video exceeds 200MB"
   }
 }

--- a/src/i18n/en/kling.json
+++ b/src/i18n/en/kling.json
@@ -770,5 +770,33 @@
   "message.uploadAudioError": {
     "message": "Audio upload failed, please retry.",
     "description": "Talking Photo audio upload error"
+  },
+  "name.referenceVideo": {
+    "message": "Reference Video",
+    "description": "Form field label: reference/editable video for Omni video editing"
+  },
+  "description.referenceVideo": {
+    "message": "Only for kling-video-o1. Upload one MP4/MOV (720-2160px, 3-10s, <=200MB) to edit or reference an existing video. The prompt automatically cites it as <<<video_1>>>; keep that token to describe the edit (e.g. 'turn <<<video_1>>> into anime').",
+    "description": "Help text for the reference video uploader"
+  },
+  "button.uploadReferenceVideo": {
+    "message": "Upload Video",
+    "description": "Button to upload the reference video"
+  },
+  "message.referenceVideoExceed": {
+    "message": "You can upload a maximum of 1 reference video",
+    "description": "Error when more than one reference video is uploaded"
+  },
+  "message.referenceVideoError": {
+    "message": "Reference video upload failed, please try again later",
+    "description": "Error when the reference video upload fails"
+  },
+  "message.referenceVideoTypeFailed": {
+    "message": "Uploaded file must be in MP4 or MOV format!",
+    "description": "Error when the reference video is not MP4/MOV"
+  },
+  "message.referenceVideoSizeExceed": {
+    "message": "Uploaded file size cannot exceed 200MB!",
+    "description": "Error when the reference video exceeds 200MB"
   }
 }

--- a/src/i18n/es/kling.json
+++ b/src/i18n/es/kling.json
@@ -770,5 +770,33 @@
   "message.uploadAudioError": {
     "message": "Error al subir el audio, inténtalo de nuevo.",
     "description": "Talking Photo audio upload error"
+  },
+  "name.referenceVideo": {
+    "message": "Reference Video",
+    "description": "Form field label: reference/editable video for Omni video editing"
+  },
+  "description.referenceVideo": {
+    "message": "Only for kling-video-o1. Upload one MP4/MOV (720-2160px, 3-10s, <=200MB) to edit or reference an existing video. The prompt automatically cites it as <<<video_1>>>; keep that token to describe the edit (e.g. 'turn <<<video_1>>> into anime').",
+    "description": "Help text for the reference video uploader"
+  },
+  "button.uploadReferenceVideo": {
+    "message": "Upload Video",
+    "description": "Button to upload the reference video"
+  },
+  "message.referenceVideoExceed": {
+    "message": "You can upload a maximum of 1 reference video",
+    "description": "Error when more than one reference video is uploaded"
+  },
+  "message.referenceVideoError": {
+    "message": "Reference video upload failed, please try again later",
+    "description": "Error when the reference video upload fails"
+  },
+  "message.referenceVideoTypeFailed": {
+    "message": "Uploaded file must be in MP4 or MOV format!",
+    "description": "Error when the reference video is not MP4/MOV"
+  },
+  "message.referenceVideoSizeExceed": {
+    "message": "Uploaded file size cannot exceed 200MB!",
+    "description": "Error when the reference video exceeds 200MB"
   }
 }

--- a/src/i18n/fi/kling.json
+++ b/src/i18n/fi/kling.json
@@ -770,5 +770,33 @@
   "message.uploadAudioError": {
     "message": "Äänen lataus epäonnistui, yritä uudelleen.",
     "description": "Talking Photo audio upload error"
+  },
+  "name.referenceVideo": {
+    "message": "Reference Video",
+    "description": "Form field label: reference/editable video for Omni video editing"
+  },
+  "description.referenceVideo": {
+    "message": "Only for kling-video-o1. Upload one MP4/MOV (720-2160px, 3-10s, <=200MB) to edit or reference an existing video. The prompt automatically cites it as <<<video_1>>>; keep that token to describe the edit (e.g. 'turn <<<video_1>>> into anime').",
+    "description": "Help text for the reference video uploader"
+  },
+  "button.uploadReferenceVideo": {
+    "message": "Upload Video",
+    "description": "Button to upload the reference video"
+  },
+  "message.referenceVideoExceed": {
+    "message": "You can upload a maximum of 1 reference video",
+    "description": "Error when more than one reference video is uploaded"
+  },
+  "message.referenceVideoError": {
+    "message": "Reference video upload failed, please try again later",
+    "description": "Error when the reference video upload fails"
+  },
+  "message.referenceVideoTypeFailed": {
+    "message": "Uploaded file must be in MP4 or MOV format!",
+    "description": "Error when the reference video is not MP4/MOV"
+  },
+  "message.referenceVideoSizeExceed": {
+    "message": "Uploaded file size cannot exceed 200MB!",
+    "description": "Error when the reference video exceeds 200MB"
   }
 }

--- a/src/i18n/fr/kling.json
+++ b/src/i18n/fr/kling.json
@@ -770,5 +770,33 @@
   "message.uploadAudioError": {
     "message": "Échec du téléversement de l’audio, veuillez réessayer.",
     "description": "Talking Photo audio upload error"
+  },
+  "name.referenceVideo": {
+    "message": "Reference Video",
+    "description": "Form field label: reference/editable video for Omni video editing"
+  },
+  "description.referenceVideo": {
+    "message": "Only for kling-video-o1. Upload one MP4/MOV (720-2160px, 3-10s, <=200MB) to edit or reference an existing video. The prompt automatically cites it as <<<video_1>>>; keep that token to describe the edit (e.g. 'turn <<<video_1>>> into anime').",
+    "description": "Help text for the reference video uploader"
+  },
+  "button.uploadReferenceVideo": {
+    "message": "Upload Video",
+    "description": "Button to upload the reference video"
+  },
+  "message.referenceVideoExceed": {
+    "message": "You can upload a maximum of 1 reference video",
+    "description": "Error when more than one reference video is uploaded"
+  },
+  "message.referenceVideoError": {
+    "message": "Reference video upload failed, please try again later",
+    "description": "Error when the reference video upload fails"
+  },
+  "message.referenceVideoTypeFailed": {
+    "message": "Uploaded file must be in MP4 or MOV format!",
+    "description": "Error when the reference video is not MP4/MOV"
+  },
+  "message.referenceVideoSizeExceed": {
+    "message": "Uploaded file size cannot exceed 200MB!",
+    "description": "Error when the reference video exceeds 200MB"
   }
 }

--- a/src/i18n/it/kling.json
+++ b/src/i18n/it/kling.json
@@ -770,5 +770,33 @@
   "message.uploadAudioError": {
     "message": "Caricamento audio non riuscito, riprova.",
     "description": "Talking Photo audio upload error"
+  },
+  "name.referenceVideo": {
+    "message": "Reference Video",
+    "description": "Form field label: reference/editable video for Omni video editing"
+  },
+  "description.referenceVideo": {
+    "message": "Only for kling-video-o1. Upload one MP4/MOV (720-2160px, 3-10s, <=200MB) to edit or reference an existing video. The prompt automatically cites it as <<<video_1>>>; keep that token to describe the edit (e.g. 'turn <<<video_1>>> into anime').",
+    "description": "Help text for the reference video uploader"
+  },
+  "button.uploadReferenceVideo": {
+    "message": "Upload Video",
+    "description": "Button to upload the reference video"
+  },
+  "message.referenceVideoExceed": {
+    "message": "You can upload a maximum of 1 reference video",
+    "description": "Error when more than one reference video is uploaded"
+  },
+  "message.referenceVideoError": {
+    "message": "Reference video upload failed, please try again later",
+    "description": "Error when the reference video upload fails"
+  },
+  "message.referenceVideoTypeFailed": {
+    "message": "Uploaded file must be in MP4 or MOV format!",
+    "description": "Error when the reference video is not MP4/MOV"
+  },
+  "message.referenceVideoSizeExceed": {
+    "message": "Uploaded file size cannot exceed 200MB!",
+    "description": "Error when the reference video exceeds 200MB"
   }
 }

--- a/src/i18n/ja/kling.json
+++ b/src/i18n/ja/kling.json
@@ -770,5 +770,33 @@
   "message.uploadAudioError": {
     "message": "音声のアップロードに失敗しました。もう一度お試しください。",
     "description": "Talking Photo audio upload error"
+  },
+  "name.referenceVideo": {
+    "message": "Reference Video",
+    "description": "Form field label: reference/editable video for Omni video editing"
+  },
+  "description.referenceVideo": {
+    "message": "Only for kling-video-o1. Upload one MP4/MOV (720-2160px, 3-10s, <=200MB) to edit or reference an existing video. The prompt automatically cites it as <<<video_1>>>; keep that token to describe the edit (e.g. 'turn <<<video_1>>> into anime').",
+    "description": "Help text for the reference video uploader"
+  },
+  "button.uploadReferenceVideo": {
+    "message": "Upload Video",
+    "description": "Button to upload the reference video"
+  },
+  "message.referenceVideoExceed": {
+    "message": "You can upload a maximum of 1 reference video",
+    "description": "Error when more than one reference video is uploaded"
+  },
+  "message.referenceVideoError": {
+    "message": "Reference video upload failed, please try again later",
+    "description": "Error when the reference video upload fails"
+  },
+  "message.referenceVideoTypeFailed": {
+    "message": "Uploaded file must be in MP4 or MOV format!",
+    "description": "Error when the reference video is not MP4/MOV"
+  },
+  "message.referenceVideoSizeExceed": {
+    "message": "Uploaded file size cannot exceed 200MB!",
+    "description": "Error when the reference video exceeds 200MB"
   }
 }

--- a/src/i18n/ko/kling.json
+++ b/src/i18n/ko/kling.json
@@ -770,5 +770,33 @@
   "message.uploadAudioError": {
     "message": "오디오 업로드에 실패했습니다. 다시 시도하세요.",
     "description": "Talking Photo audio upload error"
+  },
+  "name.referenceVideo": {
+    "message": "Reference Video",
+    "description": "Form field label: reference/editable video for Omni video editing"
+  },
+  "description.referenceVideo": {
+    "message": "Only for kling-video-o1. Upload one MP4/MOV (720-2160px, 3-10s, <=200MB) to edit or reference an existing video. The prompt automatically cites it as <<<video_1>>>; keep that token to describe the edit (e.g. 'turn <<<video_1>>> into anime').",
+    "description": "Help text for the reference video uploader"
+  },
+  "button.uploadReferenceVideo": {
+    "message": "Upload Video",
+    "description": "Button to upload the reference video"
+  },
+  "message.referenceVideoExceed": {
+    "message": "You can upload a maximum of 1 reference video",
+    "description": "Error when more than one reference video is uploaded"
+  },
+  "message.referenceVideoError": {
+    "message": "Reference video upload failed, please try again later",
+    "description": "Error when the reference video upload fails"
+  },
+  "message.referenceVideoTypeFailed": {
+    "message": "Uploaded file must be in MP4 or MOV format!",
+    "description": "Error when the reference video is not MP4/MOV"
+  },
+  "message.referenceVideoSizeExceed": {
+    "message": "Uploaded file size cannot exceed 200MB!",
+    "description": "Error when the reference video exceeds 200MB"
   }
 }

--- a/src/i18n/pl/kling.json
+++ b/src/i18n/pl/kling.json
@@ -770,5 +770,33 @@
   "message.uploadAudioError": {
     "message": "Przesłanie audio nie powiodło się, spróbuj ponownie.",
     "description": "Talking Photo audio upload error"
+  },
+  "name.referenceVideo": {
+    "message": "Reference Video",
+    "description": "Form field label: reference/editable video for Omni video editing"
+  },
+  "description.referenceVideo": {
+    "message": "Only for kling-video-o1. Upload one MP4/MOV (720-2160px, 3-10s, <=200MB) to edit or reference an existing video. The prompt automatically cites it as <<<video_1>>>; keep that token to describe the edit (e.g. 'turn <<<video_1>>> into anime').",
+    "description": "Help text for the reference video uploader"
+  },
+  "button.uploadReferenceVideo": {
+    "message": "Upload Video",
+    "description": "Button to upload the reference video"
+  },
+  "message.referenceVideoExceed": {
+    "message": "You can upload a maximum of 1 reference video",
+    "description": "Error when more than one reference video is uploaded"
+  },
+  "message.referenceVideoError": {
+    "message": "Reference video upload failed, please try again later",
+    "description": "Error when the reference video upload fails"
+  },
+  "message.referenceVideoTypeFailed": {
+    "message": "Uploaded file must be in MP4 or MOV format!",
+    "description": "Error when the reference video is not MP4/MOV"
+  },
+  "message.referenceVideoSizeExceed": {
+    "message": "Uploaded file size cannot exceed 200MB!",
+    "description": "Error when the reference video exceeds 200MB"
   }
 }

--- a/src/i18n/pt/kling.json
+++ b/src/i18n/pt/kling.json
@@ -770,5 +770,33 @@
   "message.uploadAudioError": {
     "message": "Falha no envio do áudio, tente novamente.",
     "description": "Talking Photo audio upload error"
+  },
+  "name.referenceVideo": {
+    "message": "Reference Video",
+    "description": "Form field label: reference/editable video for Omni video editing"
+  },
+  "description.referenceVideo": {
+    "message": "Only for kling-video-o1. Upload one MP4/MOV (720-2160px, 3-10s, <=200MB) to edit or reference an existing video. The prompt automatically cites it as <<<video_1>>>; keep that token to describe the edit (e.g. 'turn <<<video_1>>> into anime').",
+    "description": "Help text for the reference video uploader"
+  },
+  "button.uploadReferenceVideo": {
+    "message": "Upload Video",
+    "description": "Button to upload the reference video"
+  },
+  "message.referenceVideoExceed": {
+    "message": "You can upload a maximum of 1 reference video",
+    "description": "Error when more than one reference video is uploaded"
+  },
+  "message.referenceVideoError": {
+    "message": "Reference video upload failed, please try again later",
+    "description": "Error when the reference video upload fails"
+  },
+  "message.referenceVideoTypeFailed": {
+    "message": "Uploaded file must be in MP4 or MOV format!",
+    "description": "Error when the reference video is not MP4/MOV"
+  },
+  "message.referenceVideoSizeExceed": {
+    "message": "Uploaded file size cannot exceed 200MB!",
+    "description": "Error when the reference video exceeds 200MB"
   }
 }

--- a/src/i18n/ru/kling.json
+++ b/src/i18n/ru/kling.json
@@ -770,5 +770,33 @@
   "message.uploadAudioError": {
     "message": "Не удалось загрузить аудио, повторите попытку.",
     "description": "Talking Photo audio upload error"
+  },
+  "name.referenceVideo": {
+    "message": "Reference Video",
+    "description": "Form field label: reference/editable video for Omni video editing"
+  },
+  "description.referenceVideo": {
+    "message": "Only for kling-video-o1. Upload one MP4/MOV (720-2160px, 3-10s, <=200MB) to edit or reference an existing video. The prompt automatically cites it as <<<video_1>>>; keep that token to describe the edit (e.g. 'turn <<<video_1>>> into anime').",
+    "description": "Help text for the reference video uploader"
+  },
+  "button.uploadReferenceVideo": {
+    "message": "Upload Video",
+    "description": "Button to upload the reference video"
+  },
+  "message.referenceVideoExceed": {
+    "message": "You can upload a maximum of 1 reference video",
+    "description": "Error when more than one reference video is uploaded"
+  },
+  "message.referenceVideoError": {
+    "message": "Reference video upload failed, please try again later",
+    "description": "Error when the reference video upload fails"
+  },
+  "message.referenceVideoTypeFailed": {
+    "message": "Uploaded file must be in MP4 or MOV format!",
+    "description": "Error when the reference video is not MP4/MOV"
+  },
+  "message.referenceVideoSizeExceed": {
+    "message": "Uploaded file size cannot exceed 200MB!",
+    "description": "Error when the reference video exceeds 200MB"
   }
 }

--- a/src/i18n/sr/kling.json
+++ b/src/i18n/sr/kling.json
@@ -770,5 +770,33 @@
   "message.uploadAudioError": {
     "message": "Отпремање звука није успело, покушајте поново.",
     "description": "Talking Photo audio upload error"
+  },
+  "name.referenceVideo": {
+    "message": "Reference Video",
+    "description": "Form field label: reference/editable video for Omni video editing"
+  },
+  "description.referenceVideo": {
+    "message": "Only for kling-video-o1. Upload one MP4/MOV (720-2160px, 3-10s, <=200MB) to edit or reference an existing video. The prompt automatically cites it as <<<video_1>>>; keep that token to describe the edit (e.g. 'turn <<<video_1>>> into anime').",
+    "description": "Help text for the reference video uploader"
+  },
+  "button.uploadReferenceVideo": {
+    "message": "Upload Video",
+    "description": "Button to upload the reference video"
+  },
+  "message.referenceVideoExceed": {
+    "message": "You can upload a maximum of 1 reference video",
+    "description": "Error when more than one reference video is uploaded"
+  },
+  "message.referenceVideoError": {
+    "message": "Reference video upload failed, please try again later",
+    "description": "Error when the reference video upload fails"
+  },
+  "message.referenceVideoTypeFailed": {
+    "message": "Uploaded file must be in MP4 or MOV format!",
+    "description": "Error when the reference video is not MP4/MOV"
+  },
+  "message.referenceVideoSizeExceed": {
+    "message": "Uploaded file size cannot exceed 200MB!",
+    "description": "Error when the reference video exceeds 200MB"
   }
 }

--- a/src/i18n/sv/kling.json
+++ b/src/i18n/sv/kling.json
@@ -770,5 +770,33 @@
   "message.uploadAudioError": {
     "message": "Ljuduppladdningen misslyckades, försök igen.",
     "description": "Talking Photo audio upload error"
+  },
+  "name.referenceVideo": {
+    "message": "Reference Video",
+    "description": "Form field label: reference/editable video for Omni video editing"
+  },
+  "description.referenceVideo": {
+    "message": "Only for kling-video-o1. Upload one MP4/MOV (720-2160px, 3-10s, <=200MB) to edit or reference an existing video. The prompt automatically cites it as <<<video_1>>>; keep that token to describe the edit (e.g. 'turn <<<video_1>>> into anime').",
+    "description": "Help text for the reference video uploader"
+  },
+  "button.uploadReferenceVideo": {
+    "message": "Upload Video",
+    "description": "Button to upload the reference video"
+  },
+  "message.referenceVideoExceed": {
+    "message": "You can upload a maximum of 1 reference video",
+    "description": "Error when more than one reference video is uploaded"
+  },
+  "message.referenceVideoError": {
+    "message": "Reference video upload failed, please try again later",
+    "description": "Error when the reference video upload fails"
+  },
+  "message.referenceVideoTypeFailed": {
+    "message": "Uploaded file must be in MP4 or MOV format!",
+    "description": "Error when the reference video is not MP4/MOV"
+  },
+  "message.referenceVideoSizeExceed": {
+    "message": "Uploaded file size cannot exceed 200MB!",
+    "description": "Error when the reference video exceeds 200MB"
   }
 }

--- a/src/i18n/uk/kling.json
+++ b/src/i18n/uk/kling.json
@@ -770,5 +770,33 @@
   "message.uploadAudioError": {
     "message": "Не вдалося завантажити аудіо, повторіть спробу.",
     "description": "Talking Photo audio upload error"
+  },
+  "name.referenceVideo": {
+    "message": "Reference Video",
+    "description": "Form field label: reference/editable video for Omni video editing"
+  },
+  "description.referenceVideo": {
+    "message": "Only for kling-video-o1. Upload one MP4/MOV (720-2160px, 3-10s, <=200MB) to edit or reference an existing video. The prompt automatically cites it as <<<video_1>>>; keep that token to describe the edit (e.g. 'turn <<<video_1>>> into anime').",
+    "description": "Help text for the reference video uploader"
+  },
+  "button.uploadReferenceVideo": {
+    "message": "Upload Video",
+    "description": "Button to upload the reference video"
+  },
+  "message.referenceVideoExceed": {
+    "message": "You can upload a maximum of 1 reference video",
+    "description": "Error when more than one reference video is uploaded"
+  },
+  "message.referenceVideoError": {
+    "message": "Reference video upload failed, please try again later",
+    "description": "Error when the reference video upload fails"
+  },
+  "message.referenceVideoTypeFailed": {
+    "message": "Uploaded file must be in MP4 or MOV format!",
+    "description": "Error when the reference video is not MP4/MOV"
+  },
+  "message.referenceVideoSizeExceed": {
+    "message": "Uploaded file size cannot exceed 200MB!",
+    "description": "Error when the reference video exceeds 200MB"
   }
 }

--- a/src/i18n/zh-CN/kling.json
+++ b/src/i18n/zh-CN/kling.json
@@ -770,5 +770,33 @@
   "message.uploadAudioError": {
     "message": "音频上传失败，请重试。",
     "description": "Talking Photo 音频上传失败提示"
+  },
+  "name.referenceVideo": {
+    "message": "参考视频",
+    "description": "表单字段标签：Omni 视频编辑的参考/待编辑视频"
+  },
+  "description.referenceVideo": {
+    "message": "仅 kling-video-o1 支持。上传一个 MP4/MOV（720–2160px、3–10 秒、≤200MB）用于编辑或参考已有视频。提示词会自动以 <<<video_1>>> 引用它，请保留该标记来描述编辑效果（如「把 <<<video_1>>> 改成动漫风格」）。",
+    "description": "参考视频上传的帮助文字"
+  },
+  "button.uploadReferenceVideo": {
+    "message": "上传视频",
+    "description": "上传参考视频的按钮"
+  },
+  "message.referenceVideoExceed": {
+    "message": "最多只能上传 1 个参考视频",
+    "description": "上传超过 1 个参考视频时的错误提示"
+  },
+  "message.referenceVideoError": {
+    "message": "参考视频上传失败，请稍后重试",
+    "description": "参考视频上传失败时的错误提示"
+  },
+  "message.referenceVideoTypeFailed": {
+    "message": "上传的文件必须是 MP4 或 MOV 格式！",
+    "description": "参考视频格式不是 MP4/MOV 时的错误提示"
+  },
+  "message.referenceVideoSizeExceed": {
+    "message": "上传的文件大小不能超过 200MB！",
+    "description": "参考视频超过 200MB 时的错误提示"
   }
 }

--- a/src/i18n/zh-TW/kling.json
+++ b/src/i18n/zh-TW/kling.json
@@ -770,5 +770,33 @@
   "message.uploadAudioError": {
     "message": "音訊上傳失敗，請重試。",
     "description": "Talking Photo audio upload error"
+  },
+  "name.referenceVideo": {
+    "message": "Reference Video",
+    "description": "Form field label: reference/editable video for Omni video editing"
+  },
+  "description.referenceVideo": {
+    "message": "Only for kling-video-o1. Upload one MP4/MOV (720-2160px, 3-10s, <=200MB) to edit or reference an existing video. The prompt automatically cites it as <<<video_1>>>; keep that token to describe the edit (e.g. 'turn <<<video_1>>> into anime').",
+    "description": "Help text for the reference video uploader"
+  },
+  "button.uploadReferenceVideo": {
+    "message": "Upload Video",
+    "description": "Button to upload the reference video"
+  },
+  "message.referenceVideoExceed": {
+    "message": "You can upload a maximum of 1 reference video",
+    "description": "Error when more than one reference video is uploaded"
+  },
+  "message.referenceVideoError": {
+    "message": "Reference video upload failed, please try again later",
+    "description": "Error when the reference video upload fails"
+  },
+  "message.referenceVideoTypeFailed": {
+    "message": "Uploaded file must be in MP4 or MOV format!",
+    "description": "Error when the reference video is not MP4/MOV"
+  },
+  "message.referenceVideoSizeExceed": {
+    "message": "Uploaded file size cannot exceed 200MB!",
+    "description": "Error when the reference video exceeds 200MB"
   }
 }

--- a/src/utils/kling/capabilities.ts
+++ b/src/utils/kling/capabilities.ts
@@ -19,6 +19,9 @@ export interface IKlingCapability {
    *  camera_control whenever start_image_url is set, regardless of this flag —
    *  see findKlingConflicts. */
   motionControl: boolean;
+  /** Omni reference video (video_list) — edit/reference an existing video.
+   *  Only kling-video-o1 supports it. */
+  referenceVideo: boolean;
 }
 
 const FALLBACK: IKlingCapability = {
@@ -26,7 +29,8 @@ const FALLBACK: IKlingCapability = {
   image2video: true,
   endImage: false,
   audio: false,
-  motionControl: false
+  motionControl: false,
+  referenceVideo: false
 };
 
 /**
@@ -46,7 +50,8 @@ export function getKlingCapabilities(model?: string, mode?: string, duration?: n
         image2video: true,
         endImage: d === 5,
         audio: false,
-        motionControl: d === 5
+        motionControl: d === 5,
+        referenceVideo: false
       };
     // v1.6 / v2.5-Turbo / v2.6 / v2.1: end-frame is pro-only.
     case 'kling-v1-6':
@@ -56,7 +61,8 @@ export function getKlingCapabilities(model?: string, mode?: string, duration?: n
         image2video: true,
         endImage: m === 'pro',
         audio: false,
-        motionControl: false
+        motionControl: false,
+        referenceVideo: false
       };
     case 'kling-v2-6':
       return {
@@ -64,7 +70,8 @@ export function getKlingCapabilities(model?: string, mode?: string, duration?: n
         image2video: true,
         endImage: m === 'pro',
         audio: m === 'pro',
-        motionControl: false
+        motionControl: false,
+        referenceVideo: false
       };
     // v2-Master / v2.1-Master: single-mode, no end-frame in matrix.
     case 'kling-v2-master':
@@ -74,7 +81,8 @@ export function getKlingCapabilities(model?: string, mode?: string, duration?: n
         image2video: true,
         endImage: false,
         audio: false,
-        motionControl: false
+        motionControl: false,
+        referenceVideo: false
       };
     // v3 family: end-frame in every mode; motion control on v3 std/pro only.
     case 'kling-v3':
@@ -83,7 +91,8 @@ export function getKlingCapabilities(model?: string, mode?: string, duration?: n
         image2video: true,
         endImage: true,
         audio: true,
-        motionControl: m !== '4k'
+        motionControl: m !== '4k',
+        referenceVideo: false
       };
     case 'kling-v3-omni':
       return {
@@ -91,7 +100,8 @@ export function getKlingCapabilities(model?: string, mode?: string, duration?: n
         image2video: true,
         endImage: true,
         audio: true,
-        motionControl: false
+        motionControl: false,
+        referenceVideo: false
       };
     case 'kling-video-o1':
       return {
@@ -99,7 +109,8 @@ export function getKlingCapabilities(model?: string, mode?: string, duration?: n
         image2video: true,
         endImage: true,
         audio: false,
-        motionControl: false
+        motionControl: false,
+        referenceVideo: true
       };
     default:
       return FALLBACK;
@@ -108,9 +119,24 @@ export function getKlingCapabilities(model?: string, mode?: string, duration?: n
 
 export interface IKlingConflict {
   /** Field name in the config object. */
-  field: 'end_image_url' | 'generate_audio' | 'camera_control';
+  field: 'end_image_url' | 'generate_audio' | 'camera_control' | 'video_list';
   /** i18n key for the user-facing label of the field. */
   i18nLabel: string;
+}
+
+// The Omni reference video must be cited in the prompt as <<<video_1>>>, or the
+// upstream model ignores it. Shared so the uploader and the model-switch
+// cleanup remove it consistently.
+export const KLING_VIDEO_TOKEN = '<<<video_1>>>';
+
+/** Remove every <<<video_1>>> occurrence and collapse the leftover whitespace. */
+export function stripKlingVideoToken(prompt?: string): string {
+  if (!prompt) return '';
+  return prompt
+    .split(KLING_VIDEO_TOKEN)
+    .join(' ')
+    .replace(/\s{2,}/g, ' ')
+    .trim();
 }
 
 /**
@@ -143,6 +169,10 @@ export function findKlingConflicts(
       conflicts.push({ field: 'camera_control', i18nLabel: 'kling.name.cameraControl' });
     }
   }
+  // Omni reference video (video_list) is only valid on models that advertise it.
+  if (config.video_list?.length && !caps.referenceVideo) {
+    conflicts.push({ field: 'video_list', i18nLabel: 'kling.name.referenceVideo' });
+  }
 
   return conflicts;
 }
@@ -157,6 +187,10 @@ export function clearKlingConflicts(config: Record<string, any>, conflicts: IKli
     if (c.field === 'end_image_url') next.end_image_url = undefined;
     if (c.field === 'generate_audio') next.generate_audio = false;
     if (c.field === 'camera_control') next.camera_control = undefined;
+    if (c.field === 'video_list') {
+      next.video_list = undefined;
+      next.prompt = stripKlingVideoToken(next.prompt);
+    }
   }
   return next;
 }


### PR DESCRIPTION
## What

Add a **Reference Video** uploader to the Kling config panel so users can drive the `kling-video-o1` **Omni video editing / reference-video** capability from Nexior. Previously `kling-video-o1` was selectable but there was **no UI** to provide `video_list`, so the "edit an existing video" feature was unreachable in the app.

## Changes

- **New** `components/kling/config/ReferenceVideo.vue` — uploads one MP4/MOV (≤200MB) and writes `config.video_list = [{ video_url, refer_type: 'base', keep_original_sound: 'no' }]`. Only shown for `kling-video-o1` (gated by a new capability).
- **Prompt token** — the upstream Omni model only applies a reference video when the prompt cites it as `<<<video_1>>>`. On upload the token is auto-appended (if absent); on removal it is stripped. Centralized in `KLING_VIDEO_TOKEN` + `stripKlingVideoToken()` (global, whitespace-collapsing).
- **capabilities.ts** — new `referenceVideo` flag (true only for `kling-video-o1`); `video_list` added to `findKlingConflicts`/`clearKlingConflicts`, so switching model away from o1 clears `video_list` **and** strips the prompt token via the existing confirm/clear flow.
- **ConfigPanel.vue** — renders `<reference-video v-if="capabilities.referenceVideo">`.
- **i18n** — zh-CN + en strings; the 7 keys mirrored to all 18 locales for the coverage gate (translate CronJob localizes later).

## Validation

- `vue-tsc --noEmit` → 0 errors
- `eslint` (changed files) → clean
- `prettier --check` (all touched JSON) → clean
- `scripts/check_i18n_coverage.py` → pass

## 🤖 对抗评审

Reviewer: Codex (`codex exec --sandbox read-only`), 2 rounds.
- **Round 1 RISK**: token cleanup was single-replace / could delete a user token; model-switch left stale `video_list` + token. → **Fixed**: shared global `stripKlingVideoToken()`; `video_list` added to the conflict clear path.
- **Round 2**: probed the "stale local `fileList` vs cleared store" edge — not reachable because the uploader is `v-if`-gated on `referenceVideo` and unmounts when switching away from `kling-video-o1`. Type surface (`IKlingConfig`/`IKlingGenerateRequest` already include `video_list`) and payload path confirmed. **VERDICT: CLEAN**
