### PR TITLE
Improve Veo action configuration UX

### DIFF
--- a/change/@acedatacloud-nexior-24a6ac0a-300b-4e25-b783-ba36251ff80c.json
+++ b/change/@acedatacloud-nexior-24a6ac0a-300b-4e25-b783-ba36251ff80c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Improve Veo action tabs and model-aware generation inputs",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/veo/ConfigPanel.vue
+++ b/src/components/veo/ConfigPanel.vue
@@ -1,14 +1,19 @@
 <template>
   <div class="flex flex-col h-full">
     <div class="flex-1 overflow-y-auto p-5">
-      <action-selector class="mb-4" />
+      <action-selector class="mb-5" />
 
-      <!-- Generation actions: text2video, image2video, ingredients2video -->
-      <translation-selector class="mb-4" />
-      <aspect-ratio-selector class="mb-4" />
+      <model-selector class="mb-4" />
+      <start-end-image
+        v-if="showsImages"
+        :key="config?.action"
+        class="mb-4"
+        :limit="imageLimit"
+        :ingredients="config?.action === 'ingredients2video'"
+      />
       <prompt-input class="mb-4" />
-      <model-selector v-if="config?.action !== 'ingredients2video'" class="mb-4" />
-      <start-end-image v-if="config?.action === 'image2video' || config?.action === 'ingredients2video'" class="mb-2" />
+      <aspect-ratio-selector class="mb-4" />
+      <translation-selector class="mb-2" />
     </div>
     <div class="flex flex-col items-center justify-center px-5 pb-5">
       <consumption :value="consumption" :service="service" />
