### PR TITLE
Import memory from other AI assistants

### DIFF
--- a/change/@acedatacloud-nexior-memory-import.json
+++ b/change/@acedatacloud-nexior-memory-import.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add a guided flow for importing saved memory from other AI assistants.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/setting/Memory.import.test.ts
+++ b/src/components/setting/Memory.import.test.ts
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+import { flushPromises, shallowMount } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import Memory from './Memory.vue';
+
+const getProfileMock = vi.hoisted(() => vi.fn());
+const importTextMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@/store/lazy', () => ({ ensureStoreModule: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('@/operators/memories', () => ({
+  memoriesOperator: {
+    getProfile: getProfileMock,
+    importText: importTextMock,
+    setEnabled: vi.fn(),
+    remove: vi.fn(),
+    clear: vi.fn()
+  }
+}));
+vi.mock('copy-to-clipboard', () => ({ default: vi.fn().mockResolvedValue(true) }));
+
+const mountComponent = () =>
+  shallowMount(Memory, {
+    global: {
+      mocks: {
+        $t: (key: string) => key,
+        $store: {
+          state: { chat: { credential: { token: 'chat-token' }, memoryEnabled: true } },
+          commit: vi.fn()
+        }
+      }
+    }
+  });
+
+describe('Memory import', () => {
+  beforeEach(() => {
+    getProfileMock.mockReset().mockResolvedValue({ items: [], enabled: true });
+    importTextMock.mockReset().mockResolvedValue({ processed: 2, rejected: 0, total: 2 });
+  });
+
+  it('imports pasted text and refreshes the cloud profile', async () => {
+    const wrapper = mountComponent();
+    await flushPromises();
+    const vm = wrapper.vm as unknown as {
+      importText: string;
+      importVisible: boolean;
+      onImport: () => Promise<void>;
+    };
+    vm.importText = '  - Prefers concise answers.  ';
+    vm.importVisible = true;
+
+    await vm.onImport();
+
+    expect(importTextMock).toHaveBeenCalledWith('chat-token', '- Prefers concise answers.');
+    expect(getProfileMock).toHaveBeenCalledTimes(2);
+    expect(vm.importVisible).toBe(false);
+    expect(vm.importText).toBe('');
+  });
+});

--- a/src/components/setting/Memory.vue
+++ b/src/components/setting/Memory.vue
@@ -20,9 +20,14 @@
     <template v-else>
       <div class="section-head">
         <h3>{{ $t('common.settings.memoryStored') }}</h3>
-        <el-button v-if="entries.length" size="small" text type="danger" :loading="clearing" @click="onClearAll">
-          {{ $t('common.settings.memoryClearAll') }}
-        </el-button>
+        <div class="section-actions">
+          <el-button size="small" :disabled="!memoryEnabled" @click="openImport">
+            {{ $t('common.settings.memoryImport') }}
+          </el-button>
+          <el-button v-if="entries.length" size="small" text type="danger" :loading="clearing" @click="onClearAll">
+            {{ $t('common.settings.memoryClearAll') }}
+          </el-button>
+        </div>
       </div>
 
       <div v-loading="loading">
@@ -38,12 +43,43 @@
         </ul>
       </div>
     </template>
+
+    <el-dialog
+      v-model="importVisible"
+      :title="$t('common.settings.memoryImportTitle')"
+      width="min(640px, 92vw)"
+      append-to-body
+    >
+      <div class="import-step">
+        <div class="import-step-title">{{ $t('common.settings.memoryImportExportStep') }}</div>
+        <el-input :model-value="importPrompt" type="textarea" :rows="7" readonly resize="none" />
+        <el-button size="small" @click="copyImportPrompt">{{ $t('common.settings.memoryImportCopy') }}</el-button>
+      </div>
+      <div class="import-step">
+        <div class="import-step-title">{{ $t('common.settings.memoryImportPasteStep') }}</div>
+        <el-input
+          v-model="importText"
+          type="textarea"
+          :rows="9"
+          :maxlength="50000"
+          show-word-limit
+          :placeholder="$t('common.settings.memoryImportPlaceholder')"
+        />
+      </div>
+      <template #footer>
+        <el-button @click="importVisible = false">{{ $t('common.button.cancel') }}</el-button>
+        <el-button type="primary" :disabled="!importText.trim()" :loading="importing" @click="onImport">
+          {{ $t('common.settings.memoryImportSubmit') }}
+        </el-button>
+      </template>
+    </el-dialog>
   </div>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElButton, ElEmpty, ElMessage, ElMessageBox, ElSwitch, vLoading } from 'element-plus';
+import copy from 'copy-to-clipboard';
+import { ElButton, ElDialog, ElEmpty, ElInput, ElMessage, ElMessageBox, ElSwitch, vLoading } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { memoriesOperator, type IMemoryEntry } from '@/operators/memories';
 import type { ICredential } from '@/models';
