### PR TITLE
feat(omni): add Omni video module (omni-flash text/image/video-to-video + editing)

### DIFF
--- a/change/@acedatacloud-nexior-omni-video-module.json
+++ b/change/@acedatacloud-nexior-omni-video-module.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add Omni video module (omni-flash text/image/video-to-video and video editing)",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/common/Navigator.vue
+++ b/src/components/common/Navigator.vue
@@ -98,6 +98,7 @@ import {
   ROUTE_SEEDREAM_INDEX,
   ROUTE_SEEDANCE_INDEX,
   ROUTE_GROKVIDEO_INDEX,
+  ROUTE_OMNI_INDEX,
   ROUTE_WAN_INDEX,
   ROUTE_PRODUCER_INDEX,
   ROUTE_FISH_TTS_INDEX,
@@ -124,6 +125,7 @@ import {
   SEEDREAM_LOGO,
   SEEDANCE_LOGO,
   GROKVIDEO_LOGO,
+  OMNI_LOGO,
   SUNO_LOGO,
   LUMA_LOGO,
   HAILUO_LOGO,
@@ -331,6 +333,15 @@ export default defineComponent({
           displayName: this.$t('common.nav.grokvideo'),
           logo: GROKVIDEO_LOGO,
           routes: [ROUTE_GROKVIDEO_INDEX],
+          category: 'video'
+        });
+      }
+      if (this.$store?.state?.site?.features?.omni?.enabled) {
+        result.push({
+          route: { name: ROUTE_OMNI_INDEX },
+          displayName: this.$t('common.nav.omni'),
+          logo: OMNI_LOGO,
+          routes: [ROUTE_OMNI_INDEX],
           category: 'video'
         });
       }

--- a/src/components/omni/ConfigPanel.vue
+++ b/src/components/omni/ConfigPanel.vue
@@ -1,0 +1,62 @@
+<template>
+  <div class="flex flex-col h-full">
+    <div class="flex-1 overflow-y-auto p-5">
+      <prompt-input class="mb-4" />
+      <ratio-selector class="mb-4" />
+      <resolution-selector class="mb-4" />
+      <reference-images-input class="mb-2" />
+      <video-input class="mb-2" />
+    </div>
+    <div class="flex flex-col items-center justify-center px-5 pb-5">
+      <consumption :value="consumption" :service="service" />
+      <el-button type="primary" class="btn w-full" round @click="onGenerate">
+        <font-awesome-icon icon="fa-solid fa-magic" class="mr-2" />
+        {{ $t('omni.button.generate') }}
+      </el-button>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElButton } from 'element-plus';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import PromptInput from './config/PromptInput.vue';
+import ResolutionSelector from './config/ResolutionSelector.vue';
+import RatioSelector from './config/RatioSelector.vue';
+import ReferenceImagesInput from './config/ReferenceImagesInput.vue';
+import VideoInput from './config/VideoInput.vue';
+import Consumption from '../common/Consumption.vue';
+import { getConsumption } from '@/utils';
+
+export default defineComponent({
+  name: 'OmniConfigPanel',
+  components: {
+    ElButton,
+    FontAwesomeIcon,
+    PromptInput,
+    ResolutionSelector,
+    RatioSelector,
+    ReferenceImagesInput,
+    VideoInput,
+    Consumption
+  },
+  emits: ['generate'],
+  computed: {
+    config() {
+      return this.$store.state.omni?.config;
+    },
+    consumption() {
+      return getConsumption(this.config, this.service?.cost);
+    },
+    service() {
+      return this.$store.state.omni?.service;
+    }
+  },
+  methods: {
+    onGenerate() {
+      this.$emit('generate');
+    }
+  }
+});
+</script>

--- a/src/components/omni/RecentPanel.vue
+++ b/src/components/omni/RecentPanel.vue
@@ -1,0 +1,56 @@
+<template>
+  <div v-if="tasks?.items === undefined">
+    <bot-placeholder />
+  </div>
+  <scroll-list
+    v-else-if="tasks?.items?.length && tasks?.items?.length > 0"
+    ref="scrollList"
+    class="tasks w-full h-full overflow-y-auto"
+    :loading="loading"
+    @reach-top="$emit('reach-top')"
+  >
+    <task-preview v-for="task in tasks?.items" :key="task.id" :model-value="task" />
+  </scroll-list>
+  <div v-if="tasks?.items?.length === 0" class="w-full h-full flex items-center justify-center">
+    <no-tasks />
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import TaskPreview from './task/Preview.vue';
+import BotPlaceholder from '@/components/common/BotPlaceholder.vue';
+import NoTasks from '@/components/common/NoTasks.vue';
+import ScrollList from '@/components/common/ScrollList.vue';
+
+export default defineComponent({
+  name: 'OmniRecentPanel',
+  components: {
+    TaskPreview,
+    BotPlaceholder,
+    NoTasks,
+    ScrollList
+  },
+  props: {
+    loading: {
+      type: Boolean,
+      default: false
+    }
+  },
+  emits: ['reach-top'],
+  computed: {
+    tasks() {
+      return {
+        ...this.$store.state.omni?.tasks,
+        items: this.$store.state.omni?.tasks?.items?.slice()
+      };
+    }
+  },
+  methods: {
+    getScrollElement(): HTMLElement | undefined {
+      const list = this.$refs.scrollList as any;
+      return list?.getScrollElement?.();
+    }
+  }
+});
+</script>

--- a/src/components/omni/config/PromptInput.vue
+++ b/src/components/omni/config/PromptInput.vue
@@ -1,0 +1,41 @@
+<template>
+  <prompt-textarea
+    v-model="prompt"
+    :title="$t('omni.name.prompt')"
+    :info="$t('omni.description.prompt')"
+    :placeholder="$t('omni.placeholder.prompt')"
+    :min-rows="5"
+  />
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import PromptTextarea from '@/components/common/PromptTextarea.vue';
+
+export const DEFAULT_PROMPT = '';
+
+export default defineComponent({
+  name: 'OmniPromptInput',
+  components: {
+    PromptTextarea
+  },
+  computed: {
+    prompt: {
+      get() {
+        return this.$store.state.omni?.config?.prompt;
+      },
+      set(val: string) {
+        this.$store.commit('omni/setConfig', {
+          ...this.$store.state.omni?.config,
+          prompt: val
+        });
+      }
+    }
+  },
+  mounted() {
+    if (!this.prompt) {
+      this.prompt = DEFAULT_PROMPT;
+    }
+  }
+});
+</script>