@@ -50,6 +55,12 @@ export default defineComponent({
   computed: {
     config() {
       return this.$store.state.veo?.config;
+    },
+    showsImages() {
+      return this.config?.action === 'image2video' || this.config?.action === 'ingredients2video';
+    },
+    imageLimit() {
+      return this.config?.action === 'ingredients2video' ? 3 : 2;
     },
     consumption() {
       return getConsumption(this.config, this.service?.cost);

--- a/src/components/veo/config/ActionSelector.vue
+++ b/src/components/veo/config/ActionSelector.vue
@@ -1,24 +1,20 @@
 <template>
-  <div class="field">
-    <h2 class="title font-bold">{{ $t('veo.name.action') }}</h2>
-    <el-select v-model="value" class="value" :placeholder="$t('veo.placeholder.select')" clearable>
-      <el-option v-for="item in options" :key="item.value" :label="item.label" :value="item.value">
-        <span class="float-left">{{ item.label }}</span>
-      </el-option>
-    </el-select>
-  </div>
+  <el-tabs :model-value="value" class="action-tabs" stretch @update:model-value="onUpdate">
+    <el-tab-pane v-for="item in options" :key="item.value" :name="item.value" :label="item.label" />
+  </el-tabs>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElSelect, ElOption } from 'element-plus';
+import { ElTabs, ElTabPane } from 'element-plus';
 import { VEO_DEFAULT_ACTION } from '@/constants';
+import { normalizeVeoConfigForAction, VeoAction } from '@/utils/veo/config';
 
 export default defineComponent({
   name: 'ActionSelector',
   components: {
-    ElSelect,
-    ElOption
+    ElTabs,
+    ElTabPane
   },
   data() {
     return {};
@@ -28,51 +24,80 @@ export default defineComponent({
       return [
         {
           value: 'text2video',
-          label: this.$t('veo.button.action1')
+          label: this.$t('veo.button.actionTabText')
         },
         {
           value: 'image2video',
-          label: this.$t('veo.button.action2')
+          label: this.$t('veo.button.actionTabImage')
         },
         {
           value: 'ingredients2video',
-          label: this.$t('veo.button.actionIngredients')
+          label: this.$t('veo.button.actionTabIngredients')
         }
       ];
     },
-    value: {
-      get() {
-        return this.$store.state.veo?.config?.action;
-      },
-      set(val: string) {
-        this.$store.commit('veo/setConfig', {
-          ...this.$store.state.veo?.config,
-          action: val
-        });
-      }
+    value() {
+      return this.$store.state.veo?.config?.action || VEO_DEFAULT_ACTION;
     }
   },
   mounted() {
-    if (!this.value) {
-      this.value = VEO_DEFAULT_ACTION;
+    if (!this.$store.state.veo?.config?.action) {
+      this.onUpdate(VEO_DEFAULT_ACTION);
+    }
+  },
+  methods: {
+    onUpdate(value: string | number) {
+      this.$store.commit(
+        'veo/setConfig',
+        normalizeVeoConfigForAction(this.$store.state.veo?.config, value as VeoAction)
+      );
     }
   }
 });
 </script>
 
 <style lang="scss" scoped>
-.field {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-
-  .title {
-    font-size: 14px;
+.action-tabs {
+  :deep(.el-tabs__header) {
     margin: 0;
-    width: 30%;
   }
-  .value {
+
+  :deep(.el-tabs__nav-wrap::after) {
+    height: 1px;
+  }
+
+  :deep(.el-tabs__nav-scroll) {
+    overflow: visible;
+  }
+
+  :deep(.el-tabs__nav) {
+    width: 100%;
+    transform: none !important;
+  }
+
+  :deep(.el-tabs__nav-prev),
+  :deep(.el-tabs__nav-next) {
+    display: none;
+  }
+
+  :deep(.el-tabs__active-bar) {
+    display: none;
+  }
+
+  :deep(.el-tabs__item) {
     flex: 1;
+    min-width: 0;
+    height: 40px;
+    padding: 0 6px;
+    border-bottom: 2px solid transparent;
+    font-size: 12px;
+    line-height: 40px;
+    letter-spacing: 0;
+    text-align: center;
+  }
+
+  :deep(.el-tabs__item.is-active) {
+    border-bottom-color: var(--el-color-primary);
   }
 }
 </style>

--- a/src/components/veo/config/ModelSelector.vue
+++ b/src/components/veo/config/ModelSelector.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="field">
     <h2 class="title font-bold">{{ $t('veo.name.model') }}</h2>
-    <el-select v-model="value" class="value" :placeholder="$t('veo.placeholder.select')">
+    <el-select v-model="value" class="value" :placeholder="$t('veo.placeholder.select')" :disabled="isModelLocked">
       <el-option v-for="item in options" :key="item.value" :label="item.label" :value="item.value" />
     </el-select>
   </div>
@@ -11,6 +11,7 @@
 import { defineComponent } from 'vue';
 import { ElSelect, ElOption } from 'element-plus';
 import { VEO_DEFAULT_MODEL } from '@/constants';
+import { VEO_GENERATION_MODELS, VEO_INGREDIENTS_MODEL } from '@/utils/veo/config';
 
 export default defineComponent({
   name: 'ModelSelector',
@@ -18,48 +19,16 @@ export default defineComponent({
     ElSelect,
     ElOption
   },
-  props: {
-    modelValue: {
-      type: String,
-      default: undefined
-    }
-  },
-  emits: ['update:modelValue'],
-  data() {
-    return {
-      options: [
-        {
-          value: 'veo2',
-          label: 'veo2'
-        },
-        {
-          value: 'veo2-fast',
-          label: 'veo2-fast'
-        },
-        {
-          value: 'veo3',
-          label: 'veo3'
-        },
-        {
-          value: 'veo3-fast',
-          label: 'veo3-fast'
-        },
-        {
-          value: 'veo31-fast',
-          label: 'veo31-fast'
-        },
-        {
-          value: 'veo31',
-          label: 'veo31'
-        },
-        {
-          value: 'veo31-fast-ingredients',
-          label: 'veo31-fast-ingredients'
-        }
-      ]
-    };
-  },
   computed: {
+    isModelLocked() {
+      return this.$store.state.veo?.config?.action === 'ingredients2video';
+    },
+    options() {
+      if (this.isModelLocked) {
+        return [{ value: VEO_INGREDIENTS_MODEL, label: 'Veo 3.1 Fast' }];
+      }
+      return VEO_GENERATION_MODELS;
+    },
     value: {
       get() {
         return this.$store.state.veo?.config?.model;
@@ -93,7 +62,7 @@ export default defineComponent({
     width: 30%;
   }
   .value {
-    width: 120px;
+    flex: 1;
   }
 }
 </style>

--- a/src/components/veo/config/StartEndImage.vue
+++ b/src/components/veo/config/StartEndImage.vue
@@ -2,8 +2,8 @@
   <div class="relative">
     <div class="flex justify-between">
       <div class="flex justify-start items-center">
-        <span class="text-sm font-bold">{{ $t('veo.name.startEndImage') }}</span>
-        <info-icon :content="$t('veo.description.uploadStartEndImage')" />
+        <span class="text-sm font-bold">{{ title }}</span>
+        <info-icon :content="description" />
       </div>
     </div>
     <el-upload
@@ -11,9 +11,9 @@
       v-model:file-list="fileList"
       name="file"
       accept=".png,.jpg,.jpeg,.gif,.bmp,.webp"
-      :limit="2"
+      :limit="limit"
       class="upload-wrapper"
-      :multiple="false"
+      :multiple="true"
       :action="uploadUrl"
       list-type="picture"
       :on-exceed="onExceed"
@@ -27,7 +27,7 @@
           :url="file.url"
           :name="file.name"
           :percentage="file.percentage"
-          @remove="fileList.splice(fileList.indexOf(file), 1)"
+          @remove="onRemove(file)"
         />
       </template>
       <el-button round type="primary" size="small" class="btn btn-upload">
@@ -61,6 +61,16 @@ export default defineComponent({
     ImagePreview
   },
   mixins: [pasteUploadMixin, uploadTrackerMixin],
+  props: {
+    limit: {
+      type: Number,
+      default: 2
+    },
+    ingredients: {
+      type: Boolean,
+      default: false
+    }
+  },
   emits: ['change'],
   data(): IData {
     return {
@@ -74,9 +84,16 @@ export default defineComponent({
         Authorization: `Bearer ${this.$store.state.token.access}`
       };
     },
+    title() {
+      return this.ingredients ? this.$t('veo.button.actionIngredients') : this.$t('veo.name.startEndImage');
+    },
+    description() {
+      return this.ingredients ? this.$t('veo.description.imageUrl') : this.$t('veo.description.uploadStartEndImage');
+    },
     urls() {
-      // @ts-ignore
-      return this.fileList.map((file: UploadFile) => file?.response?.file_url);
+      return this.fileList
+        .map((file: UploadFile) => (file.response as { file_url?: string } | undefined)?.file_url || file.url)
+        .filter((url): url is string => Boolean(url));
     },
     value: {
       get() {
@@ -90,15 +107,27 @@ export default defineComponent({
       }
     }
   },
-  mounted() {
-    if (!this.value) {
-      this.value = undefined;
+  watch: {
+    limit() {
+      if (this.fileList.length > this.limit) {
+        this.fileList = this.fileList.slice(0, this.limit);
+        this.onSetStartEndImageUrl();
+      }
     }
-    this.onSetStartEndImageUrl();
+  },
+  mounted() {
+    this.fileList = (this.value || []).map((url: string, index: number) => ({
+      name: `reference-${index + 1}`,
+      percentage: 100,
+      response: { file_url: url },
+      status: 'success',
+      uid: Date.now() + index,
+      url
+    }));
   },
   methods: {
     onExceed() {
-      ElMessage.warning(this.$t('veo.message.uploadReferencesExceed'));
+      ElMessage.warning(this.$t('veo.message.uploadReferencesLimit', { limit: this.limit }));
     },
     onError() {
       ElMessage.error(this.$t('veo.message.uploadReferencesError'));
@@ -112,6 +141,13 @@ export default defineComponent({
     },
     async onSuccess() {
       this.onSetStartEndImageUrl();
+    },
+    onRemove(file: UploadFile) {
+      const index = this.fileList.indexOf(file);
+      if (index >= 0) {
+        this.fileList.splice(index, 1);
+      }
+      this.onSetStartEndImageUrl();
     }
   }
 });
@@ -124,9 +160,7 @@ export default defineComponent({
   width: 30%;
 }
 .btn.btn-upload {
-  position: absolute;
-  top: 5px;
-  right: 0;
+  margin-top: 8px;
 }
 </style>
 
@@ -134,8 +168,11 @@ export default defineComponent({
 .upload-wrapper {
   height: auto;
   display: flex;
+  flex-direction: column;
+  align-items: flex-start;
   .el-upload-list {
-    margin: 0;
+    order: 2;
+    margin: 8px 0 0;
     width: 100%;
   }
 }

--- a/src/i18n/ar/veo.json
+++ b/src/i18n/ar/veo.json
@@ -230,5 +230,21 @@
   "button.actionIngredients": {
     "message": "دمج فيديو متعدد الصور",
     "description": "ingredients2video — دمج 1-3 صور لإنشاء مشهد جديد"
+  },
+  "message.uploadReferencesLimit": {
+    "message": "You can upload a maximum of {limit} images",
+    "description": "Dynamic image limit for the selected generation mode"
+  },
+  "button.actionTabText": {
+    "message": "Text",
+    "description": "Compact Veo action tab for text-to-video"
+  },
+  "button.actionTabImage": {
+    "message": "Image",
+    "description": "Compact Veo action tab for image-to-video"
+  },
+  "button.actionTabIngredients": {
+    "message": "Ingredients",
+    "description": "Compact Veo action tab for multi-image fusion"
   }
 }

--- a/src/i18n/de/veo.json
+++ b/src/i18n/de/veo.json
@@ -230,5 +230,21 @@
   "button.actionIngredients": {
     "message": "Mehrbildfusion Video",
     "description": "ingredients2video — 1-3 Bilder fusionieren, um eine neue Szene zu erstellen"
+  },
+  "message.uploadReferencesLimit": {
+    "message": "You can upload a maximum of {limit} images",
+    "description": "Dynamic image limit for the selected generation mode"
+  },
+  "button.actionTabText": {
+    "message": "Text",
+    "description": "Compact Veo action tab for text-to-video"
+  },
+  "button.actionTabImage": {
+    "message": "Image",
+    "description": "Compact Veo action tab for image-to-video"
+  },
+  "button.actionTabIngredients": {
+    "message": "Ingredients",
+    "description": "Compact Veo action tab for multi-image fusion"
   }
 }

--- a/src/i18n/el/veo.json
+++ b/src/i18n/el/veo.json
@@ -230,5 +230,21 @@
   "button.actionIngredients": {
     "message": "Βίντεο συγχώνευσης πολλών εικόνων",
     "description": "ingredients2video — Συγχώνευση 1-3 εικόνων για δημιουργία νέας σκηνής"
+  },
+  "message.uploadReferencesLimit": {
+    "message": "You can upload a maximum of {limit} images",
+    "description": "Dynamic image limit for the selected generation mode"
+  },
+  "button.actionTabText": {
+    "message": "Text",
+    "description": "Compact Veo action tab for text-to-video"
+  },
+  "button.actionTabImage": {
+    "message": "Image",
+    "description": "Compact Veo action tab for image-to-video"
+  },
+  "button.actionTabIngredients": {
+    "message": "Ingredients",
+    "description": "Compact Veo action tab for multi-image fusion"
   }
 }

--- a/src/i18n/en/veo.json
+++ b/src/i18n/en/veo.json
@@ -68,7 +68,7 @@
     "description": "Description of the 'translation' parameter"
   },
   "description.imageUrl": {
-    "message": "In multi-image video creation tasks, multiple images must be uploaded.",
+    "message": "Upload 1–3 references to blend subjects, styles, or scenes into a video.",
     "description": "Description of the 'imageUrl' parameter"
   },
   "description.prompt": {
@@ -143,6 +143,10 @@
     "message": "You can upload a maximum of 2 images",
     "description": "Error message when the number of uploaded images exceeds the limit"
   },
+  "message.uploadReferencesLimit": {
+    "message": "You can upload a maximum of {limit} images",
+    "description": "Dynamic image limit for the selected generation mode"
+  },
   "message.uploadReferencesSuccess": {
     "message": "Images uploaded successfully",
     "description": "Success message when images are uploaded successfully"
@@ -164,7 +168,7 @@
     "description": "Error message when starting the drawing task fails"
   },
   "message.imageRequired": {
-    "message": "Please upload at least one reference image before starting the image-to-video task",
+    "message": "Please upload at least one reference image before starting generation",
     "description": "Prompt when no images are uploaded in image2video mode"
   },
   "message.usedUp": {
@@ -230,5 +234,17 @@
   "button.actionIngredients": {
     "message": "Multi-image Fusion Video",
     "description": "ingredients2video — Fuse 1-3 images to create a new scene"
+  },
+  "button.actionTabText": {
+    "message": "Text",
+    "description": "Compact Veo action tab for text-to-video"
+  },
+  "button.actionTabImage": {
+    "message": "Image",
+    "description": "Compact Veo action tab for image-to-video"
+  },
+  "button.actionTabIngredients": {
+    "message": "Ingredients",
+    "description": "Compact Veo action tab for multi-image fusion"
   }
 }

--- a/src/i18n/es/veo.json
+++ b/src/i18n/es/veo.json
@@ -230,5 +230,21 @@
   "button.actionIngredients": {
     "message": "Fusionar video de múltiples imágenes",
     "description": "ingredients2video — Fusionar 1-3 imágenes para generar una nueva escena"
+  },
+  "message.uploadReferencesLimit": {
+    "message": "You can upload a maximum of {limit} images",
+    "description": "Dynamic image limit for the selected generation mode"
+  },
+  "button.actionTabText": {
+    "message": "Text",
+    "description": "Compact Veo action tab for text-to-video"
+  },
+  "button.actionTabImage": {
+    "message": "Image",
+    "description": "Compact Veo action tab for image-to-video"
+  },
+  "button.actionTabIngredients": {
+    "message": "Ingredients",
+    "description": "Compact Veo action tab for multi-image fusion"
   }
 }

--- a/src/i18n/fi/veo.json
+++ b/src/i18n/fi/veo.json
@@ -230,5 +230,21 @@
   "button.actionIngredients": {
     "message": "Monikuvayhdistelmävideot",
     "description": "ingredients2video — 1-3 kuvaa yhdistetään uuden kohtauksen luomiseksi"
+  },
+  "message.uploadReferencesLimit": {
+    "message": "You can upload a maximum of {limit} images",
+    "description": "Dynamic image limit for the selected generation mode"
+  },
+  "button.actionTabText": {
+    "message": "Text",
+    "description": "Compact Veo action tab for text-to-video"
+  },
+  "button.actionTabImage": {
+    "message": "Image",
+    "description": "Compact Veo action tab for image-to-video"
+  },
+  "button.actionTabIngredients": {
+    "message": "Ingredients",
+    "description": "Compact Veo action tab for multi-image fusion"
   }
 }

--- a/src/i18n/fr/veo.json
+++ b/src/i18n/fr/veo.json
@@ -230,5 +230,21 @@
   "button.actionIngredients": {
     "message": "Vidéo de fusion d'images",
     "description": "ingredients2video — Fusionner 1 à 3 images pour générer une nouvelle scène"
+  },
+  "message.uploadReferencesLimit": {
+    "message": "You can upload a maximum of {limit} images",
+    "description": "Dynamic image limit for the selected generation mode"
+  },
+  "button.actionTabText": {
+    "message": "Text",
+    "description": "Compact Veo action tab for text-to-video"
+  },
+  "button.actionTabImage": {
+    "message": "Image",
+    "description": "Compact Veo action tab for image-to-video"
+  },
+  "button.actionTabIngredients": {
+    "message": "Ingredients",
+    "description": "Compact Veo action tab for multi-image fusion"
   }
 }

--- a/src/i18n/it/veo.json
+++ b/src/i18n/it/veo.json
@@ -230,5 +230,21 @@
   "button.actionIngredients": {
     "message": "Video di fusione multipla",
     "description": "ingredients2video — Fusione di 1-3 immagini per generare una nuova scena"
+  },
+  "message.uploadReferencesLimit": {
+    "message": "You can upload a maximum of {limit} images",
+    "description": "Dynamic image limit for the selected generation mode"
+  },
+  "button.actionTabText": {
+    "message": "Text",
+    "description": "Compact Veo action tab for text-to-video"
+  },
+  "button.actionTabImage": {
+    "message": "Image",
+    "description": "Compact Veo action tab for image-to-video"
+  },
+  "button.actionTabIngredients": {
+    "message": "Ingredients",
+    "description": "Compact Veo action tab for multi-image fusion"
   }
 }

--- a/src/i18n/ja/veo.json
+++ b/src/i18n/ja/veo.json
@@ -230,5 +230,21 @@
   "button.actionIngredients": {
     "message": "複数画像融合動画",
     "description": "ingredients2video — 1-3枚の画像を融合して新しいシーンを生成"
+  },
+  "message.uploadReferencesLimit": {
+    "message": "You can upload a maximum of {limit} images",
+    "description": "Dynamic image limit for the selected generation mode"
+  },
+  "button.actionTabText": {
+    "message": "Text",
+    "description": "Compact Veo action tab for text-to-video"
+  },
+  "button.actionTabImage": {
+    "message": "Image",
+    "description": "Compact Veo action tab for image-to-video"
+  },
+  "button.actionTabIngredients": {
+    "message": "Ingredients",
+    "description": "Compact Veo action tab for multi-image fusion"
   }
 }

--- a/src/i18n/ko/veo.json
+++ b/src/i18n/ko/veo.json
@@ -230,5 +230,21 @@
   "button.actionIngredients": {
     "message": "다중 이미지 융합 비디오",
     "description": "ingredients2video — 1-3장의 이미지를 융합하여 새로운 장면 생성"
+  },
+  "message.uploadReferencesLimit": {
+    "message": "You can upload a maximum of {limit} images",
+    "description": "Dynamic image limit for the selected generation mode"
+  },
+  "button.actionTabText": {
+    "message": "Text",
+    "description": "Compact Veo action tab for text-to-video"
+  },
+  "button.actionTabImage": {
+    "message": "Image",
+    "description": "Compact Veo action tab for image-to-video"
+  },
+  "button.actionTabIngredients": {
+    "message": "Ingredients",
+    "description": "Compact Veo action tab for multi-image fusion"
   }
 }

--- a/src/i18n/pl/veo.json
+++ b/src/i18n/pl/veo.json
@@ -230,5 +230,21 @@
   "button.actionIngredients": {
     "message": "Wideo z wielu obrazów",
     "description": "ingredients2video — połączenie 1-3 obrazów w nową scenę"
+  },
+  "message.uploadReferencesLimit": {
+    "message": "You can upload a maximum of {limit} images",
+    "description": "Dynamic image limit for the selected generation mode"
+  },
+  "button.actionTabText": {
+    "message": "Text",
+    "description": "Compact Veo action tab for text-to-video"
+  },
+  "button.actionTabImage": {
+    "message": "Image",
+    "description": "Compact Veo action tab for image-to-video"
+  },
+  "button.actionTabIngredients": {
+    "message": "Ingredients",
+    "description": "Compact Veo action tab for multi-image fusion"
   }
 }

--- a/src/i18n/pt/veo.json
+++ b/src/i18n/pt/veo.json
@@ -230,5 +230,21 @@
   "button.actionIngredients": {
     "message": "Vídeo de fusão de múltiplas imagens",
     "description": "ingredients2video — Fusão de 1-3 imagens para gerar uma nova cena"
+  },
+  "message.uploadReferencesLimit": {
+    "message": "You can upload a maximum of {limit} images",
+    "description": "Dynamic image limit for the selected generation mode"
+  },
+  "button.actionTabText": {
+    "message": "Text",
+    "description": "Compact Veo action tab for text-to-video"
+  },
+  "button.actionTabImage": {
+    "message": "Image",
+    "description": "Compact Veo action tab for image-to-video"
+  },
+  "button.actionTabIngredients": {
+    "message": "Ingredients",
+    "description": "Compact Veo action tab for multi-image fusion"
   }
 }

--- a/src/i18n/ru/veo.json
+++ b/src/i18n/ru/veo.json
@@ -230,5 +230,21 @@
   "button.actionIngredients": {
     "message": "Смешать видео из нескольких изображений",
     "description": "ingredients2video — объединение 1-3 изображений для создания новой сцены"
+  },
+  "message.uploadReferencesLimit": {
+    "message": "You can upload a maximum of {limit} images",
+    "description": "Dynamic image limit for the selected generation mode"
+  },
+  "button.actionTabText": {
+    "message": "Text",
+    "description": "Compact Veo action tab for text-to-video"
+  },
+  "button.actionTabImage": {
+    "message": "Image",
+    "description": "Compact Veo action tab for image-to-video"
+  },
+  "button.actionTabIngredients": {
+    "message": "Ingredients",
+    "description": "Compact Veo action tab for multi-image fusion"
   }
 }

--- a/src/i18n/sr/veo.json
+++ b/src/i18n/sr/veo.json
@@ -230,5 +230,21 @@
   "button.actionIngredients": {
     "message": "Video fuzija više slika",
     "description": "ingredients2video — fuzija 1-3 slike za generisanje nove scene"
+  },
+  "message.uploadReferencesLimit": {
+    "message": "You can upload a maximum of {limit} images",
+    "description": "Dynamic image limit for the selected generation mode"
+  },
+  "button.actionTabText": {
+    "message": "Text",
+    "description": "Compact Veo action tab for text-to-video"
+  },
+  "button.actionTabImage": {
+    "message": "Image",
+    "description": "Compact Veo action tab for image-to-video"
+  },
+  "button.actionTabIngredients": {
+    "message": "Ingredients",
+    "description": "Compact Veo action tab for multi-image fusion"
   }
 }

--- a/src/i18n/sv/veo.json
+++ b/src/i18n/sv/veo.json
@@ -230,5 +230,21 @@
   "button.actionIngredients": {
     "message": "Flera bilder till video",
     "description": "ingredients2video — 1-3 bilder kombineras för att skapa en ny scen"
+  },
+  "message.uploadReferencesLimit": {
+    "message": "You can upload a maximum of {limit} images",
+    "description": "Dynamic image limit for the selected generation mode"
+  },
+  "button.actionTabText": {
+    "message": "Text",
+    "description": "Compact Veo action tab for text-to-video"
+  },
+  "button.actionTabImage": {
+    "message": "Image",
+    "description": "Compact Veo action tab for image-to-video"
+  },
+  "button.actionTabIngredients": {
+    "message": "Ingredients",
+    "description": "Compact Veo action tab for multi-image fusion"
   }
 }

--- a/src/i18n/uk/veo.json
+++ b/src/i18n/uk/veo.json
@@ -230,5 +230,21 @@
   "button.actionIngredients": {
     "message": "Відео з кількома зображеннями",
     "description": "ingredients2video — об'єднання 1-3 зображень для створення нової сцени"
+  },
+  "message.uploadReferencesLimit": {
+    "message": "You can upload a maximum of {limit} images",
+    "description": "Dynamic image limit for the selected generation mode"
+  },
+  "button.actionTabText": {
+    "message": "Text",
+    "description": "Compact Veo action tab for text-to-video"
+  },
+  "button.actionTabImage": {
+    "message": "Image",
+    "description": "Compact Veo action tab for image-to-video"
+  },
+  "button.actionTabIngredients": {
+    "message": "Ingredients",
+    "description": "Compact Veo action tab for multi-image fusion"
   }
 }

--- a/src/i18n/zh-CN/veo.json
+++ b/src/i18n/zh-CN/veo.json
@@ -68,7 +68,7 @@
     "description": "参数'translation'的描述"
   },
   "description.imageUrl": {
-    "message": "在多图创建视频的任务中，它必须上传多张图片。",
+    "message": "上传 1–3 张参考图片，融合主体、风格或场景生成视频。",
     "description": "参数'imageUrl'的描述"
   },
   "description.prompt": {
@@ -143,6 +143,10 @@
     "message": "最多可上传 2 张图片",
     "description": "上传的图片数量超过限制时的错误消息"
   },
+  "message.uploadReferencesLimit": {
+    "message": "最多可上传 {limit} 张图片",
+    "description": "根据当前生成方式显示动态图片数量限制"
+  },
   "message.uploadReferencesSuccess": {
     "message": "成功上传图片",
     "description": "成功上传图片时的成功消息"
@@ -164,7 +168,7 @@
     "description": "启动绘图任务失败时的错误消息"
   },
   "message.imageRequired": {
-    "message": "请先上传至少一张参考图片，再发起图生视频任务",
+    "message": "请先上传至少一张参考图片，再发起生成任务",
     "description": "image2video 模式下未上传图片时的提示"
   },
   "message.usedUp": {
@@ -230,5 +234,17 @@
   "button.actionIngredients": {
     "message": "多图融合视频",
     "description": "ingredients2video — 1-3 张图融合生成新场景"
+  },
+  "button.actionTabText": {
+    "message": "文生",
+    "description": "Veo 操作标签：文生视频"
+  },
+  "button.actionTabImage": {
+    "message": "图生",
+    "description": "Veo 操作标签：图生视频"
+  },
+  "button.actionTabIngredients": {
+    "message": "融合",
+    "description": "Veo 操作标签：多图融合视频"
   }
 }

--- a/src/i18n/zh-TW/veo.json
+++ b/src/i18n/zh-TW/veo.json
@@ -230,5 +230,21 @@
   "button.actionIngredients": {
     "message": "多图融合视频",
     "description": "ingredients2video — 1-3 张图融合生成新场景"
+  },
+  "message.uploadReferencesLimit": {
+    "message": "You can upload a maximum of {limit} images",
+    "description": "Dynamic image limit for the selected generation mode"
+  },
+  "button.actionTabText": {
+    "message": "Text",
+    "description": "Compact Veo action tab for text-to-video"
+  },
+  "button.actionTabImage": {
+    "message": "Image",
+    "description": "Compact Veo action tab for image-to-video"
+  },
+  "button.actionTabIngredients": {
+    "message": "Ingredients",
+    "description": "Compact Veo action tab for multi-image fusion"
   }
 }

--- a/src/pages/veo/Index.vue
+++ b/src/pages/veo/Index.vue
@@ -22,6 +22,7 @@ import RecentPanel from '@/components/veo/RecentPanel.vue';
 import { IVeoTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
 import { uploadTrackerProviderMixin, ensureNoPendingUpload, ensureLoggedIn } from '@/utils';
+import { buildVeoGenerateRequest } from '@/utils/veo/config';
 
 interface IData {
   task: IVeoTask | undefined;
@@ -157,10 +158,7 @@ export default defineComponent({
       ) {
         return;
       }
-      const request = {
-        ...this.config,
-        async: true
-      } as IVeoGenerateRequest;
+      const request = buildVeoGenerateRequest(this.config) as IVeoGenerateRequest;
       if (!ensureLoggedIn()) {
         return;
       }
@@ -172,13 +170,12 @@ export default defineComponent({
       // image2video requires at least one image; otherwise the upstream rejects with
       // "image_urls is invalid when generate videos". Validate client-side so the user
       // gets an actionable message instead of the generic failure toast.
-      if (request.action === 'image2video' && !(request.image_urls && request.image_urls.length > 0)) {
+      if (
+        (request.action === 'image2video' || request.action === 'ingredients2video') &&
+        !(request.image_urls && request.image_urls.length > 0)
+      ) {
         ElMessage.warning(this.$t('veo.message.imageRequired'));
         return;
-      }
-      // Only send image_urls when it actually has values; the worker rejects empty arrays.
-      if (!request.image_urls || request.image_urls.length === 0) {
-        delete request.image_urls;
       }
       ElMessage.info(this.$t('veo.message.startingTask'));
       instrumentGeneration('veo', veoOperator.generate(request, { token }))

--- a/src/utils/veo/config.test.ts
+++ b/src/utils/veo/config.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { buildVeoGenerateRequest, normalizeVeoConfigForAction, VEO_INGREDIENTS_MODEL } from './config';
+
+describe('normalizeVeoConfigForAction', () => {
+  it('clears references and repairs the ingredients-only model for text-to-video', () => {
+    expect(
+      normalizeVeoConfigForAction(
+        { action: 'ingredients2video', model: VEO_INGREDIENTS_MODEL, image_urls: ['one', 'two', 'three'] },
+        'text2video'
+      )
+    ).toEqual({ action: 'text2video', model: 'veo31-fast' });
+  });
+
+  it('keeps at most two frames and a general model for image-to-video', () => {
+    expect(
+      normalizeVeoConfigForAction({ model: VEO_INGREDIENTS_MODEL, image_urls: ['one', 'two', 'three'] }, 'image2video')
+    ).toEqual({ action: 'image2video', model: 'veo31-fast', image_urls: ['one', 'two'] });
+  });
+
+  it('locks multi-image fusion to its dedicated model and keeps up to three references', () => {
+    expect(
+      normalizeVeoConfigForAction(
+        { model: 'veo3-fast', image_urls: ['one', 'two', 'three', 'four'] },
+        'ingredients2video'
+      )
+    ).toEqual({
+      action: 'ingredients2video',
+      model: VEO_INGREDIENTS_MODEL,
+      image_urls: ['one', 'two', 'three']
+    });
+  });
+
+  it('clears references when switching between image modes', () => {
+    expect(
+      normalizeVeoConfigForAction(
+        { action: 'image2video', model: 'veo31-fast', image_urls: ['start', 'end'] },
+        'ingredients2video'
+      )
+    ).toEqual({
+      action: 'ingredients2video',
+      model: VEO_INGREDIENTS_MODEL
+    });
+  });
+});
+
+describe('buildVeoGenerateRequest', () => {
+  it('omits empty image arrays from the API payload', () => {
+    expect(buildVeoGenerateRequest({ action: 'image2video', image_urls: [] })).toEqual({
+      action: 'image2video',
+      model: 'veo31-fast',
+      async: true
+    });
+  });
+});

--- a/src/utils/veo/config.ts
+++ b/src/utils/veo/config.ts
@@ -1,0 +1,58 @@
+import { IVeoConfig, IVeoGenerateRequest } from '@/models';
+import { VEO_DEFAULT_ACTION, VEO_DEFAULT_MODEL } from '@/constants';
+
+export type VeoAction = 'text2video' | 'image2video' | 'ingredients2video';
+
+export const VEO_INGREDIENTS_MODEL = 'veo31-fast-ingredients';
+
+export const VEO_GENERATION_MODELS = [
+  { value: 'veo31-fast', label: 'Veo 3.1 Fast' },
+  { value: 'veo3-fast', label: 'Veo 3 Fast' },
+  { value: 'veo31', label: 'Veo 3.1' },
+  { value: 'veo3', label: 'Veo 3' }
+] as const;
+
+export const normalizeVeoConfigForAction = (config: IVeoConfig | undefined, action: VeoAction): IVeoConfig => {
+  const actionChanged = Boolean(config?.action && config.action !== action);
+  const next: IVeoConfig = {
+    ...config,
+    action
+  };
+
+  if (action === 'text2video') {
+    next.model = next.model === VEO_INGREDIENTS_MODEL ? VEO_DEFAULT_MODEL : next.model || VEO_DEFAULT_MODEL;
+    delete next.image_urls;
+    return next;
+  }
+
+  if (action === 'ingredients2video') {
+    next.model = VEO_INGREDIENTS_MODEL;
+    if (actionChanged) {
+      delete next.image_urls;
+    } else {
+      next.image_urls = next.image_urls?.slice(0, 3);
+    }
+    return next;
+  }
+
+  next.model = next.model === VEO_INGREDIENTS_MODEL ? VEO_DEFAULT_MODEL : next.model || VEO_DEFAULT_MODEL;
+  if (actionChanged) {
+    delete next.image_urls;
+  } else {
+    next.image_urls = next.image_urls?.slice(0, 2);
+  }
+  return next;
+};
+
+export const buildVeoGenerateRequest = (config: IVeoConfig | undefined): IVeoGenerateRequest => {
+  const action = (config?.action || VEO_DEFAULT_ACTION) as VeoAction;
+  const request = {
+    ...normalizeVeoConfigForAction(config, action),
+    async: true
+  } as IVeoGenerateRequest;
+
+  if (!request.image_urls?.length) {
+    delete request.image_urls;
+  }
+  return request;
+};


### PR DESCRIPTION
## Summary
- replace the Veo action dropdown with compact, equal-width Text / Image / Ingredients tabs
- constrain the model selector to the current Veo contract and lock Ingredients to `veo31-fast-ingredients`
- make reference uploads action-aware: 1–2 frames for image-to-video, 1–3 references for Ingredients, with state reset and payload normalization on action changes
- reorder the form around the generation workflow and keep long localized upload labels from overlapping on the mobile drawer
- add focused action/model normalization tests and backfill the new tab/limit messages across all locales

## Validation
- `npm run build:web`
- `npm run lint:check`
- `npx vitest run src/utils/veo/config.test.ts` (5 tests)
- `python3 scripts/check_i18n_coverage.py`
- `npx beachball check`
- Playwright desktop `1440x900`: all three tabs visible, no page overflow, Ingredients model locked
- Playwright mobile `390x844` / `350px` drawer: no tab clipping or drawer overflow; upload title, info icon, and button do not overlap

## Adversarial review (reviewer: Explore subagent, 2 rounds)
- RISK: uploader mount cleared stored `image_urls` -> fixed by rebuilding the Element Plus file list from persisted URLs instead of committing an empty list
- RISK: pending upload callback after keyed action switch -> not accepted; destroyed component callbacks cannot mutate the replacement instance, and `clearFiles()` does not cancel the in-flight XHR
- RISK: previous limit briefly applies during keyed replacement -> not accepted; Vue replaces the keyed component in the same patch cycle, and the proposed `_isDestroyed` guard is a removed Vue 2 internal
- RISK: make `async` configurable -> not accepted; `async: true` is the existing Veo page/API contract and this change only centralizes the unchanged value