@@ -51,7 +87,7 @@ import { ensureStoreModule } from '@/store/lazy';
 
 export default defineComponent({
   name: 'MemorySetting',
-  components: { ElButton, ElEmpty, ElSwitch, FontAwesomeIcon },
+  components: { ElButton, ElDialog, ElEmpty, ElInput, ElSwitch, FontAwesomeIcon },
   directives: { loading: vLoading },
   data() {
     return {
@@ -60,12 +96,18 @@ export default defineComponent({
       removingId: null as string | null,
       memoryReady: false,
       updatingMemory: false,
+      importVisible: false,
+      importing: false,
+      importText: '',
       entries: [] as IMemoryEntry[]
     };
   },
   computed: {
     memoryEnabled(): boolean {
       return this.$store?.state?.chat?.memoryEnabled !== false;
+    },
+    importPrompt(): string {
+      return this.$t('common.settings.memoryImportPrompt') as string;
     },
     // Chat-Application credential token. The chat module is lazy-loaded
     // elsewhere; until it resolves the token can be undefined and we keep
@@ -91,6 +133,51 @@ export default defineComponent({
     if (this.token) await this.fetch();
   },
   methods: {
+    openImport() {
+      this.importText = '';
+      this.importVisible = true;
+    },
+    async copyImportPrompt() {
+      try {
+        if (await copy(this.importPrompt)) {
+          ElMessage.success(this.$t('common.settings.memoryImportCopied'));
+          return;
+        }
+      } catch (error) {
+        console.error('failed to copy memory import prompt', error);
+      }
+      ElMessage.error(this.$t('common.message.copyFailed'));
+    },
+    async onImport() {
+      if (!this.token || !this.importText.trim()) return;
+      this.importing = true;
+      try {
+        const result = await memoriesOperator.importText(this.token, this.importText.trim());
+        this.importVisible = false;
+        this.importText = '';
+        await this.fetch();
+        if (result.rejected > 0) {
+          ElMessage.warning(
+            this.$t('common.settings.memoryImportPartial', {
+              processed: result.processed,
+              rejected: result.rejected
+            })
+          );
+        } else {
+          ElMessage.success(this.$t('common.settings.memoryImportSuccess', { count: result.processed }));
+        }
+      } catch (error) {
+        console.error('failed to import memories', error);
+        const status = (error as { response?: { status?: number } })?.response?.status;
+        if (status === 400) {
+          ElMessage.error(this.$t('common.settings.memoryImportInvalid'));
+        } else {
+          ElMessage.error(this.$t('common.settings.memoryError'));
+        }
+      } finally {
+        this.importing = false;
+      }
+    },
     async onMemoryEnabledChange(value: string | number | boolean) {
       await ensureStoreModule('chat');
       if (!this.token) return;
@@ -208,6 +295,12 @@ export default defineComponent({
     }
   }
 
+  .section-actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
   // Bordered card so the list reads as one contained group instead of text
   // running flush against the dialog; rows are separated by hairline dividers.
   .rows {
@@ -252,5 +345,18 @@ export default defineComponent({
       flex-shrink: 0;
     }
   }
+}
+
+.import-step + .import-step {
+  margin-top: 20px;
+}
+
+.import-step-title {
+  margin-bottom: 8px;
+  font-weight: 600;
+}
+
+.import-step :deep(.el-button) {
+  margin-top: 8px;
 }
 </style>

--- a/src/i18n/ar/common.json
+++ b/src/i18n/ar/common.json
@@ -1550,5 +1550,53 @@
   "nav.omni": {
     "message": "Omni Video",
     "description": "Nav label for the Omni video module"
+  },
+  "settings.memoryImport": {
+    "message": "Import",
+    "description": "Button that opens the memory import dialog"
+  },
+  "settings.memoryImportTitle": {
+    "message": "Import memory from another AI",
+    "description": "Title of the memory import dialog"
+  },
+  "settings.memoryImportExportStep": {
+    "message": "1. Ask your current AI to export its memory",
+    "description": "First step heading in the memory import dialog"
+  },
+  "settings.memoryImportPrompt": {
+    "message": "I'm moving to another AI service. List every saved memory and durable context you have learned about me. Put everything in one code block, with exactly one memory per line. Format each line as: [date saved, if available] - memory content. Include response preferences, personal details, projects, goals, tools, languages, frameworks, and corrections I have made. Preserve my words where possible. Do not include secrets or sensitive information.",
+    "description": "Prompt users copy into another AI service to export memories"
+  },
+  "settings.memoryImportCopy": {
+    "message": "Copy prompt",
+    "description": "Button that copies the memory export prompt"
+  },
+  "settings.memoryImportCopied": {
+    "message": "Prompt copied",
+    "description": "Toast shown after copying the memory export prompt"
+  },
+  "settings.memoryImportPasteStep": {
+    "message": "2. Paste the exported memory",
+    "description": "Second step heading in the memory import dialog"
+  },
+  "settings.memoryImportPlaceholder": {
+    "message": "Paste the memory text returned by ChatGPT, Claude, Gemini, or another AI…",
+    "description": "Placeholder for pasted memory export text"
+  },
+  "settings.memoryImportSubmit": {
+    "message": "Add to memory",
+    "description": "Button that submits pasted memories for import"
+  },
+  "settings.memoryImportSuccess": {
+    "message": "Imported {count} memory entries",
+    "description": "Success toast after importing memory; count is the number of accepted entries"
+  },
+  "settings.memoryImportPartial": {
+    "message": "Processed {processed} entries; {rejected} unsafe or invalid entries were skipped.",
+    "description": "Warning shown after a partial memory import"
+  },
+  "settings.memoryImportInvalid": {
+    "message": "No memory could be imported. Make sure memory is on and paste one plain fact per line.",
+    "description": "Actionable error shown when the memory import request is invalid"
   }
 }

--- a/src/i18n/de/common.json
+++ b/src/i18n/de/common.json
@@ -1550,5 +1550,53 @@
   "nav.omni": {
     "message": "Omni Video",
     "description": "Nav label for the Omni video module"
+  },
+  "settings.memoryImport": {
+    "message": "Import",
+    "description": "Button that opens the memory import dialog"
+  },
+  "settings.memoryImportTitle": {
+    "message": "Import memory from another AI",
+    "description": "Title of the memory import dialog"
+  },
+  "settings.memoryImportExportStep": {
+    "message": "1. Ask your current AI to export its memory",
+    "description": "First step heading in the memory import dialog"
+  },
+  "settings.memoryImportPrompt": {
+    "message": "I'm moving to another AI service. List every saved memory and durable context you have learned about me. Put everything in one code block, with exactly one memory per line. Format each line as: [date saved, if available] - memory content. Include response preferences, personal details, projects, goals, tools, languages, frameworks, and corrections I have made. Preserve my words where possible. Do not include secrets or sensitive information.",
+    "description": "Prompt users copy into another AI service to export memories"
+  },
+  "settings.memoryImportCopy": {
+    "message": "Copy prompt",
+    "description": "Button that copies the memory export prompt"
+  },
+  "settings.memoryImportCopied": {
+    "message": "Prompt copied",
+    "description": "Toast shown after copying the memory export prompt"
+  },
+  "settings.memoryImportPasteStep": {
+    "message": "2. Paste the exported memory",
+    "description": "Second step heading in the memory import dialog"
+  },
+  "settings.memoryImportPlaceholder": {
+    "message": "Paste the memory text returned by ChatGPT, Claude, Gemini, or another AI…",
+    "description": "Placeholder for pasted memory export text"
+  },
+  "settings.memoryImportSubmit": {
+    "message": "Add to memory",
+    "description": "Button that submits pasted memories for import"
+  },
+  "settings.memoryImportSuccess": {
+    "message": "Imported {count} memory entries",
+    "description": "Success toast after importing memory; count is the number of accepted entries"
+  },
+  "settings.memoryImportPartial": {
+    "message": "Processed {processed} entries; {rejected} unsafe or invalid entries were skipped.",
+    "description": "Warning shown after a partial memory import"
+  },
+  "settings.memoryImportInvalid": {
+    "message": "No memory could be imported. Make sure memory is on and paste one plain fact per line.",
+    "description": "Actionable error shown when the memory import request is invalid"
   }
 }

--- a/src/i18n/el/common.json
+++ b/src/i18n/el/common.json
@@ -1550,5 +1550,53 @@
   "nav.omni": {
     "message": "Omni Video",
     "description": "Nav label for the Omni video module"
+  },
+  "settings.memoryImport": {
+    "message": "Import",
+    "description": "Button that opens the memory import dialog"
+  },
+  "settings.memoryImportTitle": {
+    "message": "Import memory from another AI",
+    "description": "Title of the memory import dialog"
+  },
+  "settings.memoryImportExportStep": {
+    "message": "1. Ask your current AI to export its memory",
+    "description": "First step heading in the memory import dialog"
+  },
+  "settings.memoryImportPrompt": {
+    "message": "I'm moving to another AI service. List every saved memory and durable context you have learned about me. Put everything in one code block, with exactly one memory per line. Format each line as: [date saved, if available] - memory content. Include response preferences, personal details, projects, goals, tools, languages, frameworks, and corrections I have made. Preserve my words where possible. Do not include secrets or sensitive information.",
+    "description": "Prompt users copy into another AI service to export memories"
+  },
+  "settings.memoryImportCopy": {
+    "message": "Copy prompt",
+    "description": "Button that copies the memory export prompt"
+  },
+  "settings.memoryImportCopied": {
+    "message": "Prompt copied",
+    "description": "Toast shown after copying the memory export prompt"
+  },
+  "settings.memoryImportPasteStep": {
+    "message": "2. Paste the exported memory",
+    "description": "Second step heading in the memory import dialog"
+  },
+  "settings.memoryImportPlaceholder": {
+    "message": "Paste the memory text returned by ChatGPT, Claude, Gemini, or another AI…",
+    "description": "Placeholder for pasted memory export text"
+  },
+  "settings.memoryImportSubmit": {
+    "message": "Add to memory",
+    "description": "Button that submits pasted memories for import"
+  },
+  "settings.memoryImportSuccess": {
+    "message": "Imported {count} memory entries",
+    "description": "Success toast after importing memory; count is the number of accepted entries"
+  },
+  "settings.memoryImportPartial": {
+    "message": "Processed {processed} entries; {rejected} unsafe or invalid entries were skipped.",
+    "description": "Warning shown after a partial memory import"
+  },
+  "settings.memoryImportInvalid": {
+    "message": "No memory could be imported. Make sure memory is on and paste one plain fact per line.",
+    "description": "Actionable error shown when the memory import request is invalid"
   }
 }

--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -859,6 +859,54 @@
     "message": "Saved memories",
     "description": "Section heading above the list of stored memory entries"
   },
+  "settings.memoryImport": {
+    "message": "Import",
+    "description": "Button that opens the memory import dialog"
+  },
+  "settings.memoryImportTitle": {
+    "message": "Import memory from another AI",
+    "description": "Title of the memory import dialog"
+  },
+  "settings.memoryImportExportStep": {
+    "message": "1. Ask your current AI to export its memory",
+    "description": "First step heading in the memory import dialog"
+  },
+  "settings.memoryImportPrompt": {
+    "message": "I'm moving to another AI service. List every saved memory and durable context you have learned about me. Put everything in one code block, with exactly one memory per line. Format each line as: [date saved, if available] - memory content. Include response preferences, personal details, projects, goals, tools, languages, frameworks, and corrections I have made. Preserve my words where possible. Do not include secrets or sensitive information.",
+    "description": "Prompt users copy into another AI service to export memories"
+  },
+  "settings.memoryImportCopy": {
+    "message": "Copy prompt",
+    "description": "Button that copies the memory export prompt"
+  },
+  "settings.memoryImportCopied": {
+    "message": "Prompt copied",
+    "description": "Toast shown after copying the memory export prompt"
+  },
+  "settings.memoryImportPasteStep": {
+    "message": "2. Paste the exported memory",
+    "description": "Second step heading in the memory import dialog"
+  },
+  "settings.memoryImportPlaceholder": {
+    "message": "Paste the memory text returned by ChatGPT, Claude, Gemini, or another AI…",
+    "description": "Placeholder for pasted memory export text"
+  },
+  "settings.memoryImportSubmit": {
+    "message": "Add to memory",
+    "description": "Button that submits pasted memories for import"
+  },
+  "settings.memoryImportSuccess": {
+    "message": "Processed {count} memory entries. Review the saved memories below.",
+    "description": "Success toast after importing memory; count is the number of accepted input entries before deduplication and capacity limits"
+  },
+  "settings.memoryImportPartial": {
+    "message": "Processed {processed} entries; {rejected} unsafe or invalid entries were skipped.",
+    "description": "Warning shown after a partial memory import"
+  },
+  "settings.memoryImportInvalid": {
+    "message": "No memory could be imported. Make sure memory is on and paste one plain fact per line.",
+    "description": "Actionable error shown when the memory import request is invalid"
+  },
   "settings.memoryEmpty": {
     "message": "Nothing saved yet. As you chat, the assistant will remember durable preferences and facts here.",
     "description": "Empty state shown when the user has no stored memories"

--- a/src/i18n/es/common.json
+++ b/src/i18n/es/common.json
@@ -1550,5 +1550,53 @@
   "nav.omni": {
     "message": "Omni Video",
     "description": "Nav label for the Omni video module"
+  },
+  "settings.memoryImport": {
+    "message": "Import",
+    "description": "Button that opens the memory import dialog"
+  },
+  "settings.memoryImportTitle": {
+    "message": "Import memory from another AI",
+    "description": "Title of the memory import dialog"
+  },
+  "settings.memoryImportExportStep": {
+    "message": "1. Ask your current AI to export its memory",
+    "description": "First step heading in the memory import dialog"
+  },
+  "settings.memoryImportPrompt": {
+    "message": "I'm moving to another AI service. List every saved memory and durable context you have learned about me. Put everything in one code block, with exactly one memory per line. Format each line as: [date saved, if available] - memory content. Include response preferences, personal details, projects, goals, tools, languages, frameworks, and corrections I have made. Preserve my words where possible. Do not include secrets or sensitive information.",
+    "description": "Prompt users copy into another AI service to export memories"
+  },
+  "settings.memoryImportCopy": {
+    "message": "Copy prompt",
+    "description": "Button that copies the memory export prompt"
+  },
+  "settings.memoryImportCopied": {
+    "message": "Prompt copied",
+    "description": "Toast shown after copying the memory export prompt"
+  },
+  "settings.memoryImportPasteStep": {
+    "message": "2. Paste the exported memory",
+    "description": "Second step heading in the memory import dialog"
+  },
+  "settings.memoryImportPlaceholder": {
+    "message": "Paste the memory text returned by ChatGPT, Claude, Gemini, or another AI…",
+    "description": "Placeholder for pasted memory export text"
+  },
+  "settings.memoryImportSubmit": {
+    "message": "Add to memory",
+    "description": "Button that submits pasted memories for import"
+  },
+  "settings.memoryImportSuccess": {
+    "message": "Imported {count} memory entries",
+    "description": "Success toast after importing memory; count is the number of accepted entries"
+  },
+  "settings.memoryImportPartial": {
+    "message": "Processed {processed} entries; {rejected} unsafe or invalid entries were skipped.",
+    "description": "Warning shown after a partial memory import"
+  },
+  "settings.memoryImportInvalid": {
+    "message": "No memory could be imported. Make sure memory is on and paste one plain fact per line.",
+    "description": "Actionable error shown when the memory import request is invalid"
   }
 }

--- a/src/i18n/fi/common.json
+++ b/src/i18n/fi/common.json
@@ -1550,5 +1550,53 @@
   "nav.omni": {
     "message": "Omni Video",
     "description": "Nav label for the Omni video module"
+  },
+  "settings.memoryImport": {
+    "message": "Import",
+    "description": "Button that opens the memory import dialog"
+  },
+  "settings.memoryImportTitle": {
+    "message": "Import memory from another AI",
+    "description": "Title of the memory import dialog"
+  },
+  "settings.memoryImportExportStep": {
+    "message": "1. Ask your current AI to export its memory",
+    "description": "First step heading in the memory import dialog"
+  },
+  "settings.memoryImportPrompt": {
+    "message": "I'm moving to another AI service. List every saved memory and durable context you have learned about me. Put everything in one code block, with exactly one memory per line. Format each line as: [date saved, if available] - memory content. Include response preferences, personal details, projects, goals, tools, languages, frameworks, and corrections I have made. Preserve my words where possible. Do not include secrets or sensitive information.",
+    "description": "Prompt users copy into another AI service to export memories"
+  },
+  "settings.memoryImportCopy": {
+    "message": "Copy prompt",
+    "description": "Button that copies the memory export prompt"
+  },
+  "settings.memoryImportCopied": {
+    "message": "Prompt copied",
+    "description": "Toast shown after copying the memory export prompt"
+  },
+  "settings.memoryImportPasteStep": {
+    "message": "2. Paste the exported memory",
+    "description": "Second step heading in the memory import dialog"
+  },
+  "settings.memoryImportPlaceholder": {
+    "message": "Paste the memory text returned by ChatGPT, Claude, Gemini, or another AI…",
+    "description": "Placeholder for pasted memory export text"
+  },
+  "settings.memoryImportSubmit": {
+    "message": "Add to memory",
+    "description": "Button that submits pasted memories for import"
+  },
+  "settings.memoryImportSuccess": {
+    "message": "Imported {count} memory entries",
+    "description": "Success toast after importing memory; count is the number of accepted entries"
+  },
+  "settings.memoryImportPartial": {
+    "message": "Processed {processed} entries; {rejected} unsafe or invalid entries were skipped.",
+    "description": "Warning shown after a partial memory import"
+  },
+  "settings.memoryImportInvalid": {
+    "message": "No memory could be imported. Make sure memory is on and paste one plain fact per line.",
+    "description": "Actionable error shown when the memory import request is invalid"
   }
 }

--- a/src/i18n/fr/common.json
+++ b/src/i18n/fr/common.json
@@ -1550,5 +1550,53 @@
   "nav.omni": {
     "message": "Omni Video",
     "description": "Nav label for the Omni video module"
+  },
+  "settings.memoryImport": {
+    "message": "Import",
+    "description": "Button that opens the memory import dialog"
+  },
+  "settings.memoryImportTitle": {
+    "message": "Import memory from another AI",
+    "description": "Title of the memory import dialog"
+  },
+  "settings.memoryImportExportStep": {
+    "message": "1. Ask your current AI to export its memory",
+    "description": "First step heading in the memory import dialog"
+  },
+  "settings.memoryImportPrompt": {
+    "message": "I'm moving to another AI service. List every saved memory and durable context you have learned about me. Put everything in one code block, with exactly one memory per line. Format each line as: [date saved, if available] - memory content. Include response preferences, personal details, projects, goals, tools, languages, frameworks, and corrections I have made. Preserve my words where possible. Do not include secrets or sensitive information.",
+    "description": "Prompt users copy into another AI service to export memories"
+  },
+  "settings.memoryImportCopy": {
+    "message": "Copy prompt",
+    "description": "Button that copies the memory export prompt"
+  },
+  "settings.memoryImportCopied": {
+    "message": "Prompt copied",
+    "description": "Toast shown after copying the memory export prompt"
+  },
+  "settings.memoryImportPasteStep": {
+    "message": "2. Paste the exported memory",
+    "description": "Second step heading in the memory import dialog"
+  },
+  "settings.memoryImportPlaceholder": {
+    "message": "Paste the memory text returned by ChatGPT, Claude, Gemini, or another AI…",
+    "description": "Placeholder for pasted memory export text"
+  },
+  "settings.memoryImportSubmit": {
+    "message": "Add to memory",
+    "description": "Button that submits pasted memories for import"
+  },
+  "settings.memoryImportSuccess": {
+    "message": "Imported {count} memory entries",
+    "description": "Success toast after importing memory; count is the number of accepted entries"
+  },
+  "settings.memoryImportPartial": {
+    "message": "Processed {processed} entries; {rejected} unsafe or invalid entries were skipped.",
+    "description": "Warning shown after a partial memory import"
+  },
+  "settings.memoryImportInvalid": {
+    "message": "No memory could be imported. Make sure memory is on and paste one plain fact per line.",
+    "description": "Actionable error shown when the memory import request is invalid"
   }
 }

--- a/src/i18n/it/common.json
+++ b/src/i18n/it/common.json
@@ -1550,5 +1550,53 @@
   "nav.omni": {
     "message": "Omni Video",
     "description": "Nav label for the Omni video module"
+  },
+  "settings.memoryImport": {
+    "message": "Import",
+    "description": "Button that opens the memory import dialog"
+  },
+  "settings.memoryImportTitle": {
+    "message": "Import memory from another AI",
+    "description": "Title of the memory import dialog"
+  },
+  "settings.memoryImportExportStep": {
+    "message": "1. Ask your current AI to export its memory",
+    "description": "First step heading in the memory import dialog"
+  },
+  "settings.memoryImportPrompt": {
+    "message": "I'm moving to another AI service. List every saved memory and durable context you have learned about me. Put everything in one code block, with exactly one memory per line. Format each line as: [date saved, if available] - memory content. Include response preferences, personal details, projects, goals, tools, languages, frameworks, and corrections I have made. Preserve my words where possible. Do not include secrets or sensitive information.",
+    "description": "Prompt users copy into another AI service to export memories"
+  },
+  "settings.memoryImportCopy": {
+    "message": "Copy prompt",
+    "description": "Button that copies the memory export prompt"
+  },
+  "settings.memoryImportCopied": {
+    "message": "Prompt copied",
+    "description": "Toast shown after copying the memory export prompt"
+  },
+  "settings.memoryImportPasteStep": {
+    "message": "2. Paste the exported memory",
+    "description": "Second step heading in the memory import dialog"
+  },
+  "settings.memoryImportPlaceholder": {
+    "message": "Paste the memory text returned by ChatGPT, Claude, Gemini, or another AI…",
+    "description": "Placeholder for pasted memory export text"
+  },
+  "settings.memoryImportSubmit": {
+    "message": "Add to memory",
+    "description": "Button that submits pasted memories for import"
+  },
+  "settings.memoryImportSuccess": {
+    "message": "Imported {count} memory entries",
+    "description": "Success toast after importing memory; count is the number of accepted entries"
+  },
+  "settings.memoryImportPartial": {
+    "message": "Processed {processed} entries; {rejected} unsafe or invalid entries were skipped.",
+    "description": "Warning shown after a partial memory import"
+  },
+  "settings.memoryImportInvalid": {
+    "message": "No memory could be imported. Make sure memory is on and paste one plain fact per line.",
+    "description": "Actionable error shown when the memory import request is invalid"
   }
 }

--- a/src/i18n/ja/common.json
+++ b/src/i18n/ja/common.json
@@ -1550,5 +1550,53 @@
   "nav.omni": {
     "message": "Omni Video",
     "description": "Nav label for the Omni video module"
+  },
+  "settings.memoryImport": {
+    "message": "Import",
+    "description": "Button that opens the memory import dialog"
+  },
+  "settings.memoryImportTitle": {
+    "message": "Import memory from another AI",
+    "description": "Title of the memory import dialog"
+  },
+  "settings.memoryImportExportStep": {
+    "message": "1. Ask your current AI to export its memory",
+    "description": "First step heading in the memory import dialog"
+  },
+  "settings.memoryImportPrompt": {
+    "message": "I'm moving to another AI service. List every saved memory and durable context you have learned about me. Put everything in one code block, with exactly one memory per line. Format each line as: [date saved, if available] - memory content. Include response preferences, personal details, projects, goals, tools, languages, frameworks, and corrections I have made. Preserve my words where possible. Do not include secrets or sensitive information.",
+    "description": "Prompt users copy into another AI service to export memories"
+  },
+  "settings.memoryImportCopy": {
+    "message": "Copy prompt",
+    "description": "Button that copies the memory export prompt"
+  },
+  "settings.memoryImportCopied": {
+    "message": "Prompt copied",
+    "description": "Toast shown after copying the memory export prompt"
+  },
+  "settings.memoryImportPasteStep": {
+    "message": "2. Paste the exported memory",
+    "description": "Second step heading in the memory import dialog"
+  },
+  "settings.memoryImportPlaceholder": {
+    "message": "Paste the memory text returned by ChatGPT, Claude, Gemini, or another AI…",
+    "description": "Placeholder for pasted memory export text"
+  },
+  "settings.memoryImportSubmit": {
+    "message": "Add to memory",
+    "description": "Button that submits pasted memories for import"
+  },
+  "settings.memoryImportSuccess": {
+    "message": "Imported {count} memory entries",
+    "description": "Success toast after importing memory; count is the number of accepted entries"
+  },
+  "settings.memoryImportPartial": {
+    "message": "Processed {processed} entries; {rejected} unsafe or invalid entries were skipped.",
+    "description": "Warning shown after a partial memory import"
+  },
+  "settings.memoryImportInvalid": {
+    "message": "No memory could be imported. Make sure memory is on and paste one plain fact per line.",
+    "description": "Actionable error shown when the memory import request is invalid"
   }
 }