--- a/src/components/omni/config/RatioSelector.vue
+++ b/src/components/omni/config/RatioSelector.vue
@@ -1,0 +1,149 @@
+<template>
+  <div class="ratio">
+    <div class="header">
+      <h2 class="title font-bold">{{ $t('omni.name.ratio') }}</h2>
+      <info-icon :content="$t('omni.description.ratio')" class="info" />
+    </div>
+    <div class="items">
+      <div
+        v-for="item in options"
+        :key="item.value"
+        class="item"
+        :class="{ active: value === item.value }"
+        @click="value = item.value"
+      >
+        <div class="preview">
+          <div class="rect" :style="{ width: item.w + 'px', height: item.h + 'px' }" />
+        </div>
+        <div class="name">{{ item.label }}</div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import InfoIcon from '@/components/common/InfoIcon.vue';
+import { OMNI_DEFAULT_RATIO, OMNI_RATIO_16_9, OMNI_RATIO_9_16 } from '@/constants';
+
+interface RatioOption {
+  value: string;
+  label: string;
+  w: number;
+  h: number;
+}
+
+export default defineComponent({
+  name: 'OmniRatioSelector',
+  components: {
+    InfoIcon
+  },
+  computed: {
+    options(): RatioOption[] {
+      return [
+        { value: OMNI_RATIO_16_9, label: '16:9', w: 32, h: 18 },
+        { value: OMNI_RATIO_9_16, label: '9:16', w: 18, h: 32 }
+      ];
+    },
+    value: {
+      get(): string | undefined {
+        return this.$store.state.omni?.config?.aspect_ratio;
+      },
+      set(val: string) {
+        this.$store.commit('omni/setConfig', {
+          ...this.$store.state.omni?.config,
+          aspect_ratio: val
+        });
+      }
+    }
+  },
+  mounted() {
+    if (!this.value) {
+      this.value = OMNI_DEFAULT_RATIO;
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.ratio {
+  .header {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    margin-bottom: 10px;
+
+    .title {
+      font-size: 14px;
+      margin: 0;
+    }
+
+    .info {
+      margin-left: 6px;
+    }
+  }
+
+  .items {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+
+    .item {
+      flex: 0 0 calc(25% - 6px);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 8px 0 6px;
+      border: 1px solid var(--el-border-color);
+      border-radius: 8px;
+      cursor: pointer;
+      transition:
+        background-color 0.15s ease,
+        border-color 0.15s ease,
+        color 0.15s ease;
+      background-color: var(--el-fill-color-lighter);
+
+      &:hover {
+        background-color: var(--el-fill-color);
+        border-color: var(--el-border-color-hover);
+      }
+
+      .preview {
+        width: 100%;
+        height: 40px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        margin-bottom: 4px;
+
+        .rect {
+          border: 1.5px solid var(--el-text-color-secondary);
+          border-radius: 2px;
+          background-color: transparent;
+        }
+      }
+
+      .name {
+        font-size: 12px;
+        color: var(--el-text-color-regular);
+        line-height: 1;
+      }
+
+      &.active {
+        border-color: var(--el-color-primary);
+        background-color: var(--el-color-primary-light-9);
+
+        .rect {
+          border-color: var(--el-color-primary);
+        }
+
+        .name {
+          color: var(--el-color-primary);
+          font-weight: 600;
+        }
+      }
+    }
+  }
+}
+</style>

--- a/src/components/omni/config/ReferenceImagesInput.vue
+++ b/src/components/omni/config/ReferenceImagesInput.vue
@@ -1,0 +1,192 @@
+<template>
+  <div class="field flex items-center justify-between">
+    <h2 class="title font-bold text-[14px] mb-[10px]">{{ $t('omni.name.referenceImages') }}</h2>
+    <div class="upload-wrapper flex flex-col items-start gap-[8px]">
+      <div class="controls flex items-center">
+        <el-upload
+          ref="uploader"
+          v-model:file-list="fileList"
+          accept=".png,.jpg,.jpeg,.gif,.bmp,.webp"
+          name="file"
+          class="value"
+          :limit="limit"
+          :multiple="true"
+          :show-file-list="false"
+          :action="uploadUrl"
+          :on-exceed="onExceed"
+          :on-error="onError"
+          :on-success="onSuccess"
+          :on-change="onChange"
+          :on-remove="onRemove"
+          :headers="headers"
+        >
+          <el-button size="small" type="primary" round>
+            <font-awesome-icon icon="fa-solid fa-upload" class="mr-1" />
+            {{ $t('omni.button.upload') }}
+          </el-button>
+        </el-upload>
+        <info-icon :content="$t('omni.description.referenceImages')" class="ml-2" />
+      </div>
+    </div>
+  </div>
+  <div class="file-list flex flex-wrap gap-[10px]">
+    <image-preview
+      v-for="(file, idx) in fileList"
+      :key="(file as any).uid || (file as any)?.response?.file_url || (file as any).url || idx"
+      :url="(file as any).url || (file as any)?.response?.file_url"
+      :name="(file as any).name"
+      :percentage="(file as any).percentage"
+      @remove="onRemovePreview(idx, file)"
+    />
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElButton, ElUpload, ElMessage, UploadFiles, UploadFile } from 'element-plus';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import { getBaseUrlPlatform } from '@/utils';
+import InfoIcon from '@/components/common/InfoIcon.vue';
+import ImagePreview from '@/components/common/ImagePreview.vue';
+import { pasteUploadMixin, uploadTrackerMixin } from '@/utils';
+
+const MAX_REFERENCE_IMAGES = 4;
+
+interface IData {
+  fileList: UploadFiles;
+  uploadUrl: string;
+  limit: number;
+  suppressWatch: boolean;
+}
+
+export default defineComponent({
+  name: 'OmniReferenceImagesInput',
+  components: {
+    ElUpload,
+    ElButton,
+    InfoIcon,
+    ImagePreview,
+    FontAwesomeIcon
+  },
+  mixins: [pasteUploadMixin, uploadTrackerMixin],
+  data(): IData {
+    return {
+      fileList: [],
+      uploadUrl: getBaseUrlPlatform() + '/api/v1/files/',
+      limit: MAX_REFERENCE_IMAGES,
+      // prevent feedback loops when syncing store -> fileList
+      suppressWatch: false
+    };
+  },
+  computed: {
+    headers() {
+      return {
+        Authorization: `Bearer ${this.$store.state.token.access}`
+      };
+    },
+    urls(): string[] {
+      return (
+        (this.fileList.map((file: UploadFile) => (file?.response as any)?.file_url).filter((u) => !!u) as string[]) ||
+        []
+      );
+    },
+    value(): string[] | undefined {
+      return this.$store.state.omni?.config?.image_urls;
+    }
+  },
+  watch: {
+    value: {
+      immediate: true,
+      handler(newVal?: string[]) {
+        if (this.suppressWatch) return;
+        if (!newVal || newVal.length === 0) {
+          const uploading = (this.fileList || []).filter((f: any) => !f?.response?.file_url);
+          this.fileList = uploading.length ? uploading : [];
+          return;
+        }
+        const newFiles: UploadFiles = [];
+        newVal.forEach((url: string) => {
+          const existing = this.fileList.find(
+            (file) => (file as any)?.response?.file_url === url || (file as any)?.url === url
+          );
+          if (existing) {
+            newFiles.push(existing);
+          } else {
+            newFiles.push({
+              name: url.split('/').pop() || url,
+              url,
+              status: 'success',
+              percentage: 100,
+              response: { file_url: url }
+            } as UploadFile);
+          }
+        });
+        const uploading = (this.fileList || []).filter((f: any) => !f?.response?.file_url);
+        uploading.forEach((f: any) => {
+          const exists = newFiles.some(
+            (nf: any) => nf === f || nf?.url === f?.url || nf?.response?.file_url === f?.response?.file_url
+          );
+          if (!exists) newFiles.push(f);
+        });
+        this.fileList = newFiles;
+      }
+    }
+  },
+  methods: {
+    onChange(file: any) {
+      if (!file?.url && file?.raw) {
+        try {
+          file.url = URL.createObjectURL(file.raw);
+        } catch (e) {
+          // ignore
+        }
+      }
+    },
+    onRemove(file: any) {
+      if (file?.url && typeof file.url === 'string' && file.url.startsWith('blob:')) {
+        try {
+          URL.revokeObjectURL(file.url);
+        } catch (e) {
+          // ignore
+        }
+      }
+      this.onSetReferenceImages();
+    },
+    onExceed() {
+      ElMessage.warning(this.$t('omni.message.uploadReferenceExceed'));
+    },
+    onError() {
+      ElMessage.error(this.$t('omni.message.uploadError'));
+    },
+    onSetReferenceImages() {
+      const urls = this.urls;
+      this.suppressWatch = true;
+      this.$store.commit('omni/setConfig', {
+        ...this.$store.state.omni?.config,
+        image_urls: urls.length ? urls : undefined
+      });
+      this.$nextTick(() => {
+        this.suppressWatch = false;
+      });
+    },
+    async onSuccess(response: any, file: any) {
+      if (response?.file_url) {
+        file.url = response.file_url;
+        file.response = response;
+      }
+      this.onSetReferenceImages();
+    },
+    onRemovePreview(idx: number, file: any) {
+      this.fileList.splice(idx, 1);
+      if (file?.url && typeof file.url === 'string' && file.url.startsWith('blob:')) {
+        try {
+          URL.revokeObjectURL(file.url);
+        } catch (e) {
+          // ignore
+        }
+      }
+      this.onSetReferenceImages();
+    }
+  }
+});
+</script>

--- a/src/components/omni/config/ResolutionSelector.vue
+++ b/src/components/omni/config/ResolutionSelector.vue
@@ -1,0 +1,112 @@
+<template>
+  <div class="resolution">
+    <div class="header">
+      <h2 class="title font-bold">{{ $t('omni.name.resolution') }}</h2>
+      <info-icon :content="$t('omni.description.resolution')" class="info" />
+    </div>
+    <div class="items">
+      <div
+        v-for="item in options"
+        :key="item.value"
+        class="item"
+        :class="{ active: value === item.value }"
+        @click="value = item.value"
+      >
+        {{ item.label }}
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import InfoIcon from '@/components/common/InfoIcon.vue';
+import { OMNI_DEFAULT_RESOLUTION, OMNI_RESOLUTION_720P, OMNI_RESOLUTION_1080P } from '@/constants';
+
+export default defineComponent({
+  name: 'OmniResolutionSelector',
+  components: {
+    InfoIcon
+  },
+  data() {
+    return {
+      options: [
+        { value: OMNI_RESOLUTION_720P, label: '720p' },
+        { value: OMNI_RESOLUTION_1080P, label: '1080p' }
+      ]
+    };
+  },
+  computed: {
+    value: {
+      get(): string | undefined {
+        return this.$store.state.omni?.config?.resolution;
+      },
+      set(val: string) {
+        this.$store.commit('omni/setConfig', {
+          ...this.$store.state.omni?.config,
+          resolution: val
+        });
+      }
+    }
+  },
+  mounted() {
+    if (!this.value) {
+      this.value = OMNI_DEFAULT_RESOLUTION;
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.resolution {
+  .header {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    margin-bottom: 10px;
+
+    .title {
+      font-size: 14px;
+      margin: 0;
+    }
+
+    .info {
+      margin-left: 6px;
+    }
+  }
+
+  .items {
+    display: flex;
+    flex-direction: row;
+    gap: 8px;
+
+    .item {
+      flex: 1;
+      text-align: center;
+      padding: 8px 0;
+      font-size: 13px;
+      color: var(--el-text-color-regular);
+      border: 1px solid var(--el-border-color);
+      border-radius: 8px;
+      cursor: pointer;
+      transition:
+        background-color 0.15s ease,
+        border-color 0.15s ease,
+        color 0.15s ease;
+      background-color: var(--el-fill-color-lighter);
+
+      &:hover {
+        background-color: var(--el-fill-color);
+        border-color: var(--el-border-color-hover);
+      }
+
+      &.active {
+        color: var(--el-color-primary);
+        background-color: var(--el-color-primary-light-9);
+        border-color: var(--el-color-primary);
+        font-weight: 600;
+      }
+    }
+  }
+}
+</style>

--- a/src/components/omni/config/VideoInput.vue
+++ b/src/components/omni/config/VideoInput.vue
@@ -1,0 +1,120 @@
+<template>
+  <div class="field flex items-center justify-between">
+    <h2 class="title font-bold text-[14px] mb-[10px]">{{ $t('omni.name.referenceVideo') }}</h2>
+    <div class="upload-wrapper flex flex-col items-start gap-[8px]">
+      <div class="controls flex items-center">
+        <el-upload
+          v-model:file-list="fileList"
+          accept=".mp4,.mov"
+          name="file"
+          class="value"
+          :show-file-list="false"
+          :limit="1"
+          :multiple="false"
+          :action="uploadUrl"
+          :before-upload="beforeUpload"
+          :on-exceed="onExceed"
+          :on-error="onError"
+          :on-success="onSuccess"
+          :headers="headers"
+        >
+          <el-button size="small" type="primary" round>
+            <font-awesome-icon icon="fa-solid fa-upload" class="mr-1" />
+            {{ $t('omni.button.uploadVideo') }}
+          </el-button>
+        </el-upload>
+        <info-icon :content="$t('omni.description.referenceVideo')" class="ml-2" />
+      </div>
+    </div>
+  </div>
+  <div v-if="videoUrl" class="file-list flex flex-wrap gap-[10px]">
+    <file-preview :url="videoUrl" :name="videoName" :percentage="100" @remove="onRemove" />
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElButton, ElUpload, ElMessage, UploadFiles, UploadFile } from 'element-plus';
+import { getBaseUrlPlatform, uploadTrackerMixin } from '@/utils';
+import InfoIcon from '@/components/common/InfoIcon.vue';
+import FilePreview from '@/components/common/FilePreview.vue';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+
+interface IData {
+  fileList: UploadFiles;
+  uploadUrl: string;
+}
+
+export default defineComponent({
+  name: 'OmniVideoInput',
+  components: {
+    ElUpload,
+    ElButton,
+    InfoIcon,
+    FilePreview,
+    FontAwesomeIcon
+  },
+  mixins: [uploadTrackerMixin],
+  data(): IData {
+    return {
+      fileList: [],
+      uploadUrl: getBaseUrlPlatform() + '/api/v1/files/'
+    };
+  },
+  computed: {
+    headers() {
+      return {
+        Authorization: `Bearer ${this.$store.state.token.access}`
+      };
+    },
+    videoUrl(): string | undefined {
+      return this.$store.state.omni?.config?.video_urls?.[0];
+    },
+    videoName(): string {
+      const url = this.videoUrl || '';
+      return url.split('/').pop() || url;
+    }
+  },
+  methods: {
+    onExceed() {
+      ElMessage.warning(this.$t('omni.message.uploadVideoExceed'));
+    },
+    onError() {
+      ElMessage.error(this.$t('omni.message.uploadVideoError'));
+    },
+    beforeUpload(file: File) {
+      const isMP4orMOV = file.type === 'video/mp4' || file.type === 'video/quicktime';
+      const isLt200M = file.size / 1024 / 1024 < 200;
+      if (!isMP4orMOV) {
+        ElMessage.error(this.$t('omni.message.uploadVideoTypeFailed'));
+        return false;
+      }
+      if (!isLt200M) {
+        ElMessage.error(this.$t('omni.message.uploadVideoSizeExceed'));
+        return false;
+      }
+      return true;
+    },
+    setVideoUrls(url?: string) {
+      this.$store.commit('omni/setConfig', {
+        ...this.$store.state.omni?.config,
+        video_urls: url ? [url] : undefined
+      });
+    },
+    onRemove() {
+      this.fileList = [];
+      this.setVideoUrls(undefined);
+    },
+    async onSuccess(response: any, file: UploadFile) {
+      const url = response?.file_url || (file?.response as any)?.file_url;
+      this.setVideoUrls(url || undefined);
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.title {
+  font-size: 14px;
+}
+</style>

--- a/src/components/omni/task/Preview.vue
+++ b/src/components/omni/task/Preview.vue
@@ -1,0 +1,294 @@
+<template>
+  <div class="preview">
+    <div class="left">
+      <el-image :src="omniLogo" class="avatar" />
+    </div>
+    <div class="main">
+      <div class="bot">
+        {{ $t('omni.name.bot') }}
+        <span class="datetime">
+          {{ $dayjs.format('' + new Date(parseFloat((modelValue?.created_at || '').toString()) * 1000)) }}
+        </span>
+      </div>
+      <div class="info">
+        <div v-if="inputImage" class="flex justify-start items-center gap-2 mt-2 w-full overflow-x-auto">
+          <image-preview :url="inputImage" name="image" :closable="false" />
+        </div>
+        <p v-if="modelValue?.request?.prompt" class="prompt mt-2">
+          {{ modelValue?.request?.prompt }}
+          <span v-if="!modelValue?.response"> - ({{ $t('omni.status.pending') }}) </span>
+          <span v-else-if="video?.state === 'processing' || video?.state === 'pending'">
+            - ({{ $t('omni.status.processing') }})
+          </span>
+        </p>
+      </div>
+      <div v-if="!modelValue?.response" :class="{ content: true }">
+        <el-alert :closable="false" class="info">
+          <template #template>
+            <font-awesome-icon icon="fa-regular fa-clock" class="mr-1" />
+            {{ $t('omni.status.pending') }}
+          </template>
+          <p class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <font-awesome-icon icon="fa-solid fa-magic" class="mr-1" />
+            {{ $t('omni.name.taskId') }}:
+            {{ modelValue?.id }}
+            <copy-to-clipboard :content="modelValue?.id!" class="btn-copy inline-block" />
+          </p>
+          <p v-if="pendingElapsed !== undefined" class="text-[var(--el-text-color-regular)] text-xs mb-0">
+            <font-awesome-icon icon="fa-solid fa-clock" class="mr-1" />
+            {{ $t('omni.name.elapsed') }}: {{ pendingElapsed }}s
+          </p>
+        </el-alert>
+      </div>
+      <div v-else-if="modelValue?.response?.success === true" :class="{ content: true }">
+        <div v-if="video?.video_url" class="mb-4">
+          <video-player :src="video?.video_url" />
+        </div>
+        <div v-if="video?.video_url" :class="{ operations: true, 'mt-2': true, 'mb-2': true }">
+          <el-tooltip class="box-item" effect="dark" :content="$t('omni.message.downloadVideo')" placement="top-start">
+            <el-button type="info" size="small" class="btn-action" @click.stop="onDownload(video?.video_url)">
+              {{ $t('omni.button.download') }}
+            </el-button>
+          </el-tooltip>
+          <api-code-button path="/gemini/videos" :body="modelValue?.request" />
+        </div>
+        <el-alert :closable="false" class="mt-2 success">
+          <p v-if="modelValue?.request?.model" class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <font-awesome-icon icon="fa-solid fa-cube" class="mr-1" />
+            {{ $t('omni.name.model') }}:
+            {{ modelValue?.request?.model }}
+          </p>
+          <p v-if="modelValue?.request?.resolution" class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <font-awesome-icon icon="fa-solid fa-expand" class="mr-1" />
+            {{ $t('omni.name.resolution') }}:
+            {{ modelValue?.request?.resolution }}
+            <span v-if="modelValue?.request?.aspect_ratio"> · {{ modelValue?.request?.aspect_ratio }}</span>
+          </p>
+          <p class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <font-awesome-icon icon="fa-solid fa-magic" class="mr-1" />
+            {{ $t('omni.name.taskId') }}:
+            {{ modelValue?.id }}
+            <copy-to-clipboard :content="modelValue?.id!" class="btn-copy inline-block" />
+          </p>
+          <p v-if="modelValue?.elapsed" class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <font-awesome-icon icon="fa-solid fa-clock" class="mr-1" />
+            {{ $t('omni.name.elapsed') }}: {{ modelValue?.elapsed?.toFixed(2) }}s
+          </p>
+          <p v-if="modelValue?.response?.trace_id" class="text-[var(--el-text-color-regular)] text-xs mb-0">
+            <font-awesome-icon icon="fa-solid fa-hashtag" class="mr-1" />
+            {{ $t('omni.name.traceId') }}:
+            {{ modelValue?.response?.trace_id }}
+            <copy-to-clipboard :content="modelValue?.response?.trace_id" class="btn-copy inline-block" />
+          </p>
+        </el-alert>
+      </div>
+      <div v-else-if="modelValue?.response?.success === false" :class="{ content: true }">
+        <el-alert :closable="false" class="failure">
+          <template #template>
+            <font-awesome-icon icon="fa-solid fa-exclamation-triangle" class="mr-1" />
+            {{ $t('omni.name.failure') }}
+          </template>
+          <p class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <font-awesome-icon icon="fa-solid fa-magic" class="mr-1" />
+            {{ $t('omni.name.taskId') }}:
+            {{ modelValue?.id }}
+            <copy-to-clipboard :content="modelValue?.id!" class="btn-copy inline-block" />
+          </p>
+          <p v-if="modelValue?.response?.error?.message" class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <font-awesome-icon icon="fa-solid fa-circle-info" class="mr-1" />
+            {{ $t('omni.name.failureReason') }}:
+            {{ modelValue?.response?.error?.message }}
+            <copy-to-clipboard :content="modelValue?.response?.error?.message!" class="btn-copy inline-block" />
+          </p>
+          <p v-if="modelValue?.response?.trace_id" class="text-[var(--el-text-color-regular)] text-xs mb-0">
+            <font-awesome-icon icon="fa-solid fa-hashtag" class="mr-1" />
+            {{ $t('omni.name.traceId') }}:
+            {{ modelValue?.response?.trace_id }}
+            <copy-to-clipboard :content="modelValue?.response?.trace_id" class="btn-copy inline-block" />
+          </p>
+        </el-alert>
+      </div>
+      <div v-else :class="{ content: true }">
+        <el-alert :closable="false" class="info">
+          <template #template>
+            <font-awesome-icon icon="fa-solid fa-circle-info" class="mr-1" />
+            {{ $t('omni.name.status') }}
+          </template>
+          <p class="text-[var(--el-text-color-regular)] text-xs mb-0">
+            <font-awesome-icon icon="fa-solid fa-magic" class="mr-1" />
+            {{ $t('omni.name.taskId') }}:
+            {{ modelValue?.id }}
+            <copy-to-clipboard :content="modelValue?.id!" class="btn-copy inline-block" />
+          </p>
+        </el-alert>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElImage, ElAlert, ElButton, ElTooltip } from 'element-plus';
+import { IOmniTask, IOmniVideo } from '@/models';
+import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import VideoPlayer from '@/components/common/VideoPlayer.vue';
+import ImagePreview from '@/components/common/ImagePreview.vue';
+import ApiCodeButton from '@/components/common/ApiCodeButton.vue';
+import { OMNI_LOGO } from '@/constants';
+
+export default defineComponent({
+  name: 'OmniTaskPreview',
+  components: {
+    ElImage,
+    CopyToClipboard,
+    FontAwesomeIcon,
+    ElAlert,
+    VideoPlayer,
+    ElTooltip,
+    ElButton,
+    ImagePreview,
+    ApiCodeButton
+  },
+  props: {
+    modelValue: {
+      type: Object as () => IOmniTask | undefined,
+      required: true
+    }
+  },
+  data() {
+    return {
+      omniLogo: OMNI_LOGO,
+      nowTs: Date.now(),
+      timer: 0
+    };
+  },
+  computed: {
+    video(): IOmniVideo | undefined {
+      return this.modelValue?.response?.data?.[0];
+    },
+    inputImage(): string | undefined {
+      return this.modelValue?.request?.image_urls?.[0];
+    },
+    // Live elapsed seconds shown while a task is still pending (no upstream
+    // progress %, so elapsed time is the honest signal during the 1-2 min wait).
+    pendingElapsed(): number | undefined {
+      const created = parseFloat((this.modelValue?.created_at || '').toString());
+      if (!created) {
+        return undefined;
+      }
+      return Math.max(0, Math.floor(this.nowTs / 1000 - created));
+    }
+  },
+  watch: {
+    'modelValue.response': {
+      handler(response) {
+        if (response) {
+          this.stopTimer();
+        }
+      }
+    }
+  },
+  mounted() {
+    if (!this.modelValue?.response) {
+      this.timer = window.setInterval(() => {
+        this.nowTs = Date.now();
+      }, 1000);
+    }
+  },
+  beforeUnmount() {
+    this.stopTimer();
+  },
+  methods: {
+    stopTimer() {
+      if (this.timer) {
+        window.clearInterval(this.timer);
+        this.timer = 0;
+      }
+    },
+    onDownload(videoUrl: string) {
+      window.open(videoUrl, '_blank');
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+$left-width: 70px;
+.preview {
+  width: 100%;
+  height: fit-content;
+  text-align: left;
+  display: flex;
+  flex-direction: row;
+  margin-bottom: 15px;
+  .left {
+    width: $left-width;
+    .avatar {
+      width: 50px;
+      height: 50px;
+      margin: 10px;
+      border-radius: 50%;
+      box-shadow: var(--app-shadow-xs);
+    }
+  }
+
+  .main {
+    flex: 1;
+    width: calc(100% - $left-width);
+    min-width: 0;
+    padding: 10px 10px 0 10px;
+
+    .bot {
+      font-size: 16px;
+      font-weight: bold;
+      color: var(--el-color-primary);
+      margin-bottom: 0;
+      margin-top: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      .datetime {
+        font-size: 12px;
+        font-weight: normal;
+        color: var(--el-text-color-secondary);
+        margin-left: 10px;
+      }
+    }
+
+    .info {
+      overflow: hidden;
+      .prompt {
+        font-size: 14px;
+        font-weight: bold;
+        color: var(--el-text-color-regular);
+        margin-bottom: 10px;
+        white-space: normal;
+        word-break: break-word;
+        overflow-wrap: anywhere;
+      }
+    }
+
+    .content {
+      word-break: break-word;
+      overflow-wrap: anywhere;
+      .el-alert {
+        border-left-width: 2px;
+        border-left-style: solid;
+        &.failure {
+          border-color: var(--el-color-danger);
+        }
+        &.success {
+          border-color: var(--el-color-success);
+        }
+        &.info {
+          border-color: var(--el-color-info);
+        }
+        :deep(p:last-child) {
+          margin-bottom: 0;
+        }
+      }
+    }
+  }
+}
+</style>

--- a/src/constants/i18n.ts
+++ b/src/constants/i18n.ts
@@ -40,6 +40,7 @@ export const I18N_SCOPES = [
   'seedream',
   'seedance',
   'grokvideo',
+  'omni',
   'hailuo',
   'wan',
   'headshots',

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -24,6 +24,7 @@ export * from './openaiimage';
 export * from './seedream';
 export * from './seedance';
 export * from './grokvideo';
+export * from './omni';
 export * from './serp';
 export * from './wan';
 export * from './webextrator';

--- a/src/constants/omni.ts
+++ b/src/constants/omni.ts
@@ -1,0 +1,23 @@
+// Omni video (omni-flash) is exposed under the merged `gemini` service
+// (/gemini/videos, /gemini/tasks) — the same PlatformBackend service as gemini
+// chat, so it shares the user's application / balance.
+export const OMNI_SERVICE_ID = 'dda998fe-e11f-41b8-afa9-0a9b8420d60d';
+
+export const OMNI_LOGO = 'https://cdn.acedata.cloud/psfx0g.jpg';
+
+export const OMNI_MODEL_OMNI_FLASH = 'omni-flash';
+export const OMNI_DEFAULT_MODEL = OMNI_MODEL_OMNI_FLASH;
+export const OMNI_MODELS = [OMNI_MODEL_OMNI_FLASH];
+
+export const OMNI_RATIO_16_9 = '16:9';
+export const OMNI_RATIO_9_16 = '9:16';
+export const OMNI_DEFAULT_RATIO = OMNI_RATIO_16_9;
+
+export const OMNI_RESOLUTION_720P = '720p';
+export const OMNI_RESOLUTION_1080P = '1080p';
+export const OMNI_DEFAULT_RESOLUTION = OMNI_RESOLUTION_720P;
+
+/** Reference images (image_urls) allowed to guide / edit the video. */
+export const OMNI_MAX_IMAGES = 4;
+/** Reference / editable video (video_urls) — upstream accepts at most one. */
+export const OMNI_MAX_VIDEOS = 1;

--- a/src/i18n/ar/common.json
+++ b/src/i18n/ar/common.json
@@ -1546,5 +1546,9 @@
   "settings.memoryEnabledHint": {
     "message": "When off, saved memories are not used and new chats do not create memories. Existing memories are kept.",
     "description": "Behavior explanation shown below the memory switch"
+  },
+  "nav.omni": {
+    "message": "Omni Video",
+    "description": "Nav label for the Omni video module"
   }
 }

--- a/src/i18n/ar/omni.json
+++ b/src/i18n/ar/omni.json
@@ -1,0 +1,202 @@
+{
+  "name.bot": {
+    "message": "روبوت فيديو Omni",
+    "description": "اسم مولد فيديو Omni"
+  },
+  "name.prompt": {
+    "message": "نص التوجيه",
+    "description": "نص لتوليد الفيديو"
+  },
+  "name.model": {
+    "message": "نموذج",
+    "description": "تسمية لاختيار النموذج"
+  },
+  "name.ratio": {
+    "message": "نسبة العرض إلى الارتفاع",
+    "description": "تسمية لنسبة العرض إلى الارتفاع"
+  },
+  "name.resolution": {
+    "message": "الدقة",
+    "description": "تسمية للدقة"
+  },
+  "name.duration": {
+    "message": "المدة",
+    "description": "تسمية للمدة"
+  },
+  "name.image": {
+    "message": "صورة",
+    "description": "تسمية لإدخال الصورة"
+  },
+  "name.referenceImages": {
+    "message": "Reference Images",
+    "description": "Label for reference images"
+  },
+  "name.required": {
+    "message": "مطلوب",
+    "description": "شارة مطلوبة"
+  },
+  "name.taskId": {
+    "message": "معرف المهمة",
+    "description": "تسمية معرف المهمة"
+  },
+  "name.elapsed": {
+    "message": "الوقت المستغرق",
+    "description": "تسمية الوقت المستغرق"
+  },
+  "name.traceId": {
+    "message": "معرف التتبع",
+    "description": "تسمية معرف التتبع"
+  },
+  "name.failure": {
+    "message": "فشل الإنشاء",
+    "description": "عنوان الفشل"
+  },
+  "name.failureReason": {
+    "message": "سبب الفشل",
+    "description": "تسمية سبب الفشل"
+  },
+  "name.status": {
+    "message": "الحالة",
+    "description": "عنوان الحالة"
+  },
+  "description.prompt": {
+    "message": "صف الفيديو الذي ترغب في إنشائه (المشهد، الموضوع، الحركة، اللقطة، الإضاءة، الأسلوب).",
+    "description": "تعليمات حول إدخال النص"
+  },
+  "description.model": {
+    "message": "اختر نموذج Omni. يدعم omni-flash الفيديو الناتج عن النص والصورة؛ بينما 1.5-preview يدعم فقط الفيديو الناتج عن الصورة.",
+    "description": "تعليمات حول اختيار النموذج"
+  },
+  "description.ratio": {
+    "message": "اختر نسبة عرض إلى ارتفاع الإخراج.",
+    "description": "تعليمات حول نسبة العرض إلى الارتفاع"
+  },
+  "description.resolution": {
+    "message": "اختر دقة الإخراج. كلما كانت الدقة أعلى، زادت التكلفة لكل ثانية.",
+    "description": "تعليمات حول الدقة"
+  },
+  "description.duration": {
+    "message": "مدة الفيديو (بالثواني)، يتم احتساب الرسوم حسب عدد الثواني.",
+    "description": "تعليمات حول المدة"
+  },
+  "description.image": {
+    "message": "صورة إدخال اختيارية، تستخدم لإنشاء الفيديو. omni-flash إلزامية.",
+    "description": "تعليمات حول إدخال الصورة"
+  },
+  "description.referenceImages": {
+    "message": "Optional reference images to guide the style or content of the generated video (omni-flash only).",
+    "description": "Instructions for reference images"
+  },
+  "placeholder.prompt": {
+    "message": "وصف الفيديو الخاص بك…",
+    "description": "نص بديل لنص التوجيه"
+  },
+  "placeholder.select": {
+    "message": "يرجى الاختيار",
+    "description": "نص بديل للاختيارات"
+  },
+  "model.default": {
+    "message": "فيديو Omni",
+    "description": "تسمية النموذج الافتراضي"
+  },
+  "model.preview15": {
+    "message": "فيديو Omni 1.5 (معاينة، فيديو ناتج عن الصورة)",
+    "description": "تسمية نموذج المعاينة 1.5"
+  },
+  "button.upload": {
+    "message": "رفع",
+    "description": "زر الرفع"
+  },
+  "button.generate": {
+    "message": "إنشاء",
+    "description": "زر الإنشاء"
+  },
+  "button.download": {
+    "message": "تنزيل",
+    "description": "زر التنزيل"
+  },
+  "status.pending": {
+    "message": "قيد الانتظار",
+    "description": "حالة الانتظار"
+  },
+  "status.processing": {
+    "message": "جاري المعالجة",
+    "description": "حالة المعالجة"
+  },
+  "message.uploadExceed": {
+    "message": "يمكنك رفع صورة واحدة فقط.",
+    "description": "تحذير تجاوز الرفع"
+  },
+  "message.uploadReferenceExceed": {
+    "message": "You can upload up to 4 reference images.",
+    "description": "Reference images upload exceed warning"
+  },
+  "message.uploadError": {
+    "message": "فشل رفع الصورة، يرجى المحاولة مرة أخرى.",
+    "description": "خطأ في الرفع"
+  },
+  "message.downloadVideo": {
+    "message": "تنزيل الفيديو",
+    "description": "تلميح التنزيل"
+  },
+  "message.modelRequiresImage": {
+    "message": "هذا النموذج يتطلب صورة إدخال (فيديو ناتج عن الصورة).",
+    "description": "تحذير يتطلب صورة للنموذج"
+  },
+  "message.promptOrImageRequired": {
+    "message": "يرجى إدخال نص أو رفع صورة.",
+    "description": "تحذير يتطلب نص أو صورة"
+  },
+  "message.startingTask": {
+    "message": "جارٍ تقديم مهمة إنشاء الفيديو...",
+    "description": "بدء المهمة"
+  },
+  "message.startTaskSuccess": {
+    "message": "تم تقديم المهمة بنجاح.",
+    "description": "نجاح المهمة"
+  },
+  "message.startTaskFailed": {
+    "message": "فشل تقديم المهمة:",
+    "description": "فشل المهمة"
+  },
+  "message.usedUp": {
+    "message": "تم استهلاك الرصيد، يرجى الشراء للاستمرار في الاستخدام.",
+    "description": "استهلاك الرصيد"
+  },
+  "name.referenceVideo": {
+    "message": "Reference Video",
+    "description": "Reference/editable video for Omni video editing"
+  },
+  "description.referenceVideo": {
+    "message": "Optional MP4/MOV (≤200MB) to edit or reference an existing video. Requires at least one reference image.",
+    "description": "Help text for the reference video uploader"
+  },
+  "button.uploadVideo": {
+    "message": "Upload Video",
+    "description": "Button to upload the reference video"
+  },
+  "message.uploadVideoExceed": {
+    "message": "You can upload a maximum of 1 reference video",
+    "description": "Error when more than one reference video is uploaded"
+  },
+  "message.uploadVideoError": {
+    "message": "Reference video upload failed, please try again later",
+    "description": "Error when the reference video upload fails"
+  },
+  "message.uploadVideoTypeFailed": {
+    "message": "Uploaded file must be in MP4 or MOV format!",
+    "description": "Error when the reference video is not MP4/MOV"
+  },
+  "message.uploadVideoSizeExceed": {
+    "message": "Uploaded file size cannot exceed 200MB!",
+    "description": "Error when the reference video exceeds 200MB"
+  },
+  "message.promptRequired": {
+    "message": "Please enter a prompt.",
+    "description": "Validation when prompt is empty"
+  },
+  "message.videoRequiresImage": {
+    "message": "Please add at least one reference image when using a reference video.",
+    "description": "Validation when video_urls has no reference image"
+  }
+}

--- a/src/i18n/de/common.json
+++ b/src/i18n/de/common.json
@@ -1546,5 +1546,9 @@
   "settings.memoryEnabledHint": {
     "message": "When off, saved memories are not used and new chats do not create memories. Existing memories are kept.",
     "description": "Behavior explanation shown below the memory switch"
+  },
+  "nav.omni": {
+    "message": "Omni Video",
+    "description": "Nav label for the Omni video module"
   }
 }

--- a/src/i18n/de/omni.json
+++ b/src/i18n/de/omni.json
@@ -1,0 +1,202 @@
+{
+  "name.bot": {
+    "message": "Omni Video Bot",
+    "description": "Name des Omni Video Generators"
+  },
+  "name.prompt": {
+    "message": "Eingabeaufforderung",
+    "description": "Eingabeaufforderung zur Videoerstellung"
+  },
+  "name.model": {
+    "message": "Modell",
+    "description": "Label für die Modellauswahl"
+  },
+  "name.ratio": {
+    "message": "Seitenverhältnis",
+    "description": "Label für das Seitenverhältnis"
+  },
+  "name.resolution": {
+    "message": "Auflösung",
+    "description": "Label für die Auflösung"
+  },
+  "name.duration": {
+    "message": "Dauer",
+    "description": "Bezeichnung für die Dauer"
+  },
+  "name.image": {
+    "message": "Bild",
+    "description": "Label für das Eingabebild"
+  },
+  "name.referenceImages": {
+    "message": "Reference Images",
+    "description": "Label for reference images"
+  },
+  "name.required": {
+    "message": "Pflichtfeld",
+    "description": "Pflichtfeld-Label"
+  },
+  "name.taskId": {
+    "message": "Aufgaben-ID",
+    "description": "Label für die Aufgaben-ID"
+  },
+  "name.elapsed": {
+    "message": "Verstrichene Zeit",
+    "description": "Bezeichnung für die verstrichene Zeit"
+  },
+  "name.traceId": {
+    "message": "Verfolgungs-ID",
+    "description": "Label für die Verfolgungs-ID"
+  },
+  "name.failure": {
+    "message": "Generierung fehlgeschlagen",
+    "description": "Titel für Fehler"
+  },
+  "name.failureReason": {
+    "message": "Fehlerursache",
+    "description": "Bezeichnung für die Fehlerursache"
+  },
+  "name.status": {
+    "message": "Status",
+    "description": "Statusüberschrift"
+  },
+  "description.prompt": {
+    "message": "Beschreiben Sie das Video, das Sie generieren möchten (Szene, Subjekt, Aktion, Kamera, Licht, Stil).",
+    "description": "Anweisungen zur Eingabe des Prompts"
+  },
+  "description.model": {
+    "message": "Wählen Sie das Omni Modell. omni-flash unterstützt Text-zu-Video und Bild-zu-Video; 1.5-preview unterstützt nur Bild-zu-Video.",
+    "description": "Anweisungen zur Modellauswahl"
+  },
+  "description.ratio": {
+    "message": "Wählen Sie das Ausgabe-Seitenverhältnis.",
+    "description": "Anweisungen zum Seitenverhältnis"
+  },
+  "description.resolution": {
+    "message": "Wählen Sie die Ausgabeauflösung. Höhere Auflösungen verbrauchen mehr Kontingent pro Sekunde.",
+    "description": "Anweisungen zur Auflösung"
+  },
+  "description.duration": {
+    "message": "Videodauer (Sekunden), Abrechnung nach ausgegebenen Sekunden.",
+    "description": "Anweisungen zur Dauer"
+  },
+  "description.image": {
+    "message": "Optionales Eingabebild für die Videoerstellung. omni-flash ist erforderlich.",
+    "description": "Anweisungen für die Bild-Eingabe"
+  },
+  "description.referenceImages": {
+    "message": "Optional reference images to guide the style or content of the generated video (omni-flash only).",
+    "description": "Instructions for reference images"
+  },
+  "placeholder.prompt": {
+    "message": "Beschreibe dein Video…",
+    "description": "Platzhalter für die Eingabeaufforderung"
+  },
+  "placeholder.select": {
+    "message": "Bitte auswählen",
+    "description": "Platzhalter für Auswahlfelder"
+  },
+  "model.default": {
+    "message": "Omni",
+    "description": "Standardmodellbezeichnung"
+  },
+  "model.preview15": {
+    "message": "Omni 1.5 (Vorschau, Bild-zu-Video)",
+    "description": "1.5 Vorschau Modellbezeichnung"
+  },
+  "button.upload": {
+    "message": "Hochladen",
+    "description": "Upload-Button"
+  },
+  "button.generate": {
+    "message": "Generieren",
+    "description": "Generieren-Button"
+  },
+  "button.download": {
+    "message": "Herunterladen",
+    "description": "Download-Button"
+  },
+  "status.pending": {
+    "message": "Wartend",
+    "description": "Status für ausstehende Vorgänge"
+  },
+  "status.processing": {
+    "message": "Wird erstellt",
+    "description": "Status für die Verarbeitung"
+  },
+  "message.uploadExceed": {
+    "message": "Es kann nur ein Bild hochgeladen werden.",
+    "description": "Warnung, dass das Upload-Limit überschritten wurde"
+  },
+  "message.uploadReferenceExceed": {
+    "message": "You can upload up to 4 reference images.",
+    "description": "Reference images upload exceed warning"
+  },
+  "message.uploadError": {
+    "message": "Bild-Upload fehlgeschlagen, bitte erneut versuchen.",
+    "description": "Upload-Fehler"
+  },
+  "message.downloadVideo": {
+    "message": "Video herunterladen",
+    "description": "Download-Hinweis"
+  },
+  "message.modelRequiresImage": {
+    "message": "Dieses Modell benötigt ein Eingabebild (Bild-zu-Video).",
+    "description": "Warnung, dass das Modell ein Bild benötigt"
+  },
+  "message.promptOrImageRequired": {
+    "message": "Bitte geben Sie einen Prompt ein oder laden Sie ein Bild hoch.",
+    "description": "Warnung, dass ein Prompt oder Bild erforderlich ist"
+  },
+  "message.startingTask": {
+    "message": "Videoerstellungsaufgabe wird übermittelt…",
+    "description": "Aufgabe wird gestartet"
+  },
+  "message.startTaskSuccess": {
+    "message": "Aufgabenübermittlung erfolgreich.",
+    "description": "Aufgabe erfolgreich"
+  },
+  "message.startTaskFailed": {
+    "message": "Aufgabenübermittlung fehlgeschlagen:",
+    "description": "Aufgabe fehlgeschlagen"
+  },
+  "message.usedUp": {
+    "message": "Kontingent erschöpft, bitte kaufen Sie, um fortzufahren.",
+    "description": "Erschöpft"
+  },
+  "name.referenceVideo": {
+    "message": "Reference Video",
+    "description": "Reference/editable video for Omni video editing"
+  },
+  "description.referenceVideo": {
+    "message": "Optional MP4/MOV (≤200MB) to edit or reference an existing video. Requires at least one reference image.",
+    "description": "Help text for the reference video uploader"
+  },
+  "button.uploadVideo": {
+    "message": "Upload Video",
+    "description": "Button to upload the reference video"
+  },
+  "message.uploadVideoExceed": {
+    "message": "You can upload a maximum of 1 reference video",
+    "description": "Error when more than one reference video is uploaded"
+  },
+  "message.uploadVideoError": {
+    "message": "Reference video upload failed, please try again later",
+    "description": "Error when the reference video upload fails"
+  },
+  "message.uploadVideoTypeFailed": {
+    "message": "Uploaded file must be in MP4 or MOV format!",
+    "description": "Error when the reference video is not MP4/MOV"
+  },
+  "message.uploadVideoSizeExceed": {
+    "message": "Uploaded file size cannot exceed 200MB!",
+    "description": "Error when the reference video exceeds 200MB"
+  },
+  "message.promptRequired": {
+    "message": "Please enter a prompt.",
+    "description": "Validation when prompt is empty"
+  },
+  "message.videoRequiresImage": {
+    "message": "Please add at least one reference image when using a reference video.",
+    "description": "Validation when video_urls has no reference image"
+  }
+}

--- a/src/i18n/el/common.json
+++ b/src/i18n/el/common.json
@@ -1546,5 +1546,9 @@
   "settings.memoryEnabledHint": {
     "message": "When off, saved memories are not used and new chats do not create memories. Existing memories are kept.",
     "description": "Behavior explanation shown below the memory switch"
+  },
+  "nav.omni": {
+    "message": "Omni Video",
+    "description": "Nav label for the Omni video module"
   }
 }

--- a/src/i18n/el/omni.json
+++ b/src/i18n/el/omni.json
@@ -1,0 +1,202 @@
+{
+  "name.bot": {
+    "message": "Omni βίντεο ρομπότ",
+    "description": "Όνομα του γεννήτριας βίντεο Omni"
+  },
+  "name.prompt": {
+    "message": "Προτροπή",
+    "description": "Προτροπή για τη δημιουργία του βίντεο"
+  },
+  "name.model": {
+    "message": "Μοντέλο",
+    "description": "Ετικέτα για την επιλογή μοντέλου"
+  },
+  "name.ratio": {
+    "message": "Αναλογία διαστάσεων",
+    "description": "Ετικέτα για την αναλογία διαστάσεων"
+  },
+  "name.resolution": {
+    "message": "Ανάλυση",
+    "description": "Ετικέτα για την ανάλυση"
+  },
+  "name.duration": {
+    "message": "Διάρκεια",
+    "description": "Ετικέτα για τη διάρκεια"
+  },
+  "name.image": {
+    "message": "Εικόνα",
+    "description": "Ετικέτα για την είσοδο εικόνας"
+  },
+  "name.referenceImages": {
+    "message": "Reference Images",
+    "description": "Label for reference images"
+  },
+  "name.required": {
+    "message": "Υποχρεωτικό",
+    "description": "Σήμα υποχρεωτικού πεδίου"
+  },
+  "name.taskId": {
+    "message": "ID Εργασίας",
+    "description": "Ετικέτα για το ID της εργασίας"
+  },
+  "name.elapsed": {
+    "message": "Χρόνος που πέρασε",
+    "description": "Ετικέτα για τον χρόνο που πέρασε"
+  },
+  "name.traceId": {
+    "message": "ID Ιχνηλάτη",
+    "description": "Ετικέτα για το ID ιχνηλάτη"
+  },
+  "name.failure": {
+    "message": "Αποτυχία δημιουργίας",
+    "description": "Τίτλος αποτυχίας"
+  },
+  "name.failureReason": {
+    "message": "Λόγος αποτυχίας",
+    "description": "Ετικέτα λόγου αποτυχίας"
+  },
+  "name.status": {
+    "message": "Κατάσταση",
+    "description": "Τίτλος κατάστασης"
+  },
+  "description.prompt": {
+    "message": "Περιγράψτε το βίντεο που θέλετε να δημιουργήσετε (σκηνές, υποκείμενα, δράσεις, λήψεις, φωτισμός, στυλ).",
+    "description": "Οδηγίες για την είσοδο προτροπής"
+  },
+  "description.model": {
+    "message": "Επιλέξτε το μοντέλο Omni. Το omni-flash υποστηρίζει βίντεο που δημιουργούνται από κείμενο και εικόνες; το 1.5-preview υποστηρίζει μόνο βίντεο που δημιουργούνται από εικόνες.",
+    "description": "Οδηγίες για την επιλογή μοντέλου"
+  },
+  "description.ratio": {
+    "message": "Επιλέξτε την αναλογία εξόδου.",
+    "description": "Οδηγίες για την αναλογία διαστάσεων"
+  },
+  "description.resolution": {
+    "message": "Επιλέξτε την ανάλυση εξόδου. Όσο υψηλότερη είναι η ανάλυση, τόσο περισσότερη είναι η κατανάλωση ανά δευτερόλεπτο.",
+    "description": "Οδηγίες για την ανάλυση"
+  },
+  "description.duration": {
+    "message": "Διάρκεια βίντεο (δευτερόλεπτα), χρεώνεται ανά δευτερόλεπτο εξόδου.",
+    "description": "Οδηγίες για τη διάρκεια"
+  },
+  "description.image": {
+    "message": "Προαιρετική είσοδος εικόνας, για βίντεο που δημιουργούνται από εικόνες. Το omni-flash είναι υποχρεωτικό.",
+    "description": "Οδηγίες για την είσοδο εικόνας"
+  },
+  "description.referenceImages": {
+    "message": "Optional reference images to guide the style or content of the generated video (omni-flash only).",
+    "description": "Instructions for reference images"
+  },
+  "placeholder.prompt": {
+    "message": "Περιγράψτε το βίντεό σας…",
+    "description": "Placeholder για την προτροπή"
+  },
+  "placeholder.select": {
+    "message": "Επιλέξτε",
+    "description": "Placeholder για επιλογές"
+  },
+  "model.default": {
+    "message": "Omni βίντεο",
+    "description": "Ετικέτα προεπιλεγμένου μοντέλου"
+  },
+  "model.preview15": {
+    "message": "Omni βίντεο 1.5 (προεπισκόπηση, βίντεο που δημιουργούνται από εικόνες)",
+    "description": "Ετικέτα μοντέλου προεπισκόπησης 1.5"
+  },
+  "button.upload": {
+    "message": "Ανέβασμα",
+    "description": "Κουμπί ανεβάσματος"
+  },
+  "button.generate": {
+    "message": "Δημιουργία",
+    "description": "Κουμπί δημιουργίας"
+  },
+  "button.download": {
+    "message": "Λήψη",
+    "description": "Κουμπί λήψης"
+  },
+  "status.pending": {
+    "message": "Σε αναμονή",
+    "description": "Κατάσταση αναμονής"
+  },
+  "status.processing": {
+    "message": "Δημιουργείται",
+    "description": "Κατάσταση επεξεργασίας"
+  },
+  "message.uploadExceed": {
+    "message": "Μπορείτε να ανεβάσετε μόνο μία εικόνα.",
+    "description": "Προειδοποίηση υπέρβασης ανέβασματος"
+  },
+  "message.uploadReferenceExceed": {
+    "message": "You can upload up to 4 reference images.",
+    "description": "Reference images upload exceed warning"
+  },
+  "message.uploadError": {
+    "message": "Η ανέβασμα εικόνας απέτυχε, παρακαλώ δοκιμάστε ξανά.",
+    "description": "Σφάλμα ανέβασματος"
+  },
+  "message.downloadVideo": {
+    "message": "Λήψη βίντεο",
+    "description": "Σημείωση λήψης"
+  },
+  "message.modelRequiresImage": {
+    "message": "Αυτό το μοντέλο απαιτεί είσοδο εικόνας (βίντεο που δημιουργούνται από εικόνες).",
+    "description": "Προειδοποίηση ότι το μοντέλο απαιτεί εικόνα"
+  },
+  "message.promptOrImageRequired": {
+    "message": "Παρακαλώ εισάγετε προτροπή ή ανεβάστε εικόνα.",
+    "description": "Προειδοποίηση ότι απαιτείται προτροπή ή εικόνα"
+  },
+  "message.startingTask": {
+    "message": "Υποβάλλεται η εργασία δημιουργίας βίντεο…",
+    "description": "Ξεκινώντας εργασία"
+  },
+  "message.startTaskSuccess": {
+    "message": "Η υποβολή της εργασίας ήταν επιτυχής.",
+    "description": "Επιτυχία εργασίας"
+  },
+  "message.startTaskFailed": {
+    "message": "Η υποβολή της εργασίας απέτυχε:",
+    "description": "Αποτυχία εργασίας"
+  },
+  "message.usedUp": {
+    "message": "Η ποσόστωση έχει εξαντληθεί, παρακαλώ αγοράστε για να συνεχίσετε τη χρήση.",
+    "description": "Εξαντλημένο"
+  },
+  "name.referenceVideo": {
+    "message": "Reference Video",
+    "description": "Reference/editable video for Omni video editing"
+  },
+  "description.referenceVideo": {
+    "message": "Optional MP4/MOV (≤200MB) to edit or reference an existing video. Requires at least one reference image.",
+    "description": "Help text for the reference video uploader"
+  },
+  "button.uploadVideo": {
+    "message": "Upload Video",
+    "description": "Button to upload the reference video"
+  },
+  "message.uploadVideoExceed": {
+    "message": "You can upload a maximum of 1 reference video",
+    "description": "Error when more than one reference video is uploaded"
+  },
+  "message.uploadVideoError": {
+    "message": "Reference video upload failed, please try again later",
+    "description": "Error when the reference video upload fails"
+  },
+  "message.uploadVideoTypeFailed": {
+    "message": "Uploaded file must be in MP4 or MOV format!",
+    "description": "Error when the reference video is not MP4/MOV"
+  },
+  "message.uploadVideoSizeExceed": {
+    "message": "Uploaded file size cannot exceed 200MB!",
+    "description": "Error when the reference video exceeds 200MB"
+  },
+  "message.promptRequired": {
+    "message": "Please enter a prompt.",
+    "description": "Validation when prompt is empty"
+  },
+  "message.videoRequiresImage": {
+    "message": "Please add at least one reference image when using a reference video.",
+    "description": "Validation when video_urls has no reference image"
+  }
+}

--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -1547,5 +1547,9 @@
   "settings.siteServices": {
     "message": "Price",
     "description": "Nav label for the site-wide and per-service pricing settings tab"
+  },
+  "nav.omni": {
+    "message": "Omni Video",
+    "description": "Nav label for the Omni video module"
   }
 }

--- a/src/i18n/en/omni.json
+++ b/src/i18n/en/omni.json
@@ -1,0 +1,202 @@
+{
+  "name.bot": {
+    "message": "Omni Video",
+    "description": "Module display name"
+  },
+  "name.prompt": {
+    "message": "Prompt",
+    "description": "Prompt for generating the video"
+  },
+  "name.model": {
+    "message": "Model",
+    "description": "Label for model selection"
+  },
+  "name.ratio": {
+    "message": "Aspect Ratio",
+    "description": "Label for aspect ratio"
+  },
+  "name.resolution": {
+    "message": "Resolution",
+    "description": "Label for resolution"
+  },
+  "name.duration": {
+    "message": "Duration",
+    "description": "Label for duration"
+  },
+  "name.image": {
+    "message": "Image",
+    "description": "Label for input image"
+  },
+  "name.referenceImages": {
+    "message": "Reference Images",
+    "description": "Label for reference images"
+  },
+  "name.required": {
+    "message": "Required",
+    "description": "Required badge"
+  },
+  "name.taskId": {
+    "message": "Task ID",
+    "description": "Task id label"
+  },
+  "name.elapsed": {
+    "message": "Elapsed",
+    "description": "Elapsed time label"
+  },
+  "name.traceId": {
+    "message": "Trace ID",
+    "description": "Trace id label"
+  },
+  "name.failure": {
+    "message": "Generation Failed",
+    "description": "Failure title"
+  },
+  "name.failureReason": {
+    "message": "Reason",
+    "description": "Failure reason label"
+  },
+  "name.status": {
+    "message": "Status",
+    "description": "Status title"
+  },
+  "description.prompt": {
+    "message": "Describe the video you want to generate (scene, subject, motion, camera, lighting, style).",
+    "description": "Instructions for prompt input"
+  },
+  "description.model": {
+    "message": "Choose the Omni model. omni-flash supports text and image up to 30s; 1.5-preview is image-to-video only up to 15s.",
+    "description": "Instructions for model selection"
+  },
+  "description.ratio": {
+    "message": "Select the output aspect ratio.",
+    "description": "Instructions for aspect ratio"
+  },
+  "description.resolution": {
+    "message": "Select the output resolution. 480p / 720p / 1080p are supported; higher resolution costs more.",
+    "description": "Instructions for resolution"
+  },
+  "description.duration": {
+    "message": "Video duration in seconds. omni-flash supports 1-30s with banded pricing; 1.5-preview supports 1-15s and is billed per output second.",
+    "description": "Instructions for duration"
+  },
+  "description.image": {
+    "message": "Optional input image to animate (image-to-video). Required for omni-flash.",
+    "description": "Instructions for image input"
+  },
+  "description.referenceImages": {
+    "message": "Optional reference images (up to 4) to guide the video. Required when editing a reference video.",
+    "description": "Reference images help text"
+  },
+  "placeholder.prompt": {
+    "message": "Describe your video…",
+    "description": "Placeholder for prompt"
+  },
+  "placeholder.select": {
+    "message": "Please select",
+    "description": "Placeholder for selects"
+  },
+  "model.default": {
+    "message": "Omni",
+    "description": "Default model label"
+  },
+  "model.preview15": {
+    "message": "Omni 1.5 (Preview, image-to-video)",
+    "description": "1.5 preview model label"
+  },
+  "button.upload": {
+    "message": "Upload",
+    "description": "Upload button"
+  },
+  "button.generate": {
+    "message": "Generate",
+    "description": "Generate button"
+  },
+  "button.download": {
+    "message": "Download",
+    "description": "Download button"
+  },
+  "status.pending": {
+    "message": "Pending",
+    "description": "Pending status"
+  },
+  "status.processing": {
+    "message": "Processing",
+    "description": "Processing status"
+  },
+  "message.uploadExceed": {
+    "message": "You can upload only one image.",
+    "description": "Upload exceed warning"
+  },
+  "message.uploadReferenceExceed": {
+    "message": "You can upload up to 4 reference images.",
+    "description": "Reference images upload exceed warning"
+  },
+  "message.uploadError": {
+    "message": "Image upload failed, please try again.",
+    "description": "Upload error"
+  },
+  "message.downloadVideo": {
+    "message": "Download video",
+    "description": "Download tooltip"
+  },
+  "message.modelRequiresImage": {
+    "message": "This model requires an input image (image-to-video).",
+    "description": "Model requires image warning"
+  },
+  "message.promptOrImageRequired": {
+    "message": "Please enter a prompt or upload an image.",
+    "description": "Prompt or image required warning"
+  },
+  "message.startingTask": {
+    "message": "Submitting your video generation task…",
+    "description": "Starting task"
+  },
+  "message.startTaskSuccess": {
+    "message": "Task submitted successfully.",
+    "description": "Task success"
+  },
+  "message.startTaskFailed": {
+    "message": "Failed to submit task: ",
+    "description": "Task failed"
+  },
+  "message.usedUp": {
+    "message": "Your quota has been used up. Please purchase more to continue.",
+    "description": "Used up"
+  },
+  "name.referenceVideo": {
+    "message": "Reference Video",
+    "description": "Reference/editable video for Omni video editing"
+  },
+  "description.referenceVideo": {
+    "message": "Optional MP4/MOV (≤200MB) to edit or reference an existing video. Requires at least one reference image.",
+    "description": "Help text for the reference video uploader"
+  },
+  "button.uploadVideo": {
+    "message": "Upload Video",
+    "description": "Button to upload the reference video"
+  },
+  "message.uploadVideoExceed": {
+    "message": "You can upload a maximum of 1 reference video",
+    "description": "Error when more than one reference video is uploaded"
+  },
+  "message.uploadVideoError": {
+    "message": "Reference video upload failed, please try again later",
+    "description": "Error when the reference video upload fails"
+  },
+  "message.uploadVideoTypeFailed": {
+    "message": "Uploaded file must be in MP4 or MOV format!",
+    "description": "Error when the reference video is not MP4/MOV"
+  },
+  "message.uploadVideoSizeExceed": {
+    "message": "Uploaded file size cannot exceed 200MB!",
+    "description": "Error when the reference video exceeds 200MB"
+  },
+  "message.promptRequired": {
+    "message": "Please enter a prompt.",
+    "description": "Validation when prompt is empty"
+  },
+  "message.videoRequiresImage": {
+    "message": "Please add at least one reference image when using a reference video.",
+    "description": "Validation when video_urls has no reference image"
+  }
+}

--- a/src/i18n/es/common.json
+++ b/src/i18n/es/common.json
@@ -1546,5 +1546,9 @@
   "settings.memoryEnabledHint": {
     "message": "When off, saved memories are not used and new chats do not create memories. Existing memories are kept.",
     "description": "Behavior explanation shown below the memory switch"
+  },
+  "nav.omni": {
+    "message": "Omni Video",
+    "description": "Nav label for the Omni video module"
   }
 }

--- a/src/i18n/es/omni.json
+++ b/src/i18n/es/omni.json
@@ -1,0 +1,202 @@
+{
+  "name.bot": {
+    "message": "Omni Video Bot",
+    "description": "Nombre del generador de video Omni"
+  },
+  "name.prompt": {
+    "message": "Palabra clave",
+    "description": "Palabra clave para generar el video"
+  },
+  "name.model": {
+    "message": "Modelo",
+    "description": "Etiqueta para la selección de modelo"
+  },
+  "name.ratio": {
+    "message": "Relación de aspecto",
+    "description": "Etiqueta para la relación de aspecto"
+  },
+  "name.resolution": {
+    "message": "Resolución",
+    "description": "Etiqueta para la resolución"
+  },
+  "name.duration": {
+    "message": "Duración",
+    "description": "Etiqueta para la duración"
+  },
+  "name.image": {
+    "message": "Imagen",
+    "description": "Etiqueta para la entrada de imagen"
+  },
+  "name.referenceImages": {
+    "message": "Reference Images",
+    "description": "Label for reference images"
+  },
+  "name.required": {
+    "message": "Requerido",
+    "description": "Insignia de requerido"
+  },
+  "name.taskId": {
+    "message": "ID de tarea",
+    "description": "Etiqueta para el ID de tarea"
+  },
+  "name.elapsed": {
+    "message": "Tiempo transcurrido",
+    "description": "Etiqueta de tiempo transcurrido"
+  },
+  "name.traceId": {
+    "message": "ID de seguimiento",
+    "description": "Etiqueta para el ID de seguimiento"
+  },
+  "name.failure": {
+    "message": "Error en la generación",
+    "description": "Título de error"
+  },
+  "name.failureReason": {
+    "message": "Razón del fallo",
+    "description": "Etiqueta de razón del fallo"
+  },
+  "name.status": {
+    "message": "Estado",
+    "description": "Título del estado"
+  },
+  "description.prompt": {
+    "message": "Describe el video que deseas generar (escena, sujeto, acción, toma, luz, estilo).",
+    "description": "Instrucciones para la entrada de prompt"
+  },
+  "description.model": {
+    "message": "Selecciona el modelo Omni. omni-flash admite video generado por texto e imagen; 1.5-preview solo admite video generado por imagen.",
+    "description": "Instrucciones para la selección de modelo"
+  },
+  "description.ratio": {
+    "message": "Selecciona la relación de aspecto de salida.",
+    "description": "Instrucciones para la relación de aspecto"
+  },
+  "description.resolution": {
+    "message": "Selecciona la resolución de salida. Cuanto mayor sea la resolución, más crédito se consumirá por segundo.",
+    "description": "Instrucciones para la resolución"
+  },
+  "description.duration": {
+    "message": "Duración del video (segundos), facturado por el número de segundos de salida.",
+    "description": "Instrucciones para la duración"
+  },
+  "description.image": {
+    "message": "Imagen de entrada opcional, utilizada para generar video. omni-flash es obligatorio.",
+    "description": "Instrucciones para la entrada de imagen"
+  },
+  "description.referenceImages": {
+    "message": "Optional reference images to guide the style or content of the generated video (omni-flash only).",
+    "description": "Instructions for reference images"
+  },
+  "placeholder.prompt": {
+    "message": "Describe tu video…",
+    "description": "Placeholder para la palabra clave"
+  },
+  "placeholder.select": {
+    "message": "Por favor selecciona",
+    "description": "Placeholder para selecciones"
+  },
+  "model.default": {
+    "message": "Omni",
+    "description": "Etiqueta del modelo por defecto"
+  },
+  "model.preview15": {
+    "message": "Omni 1.5 (vista previa, video generado por imagen)",
+    "description": "Etiqueta del modelo de vista previa 1.5"
+  },
+  "button.upload": {
+    "message": "Subir",
+    "description": "Botón de subida"
+  },
+  "button.generate": {
+    "message": "Generar",
+    "description": "Botón de generación"
+  },
+  "button.download": {
+    "message": "Descargar",
+    "description": "Botón de descarga"
+  },
+  "status.pending": {
+    "message": "En cola",
+    "description": "Estado pendiente"
+  },
+  "status.processing": {
+    "message": "Procesando",
+    "description": "Estado de procesamiento"
+  },
+  "message.uploadExceed": {
+    "message": "Solo se puede subir una imagen.",
+    "description": "Advertencia de exceso de subida"
+  },
+  "message.uploadReferenceExceed": {
+    "message": "You can upload up to 4 reference images.",
+    "description": "Reference images upload exceed warning"
+  },
+  "message.uploadError": {
+    "message": "Error al subir la imagen, por favor intenta de nuevo.",
+    "description": "Error de subida"
+  },
+  "message.downloadVideo": {
+    "message": "Descargar video",
+    "description": "Tooltip de descarga"
+  },
+  "message.modelRequiresImage": {
+    "message": "Este modelo requiere una imagen de entrada (video generado por imagen).",
+    "description": "Advertencia de que el modelo requiere imagen"
+  },
+  "message.promptOrImageRequired": {
+    "message": "Por favor, ingresa un prompt o sube una imagen.",
+    "description": "Advertencia de que se requiere un prompt o imagen"
+  },
+  "message.startingTask": {
+    "message": "Enviando tarea de generación de video…",
+    "description": "Iniciando tarea"
+  },
+  "message.startTaskSuccess": {
+    "message": "Tarea enviada con éxito.",
+    "description": "Éxito de tarea"
+  },
+  "message.startTaskFailed": {
+    "message": "Error al enviar la tarea:",
+    "description": "Error de tarea"
+  },
+  "message.usedUp": {
+    "message": "Crédito agotado, por favor compra más para continuar usando.",
+    "description": "Agotado"
+  },
+  "name.referenceVideo": {
+    "message": "Reference Video",
+    "description": "Reference/editable video for Omni video editing"
+  },
+  "description.referenceVideo": {
+    "message": "Optional MP4/MOV (≤200MB) to edit or reference an existing video. Requires at least one reference image.",
+    "description": "Help text for the reference video uploader"
+  },
+  "button.uploadVideo": {
+    "message": "Upload Video",
+    "description": "Button to upload the reference video"
+  },
+  "message.uploadVideoExceed": {
+    "message": "You can upload a maximum of 1 reference video",
+    "description": "Error when more than one reference video is uploaded"
+  },
+  "message.uploadVideoError": {
+    "message": "Reference video upload failed, please try again later",
+    "description": "Error when the reference video upload fails"
+  },
+  "message.uploadVideoTypeFailed": {
+    "message": "Uploaded file must be in MP4 or MOV format!",
+    "description": "Error when the reference video is not MP4/MOV"
+  },
+  "message.uploadVideoSizeExceed": {
+    "message": "Uploaded file size cannot exceed 200MB!",
+    "description": "Error when the reference video exceeds 200MB"
+  },
+  "message.promptRequired": {
+    "message": "Please enter a prompt.",
+    "description": "Validation when prompt is empty"
+  },
+  "message.videoRequiresImage": {
+    "message": "Please add at least one reference image when using a reference video.",
+    "description": "Validation when video_urls has no reference image"
+  }
+}

--- a/src/i18n/fi/common.json
+++ b/src/i18n/fi/common.json
@@ -1546,5 +1546,9 @@
   "settings.memoryEnabledHint": {
     "message": "When off, saved memories are not used and new chats do not create memories. Existing memories are kept.",
     "description": "Behavior explanation shown below the memory switch"
+  },
+  "nav.omni": {
+    "message": "Omni Video",
+    "description": "Nav label for the Omni video module"
   }
 }

--- a/src/i18n/fi/omni.json
+++ b/src/i18n/fi/omni.json
@@ -1,0 +1,202 @@
+{
+  "name.bot": {
+    "message": "Omni Video -robotti",
+    "description": "Omni-video generoijan nimi"
+  },
+  "name.prompt": {
+    "message": "Kehotus",
+    "description": "Videoiden luontikehotus"
+  },
+  "name.model": {
+    "message": "Malli",
+    "description": "Mallin valinnan etiketti"
+  },
+  "name.ratio": {
+    "message": "Kuvasuhde",
+    "description": "Kuvasuhteen etiketti"
+  },
+  "name.resolution": {
+    "message": "Resoluutio",
+    "description": "Resoluutio-etiketti"
+  },
+  "name.duration": {
+    "message": "Kesto",
+    "description": "Keston etiketti"
+  },
+  "name.image": {
+    "message": "Kuva",
+    "description": "Syöttokuvan etiketti"
+  },
+  "name.referenceImages": {
+    "message": "Reference Images",
+    "description": "Label for reference images"
+  },
+  "name.required": {
+    "message": "Pakollinen",
+    "description": "Pakollinen merkki"
+  },
+  "name.taskId": {
+    "message": "Tehtävän ID",
+    "description": "Tehtävän ID-etiketti"
+  },
+  "name.elapsed": {
+    "message": "Kulunut aika",
+    "description": "Kuluneen ajan etiketti"
+  },
+  "name.traceId": {
+    "message": "Seuranta ID",
+    "description": "Seuranta ID-etiketti"
+  },
+  "name.failure": {
+    "message": "Tuotanto epäonnistui",
+    "description": "Epäonnistumisen otsikko"
+  },
+  "name.failureReason": {
+    "message": "Epäonnistumisen syy",
+    "description": "Epäonnistumisen syyn etiketti"
+  },
+  "name.status": {
+    "message": "Tila",
+    "description": "Tilamerkintä"
+  },
+  "description.prompt": {
+    "message": "Kuvaile haluamaasi videota (kohtaus, aihe, toiminta, kuvakulma, valaistus, tyyli).",
+    "description": "Ohjeet kehotteen syöttämiseen"
+  },
+  "description.model": {
+    "message": "Valitse Omni -malli. omni-flash tukee tekstistä kuvaan -videoita; 1.5-preview tukee vain kuvaan perustuvia videoita.",
+    "description": "Ohjeet mallin valintaan"
+  },
+  "description.ratio": {
+    "message": "Valitse ulostulojen kuvasuhde.",
+    "description": "Ohjeet kuvasuhteen valintaan"
+  },
+  "description.resolution": {
+    "message": "Valitse ulostulojen resoluutio. Korkeampi resoluutio kuluttaa enemmän varoja sekunnissa.",
+    "description": "Ohjeet resoluution valintaan"
+  },
+  "description.duration": {
+    "message": "Videon kesto (sekunteina), laskutetaan ulostulojen sekuntien mukaan.",
+    "description": "Ohjeet keston syöttämiseen"
+  },
+  "description.image": {
+    "message": "Valinnainen syötekuva videon tuottamiseen. omni-flash on pakollinen.",
+    "description": "Ohjeet kuva syötteelle"
+  },
+  "description.referenceImages": {
+    "message": "Optional reference images to guide the style or content of the generated video (omni-flash only).",
+    "description": "Instructions for reference images"
+  },
+  "placeholder.prompt": {
+    "message": "Kuvaile videota…",
+    "description": "Kehotteen paikkamerkki"
+  },
+  "placeholder.select": {
+    "message": "Valitse",
+    "description": "Valintojen paikkamerkki"
+  },
+  "model.default": {
+    "message": "Omni -video",
+    "description": "Oletusmallin etiketti"
+  },
+  "model.preview15": {
+    "message": "Omni -video 1.5 (esikatselu, kuvaan perustuva video)",
+    "description": "1.5 esikatselumallin etiketti"
+  },
+  "button.upload": {
+    "message": "Lataa",
+    "description": "Latauspainike"
+  },
+  "button.generate": {
+    "message": "Tuota",
+    "description": "Tuotantopainike"
+  },
+  "button.download": {
+    "message": "Lataa",
+    "description": "Latauspainike"
+  },
+  "status.pending": {
+    "message": "Jonossa",
+    "description": "Odotustila"
+  },
+  "status.processing": {
+    "message": "Luodaan",
+    "description": "Käsittelytila"
+  },
+  "message.uploadExceed": {
+    "message": "Vain yksi kuva voidaan ladata.",
+    "description": "Latausylitysvaroitus"
+  },
+  "message.uploadReferenceExceed": {
+    "message": "You can upload up to 4 reference images.",
+    "description": "Reference images upload exceed warning"
+  },
+  "message.uploadError": {
+    "message": "Kuvan lataaminen epäonnistui, yritä uudelleen.",
+    "description": "Latausvirhe"
+  },
+  "message.downloadVideo": {
+    "message": "Lataa video",
+    "description": "Lataustyökalu"
+  },
+  "message.modelRequiresImage": {
+    "message": "Tämä malli vaatii syötekuvan (kuvaan perustuva video).",
+    "description": "Malli vaatii kuvan varoitus"
+  },
+  "message.promptOrImageRequired": {
+    "message": "Syötä kehotteet tai lataa kuva.",
+    "description": "Kehote tai kuva vaaditaan varoitus"
+  },
+  "message.startingTask": {
+    "message": "Videon tuotantotehtävää lähetetään…",
+    "description": "Tehtävän aloitus"
+  },
+  "message.startTaskSuccess": {
+    "message": "Tehtävän lähettäminen onnistui.",
+    "description": "Tehtävä onnistui"
+  },
+  "message.startTaskFailed": {
+    "message": "Tehtävän lähettäminen epäonnistui:",
+    "description": "Tehtävä epäonnistui"
+  },
+  "message.usedUp": {
+    "message": "Varat on käytetty loppuun, osta lisää jatkaaksesi käyttöä.",
+    "description": "Loppu"
+  },
+  "name.referenceVideo": {
+    "message": "Reference Video",
+    "description": "Reference/editable video for Omni video editing"
+  },
+  "description.referenceVideo": {
+    "message": "Optional MP4/MOV (≤200MB) to edit or reference an existing video. Requires at least one reference image.",
+    "description": "Help text for the reference video uploader"
+  },
+  "button.uploadVideo": {
+    "message": "Upload Video",
+    "description": "Button to upload the reference video"
+  },
+  "message.uploadVideoExceed": {
+    "message": "You can upload a maximum of 1 reference video",
+    "description": "Error when more than one reference video is uploaded"
+  },
+  "message.uploadVideoError": {
+    "message": "Reference video upload failed, please try again later",
+    "description": "Error when the reference video upload fails"
+  },
+  "message.uploadVideoTypeFailed": {
+    "message": "Uploaded file must be in MP4 or MOV format!",
+    "description": "Error when the reference video is not MP4/MOV"
+  },
+  "message.uploadVideoSizeExceed": {
+    "message": "Uploaded file size cannot exceed 200MB!",
+    "description": "Error when the reference video exceeds 200MB"
+  },
+  "message.promptRequired": {
+    "message": "Please enter a prompt.",
+    "description": "Validation when prompt is empty"
+  },
+  "message.videoRequiresImage": {
+    "message": "Please add at least one reference image when using a reference video.",
+    "description": "Validation when video_urls has no reference image"
+  }
+}

--- a/src/i18n/fr/common.json
+++ b/src/i18n/fr/common.json
@@ -1546,5 +1546,9 @@
   "settings.memoryEnabledHint": {
     "message": "When off, saved memories are not used and new chats do not create memories. Existing memories are kept.",
     "description": "Behavior explanation shown below the memory switch"
+  },
+  "nav.omni": {
+    "message": "Omni Video",
+    "description": "Nav label for the Omni video module"
   }
 }

--- a/src/i18n/fr/omni.json
+++ b/src/i18n/fr/omni.json
@@ -1,0 +1,202 @@
+{
+  "name.bot": {
+    "message": "Robot Vidéo Omni",
+    "description": "Nom du générateur de vidéo Omni"
+  },
+  "name.prompt": {
+    "message": "Invite",
+    "description": "Invite pour générer la vidéo"
+  },
+  "name.model": {
+    "message": "Modèle",
+    "description": "Étiquette pour la sélection du modèle"
+  },
+  "name.ratio": {
+    "message": "Ratio d'image",
+    "description": "Étiquette pour le rapport d'aspect"
+  },
+  "name.resolution": {
+    "message": "Résolution",
+    "description": "Étiquette pour la résolution"
+  },
+  "name.duration": {
+    "message": "Durée",
+    "description": "Étiquette pour la durée"
+  },
+  "name.image": {
+    "message": "Image",
+    "description": "Étiquette pour l'image d'entrée"
+  },
+  "name.referenceImages": {
+    "message": "Reference Images",
+    "description": "Label for reference images"
+  },
+  "name.required": {
+    "message": "Champ requis",
+    "description": "Badge indiquant que le champ est obligatoire"
+  },
+  "name.taskId": {
+    "message": "ID de tâche",
+    "description": "Étiquette pour l'identifiant de la tâche"
+  },
+  "name.elapsed": {
+    "message": "Temps écoulé",
+    "description": "Étiquette du temps écoulé"
+  },
+  "name.traceId": {
+    "message": "ID de suivi",
+    "description": "Étiquette pour l'identifiant de suivi"
+  },
+  "name.failure": {
+    "message": "Échec de la génération",
+    "description": "Titre de l'échec"
+  },
+  "name.failureReason": {
+    "message": "Raison de l'échec",
+    "description": "Étiquette de la raison de l'échec"
+  },
+  "name.status": {
+    "message": "Statut",
+    "description": "Titre du statut"
+  },
+  "description.prompt": {
+    "message": "Décrivez la vidéo que vous souhaitez générer (scène, sujet, action, plan, lumière, style).",
+    "description": "Instructions pour l'entrée de prompt"
+  },
+  "description.model": {
+    "message": "Sélectionnez le modèle Omni. omni-flash prend en charge les vidéos générées par texte et par image ; 1.5-preview prend uniquement en charge les vidéos générées par image.",
+    "description": "Instructions pour la sélection du modèle"
+  },
+  "description.ratio": {
+    "message": "Sélectionnez le rapport d'aspect de sortie.",
+    "description": "Instructions pour le rapport d'aspect"
+  },
+  "description.resolution": {
+    "message": "Sélectionnez la résolution de sortie. Plus la résolution est élevée, plus le quota consommé par seconde est important.",
+    "description": "Instructions pour la résolution"
+  },
+  "description.duration": {
+    "message": "Durée de la vidéo (secondes), facturée par seconde de sortie.",
+    "description": "Instructions pour la durée"
+  },
+  "description.image": {
+    "message": "Image d'entrée optionnelle pour générer une vidéo. omni-flash est requis.",
+    "description": "Instructions pour l'entrée d'image"
+  },
+  "description.referenceImages": {
+    "message": "Optional reference images to guide the style or content of the generated video (omni-flash only).",
+    "description": "Instructions for reference images"
+  },
+  "placeholder.prompt": {
+    "message": "Décrivez votre vidéo…",
+    "description": "Espace réservé pour l'invite"
+  },
+  "placeholder.select": {
+    "message": "Veuillez sélectionner",
+    "description": "Espace réservé pour les sélections"
+  },
+  "model.default": {
+    "message": "Omni Vidéo",
+    "description": "Étiquette du modèle par défaut"
+  },
+  "model.preview15": {
+    "message": "Omni Vidéo 1.5 (aperçu, vidéo générée par image)",
+    "description": "Étiquette du modèle 1.5 aperçu"
+  },
+  "button.upload": {
+    "message": "Téléverser",
+    "description": "Bouton de téléversement"
+  },
+  "button.generate": {
+    "message": "Générer",
+    "description": "Bouton de génération"
+  },
+  "button.download": {
+    "message": "Télécharger",
+    "description": "Bouton de téléchargement"
+  },
+  "status.pending": {
+    "message": "En attente",
+    "description": "Statut en attente"
+  },
+  "status.processing": {
+    "message": "En cours de génération",
+    "description": "Statut de traitement"
+  },
+  "message.uploadExceed": {
+    "message": "Vous ne pouvez téléverser qu'une seule image.",
+    "description": "Avertissement sur le dépassement de téléversement"
+  },
+  "message.uploadReferenceExceed": {
+    "message": "You can upload up to 4 reference images.",
+    "description": "Reference images upload exceed warning"
+  },
+  "message.uploadError": {
+    "message": "Échec du téléversement de l'image, veuillez réessayer.",
+    "description": "Erreur de téléversement"
+  },
+  "message.downloadVideo": {
+    "message": "Télécharger la vidéo",
+    "description": "Infobulle de téléchargement"
+  },
+  "message.modelRequiresImage": {
+    "message": "Ce modèle nécessite une image d'entrée (vidéo générée par image).",
+    "description": "Avertissement sur le modèle nécessitant une image"
+  },
+  "message.promptOrImageRequired": {
+    "message": "Veuillez entrer un prompt ou téléverser une image.",
+    "description": "Avertissement sur le prompt ou l'image requis"
+  },
+  "message.startingTask": {
+    "message": "Soumission de la tâche de génération de vidéo…",
+    "description": "Démarrage de la tâche"
+  },
+  "message.startTaskSuccess": {
+    "message": "Soumission de la tâche réussie.",
+    "description": "Succès de la tâche"
+  },
+  "message.startTaskFailed": {
+    "message": "Échec de la soumission de la tâche :",
+    "description": "Échec de la tâche"
+  },
+  "message.usedUp": {
+    "message": "Quota épuisé, veuillez acheter pour continuer à utiliser.",
+    "description": "Épuisé"
+  },
+  "name.referenceVideo": {
+    "message": "Reference Video",
+    "description": "Reference/editable video for Omni video editing"
+  },
+  "description.referenceVideo": {
+    "message": "Optional MP4/MOV (≤200MB) to edit or reference an existing video. Requires at least one reference image.",
+    "description": "Help text for the reference video uploader"
+  },
+  "button.uploadVideo": {
+    "message": "Upload Video",
+    "description": "Button to upload the reference video"
+  },
+  "message.uploadVideoExceed": {
+    "message": "You can upload a maximum of 1 reference video",
+    "description": "Error when more than one reference video is uploaded"
+  },
+  "message.uploadVideoError": {
+    "message": "Reference video upload failed, please try again later",
+    "description": "Error when the reference video upload fails"
+  },
+  "message.uploadVideoTypeFailed": {
+    "message": "Uploaded file must be in MP4 or MOV format!",
+    "description": "Error when the reference video is not MP4/MOV"
+  },
+  "message.uploadVideoSizeExceed": {
+    "message": "Uploaded file size cannot exceed 200MB!",
+    "description": "Error when the reference video exceeds 200MB"
+  },
+  "message.promptRequired": {
+    "message": "Please enter a prompt.",
+    "description": "Validation when prompt is empty"
+  },
+  "message.videoRequiresImage": {
+    "message": "Please add at least one reference image when using a reference video.",
+    "description": "Validation when video_urls has no reference image"
+  }
+}

--- a/src/i18n/it/common.json
+++ b/src/i18n/it/common.json
@@ -1546,5 +1546,9 @@
   "settings.memoryEnabledHint": {
     "message": "When off, saved memories are not used and new chats do not create memories. Existing memories are kept.",
     "description": "Behavior explanation shown below the memory switch"
+  },
+  "nav.omni": {
+    "message": "Omni Video",
+    "description": "Nav label for the Omni video module"
   }
 }

--- a/src/i18n/it/omni.json
+++ b/src/i18n/it/omni.json
@@ -1,0 +1,202 @@
+{
+  "name.bot": {
+    "message": "Omni Video Bot",
+    "description": "Nome del generatore di video Omni"
+  },
+  "name.prompt": {
+    "message": "Parola chiave",
+    "description": "Parola chiave per generare il video"
+  },
+  "name.model": {
+    "message": "Modello",
+    "description": "Etichetta per la selezione del modello"
+  },
+  "name.ratio": {
+    "message": "Rapporto d'aspetto",
+    "description": "Etichetta per il rapporto d'aspetto"
+  },
+  "name.resolution": {
+    "message": "Risoluzione",
+    "description": "Etichetta per la risoluzione"
+  },
+  "name.duration": {
+    "message": "Durata",
+    "description": "Etichetta per la durata"
+  },
+  "name.image": {
+    "message": "Immagine",
+    "description": "Etichetta per l'immagine di input"
+  },
+  "name.referenceImages": {
+    "message": "Reference Images",
+    "description": "Label for reference images"
+  },
+  "name.required": {
+    "message": "Obbligatorio",
+    "description": "Badge per campo obbligatorio"
+  },
+  "name.taskId": {
+    "message": "ID attività",
+    "description": "Etichetta per l'ID dell'attività"
+  },
+  "name.elapsed": {
+    "message": "Tempo trascorso",
+    "description": "Etichetta per il tempo trascorso"
+  },
+  "name.traceId": {
+    "message": "ID tracciamento",
+    "description": "Etichetta per l'ID di tracciamento"
+  },
+  "name.failure": {
+    "message": "Generazione fallita",
+    "description": "Titolo di fallimento"
+  },
+  "name.failureReason": {
+    "message": "Motivo del fallimento",
+    "description": "Etichetta per il motivo del fallimento"
+  },
+  "name.status": {
+    "message": "Stato",
+    "description": "Titolo dello stato"
+  },
+  "description.prompt": {
+    "message": "Descrivi il video che desideri generare (scena, soggetto, azione, inquadratura, luce, stile).",
+    "description": "Istruzioni per l'input del prompt"
+  },
+  "description.model": {
+    "message": "Seleziona il modello Omni. omni-flash supporta video generati da testo e da immagini; 1.5-preview supporta solo video generati da immagini.",
+    "description": "Istruzioni per la selezione del modello"
+  },
+  "description.ratio": {
+    "message": "Seleziona il rapporto d'aspetto dell'output.",
+    "description": "Istruzioni per il rapporto d'aspetto"
+  },
+  "description.resolution": {
+    "message": "Seleziona la risoluzione di output. Maggiore è la risoluzione, maggiore è il consumo per secondo.",
+    "description": "Istruzioni per la risoluzione"
+  },
+  "description.duration": {
+    "message": "Durata del video (secondi), addebitato in base ai secondi di output.",
+    "description": "Istruzioni per la durata"
+  },
+  "description.image": {
+    "message": "Immagine di input opzionale, utilizzata per generare video. omni-flash è obbligatorio.",
+    "description": "Istruzioni per l'input dell'immagine"
+  },
+  "description.referenceImages": {
+    "message": "Optional reference images to guide the style or content of the generated video (omni-flash only).",
+    "description": "Instructions for reference images"
+  },
+  "placeholder.prompt": {
+    "message": "Descrivi il tuo video…",
+    "description": "Placeholder per la parola chiave"
+  },
+  "placeholder.select": {
+    "message": "Seleziona",
+    "description": "Placeholder per le selezioni"
+  },
+  "model.default": {
+    "message": "Omni",
+    "description": "Etichetta del modello predefinito"
+  },
+  "model.preview15": {
+    "message": "Omni 1.5 (anteprima, video generato da immagini)",
+    "description": "Etichetta del modello anteprima 1.5"
+  },
+  "button.upload": {
+    "message": "Carica",
+    "description": "Pulsante di upload"
+  },
+  "button.generate": {
+    "message": "Genera",
+    "description": "Pulsante di generazione"
+  },
+  "button.download": {
+    "message": "Scarica",
+    "description": "Pulsante di download"
+  },
+  "status.pending": {
+    "message": "In coda",
+    "description": "Stato in attesa"
+  },
+  "status.processing": {
+    "message": "In elaborazione",
+    "description": "Stato di elaborazione"
+  },
+  "message.uploadExceed": {
+    "message": "Puoi caricare solo un'immagine.",
+    "description": "Avviso di superamento dell'upload"
+  },
+  "message.uploadReferenceExceed": {
+    "message": "You can upload up to 4 reference images.",
+    "description": "Reference images upload exceed warning"
+  },
+  "message.uploadError": {
+    "message": "Caricamento dell'immagine fallito, riprova.",
+    "description": "Errore di upload"
+  },
+  "message.downloadVideo": {
+    "message": "Scarica video",
+    "description": "Tooltip di download"
+  },
+  "message.modelRequiresImage": {
+    "message": "Questo modello richiede un'immagine di input (video generato da immagini).",
+    "description": "Avviso che il modello richiede un'immagine"
+  },
+  "message.promptOrImageRequired": {
+    "message": "Inserisci un prompt o carica un'immagine.",
+    "description": "Avviso che richiede un prompt o un'immagine"
+  },
+  "message.startingTask": {
+    "message": "Invio del compito di generazione video in corso…",
+    "description": "Avvio del compito"
+  },
+  "message.startTaskSuccess": {
+    "message": "Invio del compito riuscito.",
+    "description": "Successo del compito"
+  },
+  "message.startTaskFailed": {
+    "message": "Invio del compito fallito:",
+    "description": "Compito fallito"
+  },
+  "message.usedUp": {
+    "message": "Credito esaurito, acquista per continuare a utilizzare.",
+    "description": "Esaurito"
+  },
+  "name.referenceVideo": {
+    "message": "Reference Video",
+    "description": "Reference/editable video for Omni video editing"
+  },
+  "description.referenceVideo": {
+    "message": "Optional MP4/MOV (≤200MB) to edit or reference an existing video. Requires at least one reference image.",
+    "description": "Help text for the reference video uploader"
+  },
+  "button.uploadVideo": {
+    "message": "Upload Video",
+    "description": "Button to upload the reference video"
+  },
+  "message.uploadVideoExceed": {
+    "message": "You can upload a maximum of 1 reference video",
+    "description": "Error when more than one reference video is uploaded"
+  },
+  "message.uploadVideoError": {
+    "message": "Reference video upload failed, please try again later",
+    "description": "Error when the reference video upload fails"
+  },
+  "message.uploadVideoTypeFailed": {
+    "message": "Uploaded file must be in MP4 or MOV format!",
+    "description": "Error when the reference video is not MP4/MOV"
+  },
+  "message.uploadVideoSizeExceed": {
+    "message": "Uploaded file size cannot exceed 200MB!",
+    "description": "Error when the reference video exceeds 200MB"
+  },
+  "message.promptRequired": {
+    "message": "Please enter a prompt.",
+    "description": "Validation when prompt is empty"
+  },
+  "message.videoRequiresImage": {
+    "message": "Please add at least one reference image when using a reference video.",
+    "description": "Validation when video_urls has no reference image"
+  }
+}

--- a/src/i18n/ja/common.json
+++ b/src/i18n/ja/common.json
@@ -1546,5 +1546,9 @@
   "settings.memoryEnabledHint": {
     "message": "When off, saved memories are not used and new chats do not create memories. Existing memories are kept.",
     "description": "Behavior explanation shown below the memory switch"
+  },
+  "nav.omni": {
+    "message": "Omni Video",
+    "description": "Nav label for the Omni video module"
   }
 }

--- a/src/i18n/ja/omni.json
+++ b/src/i18n/ja/omni.json
@@ -1,0 +1,202 @@
+{
+  "name.bot": {
+    "message": "Omni 動画ロボット",
+    "description": "Omni動画生成器の名前"
+  },
+  "name.prompt": {
+    "message": "プロンプト",
+    "description": "ビデオ生成のためのプロンプト"
+  },
+  "name.model": {
+    "message": "モデル",
+    "description": "モデル選択のラベル"
+  },
+  "name.ratio": {
+    "message": "アスペクト比",
+    "description": "アスペクト比のラベル"
+  },
+  "name.resolution": {
+    "message": "解像度",
+    "description": "解像度のラベル"
+  },
+  "name.duration": {
+    "message": "長さ",
+    "description": "長さのラベル"
+  },
+  "name.image": {
+    "message": "画像",
+    "description": "画像入力のラベル"
+  },
+  "name.referenceImages": {
+    "message": "Reference Images",
+    "description": "Label for reference images"
+  },
+  "name.required": {
+    "message": "必須",
+    "description": "必須バッジ"
+  },
+  "name.taskId": {
+    "message": "タスク ID",
+    "description": "タスク ID のラベル"
+  },
+  "name.elapsed": {
+    "message": "経過時間",
+    "description": "経過時間のラベル"
+  },
+  "name.traceId": {
+    "message": "トレース ID",
+    "description": "トレース ID のラベル"
+  },
+  "name.failure": {
+    "message": "生成失敗",
+    "description": "失敗タイトル"
+  },
+  "name.failureReason": {
+    "message": "失敗理由",
+    "description": "失敗理由のラベル"
+  },
+  "name.status": {
+    "message": "ステータス",
+    "description": "ステータスタイトル"
+  },
+  "description.prompt": {
+    "message": "生成したい動画を説明してください（シーン、主体、アクション、ショット、光、スタイル）。",
+    "description": "プロンプト入力に関する指示"
+  },
+  "description.model": {
+    "message": "Omniモデルを選択します。omni-flashはテキストから画像生成と画像から動画生成をサポートします；1.5-previewは画像から動画生成のみサポートします。",
+    "description": "モデル選択に関する指示"
+  },
+  "description.ratio": {
+    "message": "出力画面のアスペクト比を選択します。",
+    "description": "アスペクト比に関する指示"
+  },
+  "description.resolution": {
+    "message": "出力解像度を選択します。解像度が高いほど、毎秒消費する額が増えます。",
+    "description": "解像度に関する指示"
+  },
+  "description.duration": {
+    "message": "動画の長さ（秒）、出力秒数に基づいて課金されます。",
+    "description": "長さに関する指示"
+  },
+  "description.image": {
+    "message": "オプションの入力画像、動画生成に使用します。omni-flashは必須です。",
+    "description": "画像入力に関する指示"
+  },
+  "description.referenceImages": {
+    "message": "Optional reference images to guide the style or content of the generated video (omni-flash only).",
+    "description": "Instructions for reference images"
+  },
+  "placeholder.prompt": {
+    "message": "あなたのビデオを説明してください…",
+    "description": "プロンプトのプレースホルダー"
+  },
+  "placeholder.select": {
+    "message": "選択してください",
+    "description": "選択のプレースホルダー"
+  },
+  "model.default": {
+    "message": "Omni 動画",
+    "description": "デフォルトモデルラベル"
+  },
+  "model.preview15": {
+    "message": "Omni 動画 1.5（プレビュー、画像から動画生成）",
+    "description": "1.5プレビューモデルラベル"
+  },
+  "button.upload": {
+    "message": "アップロード",
+    "description": "アップロードボタン"
+  },
+  "button.generate": {
+    "message": "生成",
+    "description": "生成ボタン"
+  },
+  "button.download": {
+    "message": "ダウンロード",
+    "description": "ダウンロードボタン"
+  },
+  "status.pending": {
+    "message": "保留中",
+    "description": "保留中のステータス"
+  },
+  "status.processing": {
+    "message": "処理中",
+    "description": "処理中のステータス"
+  },
+  "message.uploadExceed": {
+    "message": "画像は1枚のみアップロードできます。",
+    "description": "アップロード超過警告"
+  },
+  "message.uploadReferenceExceed": {
+    "message": "You can upload up to 4 reference images.",
+    "description": "Reference images upload exceed warning"
+  },
+  "message.uploadError": {
+    "message": "画像のアップロードに失敗しました。再試行してください。",
+    "description": "アップロードエラー"
+  },
+  "message.downloadVideo": {
+    "message": "動画をダウンロード",
+    "description": "ダウンロードツールチップ"
+  },
+  "message.modelRequiresImage": {
+    "message": "このモデルは画像入力が必要です（画像から動画生成）。",
+    "description": "モデルが画像を必要とする警告"
+  },
+  "message.promptOrImageRequired": {
+    "message": "プロンプトまたは画像をアップロードしてください。",
+    "description": "プロンプトまたは画像が必要な警告"
+  },
+  "message.startingTask": {
+    "message": "動画生成タスクを提出中…",
+    "description": "タスク開始"
+  },
+  "message.startTaskSuccess": {
+    "message": "タスクが正常に提出されました。",
+    "description": "タスク成功"
+  },
+  "message.startTaskFailed": {
+    "message": "タスクの提出に失敗しました：",
+    "description": "タスク失敗"
+  },
+  "message.usedUp": {
+    "message": "利用可能な額が使い切られました。購入後に続行してください。",
+    "description": "使い切り"
+  },
+  "name.referenceVideo": {
+    "message": "Reference Video",
+    "description": "Reference/editable video for Omni video editing"
+  },
+  "description.referenceVideo": {
+    "message": "Optional MP4/MOV (≤200MB) to edit or reference an existing video. Requires at least one reference image.",
+    "description": "Help text for the reference video uploader"
+  },
+  "button.uploadVideo": {
+    "message": "Upload Video",
+    "description": "Button to upload the reference video"
+  },
+  "message.uploadVideoExceed": {
+    "message": "You can upload a maximum of 1 reference video",
+    "description": "Error when more than one reference video is uploaded"
+  },
+  "message.uploadVideoError": {
+    "message": "Reference video upload failed, please try again later",
+    "description": "Error when the reference video upload fails"
+  },
+  "message.uploadVideoTypeFailed": {
+    "message": "Uploaded file must be in MP4 or MOV format!",
+    "description": "Error when the reference video is not MP4/MOV"
+  },
+  "message.uploadVideoSizeExceed": {
+    "message": "Uploaded file size cannot exceed 200MB!",
+    "description": "Error when the reference video exceeds 200MB"
+  },
+  "message.promptRequired": {
+    "message": "Please enter a prompt.",
+    "description": "Validation when prompt is empty"
+  },
+  "message.videoRequiresImage": {
+    "message": "Please add at least one reference image when using a reference video.",
+    "description": "Validation when video_urls has no reference image"
+  }
+}

--- a/src/i18n/ko/common.json
+++ b/src/i18n/ko/common.json
@@ -1546,5 +1546,9 @@
   "settings.memoryEnabledHint": {
     "message": "When off, saved memories are not used and new chats do not create memories. Existing memories are kept.",
     "description": "Behavior explanation shown below the memory switch"
+  },
+  "nav.omni": {
+    "message": "Omni Video",
+    "description": "Nav label for the Omni video module"
   }
 }

--- a/src/i18n/ko/omni.json
+++ b/src/i18n/ko/omni.json
@@ -1,0 +1,202 @@
+{
+  "name.bot": {
+    "message": "Omni 비디오 봇",
+    "description": "Omni 비디오 생성기의 이름"
+  },
+  "name.prompt": {
+    "message": "프롬프트",
+    "description": "비디오 생성을 위한 프롬프트"
+  },
+  "name.model": {
+    "message": "모델",
+    "description": "모델 선택을 위한 레이블"
+  },
+  "name.ratio": {
+    "message": "화면 비율",
+    "description": "종횡비를 위한 레이블"
+  },
+  "name.resolution": {
+    "message": "해상도",
+    "description": "해상도를 위한 레이블"
+  },
+  "name.duration": {
+    "message": "길이",
+    "description": "길이에 대한 레이블"
+  },
+  "name.image": {
+    "message": "이미지",
+    "description": "입력 이미지의 레이블"
+  },
+  "name.referenceImages": {
+    "message": "Reference Images",
+    "description": "Label for reference images"
+  },
+  "name.required": {
+    "message": "필수",
+    "description": "필수 배지"
+  },
+  "name.taskId": {
+    "message": "작업 ID",
+    "description": "작업 ID 레이블"
+  },
+  "name.elapsed": {
+    "message": "소요 시간",
+    "description": "소요 시간 레이블"
+  },
+  "name.traceId": {
+    "message": "추적 ID",
+    "description": "추적 ID 레이블"
+  },
+  "name.failure": {
+    "message": "생성 실패",
+    "description": "실패 제목"
+  },
+  "name.failureReason": {
+    "message": "실패 원인",
+    "description": "실패 원인 레이블"
+  },
+  "name.status": {
+    "message": "상태",
+    "description": "상태 제목"
+  },
+  "description.prompt": {
+    "message": "생성하고 싶은 비디오를 설명하세요(장면, 주제, 동작, 샷, 조명, 스타일).",
+    "description": "프롬프트 입력에 대한 설명"
+  },
+  "description.model": {
+    "message": "Omni 모델을 선택하세요. omni-flash는 텍스트와 이미지 기반 비디오를 지원하며; 1.5-preview는 이미지 기반 비디오만 지원합니다.",
+    "description": "모델 선택에 대한 설명"
+  },
+  "description.ratio": {
+    "message": "출력 화면 비율을 선택하세요.",
+    "description": "화면 비율에 대한 설명"
+  },
+  "description.resolution": {
+    "message": "출력 해상도를 선택하세요. 해상도가 높을수록 초당 소모되는 크레딧이 많아집니다.",
+    "description": "해상도에 대한 설명"
+  },
+  "description.duration": {
+    "message": "비디오 길이(초), 출력 초 수에 따라 요금이 청구됩니다.",
+    "description": "길이에 대한 설명"
+  },
+  "description.image": {
+    "message": "비디오 생성을 위한 선택적 입력 이미지. omni-flash는 필수입니다.",
+    "description": "이미지 입력에 대한 설명"
+  },
+  "description.referenceImages": {
+    "message": "Optional reference images to guide the style or content of the generated video (omni-flash only).",
+    "description": "Instructions for reference images"
+  },
+  "placeholder.prompt": {
+    "message": "비디오를 설명하세요…",
+    "description": "프롬프트를 위한 플레이스홀더"
+  },
+  "placeholder.select": {
+    "message": "선택하세요",
+    "description": "선택을 위한 플레이스홀더"
+  },
+  "model.default": {
+    "message": "Omni 비디오",
+    "description": "기본 모델 레이블"
+  },
+  "model.preview15": {
+    "message": "Omni 비디오 1.5(미리보기, 이미지 기반 비디오)",
+    "description": "1.5 미리보기 모델 레이블"
+  },
+  "button.upload": {
+    "message": "업로드",
+    "description": "업로드 버튼"
+  },
+  "button.generate": {
+    "message": "생성",
+    "description": "생성 버튼"
+  },
+  "button.download": {
+    "message": "다운로드",
+    "description": "다운로드 버튼"
+  },
+  "status.pending": {
+    "message": "대기 중",
+    "description": "대기 상태"
+  },
+  "status.processing": {
+    "message": "생성 중",
+    "description": "처리 상태"
+  },
+  "message.uploadExceed": {
+    "message": "이미지는 한 장만 업로드할 수 있습니다.",
+    "description": "업로드 초과 경고"
+  },
+  "message.uploadReferenceExceed": {
+    "message": "You can upload up to 4 reference images.",
+    "description": "Reference images upload exceed warning"
+  },
+  "message.uploadError": {
+    "message": "이미지 업로드 실패, 다시 시도하세요.",
+    "description": "업로드 오류"
+  },
+  "message.downloadVideo": {
+    "message": "비디오 다운로드",
+    "description": "다운로드 툴팁"
+  },
+  "message.modelRequiresImage": {
+    "message": "이 모델은 입력 이미지가 필요합니다(이미지 기반 비디오).",
+    "description": "모델에 이미지가 필요하다는 경고"
+  },
+  "message.promptOrImageRequired": {
+    "message": "프롬프트를 입력하거나 이미지를 업로드하세요.",
+    "description": "프롬프트 또는 이미지가 필요하다는 경고"
+  },
+  "message.startingTask": {
+    "message": "비디오 생성 작업을 제출하는 중…",
+    "description": "작업 시작"
+  },
+  "message.startTaskSuccess": {
+    "message": "작업 제출 성공.",
+    "description": "작업 성공"
+  },
+  "message.startTaskFailed": {
+    "message": "작업 제출 실패:",
+    "description": "작업 실패"
+  },
+  "message.usedUp": {
+    "message": "크레딧이 소진되었습니다. 구매 후 계속 사용하세요.",
+    "description": "소진됨"
+  },
+  "name.referenceVideo": {
+    "message": "Reference Video",
+    "description": "Reference/editable video for Omni video editing"
+  },
+  "description.referenceVideo": {
+    "message": "Optional MP4/MOV (≤200MB) to edit or reference an existing video. Requires at least one reference image.",
+    "description": "Help text for the reference video uploader"
+  },
+  "button.uploadVideo": {
+    "message": "Upload Video",
+    "description": "Button to upload the reference video"
+  },
+  "message.uploadVideoExceed": {
+    "message": "You can upload a maximum of 1 reference video",
+    "description": "Error when more than one reference video is uploaded"
+  },
+  "message.uploadVideoError": {
+    "message": "Reference video upload failed, please try again later",
+    "description": "Error when the reference video upload fails"
+  },
+  "message.uploadVideoTypeFailed": {
+    "message": "Uploaded file must be in MP4 or MOV format!",
+    "description": "Error when the reference video is not MP4/MOV"
+  },
+  "message.uploadVideoSizeExceed": {
+    "message": "Uploaded file size cannot exceed 200MB!",
+    "description": "Error when the reference video exceeds 200MB"
+  },
+  "message.promptRequired": {
+    "message": "Please enter a prompt.",
+    "description": "Validation when prompt is empty"
+  },
+  "message.videoRequiresImage": {
+    "message": "Please add at least one reference image when using a reference video.",
+    "description": "Validation when video_urls has no reference image"
+  }
+}

--- a/src/i18n/pl/common.json
+++ b/src/i18n/pl/common.json
@@ -1546,5 +1546,9 @@
   "settings.memoryEnabledHint": {
     "message": "When off, saved memories are not used and new chats do not create memories. Existing memories are kept.",
     "description": "Behavior explanation shown below the memory switch"
+  },
+  "nav.omni": {
+    "message": "Omni Video",
+    "description": "Nav label for the Omni video module"
   }
 }

--- a/src/i18n/pl/omni.json
+++ b/src/i18n/pl/omni.json
@@ -1,0 +1,202 @@
+{
+  "name.bot": {
+    "message": "Omni wideo bot",
+    "description": "Nazwa generatora wideo Omni"
+  },
+  "name.prompt": {
+    "message": "Podpowiedź",
+    "description": "Podpowiedź do generowania wideo"
+  },
+  "name.model": {
+    "message": "Model",
+    "description": "Etykieta dla wyboru modelu"
+  },
+  "name.ratio": {
+    "message": "Proporcje",
+    "description": "Etykieta dla proporcji obrazu"
+  },
+  "name.resolution": {
+    "message": "Rozdzielczość",
+    "description": "Etykieta dla rozdzielczości"
+  },
+  "name.duration": {
+    "message": "Czas trwania",
+    "description": "Etykieta dla czasu trwania"
+  },
+  "name.image": {
+    "message": "Obraz",
+    "description": "Etykieta dla wprowadzenia obrazu"
+  },
+  "name.referenceImages": {
+    "message": "Reference Images",
+    "description": "Label for reference images"
+  },
+  "name.required": {
+    "message": "Wymagane",
+    "description": "Odznaka wymagania"
+  },
+  "name.taskId": {
+    "message": "ID zadania",
+    "description": "Etykieta ID zadania"
+  },
+  "name.elapsed": {
+    "message": "Czas trwania",
+    "description": "Etykieta czasu trwania"
+  },
+  "name.traceId": {
+    "message": "ID śledzenia",
+    "description": "Etykieta ID śledzenia"
+  },
+  "name.failure": {
+    "message": "Generowanie nie powiodło się",
+    "description": "Tytuł niepowodzenia"
+  },
+  "name.failureReason": {
+    "message": "Powód niepowodzenia",
+    "description": "Etykieta powodu niepowodzenia"
+  },
+  "name.status": {
+    "message": "Status",
+    "description": "Tytuł statusu"
+  },
+  "description.prompt": {
+    "message": "Opisz wideo, które chcesz wygenerować (scena, obiekt, akcja, ujęcie, światło, styl).",
+    "description": "Instrukcje dotyczące wprowadzenia podpowiedzi"
+  },
+  "description.model": {
+    "message": "Wybierz model Omni. omni-flash obsługuje wideo generowane z tekstu i obrazu; 1.5-preview obsługuje tylko wideo generowane z obrazu.",
+    "description": "Instrukcje dotyczące wyboru modelu"
+  },
+  "description.ratio": {
+    "message": "Wybierz proporcje wyjściowego obrazu.",
+    "description": "Instrukcje dotyczące proporcji"
+  },
+  "description.resolution": {
+    "message": "Wybierz rozdzielczość wyjściową. Wyższa rozdzielczość zużywa więcej zasobów na sekundę.",
+    "description": "Instrukcje dotyczące rozdzielczości"
+  },
+  "description.duration": {
+    "message": "Czas trwania wideo (sekundy), rozliczany według liczby sekund.",
+    "description": "Instrukcje dotyczące czasu trwania"
+  },
+  "description.image": {
+    "message": "Opcjonalny obraz wejściowy do generowania wideo. omni-flash jest wymagany.",
+    "description": "Instrukcje dotyczące obrazu wejściowego"
+  },
+  "description.referenceImages": {
+    "message": "Optional reference images to guide the style or content of the generated video (omni-flash only).",
+    "description": "Instructions for reference images"
+  },
+  "placeholder.prompt": {
+    "message": "Opisz swoje wideo…",
+    "description": "Miejsce na podpowiedź"
+  },
+  "placeholder.select": {
+    "message": "Wybierz",
+    "description": "Miejsce na wybór"
+  },
+  "model.default": {
+    "message": "Omni wideo",
+    "description": "Etykieta domyślnego modelu"
+  },
+  "model.preview15": {
+    "message": "Omni wideo 1.5 (podgląd, wideo generowane z obrazu)",
+    "description": "Etykieta modelu podglądu 1.5"
+  },
+  "button.upload": {
+    "message": "Prześlij",
+    "description": "Przycisk przesyłania"
+  },
+  "button.generate": {
+    "message": "Generuj",
+    "description": "Przycisk generowania"
+  },
+  "button.download": {
+    "message": "Pobierz",
+    "description": "Przycisk pobierania"
+  },
+  "status.pending": {
+    "message": "Oczekiwanie",
+    "description": "Status oczekiwania"
+  },
+  "status.processing": {
+    "message": "Przetwarzanie",
+    "description": "Status przetwarzania"
+  },
+  "message.uploadExceed": {
+    "message": "Można przesłać tylko jeden obraz.",
+    "description": "Ostrzeżenie o przekroczeniu limitu przesyłania"
+  },
+  "message.uploadReferenceExceed": {
+    "message": "You can upload up to 4 reference images.",
+    "description": "Reference images upload exceed warning"
+  },
+  "message.uploadError": {
+    "message": "Nie udało się przesłać obrazu, spróbuj ponownie.",
+    "description": "Błąd przesyłania"
+  },
+  "message.downloadVideo": {
+    "message": "Pobierz wideo",
+    "description": "Podpowiedź do pobrania"
+  },
+  "message.modelRequiresImage": {
+    "message": "Ten model wymaga obrazu wejściowego (wideo generowane z obrazu).",
+    "description": "Ostrzeżenie, że model wymaga obrazu"
+  },
+  "message.promptOrImageRequired": {
+    "message": "Wprowadź podpowiedź lub prześlij obraz.",
+    "description": "Ostrzeżenie, że wymagana jest podpowiedź lub obraz"
+  },
+  "message.startingTask": {
+    "message": "Zgłaszanie zadania generowania wideo…",
+    "description": "Rozpoczynanie zadania"
+  },
+  "message.startTaskSuccess": {
+    "message": "Zgłoszenie zadania powiodło się.",
+    "description": "Sukces zadania"
+  },
+  "message.startTaskFailed": {
+    "message": "Zgłoszenie zadania nie powiodło się:",
+    "description": "Niepowodzenie zadania"
+  },
+  "message.usedUp": {
+    "message": "Limit został wykorzystany, proszę zakupić więcej, aby kontynuować korzystanie.",
+    "description": "Wykorzystano limit"
+  },
+  "name.referenceVideo": {
+    "message": "Reference Video",
+    "description": "Reference/editable video for Omni video editing"
+  },
+  "description.referenceVideo": {
+    "message": "Optional MP4/MOV (≤200MB) to edit or reference an existing video. Requires at least one reference image.",
+    "description": "Help text for the reference video uploader"
+  },
+  "button.uploadVideo": {
+    "message": "Upload Video",
+    "description": "Button to upload the reference video"
+  },
+  "message.uploadVideoExceed": {
+    "message": "You can upload a maximum of 1 reference video",
+    "description": "Error when more than one reference video is uploaded"
+  },
+  "message.uploadVideoError": {
+    "message": "Reference video upload failed, please try again later",
+    "description": "Error when the reference video upload fails"
+  },
+  "message.uploadVideoTypeFailed": {
+    "message": "Uploaded file must be in MP4 or MOV format!",
+    "description": "Error when the reference video is not MP4/MOV"
+  },
+  "message.uploadVideoSizeExceed": {
+    "message": "Uploaded file size cannot exceed 200MB!",
+    "description": "Error when the reference video exceeds 200MB"
+  },
+  "message.promptRequired": {
+    "message": "Please enter a prompt.",
+    "description": "Validation when prompt is empty"
+  },
+  "message.videoRequiresImage": {
+    "message": "Please add at least one reference image when using a reference video.",
+    "description": "Validation when video_urls has no reference image"
+  }
+}

--- a/src/i18n/pt/common.json
+++ b/src/i18n/pt/common.json
@@ -1546,5 +1546,9 @@
   "settings.memoryEnabledHint": {
     "message": "When off, saved memories are not used and new chats do not create memories. Existing memories are kept.",
     "description": "Behavior explanation shown below the memory switch"
+  },
+  "nav.omni": {
+    "message": "Omni Video",
+    "description": "Nav label for the Omni video module"
   }
 }

--- a/src/i18n/pt/omni.json
+++ b/src/i18n/pt/omni.json
@@ -1,0 +1,202 @@
+{
+  "name.bot": {
+    "message": "Robô de Vídeo Omni",
+    "description": "Nome do gerador de vídeo Omni"
+  },
+  "name.prompt": {
+    "message": "Prompt",
+    "description": "Prompt para gerar o vídeo"
+  },
+  "name.model": {
+    "message": "Modelo",
+    "description": "Rótulo para seleção de modelo"
+  },
+  "name.ratio": {
+    "message": "Proporção",
+    "description": "Rótulo para proporção de aspecto"
+  },
+  "name.resolution": {
+    "message": "Resolução",
+    "description": "Rótulo para resolução"
+  },
+  "name.duration": {
+    "message": "Duração",
+    "description": "Rótulo para duração"
+  },
+  "name.image": {
+    "message": "Imagem",
+    "description": "Rótulo para entrada de imagem"
+  },
+  "name.referenceImages": {
+    "message": "Reference Images",
+    "description": "Label for reference images"
+  },
+  "name.required": {
+    "message": "Obrigatório",
+    "description": "Sinalizador de campo obrigatório"
+  },
+  "name.taskId": {
+    "message": "ID da Tarefa",
+    "description": "Rótulo para ID da tarefa"
+  },
+  "name.elapsed": {
+    "message": "Tempo decorrido",
+    "description": "Rótulo de tempo decorrido"
+  },
+  "name.traceId": {
+    "message": "ID de Rastreamento",
+    "description": "Rótulo para ID de rastreamento"
+  },
+  "name.failure": {
+    "message": "Falha na geração",
+    "description": "Título de falha"
+  },
+  "name.failureReason": {
+    "message": "Razão da falha",
+    "description": "Rótulo da razão da falha"
+  },
+  "name.status": {
+    "message": "Status",
+    "description": "Título do status"
+  },
+  "description.prompt": {
+    "message": "Descreva o vídeo que você deseja gerar (cena, sujeito, ação, ângulo, iluminação, estilo).",
+    "description": "Instruções para entrada de prompt"
+  },
+  "description.model": {
+    "message": "Escolha o modelo Omni. omni-flash suporta vídeos gerados por texto e imagem; 1.5-preview suporta apenas vídeos gerados por imagem.",
+    "description": "Instruções para seleção de modelo"
+  },
+  "description.ratio": {
+    "message": "Escolha a proporção da saída.",
+    "description": "Instruções para a proporção da imagem"
+  },
+  "description.resolution": {
+    "message": "Escolha a resolução de saída. Quanto maior a resolução, mais crédito será consumido por segundo.",
+    "description": "Instruções para resolução"
+  },
+  "description.duration": {
+    "message": "Duração do vídeo (segundos), cobrado por segundo de saída.",
+    "description": "Instruções para a duração"
+  },
+  "description.image": {
+    "message": "Imagem de entrada opcional, usada para gerar vídeo. omni-flash é obrigatório.",
+    "description": "Instruções para a entrada de imagem"
+  },
+  "description.referenceImages": {
+    "message": "Optional reference images to guide the style or content of the generated video (omni-flash only).",
+    "description": "Instructions for reference images"
+  },
+  "placeholder.prompt": {
+    "message": "Descreva seu vídeo…",
+    "description": "Texto de espaço reservado para prompt"
+  },
+  "placeholder.select": {
+    "message": "Selecione",
+    "description": "Texto de espaço reservado para seleções"
+  },
+  "model.default": {
+    "message": "Omni Vídeo",
+    "description": "Rótulo do modelo padrão"
+  },
+  "model.preview15": {
+    "message": "Omni Vídeo 1.5 (prévia, vídeo gerado por imagem)",
+    "description": "Rótulo do modelo prévia 1.5"
+  },
+  "button.upload": {
+    "message": "Enviar",
+    "description": "Botão de upload"
+  },
+  "button.generate": {
+    "message": "Gerar",
+    "description": "Botão de gerar"
+  },
+  "button.download": {
+    "message": "Baixar",
+    "description": "Botão de download"
+  },
+  "status.pending": {
+    "message": "Pendente",
+    "description": "Status pendente"
+  },
+  "status.processing": {
+    "message": "Processando",
+    "description": "Status de processamento"
+  },
+  "message.uploadExceed": {
+    "message": "Somente uma imagem pode ser enviada.",
+    "description": "Aviso de excesso de upload"
+  },
+  "message.uploadReferenceExceed": {
+    "message": "You can upload up to 4 reference images.",
+    "description": "Reference images upload exceed warning"
+  },
+  "message.uploadError": {
+    "message": "Falha ao enviar a imagem, por favor tente novamente.",
+    "description": "Erro de upload"
+  },
+  "message.downloadVideo": {
+    "message": "Baixar vídeo",
+    "description": "Dica de download"
+  },
+  "message.modelRequiresImage": {
+    "message": "Este modelo requer uma imagem de entrada (vídeo gerado por imagem).",
+    "description": "Aviso de que o modelo requer imagem"
+  },
+  "message.promptOrImageRequired": {
+    "message": "Por favor, insira um prompt ou envie uma imagem.",
+    "description": "Aviso de que prompt ou imagem são necessários"
+  },
+  "message.startingTask": {
+    "message": "Enviando tarefa de geração de vídeo…",
+    "description": "Iniciando tarefa"
+  },
+  "message.startTaskSuccess": {
+    "message": "Tarefa enviada com sucesso.",
+    "description": "Sucesso na tarefa"
+  },
+  "message.startTaskFailed": {
+    "message": "Falha ao enviar a tarefa:",
+    "description": "Falha na tarefa"
+  },
+  "message.usedUp": {
+    "message": "Créditos esgotados, por favor compre mais para continuar usando.",
+    "description": "Esgotado"
+  },
+  "name.referenceVideo": {
+    "message": "Reference Video",
+    "description": "Reference/editable video for Omni video editing"
+  },
+  "description.referenceVideo": {
+    "message": "Optional MP4/MOV (≤200MB) to edit or reference an existing video. Requires at least one reference image.",
+    "description": "Help text for the reference video uploader"
+  },
+  "button.uploadVideo": {
+    "message": "Upload Video",
+    "description": "Button to upload the reference video"
+  },
+  "message.uploadVideoExceed": {
+    "message": "You can upload a maximum of 1 reference video",
+    "description": "Error when more than one reference video is uploaded"
+  },
+  "message.uploadVideoError": {
+    "message": "Reference video upload failed, please try again later",
+    "description": "Error when the reference video upload fails"
+  },
+  "message.uploadVideoTypeFailed": {
+    "message": "Uploaded file must be in MP4 or MOV format!",
+    "description": "Error when the reference video is not MP4/MOV"
+  },
+  "message.uploadVideoSizeExceed": {
+    "message": "Uploaded file size cannot exceed 200MB!",
+    "description": "Error when the reference video exceeds 200MB"
+  },
+  "message.promptRequired": {
+    "message": "Please enter a prompt.",
+    "description": "Validation when prompt is empty"
+  },
+  "message.videoRequiresImage": {
+    "message": "Please add at least one reference image when using a reference video.",
+    "description": "Validation when video_urls has no reference image"
+  }
+}

--- a/src/i18n/ru/common.json
+++ b/src/i18n/ru/common.json
@@ -1546,5 +1546,9 @@
   "settings.memoryEnabledHint": {
     "message": "When off, saved memories are not used and new chats do not create memories. Existing memories are kept.",
     "description": "Behavior explanation shown below the memory switch"
+  },
+  "nav.omni": {
+    "message": "Omni Video",
+    "description": "Nav label for the Omni video module"
   }
 }

--- a/src/i18n/ru/omni.json
+++ b/src/i18n/ru/omni.json
@@ -1,0 +1,202 @@
+{
+  "name.bot": {
+    "message": "Omni Видео Бот",
+    "description": "Название генератора видео Omni"
+  },
+  "name.prompt": {
+    "message": "Подсказка",
+    "description": "Подсказка для генерации видео"
+  },
+  "name.model": {
+    "message": "Модель",
+    "description": "Метка для выбора модели"
+  },
+  "name.ratio": {
+    "message": "Соотношение сторон",
+    "description": "Метка для соотношения сторон"
+  },
+  "name.resolution": {
+    "message": "Разрешение",
+    "description": "Метка для разрешения"
+  },
+  "name.duration": {
+    "message": "Длительность",
+    "description": "Этикетка для длительности"
+  },
+  "name.image": {
+    "message": "Изображение",
+    "description": "Метка для ввода изображения"
+  },
+  "name.referenceImages": {
+    "message": "Reference Images",
+    "description": "Label for reference images"
+  },
+  "name.required": {
+    "message": "Обязательно",
+    "description": "Значок обязательного поля"
+  },
+  "name.taskId": {
+    "message": "ID задачи",
+    "description": "Метка для ID задачи"
+  },
+  "name.elapsed": {
+    "message": "Затраченное время",
+    "description": "Этикетка затраченного времени"
+  },
+  "name.traceId": {
+    "message": "ID отслеживания",
+    "description": "Метка для ID отслеживания"
+  },
+  "name.failure": {
+    "message": "Ошибка генерации",
+    "description": "Заголовок ошибки"
+  },
+  "name.failureReason": {
+    "message": "Причина ошибки",
+    "description": "Этикетка причины ошибки"
+  },
+  "name.status": {
+    "message": "Статус",
+    "description": "Название статуса"
+  },
+  "description.prompt": {
+    "message": "Опишите, какое видео вы хотите сгенерировать (сцена, объект, действие, кадр, освещение, стиль).",
+    "description": "Инструкции по вводу подсказки"
+  },
+  "description.model": {
+    "message": "Выберите модель Omni. omni-flash поддерживает генерацию видео по тексту и изображению; 1.5-preview поддерживает только генерацию по изображению.",
+    "description": "Инструкции по выбору модели"
+  },
+  "description.ratio": {
+    "message": "Выберите соотношение сторон выходного видео.",
+    "description": "Инструкции по соотношению сторон"
+  },
+  "description.resolution": {
+    "message": "Выберите выходное разрешение. Чем выше разрешение, тем больше тратится кредитов в секунду.",
+    "description": "Инструкции по разрешению"
+  },
+  "description.duration": {
+    "message": "Длительность видео (в секундах), оплата по количеству секунд.",
+    "description": "Инструкции по длительности"
+  },
+  "description.image": {
+    "message": "Необязательное входное изображение для генерации видео. omni-flash обязательно.",
+    "description": "Инструкции по входному изображению"
+  },
+  "description.referenceImages": {
+    "message": "Optional reference images to guide the style or content of the generated video (omni-flash only).",
+    "description": "Instructions for reference images"
+  },
+  "placeholder.prompt": {
+    "message": "Опишите ваше видео…",
+    "description": "Заполнитель для подсказки"
+  },
+  "placeholder.select": {
+    "message": "Пожалуйста, выберите",
+    "description": "Заполнитель для выбора"
+  },
+  "model.default": {
+    "message": "Omni Видео",
+    "description": "Этикетка по умолчанию для модели"
+  },
+  "model.preview15": {
+    "message": "Omni Видео 1.5 (предварительный просмотр, генерация по изображению)",
+    "description": "Этикетка модели 1.5 предварительного просмотра"
+  },
+  "button.upload": {
+    "message": "Загрузить",
+    "description": "Кнопка загрузки"
+  },
+  "button.generate": {
+    "message": "Сгенерировать",
+    "description": "Кнопка генерации"
+  },
+  "button.download": {
+    "message": "Скачать",
+    "description": "Кнопка загрузки"
+  },
+  "status.pending": {
+    "message": "В очереди",
+    "description": "Статус ожидания"
+  },
+  "status.processing": {
+    "message": "В процессе",
+    "description": "Статус обработки"
+  },
+  "message.uploadExceed": {
+    "message": "Можно загрузить только одно изображение.",
+    "description": "Предупреждение о превышении загрузки"
+  },
+  "message.uploadReferenceExceed": {
+    "message": "You can upload up to 4 reference images.",
+    "description": "Reference images upload exceed warning"
+  },
+  "message.uploadError": {
+    "message": "Ошибка загрузки изображения, пожалуйста, попробуйте снова.",
+    "description": "Ошибка загрузки"
+  },
+  "message.downloadVideo": {
+    "message": "Скачать видео",
+    "description": "Подсказка для загрузки"
+  },
+  "message.modelRequiresImage": {
+    "message": "Эта модель требует входного изображения (генерация по изображению).",
+    "description": "Предупреждение о необходимости изображения для модели"
+  },
+  "message.promptOrImageRequired": {
+    "message": "Введите подсказку или загрузите изображение.",
+    "description": "Предупреждение о необходимости подсказки или изображения"
+  },
+  "message.startingTask": {
+    "message": "Отправка задачи на генерацию видео…",
+    "description": "Начало задачи"
+  },
+  "message.startTaskSuccess": {
+    "message": "Задача успешно отправлена.",
+    "description": "Успех выполнения задачи"
+  },
+  "message.startTaskFailed": {
+    "message": "Не удалось отправить задачу:",
+    "description": "Ошибка при выполнении задачи"
+  },
+  "message.usedUp": {
+    "message": "Кредиты исчерпаны, пожалуйста, купите больше для продолжения использования.",
+    "description": "Исчерпано"
+  },
+  "name.referenceVideo": {
+    "message": "Reference Video",
+    "description": "Reference/editable video for Omni video editing"
+  },
+  "description.referenceVideo": {
+    "message": "Optional MP4/MOV (≤200MB) to edit or reference an existing video. Requires at least one reference image.",
+    "description": "Help text for the reference video uploader"
+  },
+  "button.uploadVideo": {
+    "message": "Upload Video",
+    "description": "Button to upload the reference video"
+  },
+  "message.uploadVideoExceed": {
+    "message": "You can upload a maximum of 1 reference video",
+    "description": "Error when more than one reference video is uploaded"
+  },
+  "message.uploadVideoError": {
+    "message": "Reference video upload failed, please try again later",
+    "description": "Error when the reference video upload fails"
+  },
+  "message.uploadVideoTypeFailed": {
+    "message": "Uploaded file must be in MP4 or MOV format!",
+    "description": "Error when the reference video is not MP4/MOV"
+  },
+  "message.uploadVideoSizeExceed": {
+    "message": "Uploaded file size cannot exceed 200MB!",
+    "description": "Error when the reference video exceeds 200MB"
+  },
+  "message.promptRequired": {
+    "message": "Please enter a prompt.",
+    "description": "Validation when prompt is empty"
+  },
+  "message.videoRequiresImage": {
+    "message": "Please add at least one reference image when using a reference video.",
+    "description": "Validation when video_urls has no reference image"
+  }
+}

--- a/src/i18n/sr/common.json
+++ b/src/i18n/sr/common.json
@@ -1546,5 +1546,9 @@
   "settings.memoryEnabledHint": {
     "message": "When off, saved memories are not used and new chats do not create memories. Existing memories are kept.",
     "description": "Behavior explanation shown below the memory switch"
+  },
+  "nav.omni": {
+    "message": "Omni Video",
+    "description": "Nav label for the Omni video module"
   }
 }

