### PR TITLE
feat(kling): show task input media

### DIFF
--- a/change/@acedatacloud-nexior-kling-input-previews.json
+++ b/change/@acedatacloud-nexior-kling-input-previews.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Show Kling image, video, and audio inputs in task history",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/kling/task/Preview.test.ts
+++ b/src/components/kling/task/Preview.test.ts
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+import { shallowMount } from '@vue/test-utils';
+import { describe, expect, it, vi } from 'vitest';
+import type { IKlingTask } from '@/models';
+
+vi.mock('@/components/common/VideoPlayer.vue', () => ({
+  default: { name: 'VideoPlayer', template: '<div />' }
+}));
+
+import TaskPreview from './Preview.vue';
+
+const task: IKlingTask = {
+  id: 'kling-task',
+  created_at: 1,
+  request: {
+    prompt: 'Restyle the scene',
+    start_image_url: 'https://cdn.example.com/start.jpg',
+    end_image_url: 'https://cdn.example.com/end.jpg',
+    image_url: 'https://cdn.example.com/character.jpg',
+    video_url: 'https://cdn.example.com/motion.mp4',
+    video_list: [
+      { video_url: 'https://cdn.example.com/reference-1.mp4' },
+      { video_url: 'https://cdn.example.com/reference-2.mp4' }
+    ],
+    audio_url: 'https://cdn.example.com/speech.mp3'
+  },
+  response: {
+    success: true,
+    task_id: 'kling-task'
+  }
+};
+
+const mountPreview = (modelValue = task) =>
+  shallowMount(TaskPreview, {
+    props: { modelValue },
+    global: {
+      mocks: {
+        $t: (key: string) => key,
+        $dayjs: { format: () => '' },
+        $store: { state: { kling: {} } }
+      }
+    }
+  });
+
+describe('kling/task/Preview', () => {
+  it('shows every previewable request input before the prompt', () => {
+    const wrapper = mountPreview();
+
+    expect(wrapper.findAllComponents({ name: 'ImagePreview' }).map((preview) => preview.props('url'))).toEqual([
+      'https://cdn.example.com/start.jpg',
+      'https://cdn.example.com/end.jpg',
+      'https://cdn.example.com/character.jpg'
+    ]);
+    expect(wrapper.findAllComponents({ name: 'VideoPreview' }).map((preview) => preview.props('url'))).toEqual([
+      'https://cdn.example.com/motion.mp4',
+      'https://cdn.example.com/reference-1.mp4',
+      'https://cdn.example.com/reference-2.mp4'
+    ]);
+    expect(wrapper.findComponent({ name: 'AudioPreview' }).props('url')).toBe('https://cdn.example.com/speech.mp3');
+
+    const media = wrapper.find('.info > div').element;
+    const prompt = wrapper.find('.prompt').element;
+    expect(media.compareDocumentPosition(prompt) & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(0);
+  });
+
+  it.each([{ video_url: 'https://cdn.example.com/not-an-array.mp4' }, [null]])(
+    'ignores a malformed video list from stored task data',
+    (videoList) => {
+      const malformedTask = {
+        ...task,
+        request: {
+          ...task.request,
+          video_list: videoList
+        }
+      } as unknown as IKlingTask;
+
+      expect(() => mountPreview(malformedTask)).not.toThrow();
+    }
+  );
+});

--- a/src/components/kling/task/Preview.vue
+++ b/src/components/kling/task/Preview.vue
@@ -12,15 +12,27 @@
       </div>
       <div class="info">
         <div
-          v-if="referenceImages.length > 0"
+          v-if="referenceImages.length > 0 || referenceVideos.length > 0 || referenceAudios.length > 0"
           class="flex justify-start items-center gap-2 mt-2 w-full overflow-x-auto"
         >
           <image-preview
             v-for="(image, idx) in referenceImages"
-            :key="idx"
+            :key="`image-${idx}`"
             :url="image.url"
             :name="image.name"
             :closable="false"
+          />
+          <video-preview
+            v-for="(video, idx) in referenceVideos"
+            :key="`video-${idx}`"
+            :url="video.url"
+            :name="video.name"
+          />
+          <audio-preview
+            v-for="(audio, idx) in referenceAudios"
+            :key="`audio-${idx}`"
+            :url="audio.url"
+            :name="audio.name"
           />
         </div>
         <p v-if="modelValue?.request?.prompt" class="prompt mt-2">
@@ -139,6 +151,8 @@ import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import VideoPlayer from '@/components/common/VideoPlayer.vue';
 import ImagePreview from '@/components/common/ImagePreview.vue';
+import VideoPreview from '@/components/common/VideoPreview.vue';
+import AudioPreview from '@/components/common/AudioPreview.vue';
 import ApiCodeButton from '@/components/common/ApiCodeButton.vue';
 
 export default defineComponent({
@@ -152,6 +166,8 @@ export default defineComponent({
     ElTooltip,
     ElButton,
     ImagePreview,
+    VideoPreview,
+    AudioPreview,
     ApiCodeButton
   },
   props: {
@@ -174,13 +190,35 @@ export default defineComponent({
       const images: { url: string; name: string }[] = [];
       const startImageUrl = this.modelValue?.request?.start_image_url;
       const endImageUrl = this.modelValue?.request?.end_image_url;
+      const imageUrl = this.modelValue?.request?.image_url;
       if (startImageUrl) {
         images.push({ url: startImageUrl, name: 'start-image' });
       }
       if (endImageUrl) {
         images.push({ url: endImageUrl, name: 'end-image' });
       }
+      if (imageUrl) {
+        images.push({ url: imageUrl, name: 'reference-image' });
+      }
       return images;
+    },
+    referenceVideos(): { url: string; name: string }[] {
+      const videos: { url: string; name: string }[] = [];
+      const videoUrl = this.modelValue?.request?.video_url;
+      if (videoUrl) {
+        videos.push({ url: videoUrl, name: 'reference-video' });
+      }
+      const videoList = this.modelValue?.request?.video_list;
+      (Array.isArray(videoList) ? videoList : []).forEach((video, idx) => {
+        if (video?.video_url) {
+          videos.push({ url: video.video_url, name: `reference-video-${idx + 1}` });
+        }
+      });
+      return videos;
+    },
+    referenceAudios(): { url: string; name: string }[] {
+      const audioUrl = this.modelValue?.request?.audio_url;
+      return audioUrl ? [{ url: audioUrl, name: 'reference-audio' }] : [];
     }
   },
   methods: {

--- a/src/models/kling.ts
+++ b/src/models/kling.ts
@@ -99,6 +99,7 @@ export interface IKlingGenerateRequest {
   mode?: string;
   model?: string;
   video_id?: string;
+  video_url?: string;
   prompt?: string;
   start_image_url?: string;
   end_image_url?: string;
@@ -141,7 +142,7 @@ export interface IKlingTask {
   created_at?: number;
   elapsed?: number;
   type?: IKlingTaskType;
-  request?: IKlingGenerateRequest & IKlingMotionRequest;
+  request?: Partial<IKlingGenerateRequest & IKlingMotionRequest & IKlingTalkingPhotoRequest>;
   response?: IKlingGenerateResponse;
 }
 


### PR DESCRIPTION
## Summary
- show Kling input images, videos, and talking-photo audio above each task prompt
- cover first/last frames, motion/talking-photo media, direct video input, and `video_list` references
- harden persisted task rendering against malformed `video_list` data

## Validation
- `vitest run src/components/kling/task/Preview.test.ts` (3 tests passed)
- focused ESLint and Prettier checks
- `vue-tsc --noEmit`
- `beachball check`
- `npm run build:web`

## 🤖 对抗评审 (reviewer: codex, 3 rounds)
- RISK: non-array persisted `video_list` could crash Kling history -> fixed with an `Array.isArray` guard and regression coverage
- RISK: null entries inside persisted `video_list` could crash Kling history -> fixed with optional entry access and regression coverage
- Final verdict: `VERDICT: CLEAN`