--- a/src/i18n/ko/common.json
+++ b/src/i18n/ko/common.json
@@ -1550,5 +1550,53 @@
   "nav.omni": {
     "message": "Omni Video",
     "description": "Nav label for the Omni video module"
+  },
+  "settings.memoryImport": {
+    "message": "Import",
+    "description": "Button that opens the memory import dialog"
+  },
+  "settings.memoryImportTitle": {
+    "message": "Import memory from another AI",
+    "description": "Title of the memory import dialog"
+  },
+  "settings.memoryImportExportStep": {
+    "message": "1. Ask your current AI to export its memory",
+    "description": "First step heading in the memory import dialog"
+  },
+  "settings.memoryImportPrompt": {
+    "message": "I'm moving to another AI service. List every saved memory and durable context you have learned about me. Put everything in one code block, with exactly one memory per line. Format each line as: [date saved, if available] - memory content. Include response preferences, personal details, projects, goals, tools, languages, frameworks, and corrections I have made. Preserve my words where possible. Do not include secrets or sensitive information.",
+    "description": "Prompt users copy into another AI service to export memories"
+  },
+  "settings.memoryImportCopy": {
+    "message": "Copy prompt",
+    "description": "Button that copies the memory export prompt"
+  },
+  "settings.memoryImportCopied": {
+    "message": "Prompt copied",
+    "description": "Toast shown after copying the memory export prompt"
+  },
+  "settings.memoryImportPasteStep": {
+    "message": "2. Paste the exported memory",
+    "description": "Second step heading in the memory import dialog"
+  },
+  "settings.memoryImportPlaceholder": {
+    "message": "Paste the memory text returned by ChatGPT, Claude, Gemini, or another AI…",
+    "description": "Placeholder for pasted memory export text"
+  },
+  "settings.memoryImportSubmit": {
+    "message": "Add to memory",
+    "description": "Button that submits pasted memories for import"
+  },
+  "settings.memoryImportSuccess": {
+    "message": "Imported {count} memory entries",
+    "description": "Success toast after importing memory; count is the number of accepted entries"
+  },
+  "settings.memoryImportPartial": {
+    "message": "Processed {processed} entries; {rejected} unsafe or invalid entries were skipped.",
+    "description": "Warning shown after a partial memory import"
+  },
+  "settings.memoryImportInvalid": {
+    "message": "No memory could be imported. Make sure memory is on and paste one plain fact per line.",
+    "description": "Actionable error shown when the memory import request is invalid"
   }
 }