--- a/src/i18n/sr/omni.json
+++ b/src/i18n/sr/omni.json
@@ -1,0 +1,202 @@
+{
+  "name.bot": {
+    "message": "Omni video robot",
+    "description": "Ime Omni generatora videa"
+  },
+  "name.prompt": {
+    "message": "Упитник",
+    "description": "Упит за генерисање видеа"
+  },
+  "name.model": {
+    "message": "Модел",
+    "description": "Ознака за избор модела"
+  },
+  "name.ratio": {
+    "message": "Однос страна",
+    "description": "Ознака за однос страна"
+  },
+  "name.resolution": {
+    "message": "Решење",
+    "description": "Ознака за резолуцију"
+  },
+  "name.duration": {
+    "message": "Trajanje",
+    "description": "Oznaka za trajanje"
+  },
+  "name.image": {
+    "message": "Слика",
+    "description": "Ознака за унос слике"
+  },
+  "name.referenceImages": {
+    "message": "Reference Images",
+    "description": "Label for reference images"
+  },
+  "name.required": {
+    "message": "Обавезно",
+    "description": "Ознака за обавезна поља"
+  },
+  "name.taskId": {
+    "message": "ID задатка",
+    "description": "Ознака за ID задатка"
+  },
+  "name.elapsed": {
+    "message": "Proteklo vreme",
+    "description": "Oznaka za proteklo vreme"
+  },
+  "name.traceId": {
+    "message": "ID трага",
+    "description": "Ознака за ID трага"
+  },
+  "name.failure": {
+    "message": "Generisanje nije uspelo",
+    "description": "Naslov za neuspeh"
+  },
+  "name.failureReason": {
+    "message": "Razlog neuspeha",
+    "description": "Oznaka za razlog neuspeha"
+  },
+  "name.status": {
+    "message": "Статус",
+    "description": "Наслов статуса"
+  },
+  "description.prompt": {
+    "message": "Opisujte video koji želite da generišete (scena, subjekat, akcija, kadar, svetlost, stil).",
+    "description": "Uputstvo za unos prompta"
+  },
+  "description.model": {
+    "message": "Izaberite Omni model. omni-flash podržava generisanje videa iz teksta i slike; 1.5-preview podržava samo generisanje videa iz slike.",
+    "description": "Uputstvo za izbor modela"
+  },
+  "description.ratio": {
+    "message": "Izaberite odnos stranica izlaznog videa.",
+    "description": "Uputstvo za odnos stranica"
+  },
+  "description.resolution": {
+    "message": "Izaberite izlaznu rezoluciju. Što je rezolucija viša, to je veća potrošnja po sekundi.",
+    "description": "Uputstvo za rezoluciju"
+  },
+  "description.duration": {
+    "message": "Trajanje videa (sekunde), naplaćuje se po broju sekundi.",
+    "description": "Uputstvo za trajanje"
+  },
+  "description.image": {
+    "message": "Opcionalna ulazna slika, koristi se za generisanje videa. omni-flash je obavezno.",
+    "description": "Uputstvo za ulaznu sliku"
+  },
+  "description.referenceImages": {
+    "message": "Optional reference images to guide the style or content of the generated video (omni-flash only).",
+    "description": "Instructions for reference images"
+  },
+  "placeholder.prompt": {
+    "message": "Опишите ваш видео…",
+    "description": "Плацехолдер за упитник"
+  },
+  "placeholder.select": {
+    "message": "Изаберите",
+    "description": "Плацехолдер за избор"
+  },
+  "model.default": {
+    "message": "Omni video",
+    "description": "Oznaka za podrazumevani model"
+  },
+  "model.preview15": {
+    "message": "Omni video 1.5 (preview, generisanje videa iz slike)",
+    "description": "Oznaka za 1.5 preview model"
+  },
+  "button.upload": {
+    "message": "Otpremi",
+    "description": "Dugme za otpremanje"
+  },
+  "button.generate": {
+    "message": "Generiši",
+    "description": "Dugme za generisanje"
+  },
+  "button.download": {
+    "message": "Preuzmi",
+    "description": "Dugme za preuzimanje"
+  },
+  "status.pending": {
+    "message": "На чекању",
+    "description": "Статус на чекању"
+  },
+  "status.processing": {
+    "message": "Генерише се",
+    "description": "Статус обраде"
+  },
+  "message.uploadExceed": {
+    "message": "Možete otpremiti samo jednu sliku.",
+    "description": "Upozorenje o prekoračenju otpremanja"
+  },
+  "message.uploadReferenceExceed": {
+    "message": "You can upload up to 4 reference images.",
+    "description": "Reference images upload exceed warning"
+  },
+  "message.uploadError": {
+    "message": "Otpremanje slike nije uspelo, molimo pokušajte ponovo.",
+    "description": "Greška prilikom otpremanja"
+  },
+  "message.downloadVideo": {
+    "message": "Preuzmi video",
+    "description": "Tooltip za preuzimanje"
+  },
+  "message.modelRequiresImage": {
+    "message": "Ovaj model zahteva ulaznu sliku (generisanje videa iz slike).",
+    "description": "Upozorenje da model zahteva sliku"
+  },
+  "message.promptOrImageRequired": {
+    "message": "Unesite prompt ili otpremite sliku.",
+    "description": "Upozorenje da je potreban prompt ili slika"
+  },
+  "message.startingTask": {
+    "message": "Podnošenje zadatka za generisanje videa…",
+    "description": "Pokretanje zadatka"
+  },
+  "message.startTaskSuccess": {
+    "message": "Podnošenje zadatka je uspešno.",
+    "description": "Uspeh zadatka"
+  },
+  "message.startTaskFailed": {
+    "message": "Podnošenje zadatka nije uspelo:",
+    "description": "Zadatak nije uspeo"
+  },
+  "message.usedUp": {
+    "message": "Kredit je iskorišćen, molimo kupite više da biste nastavili sa korišćenjem.",
+    "description": "Iskorišćeno"
+  },
+  "name.referenceVideo": {
+    "message": "Reference Video",
+    "description": "Reference/editable video for Omni video editing"
+  },
+  "description.referenceVideo": {
+    "message": "Optional MP4/MOV (≤200MB) to edit or reference an existing video. Requires at least one reference image.",
+    "description": "Help text for the reference video uploader"
+  },
+  "button.uploadVideo": {
+    "message": "Upload Video",
+    "description": "Button to upload the reference video"
+  },
+  "message.uploadVideoExceed": {
+    "message": "You can upload a maximum of 1 reference video",
+    "description": "Error when more than one reference video is uploaded"
+  },
+  "message.uploadVideoError": {
+    "message": "Reference video upload failed, please try again later",
+    "description": "Error when the reference video upload fails"
+  },
+  "message.uploadVideoTypeFailed": {
+    "message": "Uploaded file must be in MP4 or MOV format!",
+    "description": "Error when the reference video is not MP4/MOV"
+  },
+  "message.uploadVideoSizeExceed": {
+    "message": "Uploaded file size cannot exceed 200MB!",
+    "description": "Error when the reference video exceeds 200MB"
+  },
+  "message.promptRequired": {
+    "message": "Please enter a prompt.",
+    "description": "Validation when prompt is empty"
+  },
+  "message.videoRequiresImage": {
+    "message": "Please add at least one reference image when using a reference video.",
+    "description": "Validation when video_urls has no reference image"
+  }
+}

--- a/src/i18n/sv/common.json
+++ b/src/i18n/sv/common.json
@@ -1546,5 +1546,9 @@
   "settings.memoryEnabledHint": {
     "message": "When off, saved memories are not used and new chats do not create memories. Existing memories are kept.",
     "description": "Behavior explanation shown below the memory switch"
+  },
+  "nav.omni": {
+    "message": "Omni Video",
+    "description": "Nav label for the Omni video module"
   }
 }

--- a/src/i18n/sv/omni.json
+++ b/src/i18n/sv/omni.json
@@ -1,0 +1,202 @@
+{
+  "name.bot": {
+    "message": "Omni Video Bot",
+    "description": "Namn på Omni video-generatorn"
+  },
+  "name.prompt": {
+    "message": "Prompt",
+    "description": "Prompt för att generera videon"
+  },
+  "name.model": {
+    "message": "Modell",
+    "description": "Etikett för modellval"
+  },
+  "name.ratio": {
+    "message": "Bildförhållande",
+    "description": "Etikett för bildförhållande"
+  },
+  "name.resolution": {
+    "message": "Upplösning",
+    "description": "Etikett för upplösning"
+  },
+  "name.duration": {
+    "message": "Längd",
+    "description": "Etikett för längd"
+  },
+  "name.image": {
+    "message": "Bild",
+    "description": "Etikett för inmatningsbild"
+  },
+  "name.referenceImages": {
+    "message": "Reference Images",
+    "description": "Label for reference images"
+  },
+  "name.required": {
+    "message": "Obligatorisk",
+    "description": "Obligatorisk märkning"
+  },
+  "name.taskId": {
+    "message": "Uppgift ID",
+    "description": "Etikett för uppgifts-ID"
+  },
+  "name.elapsed": {
+    "message": "Tid som förflutit",
+    "description": "Etikett för förfluten tid"
+  },
+  "name.traceId": {
+    "message": "Spårnings ID",
+    "description": "Etikett för spårnings-ID"
+  },
+  "name.failure": {
+    "message": "Generering misslyckades",
+    "description": "Titel för misslyckande"
+  },
+  "name.failureReason": {
+    "message": "Orsak till misslyckande",
+    "description": "Etikett för orsak till misslyckande"
+  },
+  "name.status": {
+    "message": "Status",
+    "description": "Statusrubrik"
+  },
+  "description.prompt": {
+    "message": "Beskriv videon du vill generera (scen, ämne, handling, kameravinkel, ljus, stil).",
+    "description": "Instruktioner för promptinmatning"
+  },
+  "description.model": {
+    "message": "Välj Omni-modell. omni-flash stöder text-till-video och bild-till-video; 1.5-preview stöder endast bild-till-video.",
+    "description": "Instruktioner för modellval"
+  },
+  "description.ratio": {
+    "message": "Välj utgångsbildförhållande.",
+    "description": "Instruktioner för bildförhållande"
+  },
+  "description.resolution": {
+    "message": "Välj utgångsupplösning. Ju högre upplösning, desto mer förbrukas per sekund.",
+    "description": "Instruktioner för upplösning"
+  },
+  "description.duration": {
+    "message": "Videons längd (sekunder), debiteras baserat på utgångssekunder.",
+    "description": "Instruktioner för längd"
+  },
+  "description.image": {
+    "message": "Valfri inmatningsbild för att generera video. omni-flash är obligatorisk.",
+    "description": "Instruktioner för bildinmatning"
+  },
+  "description.referenceImages": {
+    "message": "Optional reference images to guide the style or content of the generated video (omni-flash only).",
+    "description": "Instructions for reference images"
+  },
+  "placeholder.prompt": {
+    "message": "Beskriv din video…",
+    "description": "Platsinnehåll för prompt"
+  },
+  "placeholder.select": {
+    "message": "Vänligen välj",
+    "description": "Platsinnehåll för val"
+  },
+  "model.default": {
+    "message": "Omni",
+    "description": "Standardmodellens etikett"
+  },
+  "model.preview15": {
+    "message": "Omni 1.5 (förhandsvisning, bild-till-video)",
+    "description": "1.5 förhandsvisningsmodellens etikett"
+  },
+  "button.upload": {
+    "message": "Ladda upp",
+    "description": "Ladda upp-knapp"
+  },
+  "button.generate": {
+    "message": "Generera",
+    "description": "Generera-knapp"
+  },
+  "button.download": {
+    "message": "Ladda ner",
+    "description": "Ladda ner-knapp"
+  },
+  "status.pending": {
+    "message": "I kö",
+    "description": "Väntande status"
+  },
+  "status.processing": {
+    "message": "Bearbetar",
+    "description": "Bearbetningsstatus"
+  },
+  "message.uploadExceed": {
+    "message": "Endast en bild kan laddas upp.",
+    "description": "Varning för överskridning av uppladdning"
+  },
+  "message.uploadReferenceExceed": {
+    "message": "You can upload up to 4 reference images.",
+    "description": "Reference images upload exceed warning"
+  },
+  "message.uploadError": {
+    "message": "Bilduppladdning misslyckades, försök igen.",
+    "description": "Uppladdningsfel"
+  },
+  "message.downloadVideo": {
+    "message": "Ladda ner video",
+    "description": "Ladda ner-tooltip"
+  },
+  "message.modelRequiresImage": {
+    "message": "Denna modell kräver en inmatningsbild (bild-till-video).",
+    "description": "Varning för att modellen kräver bild"
+  },
+  "message.promptOrImageRequired": {
+    "message": "Ange en prompt eller ladda upp en bild.",
+    "description": "Varning för att prompt eller bild krävs"
+  },
+  "message.startingTask": {
+    "message": "Skickar video-genereringsuppgift…",
+    "description": "Startar uppgift"
+  },
+  "message.startTaskSuccess": {
+    "message": "Uppgiften har skickats.",
+    "description": "Uppgift lyckades"
+  },
+  "message.startTaskFailed": {
+    "message": "Uppgiften kunde inte skickas:",
+    "description": "Uppgift misslyckades"
+  },
+  "message.usedUp": {
+    "message": "Krediten är slut, vänligen köp mer för att fortsätta använda.",
+    "description": "Användning slut"
+  },
+  "name.referenceVideo": {
+    "message": "Reference Video",
+    "description": "Reference/editable video for Omni video editing"
+  },
+  "description.referenceVideo": {
+    "message": "Optional MP4/MOV (≤200MB) to edit or reference an existing video. Requires at least one reference image.",
+    "description": "Help text for the reference video uploader"
+  },
+  "button.uploadVideo": {
+    "message": "Upload Video",
+    "description": "Button to upload the reference video"
+  },
+  "message.uploadVideoExceed": {
+    "message": "You can upload a maximum of 1 reference video",
+    "description": "Error when more than one reference video is uploaded"
+  },
+  "message.uploadVideoError": {
+    "message": "Reference video upload failed, please try again later",
+    "description": "Error when the reference video upload fails"
+  },
+  "message.uploadVideoTypeFailed": {
+    "message": "Uploaded file must be in MP4 or MOV format!",
+    "description": "Error when the reference video is not MP4/MOV"
+  },
+  "message.uploadVideoSizeExceed": {
+    "message": "Uploaded file size cannot exceed 200MB!",
+    "description": "Error when the reference video exceeds 200MB"
+  },
+  "message.promptRequired": {
+    "message": "Please enter a prompt.",
+    "description": "Validation when prompt is empty"
+  },
+  "message.videoRequiresImage": {
+    "message": "Please add at least one reference image when using a reference video.",
+    "description": "Validation when video_urls has no reference image"
+  }
+}