--- a/src/i18n/pl/common.json
+++ b/src/i18n/pl/common.json
@@ -1550,5 +1550,53 @@
   "nav.omni": {
     "message": "Omni Video",
     "description": "Nav label for the Omni video module"
+  },
+  "settings.memoryImport": {
+    "message": "Import",
+    "description": "Button that opens the memory import dialog"
+  },
+  "settings.memoryImportTitle": {
+    "message": "Import memory from another AI",
+    "description": "Title of the memory import dialog"
+  },
+  "settings.memoryImportExportStep": {
+    "message": "1. Ask your current AI to export its memory",
+    "description": "First step heading in the memory import dialog"
+  },
+  "settings.memoryImportPrompt": {
+    "message": "I'm moving to another AI service. List every saved memory and durable context you have learned about me. Put everything in one code block, with exactly one memory per line. Format each line as: [date saved, if available] - memory content. Include response preferences, personal details, projects, goals, tools, languages, frameworks, and corrections I have made. Preserve my words where possible. Do not include secrets or sensitive information.",
+    "description": "Prompt users copy into another AI service to export memories"
+  },
+  "settings.memoryImportCopy": {
+    "message": "Copy prompt",
+    "description": "Button that copies the memory export prompt"
+  },
+  "settings.memoryImportCopied": {
+    "message": "Prompt copied",
+    "description": "Toast shown after copying the memory export prompt"
+  },
+  "settings.memoryImportPasteStep": {
+    "message": "2. Paste the exported memory",
+    "description": "Second step heading in the memory import dialog"
+  },
+  "settings.memoryImportPlaceholder": {
+    "message": "Paste the memory text returned by ChatGPT, Claude, Gemini, or another AI…",
+    "description": "Placeholder for pasted memory export text"
+  },
+  "settings.memoryImportSubmit": {
+    "message": "Add to memory",
+    "description": "Button that submits pasted memories for import"
+  },
+  "settings.memoryImportSuccess": {
+    "message": "Imported {count} memory entries",
+    "description": "Success toast after importing memory; count is the number of accepted entries"
+  },
+  "settings.memoryImportPartial": {
+    "message": "Processed {processed} entries; {rejected} unsafe or invalid entries were skipped.",
+    "description": "Warning shown after a partial memory import"
+  },
+  "settings.memoryImportInvalid": {
+    "message": "No memory could be imported. Make sure memory is on and paste one plain fact per line.",
+    "description": "Actionable error shown when the memory import request is invalid"
   }
 }