--- a/src/i18n/uk/common.json
+++ b/src/i18n/uk/common.json
@@ -1546,5 +1546,9 @@
   "settings.memoryEnabledHint": {
     "message": "When off, saved memories are not used and new chats do not create memories. Existing memories are kept.",
     "description": "Behavior explanation shown below the memory switch"
+  },
+  "nav.omni": {
+    "message": "Omni Video",
+    "description": "Nav label for the Omni video module"
   }
 }

--- a/src/i18n/uk/omni.json
+++ b/src/i18n/uk/omni.json
@@ -1,0 +1,202 @@
+{
+  "name.bot": {
+    "message": "Omni відео робот",
+    "description": "Назва генератора відео Omni"
+  },
+  "name.prompt": {
+    "message": "Запит",
+    "description": "Запит для генерації відео"
+  },
+  "name.model": {
+    "message": "Модель",
+    "description": "Мітка для вибору моделі"
+  },
+  "name.ratio": {
+    "message": "Співвідношення сторін",
+    "description": "Мітка для співвідношення сторін"
+  },
+  "name.resolution": {
+    "message": "Роздільна здатність",
+    "description": "Мітка для роздільної здатності"
+  },
+  "name.duration": {
+    "message": "Тривалість",
+    "description": "Мітка для тривалості"
+  },
+  "name.image": {
+    "message": "Зображення",
+    "description": "Мітка для введення зображення"
+  },
+  "name.referenceImages": {
+    "message": "Reference Images",
+    "description": "Label for reference images"
+  },
+  "name.required": {
+    "message": "Обов'язково",
+    "description": "Знак обов'язковості"
+  },
+  "name.taskId": {
+    "message": "ID завдання",
+    "description": "Мітка для ID завдання"
+  },
+  "name.elapsed": {
+    "message": "Час виконання",
+    "description": "Мітка для витраченого часу"
+  },
+  "name.traceId": {
+    "message": "ID відстеження",
+    "description": "Мітка для ID відстеження"
+  },
+  "name.failure": {
+    "message": "Генерація не вдалася",
+    "description": "Заголовок для невдачі"
+  },
+  "name.failureReason": {
+    "message": "Причина невдачі",
+    "description": "Мітка для причини невдачі"
+  },
+  "name.status": {
+    "message": "Статус",
+    "description": "Заголовок статусу"
+  },
+  "description.prompt": {
+    "message": "Опишіть відео, яке ви хочете згенерувати (сцена, об'єкт, дія, кадри, світло, стиль).",
+    "description": "Інструкції щодо введення підказки"
+  },
+  "description.model": {
+    "message": "Виберіть модель Omni. omni-flash підтримує текстове та зображення відео; 1.5-preview підтримує лише зображення відео.",
+    "description": "Інструкції щодо вибору моделі"
+  },
+  "description.ratio": {
+    "message": "Виберіть співвідношення сторін виходу.",
+    "description": "Інструкції щодо співвідношення сторін"
+  },
+  "description.resolution": {
+    "message": "Виберіть роздільну здатність виходу. Чим вища роздільна здатність, тим більше витрат на секунду.",
+    "description": "Інструкції щодо роздільної здатності"
+  },
+  "description.duration": {
+    "message": "Тривалість відео (секунди), оплата за вихідну кількість секунд.",
+    "description": "Інструкції щодо тривалості"
+  },
+  "description.image": {
+    "message": "Додаткове зображення для генерації відео. omni-flash є обов'язковим.",
+    "description": "Інструкції щодо введення зображення"
+  },
+  "description.referenceImages": {
+    "message": "Optional reference images to guide the style or content of the generated video (omni-flash only).",
+    "description": "Instructions for reference images"
+  },
+  "placeholder.prompt": {
+    "message": "Опишіть ваше відео…",
+    "description": "Заповнювач для запиту"
+  },
+  "placeholder.select": {
+    "message": "Будь ласка, виберіть",
+    "description": "Заповнювач для вибору"
+  },
+  "model.default": {
+    "message": "Omni відео",
+    "description": "Мітка за замовчуванням для моделі"
+  },
+  "model.preview15": {
+    "message": "Omni відео 1.5 (попередній перегляд, зображення відео)",
+    "description": "Мітка для моделі попереднього перегляду 1.5"
+  },
+  "button.upload": {
+    "message": "Завантажити",
+    "description": "Кнопка для завантаження"
+  },
+  "button.generate": {
+    "message": "Генерувати",
+    "description": "Кнопка для генерації"
+  },
+  "button.download": {
+    "message": "Завантажити",
+    "description": "Кнопка для завантаження"
+  },
+  "status.pending": {
+    "message": "В черзі",
+    "description": "Статус очікування"
+  },
+  "status.processing": {
+    "message": "В обробці",
+    "description": "Статус обробки"
+  },
+  "message.uploadExceed": {
+    "message": "Можна завантажити лише одне зображення.",
+    "description": "Попередження про перевищення завантаження"
+  },
+  "message.uploadReferenceExceed": {
+    "message": "You can upload up to 4 reference images.",
+    "description": "Reference images upload exceed warning"
+  },
+  "message.uploadError": {
+    "message": "Не вдалося завантажити зображення, будь ласка, спробуйте ще раз.",
+    "description": "Помилка завантаження"
+  },
+  "message.downloadVideo": {
+    "message": "Завантажити відео",
+    "description": "Підказка для завантаження"
+  },
+  "message.modelRequiresImage": {
+    "message": "Ця модель потребує введення зображення (зображення відео).",
+    "description": "Попередження про необхідність зображення для моделі"
+  },
+  "message.promptOrImageRequired": {
+    "message": "Будь ласка, введіть підказку або завантажте зображення.",
+    "description": "Попередження про необхідність підказки або зображення"
+  },
+  "message.startingTask": {
+    "message": "Надсилається завдання на генерацію відео…",
+    "description": "Початок завдання"
+  },
+  "message.startTaskSuccess": {
+    "message": "Завдання надіслано успішно.",
+    "description": "Успішне виконання завдання"
+  },
+  "message.startTaskFailed": {
+    "message": "Не вдалося надіслати завдання:",
+    "description": "Не вдалося виконати завдання"
+  },
+  "message.usedUp": {
+    "message": "Ліміт вичерпано, будь ласка, купіть, щоб продовжити використання.",
+    "description": "Вичерпано"
+  },
+  "name.referenceVideo": {
+    "message": "Reference Video",
+    "description": "Reference/editable video for Omni video editing"
+  },
+  "description.referenceVideo": {
+    "message": "Optional MP4/MOV (≤200MB) to edit or reference an existing video. Requires at least one reference image.",
+    "description": "Help text for the reference video uploader"
+  },
+  "button.uploadVideo": {
+    "message": "Upload Video",
+    "description": "Button to upload the reference video"
+  },
+  "message.uploadVideoExceed": {
+    "message": "You can upload a maximum of 1 reference video",
+    "description": "Error when more than one reference video is uploaded"
+  },
+  "message.uploadVideoError": {
+    "message": "Reference video upload failed, please try again later",
+    "description": "Error when the reference video upload fails"
+  },
+  "message.uploadVideoTypeFailed": {
+    "message": "Uploaded file must be in MP4 or MOV format!",
+    "description": "Error when the reference video is not MP4/MOV"
+  },
+  "message.uploadVideoSizeExceed": {
+    "message": "Uploaded file size cannot exceed 200MB!",
+    "description": "Error when the reference video exceeds 200MB"
+  },
+  "message.promptRequired": {
+    "message": "Please enter a prompt.",
+    "description": "Validation when prompt is empty"
+  },
+  "message.videoRequiresImage": {
+    "message": "Please add at least one reference image when using a reference video.",
+    "description": "Validation when video_urls has no reference image"
+  }
+}