--- a/src/i18n/pt/common.json
+++ b/src/i18n/pt/common.json
@@ -1550,5 +1550,53 @@
   "nav.omni": {
     "message": "Omni Video",
     "description": "Nav label for the Omni video module"
+  },
+  "settings.memoryImport": {
+    "message": "Import",
+    "description": "Button that opens the memory import dialog"
+  },
+  "settings.memoryImportTitle": {
+    "message": "Import memory from another AI",
+    "description": "Title of the memory import dialog"
+  },
+  "settings.memoryImportExportStep": {
+    "message": "1. Ask your current AI to export its memory",
+    "description": "First step heading in the memory import dialog"
+  },
+  "settings.memoryImportPrompt": {
+    "message": "I'm moving to another AI service. List every saved memory and durable context you have learned about me. Put everything in one code block, with exactly one memory per line. Format each line as: [date saved, if available] - memory content. Include response preferences, personal details, projects, goals, tools, languages, frameworks, and corrections I have made. Preserve my words where possible. Do not include secrets or sensitive information.",
+    "description": "Prompt users copy into another AI service to export memories"
+  },
+  "settings.memoryImportCopy": {
+    "message": "Copy prompt",
+    "description": "Button that copies the memory export prompt"
+  },
+  "settings.memoryImportCopied": {
+    "message": "Prompt copied",
+    "description": "Toast shown after copying the memory export prompt"
+  },
+  "settings.memoryImportPasteStep": {
+    "message": "2. Paste the exported memory",
+    "description": "Second step heading in the memory import dialog"
+  },
+  "settings.memoryImportPlaceholder": {
+    "message": "Paste the memory text returned by ChatGPT, Claude, Gemini, or another AI…",
+    "description": "Placeholder for pasted memory export text"
+  },
+  "settings.memoryImportSubmit": {
+    "message": "Add to memory",
+    "description": "Button that submits pasted memories for import"
+  },
+  "settings.memoryImportSuccess": {
+    "message": "Imported {count} memory entries",
+    "description": "Success toast after importing memory; count is the number of accepted entries"
+  },
+  "settings.memoryImportPartial": {
+    "message": "Processed {processed} entries; {rejected} unsafe or invalid entries were skipped.",
+    "description": "Warning shown after a partial memory import"
+  },
+  "settings.memoryImportInvalid": {
+    "message": "No memory could be imported. Make sure memory is on and paste one plain fact per line.",
+    "description": "Actionable error shown when the memory import request is invalid"
   }
 }