--- a/src/i18n/zh-CN/common.json
+++ b/src/i18n/zh-CN/common.json
@@ -1547,5 +1547,9 @@
   "settings.siteServices": {
     "message": "价格",
     "description": "用户设置弹窗中「全站与服务价格」Tab 的导航标签"
+  },
+  "nav.omni": {
+    "message": "Omni 视频",
+    "description": "Omni 视频模块的导航标签"
   }
 }

--- a/src/i18n/zh-CN/omni.json
+++ b/src/i18n/zh-CN/omni.json
@@ -1,0 +1,202 @@
+{
+  "name.bot": {
+    "message": "Omni 视频",
+    "description": "模块显示名称"
+  },
+  "name.prompt": {
+    "message": "提示词",
+    "description": "Prompt for generating the video"
+  },
+  "name.model": {
+    "message": "模型",
+    "description": "Label for model selection"
+  },
+  "name.ratio": {
+    "message": "画面比例",
+    "description": "Label for aspect ratio"
+  },
+  "name.resolution": {
+    "message": "分辨率",
+    "description": "Label for resolution"
+  },
+  "name.duration": {
+    "message": "时长",
+    "description": "Label for duration"
+  },
+  "name.image": {
+    "message": "图片",
+    "description": "Label for input image"
+  },
+  "name.referenceImages": {
+    "message": "参考图",
+    "description": "Label for reference images"
+  },
+  "name.required": {
+    "message": "必填",
+    "description": "Required badge"
+  },
+  "name.taskId": {
+    "message": "任务 ID",
+    "description": "Task id label"
+  },
+  "name.elapsed": {
+    "message": "耗时",
+    "description": "Elapsed time label"
+  },
+  "name.traceId": {
+    "message": "追踪 ID",
+    "description": "Trace id label"
+  },
+  "name.failure": {
+    "message": "生成失败",
+    "description": "Failure title"
+  },
+  "name.failureReason": {
+    "message": "失败原因",
+    "description": "Failure reason label"
+  },
+  "name.status": {
+    "message": "状态",
+    "description": "Status title"
+  },
+  "description.prompt": {
+    "message": "描述你想生成的视频（场景、主体、动作、镜头、光线、风格）。",
+    "description": "Instructions for prompt input"
+  },
+  "description.model": {
+    "message": "选择 Omni 模型。omni-flash 支持文生与图生视频，时长最长 30 秒；1.5-preview 仅支持图生视频，时长最长 15 秒。",
+    "description": "Instructions for model selection"
+  },
+  "description.ratio": {
+    "message": "选择输出画面比例。",
+    "description": "Instructions for aspect ratio"
+  },
+  "description.resolution": {
+    "message": "选择输出分辨率，支持 480p / 720p / 1080p。分辨率越高，消耗的额度越多。",
+    "description": "Instructions for resolution"
+  },
+  "description.duration": {
+    "message": "视频时长（秒）。omni-flash 支持 1-30 秒，按时长分档计费；1.5-preview 支持 1-15 秒，按输出秒数计费。",
+    "description": "Instructions for duration"
+  },
+  "description.image": {
+    "message": "可选的输入图片，用于图生视频。omni-flash 为必填。",
+    "description": "Instructions for image input"
+  },
+  "description.referenceImages": {
+    "message": "可选的参考图片（最多 4 张），用于引导视频；编辑参考视频时必填。",
+    "description": "参考图片帮助文字"
+  },
+  "placeholder.prompt": {
+    "message": "描述你的视频…",
+    "description": "Placeholder for prompt"
+  },
+  "placeholder.select": {
+    "message": "请选择",
+    "description": "Placeholder for selects"
+  },
+  "model.default": {
+    "message": "Omni 视频",
+    "description": "Default model label"
+  },
+  "model.preview15": {
+    "message": "Omni 视频 1.5（预览，图生视频）",
+    "description": "1.5 preview model label"
+  },
+  "button.upload": {
+    "message": "上传",
+    "description": "Upload button"
+  },
+  "button.generate": {
+    "message": "生成",
+    "description": "Generate button"
+  },
+  "button.download": {
+    "message": "下载",
+    "description": "Download button"
+  },
+  "status.pending": {
+    "message": "排队中",
+    "description": "Pending status"
+  },
+  "status.processing": {
+    "message": "生成中",
+    "description": "Processing status"
+  },
+  "message.uploadExceed": {
+    "message": "只能上传一张图片。",
+    "description": "Upload exceed warning"
+  },
+  "message.uploadReferenceExceed": {
+    "message": "最多可上传 4 张参考图。",
+    "description": "Reference images upload exceed warning"
+  },
+  "message.uploadError": {
+    "message": "图片上传失败，请重试。",
+    "description": "Upload error"
+  },
+  "message.downloadVideo": {
+    "message": "下载视频",
+    "description": "Download tooltip"
+  },
+  "message.modelRequiresImage": {
+    "message": "该模型需要输入图片（图生视频）。",
+    "description": "Model requires image warning"
+  },
+  "message.promptOrImageRequired": {
+    "message": "请输入提示词或上传图片。",
+    "description": "Prompt or image required warning"
+  },
+  "message.startingTask": {
+    "message": "正在提交视频生成任务…",
+    "description": "Starting task"
+  },
+  "message.startTaskSuccess": {
+    "message": "任务提交成功。",
+    "description": "Task success"
+  },
+  "message.startTaskFailed": {
+    "message": "任务提交失败：",
+    "description": "Task failed"
+  },
+  "message.usedUp": {
+    "message": "额度已用尽，请购买后继续使用。",
+    "description": "Used up"
+  },
+  "name.referenceVideo": {
+    "message": "参考视频",
+    "description": "Omni 视频编辑的参考/待编辑视频"
+  },
+  "description.referenceVideo": {
+    "message": "可选的 MP4/MOV（≤200MB），用于编辑或参考已有视频。需至少一张参考图片。",
+    "description": "参考视频上传的帮助文字"
+  },
+  "button.uploadVideo": {
+    "message": "上传视频",
+    "description": "上传参考视频的按钮"
+  },
+  "message.uploadVideoExceed": {
+    "message": "最多只能上传 1 个参考视频",
+    "description": "超过 1 个参考视频时的错误提示"
+  },
+  "message.uploadVideoError": {
+    "message": "参考视频上传失败，请稍后重试",
+    "description": "参考视频上传失败时的错误提示"
+  },
+  "message.uploadVideoTypeFailed": {
+    "message": "上传的文件必须是 MP4 或 MOV 格式！",
+    "description": "参考视频格式不是 MP4/MOV 时的错误提示"
+  },
+  "message.uploadVideoSizeExceed": {
+    "message": "上传的文件大小不能超过 200MB！",
+    "description": "参考视频超过 200MB 时的错误提示"
+  },
+  "message.promptRequired": {
+    "message": "请输入提示词。",
+    "description": "提示词为空时的校验提示"
+  },
+  "message.videoRequiresImage": {
+    "message": "使用参考视频时，请至少添加一张参考图片。",
+    "description": "提供 video_urls 但缺少参考图片时的校验提示"
+  }
+}