--- a/src/i18n/ru/common.json
+++ b/src/i18n/ru/common.json
@@ -1550,5 +1550,53 @@
   "nav.omni": {
     "message": "Omni Video",
     "description": "Nav label for the Omni video module"
+  },
+  "settings.memoryImport": {
+    "message": "Import",
+    "description": "Button that opens the memory import dialog"
+  },
+  "settings.memoryImportTitle": {
+    "message": "Import memory from another AI",
+    "description": "Title of the memory import dialog"
+  },
+  "settings.memoryImportExportStep": {
+    "message": "1. Ask your current AI to export its memory",
+    "description": "First step heading in the memory import dialog"
+  },
+  "settings.memoryImportPrompt": {
+    "message": "I'm moving to another AI service. List every saved memory and durable context you have learned about me. Put everything in one code block, with exactly one memory per line. Format each line as: [date saved, if available] - memory content. Include response preferences, personal details, projects, goals, tools, languages, frameworks, and corrections I have made. Preserve my words where possible. Do not include secrets or sensitive information.",
+    "description": "Prompt users copy into another AI service to export memories"
+  },
+  "settings.memoryImportCopy": {
+    "message": "Copy prompt",
+    "description": "Button that copies the memory export prompt"
+  },
+  "settings.memoryImportCopied": {
+    "message": "Prompt copied",
+    "description": "Toast shown after copying the memory export prompt"
+  },
+  "settings.memoryImportPasteStep": {
+    "message": "2. Paste the exported memory",
+    "description": "Second step heading in the memory import dialog"
+  },
+  "settings.memoryImportPlaceholder": {
+    "message": "Paste the memory text returned by ChatGPT, Claude, Gemini, or another AI…",
+    "description": "Placeholder for pasted memory export text"
+  },
+  "settings.memoryImportSubmit": {
+    "message": "Add to memory",
+    "description": "Button that submits pasted memories for import"
+  },
+  "settings.memoryImportSuccess": {
+    "message": "Imported {count} memory entries",
+    "description": "Success toast after importing memory; count is the number of accepted entries"
+  },
+  "settings.memoryImportPartial": {
+    "message": "Processed {processed} entries; {rejected} unsafe or invalid entries were skipped.",
+    "description": "Warning shown after a partial memory import"
+  },
+  "settings.memoryImportInvalid": {
+    "message": "No memory could be imported. Make sure memory is on and paste one plain fact per line.",
+    "description": "Actionable error shown when the memory import request is invalid"
   }
 }

--- a/src/i18n/sr/common.json
+++ b/src/i18n/sr/common.json
@@ -1550,5 +1550,53 @@
   "nav.omni": {
     "message": "Omni Video",
     "description": "Nav label for the Omni video module"
+  },
+  "settings.memoryImport": {
+    "message": "Import",
+    "description": "Button that opens the memory import dialog"
+  },
+  "settings.memoryImportTitle": {
+    "message": "Import memory from another AI",
+    "description": "Title of the memory import dialog"
+  },
+  "settings.memoryImportExportStep": {
+    "message": "1. Ask your current AI to export its memory",
+    "description": "First step heading in the memory import dialog"
+  },
+  "settings.memoryImportPrompt": {
+    "message": "I'm moving to another AI service. List every saved memory and durable context you have learned about me. Put everything in one code block, with exactly one memory per line. Format each line as: [date saved, if available] - memory content. Include response preferences, personal details, projects, goals, tools, languages, frameworks, and corrections I have made. Preserve my words where possible. Do not include secrets or sensitive information.",
+    "description": "Prompt users copy into another AI service to export memories"
+  },
+  "settings.memoryImportCopy": {
+    "message": "Copy prompt",
+    "description": "Button that copies the memory export prompt"
+  },
+  "settings.memoryImportCopied": {
+    "message": "Prompt copied",
+    "description": "Toast shown after copying the memory export prompt"
+  },
+  "settings.memoryImportPasteStep": {
+    "message": "2. Paste the exported memory",
+    "description": "Second step heading in the memory import dialog"
+  },
+  "settings.memoryImportPlaceholder": {
+    "message": "Paste the memory text returned by ChatGPT, Claude, Gemini, or another AI…",
+    "description": "Placeholder for pasted memory export text"
+  },
+  "settings.memoryImportSubmit": {
+    "message": "Add to memory",
+    "description": "Button that submits pasted memories for import"
+  },
+  "settings.memoryImportSuccess": {
+    "message": "Imported {count} memory entries",
+    "description": "Success toast after importing memory; count is the number of accepted entries"
+  },
+  "settings.memoryImportPartial": {
+    "message": "Processed {processed} entries; {rejected} unsafe or invalid entries were skipped.",
+    "description": "Warning shown after a partial memory import"
+  },
+  "settings.memoryImportInvalid": {
+    "message": "No memory could be imported. Make sure memory is on and paste one plain fact per line.",
+    "description": "Actionable error shown when the memory import request is invalid"
   }
 }

--- a/src/i18n/sv/common.json
+++ b/src/i18n/sv/common.json
@@ -1550,5 +1550,53 @@
   "nav.omni": {
     "message": "Omni Video",
     "description": "Nav label for the Omni video module"
+  },
+  "settings.memoryImport": {
+    "message": "Import",
+    "description": "Button that opens the memory import dialog"
+  },
+  "settings.memoryImportTitle": {
+    "message": "Import memory from another AI",
+    "description": "Title of the memory import dialog"
+  },
+  "settings.memoryImportExportStep": {
+    "message": "1. Ask your current AI to export its memory",
+    "description": "First step heading in the memory import dialog"
+  },
+  "settings.memoryImportPrompt": {
+    "message": "I'm moving to another AI service. List every saved memory and durable context you have learned about me. Put everything in one code block, with exactly one memory per line. Format each line as: [date saved, if available] - memory content. Include response preferences, personal details, projects, goals, tools, languages, frameworks, and corrections I have made. Preserve my words where possible. Do not include secrets or sensitive information.",
+    "description": "Prompt users copy into another AI service to export memories"
+  },
+  "settings.memoryImportCopy": {
+    "message": "Copy prompt",
+    "description": "Button that copies the memory export prompt"
+  },
+  "settings.memoryImportCopied": {
+    "message": "Prompt copied",
+    "description": "Toast shown after copying the memory export prompt"
+  },
+  "settings.memoryImportPasteStep": {
+    "message": "2. Paste the exported memory",
+    "description": "Second step heading in the memory import dialog"
+  },
+  "settings.memoryImportPlaceholder": {
+    "message": "Paste the memory text returned by ChatGPT, Claude, Gemini, or another AI…",
+    "description": "Placeholder for pasted memory export text"
+  },
+  "settings.memoryImportSubmit": {
+    "message": "Add to memory",
+    "description": "Button that submits pasted memories for import"
+  },
+  "settings.memoryImportSuccess": {
+    "message": "Imported {count} memory entries",
+    "description": "Success toast after importing memory; count is the number of accepted entries"
+  },
+  "settings.memoryImportPartial": {
+    "message": "Processed {processed} entries; {rejected} unsafe or invalid entries were skipped.",
+    "description": "Warning shown after a partial memory import"
+  },
+  "settings.memoryImportInvalid": {
+    "message": "No memory could be imported. Make sure memory is on and paste one plain fact per line.",
+    "description": "Actionable error shown when the memory import request is invalid"
   }
 }

--- a/src/i18n/uk/common.json
+++ b/src/i18n/uk/common.json
@@ -1550,5 +1550,53 @@
   "nav.omni": {
     "message": "Omni Video",
     "description": "Nav label for the Omni video module"
+  },
+  "settings.memoryImport": {
+    "message": "Import",
+    "description": "Button that opens the memory import dialog"
+  },
+  "settings.memoryImportTitle": {
+    "message": "Import memory from another AI",
+    "description": "Title of the memory import dialog"
+  },
+  "settings.memoryImportExportStep": {
+    "message": "1. Ask your current AI to export its memory",
+    "description": "First step heading in the memory import dialog"
+  },
+  "settings.memoryImportPrompt": {
+    "message": "I'm moving to another AI service. List every saved memory and durable context you have learned about me. Put everything in one code block, with exactly one memory per line. Format each line as: [date saved, if available] - memory content. Include response preferences, personal details, projects, goals, tools, languages, frameworks, and corrections I have made. Preserve my words where possible. Do not include secrets or sensitive information.",
+    "description": "Prompt users copy into another AI service to export memories"
+  },
+  "settings.memoryImportCopy": {
+    "message": "Copy prompt",
+    "description": "Button that copies the memory export prompt"
+  },
+  "settings.memoryImportCopied": {
+    "message": "Prompt copied",
+    "description": "Toast shown after copying the memory export prompt"
+  },
+  "settings.memoryImportPasteStep": {
+    "message": "2. Paste the exported memory",
+    "description": "Second step heading in the memory import dialog"
+  },
+  "settings.memoryImportPlaceholder": {
+    "message": "Paste the memory text returned by ChatGPT, Claude, Gemini, or another AI…",
+    "description": "Placeholder for pasted memory export text"
+  },
+  "settings.memoryImportSubmit": {
+    "message": "Add to memory",
+    "description": "Button that submits pasted memories for import"
+  },
+  "settings.memoryImportSuccess": {
+    "message": "Imported {count} memory entries",
+    "description": "Success toast after importing memory; count is the number of accepted entries"
+  },
+  "settings.memoryImportPartial": {
+    "message": "Processed {processed} entries; {rejected} unsafe or invalid entries were skipped.",
+    "description": "Warning shown after a partial memory import"
+  },
+  "settings.memoryImportInvalid": {
+    "message": "No memory could be imported. Make sure memory is on and paste one plain fact per line.",
+    "description": "Actionable error shown when the memory import request is invalid"
   }
 }

--- a/src/i18n/zh-CN/common.json
+++ b/src/i18n/zh-CN/common.json
@@ -879,6 +879,54 @@
     "message": "已保存的记忆",
     "description": "已存储记忆条目列表上方的分区标题"
   },