--- a/src/i18n/zh-TW/common.json
+++ b/src/i18n/zh-TW/common.json
@@ -1546,5 +1546,9 @@
   "settings.memoryEnabledHint": {
     "message": "When off, saved memories are not used and new chats do not create memories. Existing memories are kept.",
     "description": "Behavior explanation shown below the memory switch"
+  },
+  "nav.omni": {
+    "message": "Omni 视频",
+    "description": "Omni 视频模块的导航标签"
   }
 }

--- a/src/i18n/zh-TW/omni.json
+++ b/src/i18n/zh-TW/omni.json
@@ -1,0 +1,202 @@
+{
+  "name.bot": {
+    "message": "Omni 視頻機器人",
+    "description": "Omni 視頻生成器的名稱"
+  },
+  "name.prompt": {
+    "message": "提示詞",
+    "description": "用於生成視頻的提示"
+  },
+  "name.model": {
+    "message": "模型",
+    "description": "模型選擇的標籤"
+  },
+  "name.ratio": {
+    "message": "畫面比例",
+    "description": "畫面比例的標籤"
+  },
+  "name.resolution": {
+    "message": "分辨率",
+    "description": "分辨率的標籤"
+  },
+  "name.duration": {
+    "message": "時長",
+    "description": "時長標籤"
+  },
+  "name.image": {
+    "message": "圖片",
+    "description": "輸入圖片的標籤"
+  },
+  "name.referenceImages": {
+    "message": "Reference Images",
+    "description": "Label for reference images"
+  },
+  "name.required": {
+    "message": "必填",
+    "description": "必填標籤"
+  },
+  "name.taskId": {
+    "message": "任務 ID",
+    "description": "任務 ID 的標籤"
+  },
+  "name.elapsed": {
+    "message": "耗時",
+    "description": "耗時標籤"
+  },
+  "name.traceId": {
+    "message": "追蹤 ID",
+    "description": "追蹤 ID 的標籤"
+  },
+  "name.failure": {
+    "message": "生成失敗",
+    "description": "失敗標題"
+  },
+  "name.failureReason": {
+    "message": "失敗原因",
+    "description": "失敗原因標籤"
+  },
+  "name.status": {
+    "message": "狀態",
+    "description": "狀態標題"
+  },
+  "description.prompt": {
+    "message": "描述你想生成的視頻（場景、主體、動作、鏡頭、光線、風格）。",
+    "description": "有關提示輸入的說明"
+  },
+  "description.model": {
+    "message": "選擇 Omni 模型。omni-flash 支持文生與圖生視頻；1.5-preview 僅支持圖生視頻。",
+    "description": "有關模型選擇的說明"
+  },
+  "description.ratio": {
+    "message": "選擇輸出畫面比例。",
+    "description": "有關畫面比例的說明"
+  },
+  "description.resolution": {
+    "message": "選擇輸出分辨率。分辨率越高，每秒消耗的額度越多。",
+    "description": "有關分辨率的說明"
+  },
+  "description.duration": {
+    "message": "視頻時長（秒），按輸出秒數計費。",
+    "description": "有關時長的說明"
+  },
+  "description.image": {
+    "message": "可選的輸入圖片，用於圖生視頻。omni-flash 為必填。",
+    "description": "有關圖片輸入的說明"
+  },
+  "description.referenceImages": {
+    "message": "Optional reference images to guide the style or content of the generated video (omni-flash only).",
+    "description": "Instructions for reference images"
+  },
+  "placeholder.prompt": {
+    "message": "描述你的视频…",
+    "description": "提示的佔位符"
+  },
+  "placeholder.select": {
+    "message": "請選擇",
+    "description": "選擇的佔位符"
+  },
+  "model.default": {
+    "message": "Omni 視頻",
+    "description": "默認模型標籤"
+  },
+  "model.preview15": {
+    "message": "Omni 視頻 1.5（預覽，圖生視頻）",
+    "description": "1.5 預覽模型標籤"
+  },
+  "button.upload": {
+    "message": "上傳",
+    "description": "上傳按鈕"
+  },
+  "button.generate": {
+    "message": "生成",
+    "description": "生成按鈕"
+  },
+  "button.download": {
+    "message": "下載",
+    "description": "下載按鈕"
+  },
+  "status.pending": {
+    "message": "排隊中",
+    "description": "待處理狀態"
+  },
+  "status.processing": {
+    "message": "生成中",
+    "description": "處理中狀態"
+  },
+  "message.uploadExceed": {
+    "message": "只能上傳一張圖片。",
+    "description": "上傳超過限制的警告"
+  },
+  "message.uploadReferenceExceed": {
+    "message": "You can upload up to 4 reference images.",
+    "description": "Reference images upload exceed warning"
+  },
+  "message.uploadError": {
+    "message": "圖片上傳失敗，請重試。",
+    "description": "上傳錯誤"
+  },
+  "message.downloadVideo": {
+    "message": "下載視頻",
+    "description": "下載提示"
+  },
+  "message.modelRequiresImage": {
+    "message": "該模型需要輸入圖片（圖生視頻）。",
+    "description": "模型需要圖片的警告"
+  },
+  "message.promptOrImageRequired": {
+    "message": "請輸入提示詞或上傳圖片。",
+    "description": "提示詞或圖片必需的警告"
+  },
+  "message.startingTask": {
+    "message": "正在提交視頻生成任務…",
+    "description": "開始任務"
+  },
+  "message.startTaskSuccess": {
+    "message": "任務提交成功。",
+    "description": "任務成功"
+  },
+  "message.startTaskFailed": {
+    "message": "任務提交失敗：",
+    "description": "任務失敗"
+  },
+  "message.usedUp": {
+    "message": "額度已用盡，請購買後繼續使用。",
+    "description": "已用盡"
+  },
+  "name.referenceVideo": {
+    "message": "Reference Video",
+    "description": "Reference/editable video for Omni video editing"
+  },
+  "description.referenceVideo": {
+    "message": "Optional MP4/MOV (≤200MB) to edit or reference an existing video. Requires at least one reference image.",
+    "description": "Help text for the reference video uploader"
+  },
+  "button.uploadVideo": {
+    "message": "Upload Video",
+    "description": "Button to upload the reference video"
+  },
+  "message.uploadVideoExceed": {
+    "message": "You can upload a maximum of 1 reference video",
+    "description": "Error when more than one reference video is uploaded"
+  },
+  "message.uploadVideoError": {
+    "message": "Reference video upload failed, please try again later",
+    "description": "Error when the reference video upload fails"
+  },
+  "message.uploadVideoTypeFailed": {
+    "message": "Uploaded file must be in MP4 or MOV format!",
+    "description": "Error when the reference video is not MP4/MOV"
+  },
+  "message.uploadVideoSizeExceed": {
+    "message": "Uploaded file size cannot exceed 200MB!",
+    "description": "Error when the reference video exceeds 200MB"
+  },
+  "message.promptRequired": {
+    "message": "Please enter a prompt.",
+    "description": "Validation when prompt is empty"
+  },
+  "message.videoRequiresImage": {
+    "message": "Please add at least one reference image when using a reference video.",
+    "description": "Validation when video_urls has no reference image"
+  }
+}