+  "settings.memoryImport": {
+    "message": "导入",
+    "description": "打开记忆导入弹窗的按钮"
+  },
+  "settings.memoryImportTitle": {
+    "message": "从其他 AI 导入记忆",
+    "description": "记忆导入弹窗标题"
+  },
+  "settings.memoryImportExportStep": {
+    "message": "1. 让当前使用的 AI 导出记忆",
+    "description": "记忆导入弹窗第一步标题"
+  },
+  "settings.memoryImportPrompt": {
+    "message": "我要迁移到另一个 AI 服务。请列出你保存的关于我的每一条记忆，以及从过往对话中学到的持久信息。把全部内容放在一个代码块中，每行只写一条记忆，格式为：[保存日期，如有] - 记忆内容。请包括回复偏好、个人信息、项目、目标、常用工具、语言、框架，以及我对你做过的纠正。尽量保留我的原话，不要包含密码、密钥等敏感信息。",
+    "description": "复制到其他 AI 服务中用于导出记忆的提示词"
+  },
+  "settings.memoryImportCopy": {
+    "message": "复制提示词",
+    "description": "复制记忆导出提示词的按钮"
+  },
+  "settings.memoryImportCopied": {
+    "message": "提示词已复制",
+    "description": "成功复制记忆导出提示词后的提示"
+  },
+  "settings.memoryImportPasteStep": {
+    "message": "2. 粘贴导出的记忆",
+    "description": "记忆导入弹窗第二步标题"
+  },
+  "settings.memoryImportPlaceholder": {
+    "message": "粘贴 ChatGPT、Claude、Gemini 或其他 AI 返回的记忆内容…",
+    "description": "粘贴导出记忆内容的输入框占位文字"
+  },
+  "settings.memoryImportSubmit": {
+    "message": "添加到记忆",
+    "description": "提交粘贴内容进行导入的按钮"
+  },
+  "settings.memoryImportSuccess": {
+    "message": "已处理 {count} 条记忆，请在下方检查保存结果。",
+    "description": "记忆导入成功提示，count 为去重和容量限制前通过校验的输入条目数"
+  },
+  "settings.memoryImportPartial": {
+    "message": "已处理 {processed} 条内容，另有 {rejected} 条不安全或无效内容已跳过。",
+    "description": "部分记忆导入成功时显示的警告"
+  },
+  "settings.memoryImportInvalid": {
+    "message": "未能导入记忆。请确认记忆已开启，并按每行一条普通事实的格式粘贴。",
+    "description": "记忆导入请求无效时显示的可操作错误提示"
+  },
   "settings.memoryEmpty": {
     "message": "暂无保存的记忆。随着你的使用，助手会在这里记住持久的偏好和信息。",
     "description": "用户没有任何已存储记忆时显示的空状态"

--- a/src/i18n/zh-TW/common.json
+++ b/src/i18n/zh-TW/common.json
@@ -1550,5 +1550,53 @@
   "nav.omni": {
     "message": "Omni 视频",
     "description": "Omni 视频模块的导航标签"
+  },
+  "settings.memoryImport": {
+    "message": "Import",
+    "description": "Button that opens the memory import dialog"
+  },
+  "settings.memoryImportTitle": {
+    "message": "Import memory from another AI",
+    "description": "Title of the memory import dialog"
+  },
+  "settings.memoryImportExportStep": {
+    "message": "1. Ask your current AI to export its memory",
+    "description": "First step heading in the memory import dialog"
+  },
+  "settings.memoryImportPrompt": {
+    "message": "I'm moving to another AI service. List every saved memory and durable context you have learned about me. Put everything in one code block, with exactly one memory per line. Format each line as: [date saved, if available] - memory content. Include response preferences, personal details, projects, goals, tools, languages, frameworks, and corrections I have made. Preserve my words where possible. Do not include secrets or sensitive information.",
+    "description": "Prompt users copy into another AI service to export memories"
+  },
+  "settings.memoryImportCopy": {
+    "message": "Copy prompt",
+    "description": "Button that copies the memory export prompt"
+  },
+  "settings.memoryImportCopied": {
+    "message": "Prompt copied",
+    "description": "Toast shown after copying the memory export prompt"
+  },
+  "settings.memoryImportPasteStep": {
+    "message": "2. Paste the exported memory",
+    "description": "Second step heading in the memory import dialog"
+  },
+  "settings.memoryImportPlaceholder": {
+    "message": "Paste the memory text returned by ChatGPT, Claude, Gemini, or another AI…",
+    "description": "Placeholder for pasted memory export text"
+  },
+  "settings.memoryImportSubmit": {
+    "message": "Add to memory",
+    "description": "Button that submits pasted memories for import"
+  },
+  "settings.memoryImportSuccess": {
+    "message": "Imported {count} memory entries",
+    "description": "Success toast after importing memory; count is the number of accepted entries"
+  },
+  "settings.memoryImportPartial": {
+    "message": "Processed {processed} entries; {rejected} unsafe or invalid entries were skipped.",
+    "description": "Warning shown after a partial memory import"
+  },
+  "settings.memoryImportInvalid": {
+    "message": "No memory could be imported. Make sure memory is on and paste one plain fact per line.",
+    "description": "Actionable error shown when the memory import request is invalid"
   }
 }

--- a/src/operators/memories.test.ts
+++ b/src/operators/memories.test.ts
@@ -32,4 +32,19 @@ describe('memoriesOperator', () => {
       expect.objectContaining({ headers: expect.objectContaining({ Authorization: 'Bearer token' }) })
     );
   });
+
+  it('imports pasted memory text', async () => {
+    const post = vi.spyOn(axios, 'post').mockResolvedValue({ data: { processed: 3, rejected: 1, total: 8 } });
+
+    await expect(memoriesOperator.importText('token', '- Prefers concise answers.')).resolves.toEqual({
+      processed: 3,
+      rejected: 1,
+      total: 8
+    });
+    expect(post).toHaveBeenCalledWith(
+      expect.stringContaining('/aichat2/memories'),
+      { action: 'import', text: '- Prefers concise answers.' },
+      expect.objectContaining({ headers: expect.objectContaining({ Authorization: 'Bearer token' }) })
+    );
+  });
 });

--- a/src/operators/memories.ts
+++ b/src/operators/memories.ts
@@ -28,6 +28,12 @@ export interface IMemoryProfile {
   enabled: boolean;
 }
 
+export interface IMemoryImportResult {
+  processed: number;
+  rejected: number;
+  total: number;
+}
+
 class MemoriesOperator {
   async getProfile(token: string): Promise<IMemoryProfile> {
     const { data } = await axios.post(BASE, { action: 'list' }, { headers: headers(token) });
@@ -40,6 +46,15 @@ class MemoriesOperator {
   async setEnabled(token: string, enabled: boolean): Promise<boolean> {
     const { data } = await axios.post(BASE, { action: 'set_enabled', enabled }, { headers: headers(token) });
     return data?.enabled !== false;
+  }
+
+  async importText(token: string, text: string): Promise<IMemoryImportResult> {
+    const { data } = await axios.post(BASE, { action: 'import', text }, { headers: headers(token) });
+    return {
+      processed: data?.processed ?? 0,
+      rejected: data?.rejected ?? 0,
+      total: data?.total ?? 0
+    };
   }
 
   async remove(token: string, id: string): Promise<boolean> {


### PR DESCRIPTION
## Summary
- add a guided Claude-style memory import flow in Settings > Memory
- let users copy an export prompt, paste results from ChatGPT, Claude, Gemini, or another AI, and review imported entries immediately
- show processed/rejected feedback, actionable invalid-input errors, and clipboard permission failures
- add 12 localized import strings across all 18 locales and a Beachball change file
- backend dependency merged: https://github.com/AceDataCloud/PlatformService/pull/1477

## Validation
- npm run build:web
- npm run lint:check
- vue-tsc --noEmit
- 24 focused operator/component/i18n tests passed
- i18n coverage: 17 locale bundles x 45 namespaces
- Prettier and Beachball checks passed

## Adversarial review (reviewer: Explore fallback, 2 rounds)
- fixed ambiguous accepted semantics by using processed plus final total
- added partial-rejection feedback and actionable 400 error copy
- added clipboard rejection handling
- confirmed dialog closes before cloud-profile refresh and site scope always resolves server-side
- second frontend/companion-backend review: VERDICT CLEAN