--- a/src/layouts/Omni.vue
+++ b/src/layouts/Omni.vue
@@ -1,0 +1,57 @@
+<template>
+  <div class="main flex flex-row flex-1">
+    <div
+      class="config w-[320px] flex-none h-full overflow-y-auto bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
+    >
+      <slot name="config" />
+    </div>
+    <div class="result h-full p-6 flex-1 flex flex-col min-w-0 overflow-x-hidden bg-[var(--app-content-bg)]">
+      <slot name="result" />
+    </div>
+    <el-button v-show="!tasksEmpty" circle class="menu" @click="drawer = true">
+      <font-awesome-icon icon="fa-solid fa-magic" />
+    </el-button>
+    <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="350px">
+      <slot name="config" />
+    </el-drawer>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElDrawer, ElButton } from 'element-plus';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import taskDrawerMixin from '@/utils/taskDrawerMixin';
+
+export default defineComponent({
+  name: 'LayoutOmni',
+  components: {
+    ElDrawer,
+    ElButton,
+    FontAwesomeIcon
+  },
+  mixins: [taskDrawerMixin]
+});
+</script>
+
+<style lang="scss" scoped>
+.menu {
+  display: none;
+}
+
+@media (max-width: 767px) {
+  .config {
+    display: none;
+  }
+  .result {
+    width: 100%;
+  }
+  .menu {
+    display: block;
+    position: absolute;
+    right: 8px;
+    top: calc(45px + var(--app-safe-area-top));
+    z-index: 1000;
+  }
+}
+</style>

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -29,6 +29,7 @@ export * from './openaiimage';
 export * from './seedream';
 export * from './seedance';
 export * from './grokvideo';
+export * from './omni';
 export * from './serp';
 export * from './wan';
 export * from './webextrator';

--- a/src/models/omni.ts
+++ b/src/models/omni.ts
@@ -1,0 +1,60 @@
+export type OmniResolution = '720p' | '1080p';
+export type OmniRatio = '16:9' | '9:16';
+
+export interface IOmniConfig {
+  model?: string;
+  prompt?: string;
+  image_urls?: string[];
+  video_urls?: string[];
+  aspect_ratio?: OmniRatio;
+  resolution?: OmniResolution;
+  callback_url?: string;
+  async?: boolean;
+}
+
+export interface IOmniGenerateRequest {
+  model?: string;
+  prompt?: string;
+  image_urls?: string[];
+  video_urls?: string[];
+  aspect_ratio?: OmniRatio;
+  resolution?: OmniResolution;
+  callback_url?: string;
+  async?: boolean;
+}
+
+export interface IOmniVideo {
+  id?: string;
+  task_id?: string;
+  state?: string;
+  status?: string;
+  video_url?: string;
+  aspect_ratio?: string;
+  prompt?: string;
+}
+
+export interface IOmniGenerateResponse {
+  success: boolean;
+  task_id: string;
+  trace_id?: string;
+  data?: IOmniVideo[];
+  error?: {
+    code?: string;
+    message?: string;
+  };
+}
+
+export interface IOmniTask {
+  id: string;
+  created_at?: number;
+  elapsed?: number;
+  request?: IOmniGenerateRequest;
+  response?: IOmniGenerateResponse;
+}
+
+export type IOmniTaskResponse = IOmniTask;
+
+export interface IOmniTasksResponse {
+  count: number;
+  items: IOmniTask[];
+}

--- a/src/models/site.ts
+++ b/src/models/site.ts
@@ -23,6 +23,7 @@ export interface ISiteFeatures {
   seedream?: any;
   seedance?: any;
   grokvideo?: any;
+  omni?: any;
   wan?: any;
   producer?: any;
   kimi?: any;

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -36,6 +36,7 @@ export * from './openaiimage';
 export * from './seedream';
 export * from './seedance';
 export * from './grokvideo';
+export * from './omni';
 export * from './serp';
 export * from './wan';
 export * from './webextrator';

--- a/src/operators/omni.ts
+++ b/src/operators/omni.ts
@@ -1,0 +1,16 @@
+import { IOmniGenerateRequest, IOmniGenerateResponse, IOmniTaskResponse, IOmniTasksResponse } from '@/models';
+import { BaseTaskOperator, ITaskListFilter } from './baseTaskOperator';
+
+class OmniOperator extends BaseTaskOperator<
+  IOmniGenerateRequest,
+  IOmniGenerateResponse,
+  IOmniTaskResponse,
+  IOmniTasksResponse,
+  ITaskListFilter & { type?: string }
+> {
+  constructor() {
+    super({ tasksPath: '/gemini/tasks', generatePath: '/gemini/videos' });
+  }
+}
+
+export const omniOperator = new OmniOperator();

--- a/src/pages/omni/Index.vue
+++ b/src/pages/omni/Index.vue
@@ -1,0 +1,201 @@
+<template>
+  <layout>
+    <template #config>
+      <config-panel @generate="onGenerate" />
+    </template>
+    <template #result>
+      <recent-panel ref="recentPanel" :loading="loadingMore" @reach-top="onReachTop" />
+    </template>
+  </layout>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import Layout from '@/layouts/Omni.vue';
+import ConfigPanel from '@/components/omni/ConfigPanel.vue';
+import RecentPanel from '@/components/omni/RecentPanel.vue';
+import { omniOperator } from '@/operators';
+import { instrumentGeneration } from '@/plugins/telemetry';
+import { IOmniGenerateRequest, IOmniTask, Status } from '@/models';
+import { ElMessage } from 'element-plus';
+import { ERROR_CODE_USED_UP } from '@/constants';
+import { loadPreviousPage } from '@/utils/pagination';
+import { uploadTrackerProviderMixin, ensureNoPendingUpload, ensureLoggedIn } from '@/utils';
+
+interface IData {
+  task: IOmniTask | undefined;
+  job: number;
+  loadingMore: boolean;
+  fetchingTasks: boolean;
+}
+
+export default defineComponent({
+  name: 'OmniIndex',
+  components: {
+    ConfigPanel,
+    Layout,
+    RecentPanel
+  },
+  mixins: [uploadTrackerProviderMixin],
+  inject: ['initialized'],
+  data(): IData {
+    return {
+      task: undefined,
+      job: 0,
+      loadingMore: false,
+      fetchingTasks: false
+    };
+  },
+  computed: {
+    applicationsLoading() {
+      return this.$store.state.omni?.status?.getApplications === Status.Request;
+    },
+    tasksLoading() {
+      return this.$store.state.omni?.status?.getTasks === Status.Request || this.fetchingTasks;
+    },
+    credential() {
+      return this.$store.state.omni?.credential;
+    },
+    config() {
+      return this.$store.state.omni?.config;
+    },
+    tasks() {
+      return this.$store.state.omni?.tasks;
+    }
+  },
+  watch: {
+    initialized: {
+      async handler(newValue) {
+        if (newValue) {
+          await this.onGetTasks();
+          await this.onScrollDown();
+          this.job = window.setInterval(() => {
+            this.onGetTasks();
+          }, 5000);
+        }
+      },
+      immediate: true
+    }
+  },
+  async mounted() {
+    await this.onGetService();
+  },
+  async unmounted() {
+    window.clearInterval(this.job);
+  },
+  methods: {
+    async onReachTop() {
+      await loadPreviousPage({
+        tasks: this.tasks,
+        loading: this.loadingMore,
+        setLoading: (v) => (this.loadingMore = v),
+        isBlocked: () => this.tasksLoading || this.applicationsLoading,
+        fetch: (createdAtMax) =>
+          this.onGetTasks({
+            createdAtMax
+          }),
+        getScrollElement: () => this.getTasksScrollElement()
+      });
+    },
+    async onGetService() {
+      await this.$store.dispatch('omni/getService');
+    },
+    async onScrollDown() {
+      await this.$nextTick();
+      const el = this.getTasksScrollElement();
+      if (el) {
+        el.scrollTop = el.scrollHeight;
+      }
+    },
+    async onGetTasks(payload?: { limit?: number; createdAtMin?: number; createdAtMax?: number }) {
+      if (this.applicationsLoading || this.fetchingTasks) {
+        return;
+      }
+      const { limit = 5, createdAtMin, createdAtMax } = payload || {};
+      this.fetchingTasks = true;
+      try {
+        await this.$store.dispatch('omni/getTasks', {
+          limit,
+          createdAtMin,
+          createdAtMax
+        });
+      } finally {
+        this.fetchingTasks = false;
+      }
+    },
+    async onGenerate() {
+      if (
+        !ensureNoPendingUpload(
+          this.uploadTracker,
+          (k) => this.$t(k) as string,
+          (m) => ElMessage.warning(m)
+        )
+      ) {
+        return;
+      }
+      const cfg: any = { ...(this.config || {}) };
+      if (typeof cfg?.prompt === 'string') {
+        cfg.prompt = cfg.prompt.trim();
+        if (!cfg.prompt) delete cfg.prompt;
+      }
+      // Normalize reference images / video: drop blank entries and empty arrays.
+      if (Array.isArray(cfg?.image_urls)) {
+        cfg.image_urls = cfg.image_urls.filter((u: string) => typeof u === 'string' && u.trim());
+        if (!cfg.image_urls.length) delete cfg.image_urls;
+      }
+      if (Array.isArray(cfg?.video_urls)) {
+        cfg.video_urls = cfg.video_urls.filter((u: string) => typeof u === 'string' && u.trim());
+        if (!cfg.video_urls.length) delete cfg.video_urls;
+      }
+
+      // Prompt is always required by /gemini/videos.
+      if (!cfg?.prompt) {
+        ElMessage.warning(this.$t('omni.message.promptRequired'));
+        return;
+      }
+      // Video editing (video_urls) requires at least one reference image upstream.
+      if (cfg?.video_urls && !cfg?.image_urls) {
+        ElMessage.warning(this.$t('omni.message.videoRequiresImage'));
+        return;
+      }
+
+      const request = {
+        ...cfg,
+        async: true
+      } as IOmniGenerateRequest;
+
+      if (!ensureLoggedIn()) {
+        return;
+      }
+      const token = this.credential?.token;
+      if (!token) {
+        console.error('no token specified');
+        return;
+      }
+      ElMessage.info(this.$t('omni.message.startingTask'));
+      instrumentGeneration('omni', omniOperator.generate(request, { token }))
+        .then(() => {
+          ElMessage.success(this.$t('omni.message.startTaskSuccess'));
+        })
+        .catch((error) => {
+          const response = error?.response?.data;
+          if (response?.error?.code === ERROR_CODE_USED_UP) {
+            ElMessage.error(this.$t('omni.message.usedUp'));
+          } else {
+            ElMessage.error(this.$t('omni.message.startTaskFailed') + (response?.error?.message || ''));
+          }
+        })
+        .finally(async () => {
+          setTimeout(async () => {
+            await this.onGetTasks();
+            await this.onScrollDown();
+          }, 1000);
+        });
+    },
+    getTasksScrollElement(): HTMLElement | undefined {
+      const panel = this.$refs.recentPanel as any;
+      return panel?.getScrollElement?.();
+    }
+  }
+});
+</script>

--- a/src/router/constants.ts
+++ b/src/router/constants.ts
@@ -74,6 +74,7 @@ export const ROUTE_SEEDREAM_INDEX = 'seedream-index';
 
 export const ROUTE_SEEDANCE_INDEX = 'seedance-index';
 export const ROUTE_GROKVIDEO_INDEX = 'grokvideo-index';
+export const ROUTE_OMNI_INDEX = 'omni-index';
 
 export const ROUTE_SERP_INDEX = 'serp-index';
 

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -32,6 +32,7 @@ import openaiimage from './openaiimage';
 import seedream from './seedream';
 import seedance from './seedance';
 import grokvideo from './grokvideo';
+import omni from './omni';
 import serp from './serp';
 import wan from './wan';
 import fish from './fish';
@@ -56,6 +57,7 @@ import {
   ROUTE_PRODUCER_INDEX,
   ROUTE_SEEDANCE_INDEX,
   ROUTE_GROKVIDEO_INDEX,
+  ROUTE_OMNI_INDEX,
   ROUTE_LUMA_INDEX,
   ROUTE_HAILUO_INDEX,
   ROUTE_KLING_INDEX,
@@ -240,6 +242,13 @@ const ROUTE_SEO: Record<string, { title: string; description: string; keywords: 
     keywords: ['Grok', 'Grok Imagine', 'AI Video', 'Text to Video', 'Image to Video', 'xAI'],
     category: 'AI Video Generation'
   },
+  omni: {
+    title: 'Omni Video',
+    description:
+      'Generate and edit AI videos with Omni (omni-flash) — text-to-video, image-to-video and video editing.',
+    keywords: ['Omni', 'omni-flash', 'AI Video', 'Text to Video', 'Image to Video', 'Video Editing', 'Gemini'],
+    category: 'AI Video Generation'
+  },
   wan: {
     title: 'Wan',
     description: 'Generate AI videos with Wan — high-quality video generation by Tongyi Wanxiang.',
@@ -327,6 +336,7 @@ const FEATURE_ROUTE_PRIORITY: Array<[string, string]> = [
   ['hailuo', ROUTE_HAILUO_INDEX],
   ['seedance', ROUTE_SEEDANCE_INDEX],
   ['grokvideo', ROUTE_GROKVIDEO_INDEX],
+  ['omni', ROUTE_OMNI_INDEX],
   ['pixverse', ROUTE_PIXVERSE_INDEX],
   ['wan', ROUTE_WAN_INDEX],
   ['serp', ROUTE_SERP_INDEX],
@@ -382,6 +392,7 @@ export const routes = [
   seedream,
   seedance,
   grokvideo,
+  omni,
   serp,
   wan,
   fish,

--- a/src/router/omni.ts
+++ b/src/router/omni.ts
@@ -1,0 +1,17 @@
+import { ROUTE_OMNI_INDEX } from './constants';
+
+export default {
+  path: '/omni',
+  meta: {
+    auth: true,
+    appName: 'omni'
+  },
+  component: () => import('@/layouts/Main.vue'),
+  children: [
+    {
+      path: '',
+      name: ROUTE_OMNI_INDEX,
+      component: () => import('@/pages/omni/Index.vue')
+    }
+  ]
+};

--- a/src/store/common/models.ts
+++ b/src/store/common/models.ts
@@ -21,6 +21,7 @@ import { IOpenAIImageState } from '../openaiimage/models';
 import { ISeedreamState } from '../seedream/models';
 import { ISeedanceState } from '../seedance/models';
 import { IGrokVideoState } from '../grokvideo/models';
+import { IOmniState } from '../omni/models';
 import { ISerpState } from '../serp/models';
 import { IWanState } from '../wan/models';
 import { IFishState } from '../fish/models';
@@ -81,6 +82,7 @@ export interface IAppState {
   seedream: ISeedreamState;
   seedance: ISeedanceState;
   grokvideo: IGrokVideoState;
+  omni: IOmniState;
   serp: ISerpState;
   wan: IWanState;
   fish: IFishState;

--- a/src/store/common/state.ts
+++ b/src/store/common/state.ts
@@ -20,6 +20,7 @@ import openaiimageState from '../openaiimage/state';
 import seedreamState from '../seedream/state';
 import seedanceState from '../seedance/state';
 import grokvideoState from '../grokvideo/state';
+import omniState from '../omni/state';
 import serpState from '../serp/state';
 import wanState from '../wan/state';
 import fishState from '../fish/state';
@@ -72,6 +73,7 @@ export default (): IRootState => {
     seedream: seedreamState(),
     seedance: seedanceState(),
     grokvideo: grokvideoState(),
+    omni: omniState(),
     serp: serpState(),
     wan: wanState(),
     fish: fishState(),

--- a/src/store/lazy.ts
+++ b/src/store/lazy.ts
@@ -44,6 +44,7 @@ const moduleLoaders: Record<string, () => Promise<{ default: AnyVuexModule }>> =
   seedream: () => import('./seedream'),
   seedance: () => import('./seedance'),
   grokvideo: () => import('./grokvideo'),
+  omni: () => import('./omni'),
   serp: () => import('./serp'),
   wan: () => import('./wan'),
   fish: () => import('./fish'),

--- a/src/store/omni/actions.ts
+++ b/src/store/omni/actions.ts
@@ -1,0 +1,13 @@
+import { omniOperator } from '@/operators';
+import { IOmniConfig, IOmniTask } from '@/models';
+import { OMNI_SERVICE_ID } from '@/constants';
+import { createTaskActions } from '@/store/factories/createTaskActions';
+
+const actions = createTaskActions<IOmniConfig, IOmniTask, Record<string, unknown>>({
+  serviceId: OMNI_SERVICE_ID,
+  operator: omniOperator,
+  paginated: true,
+  type: 'videos'
+});
+
+export default actions;

--- a/src/store/omni/index.ts
+++ b/src/store/omni/index.ts
@@ -1,0 +1,14 @@
+import { Module } from 'vuex';
+import { IOmniState } from './models';
+import actions from './actions';
+import mutations from './mutations';
+import state from './state';
+
+export const omni: Module<IOmniState, any> = {
+  namespaced: true,
+  state,
+  mutations,
+  actions
+};
+
+export default omni;

--- a/src/store/omni/models.ts
+++ b/src/store/omni/models.ts
@@ -1,0 +1,21 @@
+import { IApplication, ICredential, IOmniConfig, IOmniTask, IService, Status } from '@/models';
+
+export interface IOmniState {
+  service: IService | undefined;
+  application: IApplication | undefined;
+  applications: IApplication[] | undefined;
+  tasks:
+    | {
+        items: IOmniTask[] | undefined;
+        total: number | undefined;
+        active: IOmniTask | undefined;
+      }
+    | undefined;
+  credential: ICredential | undefined;
+  config: IOmniConfig | undefined;
+  status: {
+    getService: Status;
+    getApplications: Status;
+    getTasks: Status;
+  };
+}

--- a/src/store/omni/mutations.ts
+++ b/src/store/omni/mutations.ts
@@ -1,0 +1,74 @@
+import { IApplication, ICredential, IOmniConfig, IOmniTask, IService } from '@/models';
+import initialState from './state';
+import { IOmniState } from './models';
+
+const defaultTasks = {
+  items: undefined,
+  total: undefined,
+  active: undefined
+};
+
+export const resetAll = (state: IOmniState): void => {
+  Object.assign(state, initialState());
+};
+
+export const setService = (state: IOmniState, payload: IService): void => {
+  state.service = payload;
+};
+
+export const setCredential = (state: IOmniState, payload: ICredential): void => {
+  state.credential = payload;
+};
+
+export const setApplication = (state: IOmniState, payload: IApplication): void => {
+  state.application = payload;
+};
+
+export const setApplications = (state: IOmniState, payload: IApplication[]): void => {
+  state.applications = payload;
+};
+
+export const setConfig = (state: IOmniState, payload: IOmniConfig): void => {
+  state.config = payload;
+};
+
+export const setTasksItems = (state: IOmniState, payload: IOmniTask[]): void => {
+  const newPayload = {
+    ...(state.tasks || defaultTasks),
+    items: payload
+  } as typeof state.tasks;
+  state.tasks = newPayload;
+};
+
+export const setTasksTotal = (state: IOmniState, payload: number): void => {
+  const newPayload = {
+    ...(state.tasks || defaultTasks),
+    total: payload
+  } as typeof state.tasks;
+  state.tasks = newPayload;
+};
+
+export const setTasksActive = (state: IOmniState, payload: IOmniTask): void => {
+  const newPayload = {
+    ...(state.tasks || defaultTasks),
+    active: payload
+  } as typeof state.tasks;
+  state.tasks = newPayload;
+};
+
+export const setTasks = (state: IOmniState, payload: any): void => {
+  state.tasks = payload;
+};
+
+export default {
+  setTasks,
+  setApplication,
+  setApplications,
+  setConfig,
+  setCredential,
+  setService,
+  setTasksActive,
+  setTasksItems,
+  setTasksTotal,
+  resetAll
+};

--- a/src/store/omni/persist.ts
+++ b/src/store/omni/persist.ts
@@ -1,0 +1,2 @@
+// See flux/persist.ts for why `.tasks` is no longer persisted.
+export default ['omni.credential', 'omni.application', 'omni.applications'];

--- a/src/store/omni/state.ts
+++ b/src/store/omni/state.ts
@@ -1,0 +1,23 @@
+import { IOmniState } from './models';
+import { Status } from '@/models';
+import { OMNI_DEFAULT_MODEL, OMNI_DEFAULT_RATIO, OMNI_DEFAULT_RESOLUTION } from '@/constants';
+
+export default (): IOmniState => {
+  return {
+    service: undefined,
+    application: undefined,
+    applications: undefined,
+    tasks: undefined,
+    credential: undefined,
+    config: {
+      model: OMNI_DEFAULT_MODEL,
+      aspect_ratio: OMNI_DEFAULT_RATIO,
+      resolution: OMNI_DEFAULT_RESOLUTION
+    },
+    status: {
+      getService: Status.None,
+      getApplications: Status.None,
+      getTasks: Status.None
+    }
+  };
+};


### PR DESCRIPTION
## What

Adds a standalone **`/omni`** consumer video module to Nexior — text-to-video, image-to-video and **video editing** powered by **omni-flash** via `POST /gemini/videos` + `/gemini/tasks`.

This is the missing consumer surface for the omni-flash video capability (docs/pricing already shipped in PlatformBackend; kling video-input landed in #1295). It follows the established **standalone video module** pattern (same as `grokvideo`, `sora`, `seedance`), *not* a tab inside gemini chat.

## Design

- **Route:** `/omni` (symmetric with `/grok-video`). Reachable via the Navigator (gated by `site.features.omni.enabled`, same as every other app).
- **Service:** `OMNI_SERVICE_ID = dda998fe-…` — the **gemini** PlatformBackend service (which owns `/gemini/chat/completions` + `/gemini/videos` + `/gemini/tasks`), so it shares the user's application/balance, exactly like `grokvideo` reuses the grok service id.
- **Config:** `prompt` (required), `aspect_ratio` (16:9 / 9:16), `resolution` (720p / 1080p), up to **4 reference images** (`image_urls`), and **one reference/editable video** (`video_urls`) for video editing. Client-side rule: a reference video requires ≥1 reference image (matches upstream).

## Changes

- New module: `operators/omni.ts`, `models/omni.ts`, `constants/omni.ts`, `store/omni/*`, `components/omni/*` (ConfigPanel + Prompt/Ratio/Resolution/ReferenceImages/**VideoInput** + RecentPanel + task/Preview), `pages/omni/Index.vue`, `layouts/Omni.vue`, `router/omni.ts`.
- Cloned from `grokvideo` then adapted: dropped duration / single-image / grok models; added `video_urls` editing input; trimmed ratios/resolutions; de-branded strings.
- Registered in: `router/index.ts` (+ `constants.ts`), `store/lazy.ts`, `operators/index.ts`, `models/index.ts`, `constants/index.ts`, `constants/i18n.ts`, `models/site.ts` (feature flag), `components/common/Navigator.vue`.
- i18n: `omni.json` for all 18 locales + `common.nav.omni`. Beachball change file included.

## Validation

- `vue-tsc --noEmit` → 0 errors
- `eslint` (all changed files) → clean
- `scripts/check_i18n_coverage.py` → pass
- `beachball check` → pass
- Backend already live-verified: `/gemini/videos` omni-flash text/image/video-edit (see PlatformService #1461 / PlatformBackend #974).

## 🤖 对抗评审

Reviewer: Codex (`codex exec --sandbox read-only`), 2 rounds.
- **RISK (round 1):** `omniOperator` imported from `@/operators` but `operators/index.ts` didn't re-export `./omni` → runtime load blocker. **Fixed** (added the barrel export).
- Two other round-1 flags (missing `common.nav.omni`, missing `zh-CN/omni.json`) were **false positives** from a partial review diff — both exist and i18n coverage passes.
- Round 2 flags were diff artifacts from a stale `origin/main` base; branch **rebased** onto latest main, diff now scoped to the omni module only. **VERDICT: CLEAN** on the module.
