### PR TITLE
Poll long memory imports asynchronously

### DIFF
--- a/change/@acedatacloud-nexior-memory-import-async.json
+++ b/change/@acedatacloud-nexior-memory-import-async.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Run long memory imports asynchronously and resume status polling after reloads.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/setting/Memory.import.test.ts
+++ b/src/components/setting/Memory.import.test.ts
@@ -5,12 +5,14 @@ import Memory from './Memory.vue';
 
 const getProfileMock = vi.hoisted(() => vi.fn());
 const importTextMock = vi.hoisted(() => vi.fn());
+const waitForImportMock = vi.hoisted(() => vi.fn());
 
 vi.mock('@/store/lazy', () => ({ ensureStoreModule: vi.fn().mockResolvedValue(undefined) }));
 vi.mock('@/operators/memories', () => ({
   memoriesOperator: {
     getProfile: getProfileMock,
     importText: importTextMock,
+    waitForImport: waitForImportMock,
     setEnabled: vi.fn(),
     remove: vi.fn(),
     clear: vi.fn()
@@ -33,8 +35,9 @@ const mountComponent = () =>
 
 describe('Memory import', () => {
   beforeEach(() => {
-    getProfileMock.mockReset().mockResolvedValue({ items: [], enabled: true });
+    getProfileMock.mockReset().mockResolvedValue({ items: [], enabled: true, importJob: null });
     importTextMock.mockReset().mockResolvedValue({ processed: 2, rejected: 0, total: 2 });
+    waitForImportMock.mockReset().mockResolvedValue({ processed: 2, rejected: 0, total: 2 });
   });
 
   it('imports pasted text and refreshes the cloud profile', async () => {
@@ -50,9 +53,30 @@ describe('Memory import', () => {
 
     await vm.onImport();
 
-    expect(importTextMock).toHaveBeenCalledWith('chat-token', '- Prefers concise answers.');
+    expect(importTextMock).toHaveBeenCalledWith(
+      'chat-token',
+      '- Prefers concise answers.',
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
     expect(getProfileMock).toHaveBeenCalledTimes(2);
     expect(vm.importVisible).toBe(false);
     expect(vm.importText).toBe('');
+  });
+
+  it('resumes a running import when the settings panel reloads', async () => {
+    getProfileMock
+      .mockResolvedValueOnce({ items: [], enabled: true, importJob: { id: 'job-resume', status: 'running' } })
+      .mockResolvedValueOnce({ items: [], enabled: true, importJob: null });
+
+    const wrapper = mountComponent();
+    await flushPromises();
+
+    expect(waitForImportMock).toHaveBeenCalledWith(
+      'chat-token',
+      'job-resume',
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
+    expect(getProfileMock).toHaveBeenCalledTimes(2);
+    wrapper.unmount();
   });
 });

--- a/src/components/setting/Memory.vue
+++ b/src/components/setting/Memory.vue
@@ -49,6 +49,9 @@
       :title="$t('common.settings.memoryImportTitle')"
       width="min(640px, 92vw)"
       append-to-body
+      :close-on-click-modal="!importing"
+      :close-on-press-escape="!importing"
+      :show-close="!importing"
     >
       <div class="import-step">
         <div class="import-step-title">{{ $t('common.settings.memoryImportExportStep') }}</div>
@@ -67,7 +70,7 @@
         />
       </div>
       <template #footer>
-        <el-button @click="importVisible = false">{{ $t('common.button.cancel') }}</el-button>
+        <el-button :disabled="importing" @click="closeImport">{{ $t('common.button.cancel') }}</el-button>
         <el-button type="primary" :disabled="!importText.trim()" :loading="importing" @click="onImport">
           {{ $t('common.settings.memoryImportSubmit') }}
         </el-button>
@@ -99,6 +102,7 @@ export default defineComponent({
       importVisible: false,
       importing: false,
       importText: '',
+      importController: null as AbortController | null,
       entries: [] as IMemoryEntry[]
     };
   },
@@ -132,10 +136,19 @@ export default defineComponent({
     await ensureStoreModule('chat');
     if (this.token) await this.fetch();
   },
+  beforeUnmount() {
+    this.importController?.abort();
+  },
   methods: {
     openImport() {
       this.importText = '';
       this.importVisible = true;
+    },
+    closeImport() {
+      if (this.importing) return;
+      this.importVisible = false;
+      this.importController?.abort();
+      this.importController = null;
     },
     async copyImportPrompt() {
       try {
@@ -149,10 +162,14 @@ export default defineComponent({
       ElMessage.error(this.$t('common.message.copyFailed'));
     },
     async onImport() {
-      if (!this.token || !this.importText.trim()) return;
+      if (!this.token || !this.importText.trim() || this.importing) return;
       this.importing = true;
+      this.importController?.abort();
+      this.importController = new AbortController();
       try {
-        const result = await memoriesOperator.importText(this.token, this.importText.trim());
+        const result = await memoriesOperator.importText(this.token, this.importText.trim(), {
+          signal: this.importController.signal
+        });
         this.importVisible = false;
         this.importText = '';
         await this.fetch();
@@ -169,13 +186,40 @@ export default defineComponent({
       } catch (error) {
         console.error('failed to import memories', error);
         const status = (error as { response?: { status?: number } })?.response?.status;
-        if (status === 400) {
+        if ((error as Error)?.name === 'AbortError') {
+          return;
+        } else if (status === 409) {
+          ElMessage.warning(this.$t('common.settings.memoryImportInProgress'));
+        } else if (status === 400) {
           ElMessage.error(this.$t('common.settings.memoryImportInvalid'));
         } else {
           ElMessage.error(this.$t('common.settings.memoryError'));
         }
       } finally {
         this.importing = false;
+        this.importController = null;
+      }
+    },
+    async resumeImport(taskId: string) {
+      if (!this.token || this.importing) return;
+      this.importing = true;
+      this.importVisible = true;
+      this.importController = new AbortController();
+      try {
+        const result = await memoriesOperator.waitForImport(this.token, taskId, {
+          signal: this.importController.signal
+        });
+        this.importVisible = false;
+        await this.fetch();
+        ElMessage.success(this.$t('common.settings.memoryImportSuccess', { count: result.processed }));
+      } catch (error) {
+        if ((error as Error)?.name !== 'AbortError') {
+          console.error('failed to resume memory import', error);
+          ElMessage.error(this.$t('common.settings.memoryError'));
+        }
+      } finally {
+        this.importing = false;
+        this.importController = null;
       }
     },
     async onMemoryEnabledChange(value: string | number | boolean) {
@@ -203,6 +247,9 @@ export default defineComponent({
         this.entries = profile.items;
         this.$store.commit('chat/setMemoryEnabled', profile.enabled);
         this.memoryReady = true;
+        if (profile.importJob?.status === 'running' && !this.importing) {
+          void this.resumeImport(profile.importJob.id);
+        }
       } catch (error) {
         console.error('failed to load memories', error);
       } finally {

--- a/src/i18n/ar/common.json
+++ b/src/i18n/ar/common.json
@@ -1594,5 +1594,9 @@
   "settings.memoryImportInvalid": {
     "message": "No memory could be imported. Make sure memory is on and paste one plain fact per line.",
     "description": "Actionable error shown when the memory import request is invalid"
+  },
+  "settings.memoryImportInProgress": {
+    "message": "A memory import is already running. Keep this dialog open and try again shortly.",
+    "description": "Warning shown when another memory import job is active"
   }
 }

--- a/src/i18n/de/common.json
+++ b/src/i18n/de/common.json
@@ -1594,5 +1594,9 @@
   "settings.memoryImportInvalid": {
     "message": "No memory could be imported. Make sure memory is on and paste one plain fact per line.",
     "description": "Actionable error shown when the memory import request is invalid"
+  },
+  "settings.memoryImportInProgress": {
+    "message": "A memory import is already running. Keep this dialog open and try again shortly.",
+    "description": "Warning shown when another memory import job is active"
   }
 }

--- a/src/i18n/el/common.json
+++ b/src/i18n/el/common.json
@@ -1594,5 +1594,9 @@
   "settings.memoryImportInvalid": {
     "message": "No memory could be imported. Make sure memory is on and paste one plain fact per line.",
     "description": "Actionable error shown when the memory import request is invalid"
+  },
+  "settings.memoryImportInProgress": {
+    "message": "A memory import is already running. Keep this dialog open and try again shortly.",
+    "description": "Warning shown when another memory import job is active"
   }
 }

--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -903,6 +903,10 @@
     "message": "No memory could be imported. Make sure memory is on and paste one plain fact per line.",
     "description": "Actionable error shown when the memory import request is invalid"
   },
+  "settings.memoryImportInProgress": {
+    "message": "A memory import is already running. Keep this dialog open and try again shortly.",
+    "description": "Warning shown when another memory import job is active"
+  },
   "settings.memoryEmpty": {
     "message": "Nothing saved yet. As you chat, the assistant will remember durable preferences and facts here.",
     "description": "Empty state shown when the user has no stored memories"

--- a/src/i18n/es/common.json
+++ b/src/i18n/es/common.json
@@ -1594,5 +1594,9 @@
   "settings.memoryImportInvalid": {
     "message": "No memory could be imported. Make sure memory is on and paste one plain fact per line.",
     "description": "Actionable error shown when the memory import request is invalid"
+  },
+  "settings.memoryImportInProgress": {
+    "message": "A memory import is already running. Keep this dialog open and try again shortly.",
+    "description": "Warning shown when another memory import job is active"
   }
 }

--- a/src/i18n/fi/common.json
+++ b/src/i18n/fi/common.json
@@ -1594,5 +1594,9 @@
   "settings.memoryImportInvalid": {
     "message": "No memory could be imported. Make sure memory is on and paste one plain fact per line.",
     "description": "Actionable error shown when the memory import request is invalid"
+  },
+  "settings.memoryImportInProgress": {
+    "message": "A memory import is already running. Keep this dialog open and try again shortly.",
+    "description": "Warning shown when another memory import job is active"
   }
 }

--- a/src/i18n/fr/common.json
+++ b/src/i18n/fr/common.json
@@ -1594,5 +1594,9 @@
   "settings.memoryImportInvalid": {
     "message": "No memory could be imported. Make sure memory is on and paste one plain fact per line.",
     "description": "Actionable error shown when the memory import request is invalid"
+  },
+  "settings.memoryImportInProgress": {
+    "message": "A memory import is already running. Keep this dialog open and try again shortly.",
+    "description": "Warning shown when another memory import job is active"
   }
 }

--- a/src/i18n/it/common.json
+++ b/src/i18n/it/common.json
@@ -1594,5 +1594,9 @@
   "settings.memoryImportInvalid": {
     "message": "No memory could be imported. Make sure memory is on and paste one plain fact per line.",
     "description": "Actionable error shown when the memory import request is invalid"
+  },
+  "settings.memoryImportInProgress": {
+    "message": "A memory import is already running. Keep this dialog open and try again shortly.",
+    "description": "Warning shown when another memory import job is active"
   }
 }

--- a/src/i18n/ja/common.json
+++ b/src/i18n/ja/common.json
@@ -1594,5 +1594,9 @@
   "settings.memoryImportInvalid": {
     "message": "No memory could be imported. Make sure memory is on and paste one plain fact per line.",
     "description": "Actionable error shown when the memory import request is invalid"
+  },
+  "settings.memoryImportInProgress": {
+    "message": "A memory import is already running. Keep this dialog open and try again shortly.",
+    "description": "Warning shown when another memory import job is active"
   }
 }

--- a/src/i18n/ko/common.json
+++ b/src/i18n/ko/common.json
@@ -1594,5 +1594,9 @@
   "settings.memoryImportInvalid": {
     "message": "No memory could be imported. Make sure memory is on and paste one plain fact per line.",
     "description": "Actionable error shown when the memory import request is invalid"
+  },
+  "settings.memoryImportInProgress": {
+    "message": "A memory import is already running. Keep this dialog open and try again shortly.",
+    "description": "Warning shown when another memory import job is active"
   }
 }

--- a/src/i18n/pl/common.json
+++ b/src/i18n/pl/common.json
@@ -1594,5 +1594,9 @@
   "settings.memoryImportInvalid": {
     "message": "No memory could be imported. Make sure memory is on and paste one plain fact per line.",
     "description": "Actionable error shown when the memory import request is invalid"
+  },
+  "settings.memoryImportInProgress": {
+    "message": "A memory import is already running. Keep this dialog open and try again shortly.",
+    "description": "Warning shown when another memory import job is active"
   }
 }

--- a/src/i18n/pt/common.json
+++ b/src/i18n/pt/common.json
@@ -1594,5 +1594,9 @@
   "settings.memoryImportInvalid": {
     "message": "No memory could be imported. Make sure memory is on and paste one plain fact per line.",
     "description": "Actionable error shown when the memory import request is invalid"
+  },
+  "settings.memoryImportInProgress": {
+    "message": "A memory import is already running. Keep this dialog open and try again shortly.",
+    "description": "Warning shown when another memory import job is active"
   }
 }

--- a/src/i18n/ru/common.json
+++ b/src/i18n/ru/common.json
@@ -1594,5 +1594,9 @@
   "settings.memoryImportInvalid": {
     "message": "No memory could be imported. Make sure memory is on and paste one plain fact per line.",
     "description": "Actionable error shown when the memory import request is invalid"
+  },
+  "settings.memoryImportInProgress": {
+    "message": "A memory import is already running. Keep this dialog open and try again shortly.",
+    "description": "Warning shown when another memory import job is active"
   }
 }

--- a/src/i18n/sr/common.json
+++ b/src/i18n/sr/common.json
@@ -1594,5 +1594,9 @@
   "settings.memoryImportInvalid": {
     "message": "No memory could be imported. Make sure memory is on and paste one plain fact per line.",
     "description": "Actionable error shown when the memory import request is invalid"
+  },
+  "settings.memoryImportInProgress": {
+    "message": "A memory import is already running. Keep this dialog open and try again shortly.",
+    "description": "Warning shown when another memory import job is active"
   }
 }

--- a/src/i18n/sv/common.json
+++ b/src/i18n/sv/common.json
@@ -1594,5 +1594,9 @@
   "settings.memoryImportInvalid": {
     "message": "No memory could be imported. Make sure memory is on and paste one plain fact per line.",
     "description": "Actionable error shown when the memory import request is invalid"
+  },
+  "settings.memoryImportInProgress": {
+    "message": "A memory import is already running. Keep this dialog open and try again shortly.",
+    "description": "Warning shown when another memory import job is active"
   }
 }

--- a/src/i18n/uk/common.json
+++ b/src/i18n/uk/common.json
@@ -1594,5 +1594,9 @@
   "settings.memoryImportInvalid": {
     "message": "No memory could be imported. Make sure memory is on and paste one plain fact per line.",
     "description": "Actionable error shown when the memory import request is invalid"
+  },
+  "settings.memoryImportInProgress": {
+    "message": "A memory import is already running. Keep this dialog open and try again shortly.",
+    "description": "Warning shown when another memory import job is active"
   }
 }

--- a/src/i18n/zh-CN/common.json
+++ b/src/i18n/zh-CN/common.json
@@ -923,6 +923,10 @@
     "message": "未能导入记忆。请确认记忆已开启，并按每行一条普通事实的格式粘贴。",
     "description": "记忆导入请求无效时显示的可操作错误提示"
   },
+  "settings.memoryImportInProgress": {
+    "message": "已有记忆导入任务正在运行，请保持弹窗打开并稍后重试。",
+    "description": "已有另一个记忆导入任务运行时显示的警告"
+  },
   "settings.memoryEmpty": {
     "message": "暂无保存的记忆。随着你的使用，助手会在这里记住持久的偏好和信息。",
     "description": "用户没有任何已存储记忆时显示的空状态"

--- a/src/i18n/zh-TW/common.json
+++ b/src/i18n/zh-TW/common.json
@@ -1594,5 +1594,9 @@
   "settings.memoryImportInvalid": {
     "message": "No memory could be imported. Make sure memory is on and paste one plain fact per line.",
     "description": "Actionable error shown when the memory import request is invalid"
+  },
+  "settings.memoryImportInProgress": {
+    "message": "A memory import is already running. Keep this dialog open and try again shortly.",
+    "description": "Warning shown when another memory import job is active"
   }
 }

--- a/src/operators/memories.test.ts
+++ b/src/operators/memories.test.ts
@@ -4,7 +4,10 @@ import { memoriesOperator } from './memories';
 
 vi.mock('@/utils', () => ({ currentSiteOrigin: () => '' }));
 
-afterEach(() => vi.restoreAllMocks());
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
 
 describe('memoriesOperator', () => {
   it('loads entries and the account preference', async () => {
@@ -12,14 +15,25 @@ describe('memoriesOperator', () => {
 
     await expect(memoriesOperator.getProfile('token')).resolves.toMatchObject({
       items: [{ id: 'm1' }],
-      enabled: false
+      enabled: false,
+      importJob: null
     });
   });
 
   it('defaults legacy profiles to enabled', async () => {
     vi.spyOn(axios, 'post').mockResolvedValue({ data: { items: [] } });
 
-    await expect(memoriesOperator.getProfile('token')).resolves.toEqual({ items: [], enabled: true });
+    await expect(memoriesOperator.getProfile('token')).resolves.toEqual({ items: [], enabled: true, importJob: null });
+  });
+
+  it('hydrates a running import job with the profile', async () => {
+    vi.spyOn(axios, 'post').mockResolvedValue({
+      data: { items: [], enabled: true, import_job: { id: 'job-0', status: 'running' } }
+    });
+
+    await expect(memoriesOperator.getProfile('token')).resolves.toMatchObject({
+      importJob: { id: 'job-0', status: 'running' }
+    });
   });
 
   it('persists the account preference', async () => {
@@ -33,8 +47,11 @@ describe('memoriesOperator', () => {
     );
   });
 
-  it('imports pasted memory text', async () => {
-    const post = vi.spyOn(axios, 'post').mockResolvedValue({ data: { processed: 3, rejected: 1, total: 8 } });
+  it('starts an import and returns its completed status', async () => {
+    const post = vi
+      .spyOn(axios, 'post')
+      .mockResolvedValueOnce({ data: { task_id: 'job-1', status: 'running' } })
+      .mockResolvedValueOnce({ data: { id: 'job-1', status: 'success', processed: 3, rejected: 1, total: 8 } });
 
     await expect(memoriesOperator.importText('token', '- Prefers concise answers.')).resolves.toEqual({
       processed: 3,
@@ -43,8 +60,82 @@ describe('memoriesOperator', () => {
     });
     expect(post).toHaveBeenCalledWith(
       expect.stringContaining('/aichat2/memories'),
-      { action: 'import', text: '- Prefers concise answers.' },
-      expect.objectContaining({ headers: expect.objectContaining({ Authorization: 'Bearer token' }) })
+      expect.objectContaining({
+        action: 'import',
+        id: expect.stringMatching(/^[0-9a-f-]{36}$/),
+        text: '- Prefers concise answers.'
+      }),
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: 'Bearer token' }),
+        signal: undefined
+      })
     );
+    expect(post).toHaveBeenCalledWith(
+      expect.stringContaining('/aichat2/memories'),
+      { action: 'import_status', id: 'job-1' },
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: 'Bearer token' }),
+        signal: undefined
+      })
+    );
+  });
+
+  it('surfaces a failed import job', async () => {
+    vi.spyOn(axios, 'post')
+      .mockResolvedValueOnce({ data: { task_id: 'job-2', status: 'running' } })
+      .mockResolvedValueOnce({ data: { id: 'job-2', status: 'failed', error: 'memory import extraction failed' } });
+
+    await expect(memoriesOperator.importText('token', 'random export')).rejects.toThrow(
+      'memory import extraction failed'
+    );
+  });
+
+  it('supports polling an existing job after page reload', async () => {
+    const post = vi.spyOn(axios, 'post').mockResolvedValue({
+      data: { id: 'job-resume', status: 'success', processed: 2, rejected: 0, total: 48 }
+    });
+
+    await expect(memoriesOperator.waitForImport('token', 'job-resume')).resolves.toEqual({
+      processed: 2,
+      rejected: 0,
+      total: 48
+    });
+    expect(post).toHaveBeenCalledWith(
+      expect.stringContaining('/aichat2/memories'),
+      { action: 'import_status', id: 'job-resume' },
+      expect.anything()
+    );
+  });
+
+  it('retries a transient admission failure with the same task id', async () => {
+    vi.useFakeTimers();
+    const post = vi
+      .spyOn(axios, 'post')
+      .mockRejectedValueOnce(new Error('network reset'))
+      .mockResolvedValueOnce({ data: { task_id: 'job-retry', status: 'running' } })
+      .mockResolvedValueOnce({ data: { id: 'job-retry', status: 'success', processed: 1, rejected: 0, total: 48 } });
+
+    const importPromise = memoriesOperator.importText('token', 'random export');
+    await vi.advanceTimersByTimeAsync(500);
+    await expect(importPromise).resolves.toMatchObject({ processed: 1 });
+
+    const admissionCalls = post.mock.calls.filter(
+      ([, payload]) => (payload as { action?: string }).action === 'import'
+    );
+    expect(admissionCalls).toHaveLength(2);
+    expect((admissionCalls[0][1] as { id: string }).id).toBe((admissionCalls[1][1] as { id: string }).id);
+  });
+
+  it('stops polling when aborted', async () => {
+    const controller = new AbortController();
+    const post = vi.spyOn(axios, 'post').mockResolvedValue({ data: { task_id: 'job-abort', status: 'running' } });
+    controller.abort();
+
+    await expect(
+      memoriesOperator.importText('token', 'random export', { signal: controller.signal })
+    ).rejects.toMatchObject({
+      name: 'AbortError'
+    });
+    expect(post).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/operators/memories.ts
+++ b/src/operators/memories.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { v4 as uuidv4 } from 'uuid';
 import { BASE_URL_API } from '@/constants';
 import { currentSiteOrigin } from '@/utils';
 
@@ -26,6 +27,7 @@ export interface IMemoryEntry {
 export interface IMemoryProfile {
   items: IMemoryEntry[];
   enabled: boolean;
+  importJob: IMemoryImportStatus | null;
 }
 
 export interface IMemoryImportResult {
@@ -34,12 +36,53 @@ export interface IMemoryImportResult {
   total: number;
 }
 
+export interface IMemoryImportStatus extends Partial<IMemoryImportResult> {
+  id: string;
+  status: 'running' | 'success' | 'failed';
+  error?: string;
+}
+
+const IMPORT_POLL_INTERVAL_MS = 1500;
+const IMPORT_TIMEOUT_MS = 8 * 60 * 1000;
+const MAX_POLL_FAILURES = 5;
+
+function abortError(): Error {
+  const error = new Error('memory import canceled');
+  error.name = 'AbortError';
+  return error;
+}
+
+function wait(ms: number, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) return Promise.reject(abortError());
+  return new Promise((resolve, reject) => {
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(abortError());
+    };
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+function importStatus(data: unknown): IMemoryImportStatus {
+  if (!data || typeof data !== 'object') throw new Error('invalid memory import status response');
+  const status = (data as { status?: unknown }).status;
+  if (status !== 'running' && status !== 'success' && status !== 'failed') {
+    throw new Error('invalid memory import status response');
+  }
+  return data as IMemoryImportStatus;
+}
+
 class MemoriesOperator {
   async getProfile(token: string): Promise<IMemoryProfile> {
     const { data } = await axios.post(BASE, { action: 'list' }, { headers: headers(token) });
     return {
       items: data?.items ?? [],
-      enabled: data?.enabled !== false
+      enabled: data?.enabled !== false,
+      importJob: data?.import_job ? importStatus(data.import_job) : null
     };
   }
 
@@ -48,13 +91,63 @@ class MemoriesOperator {
     return data?.enabled !== false;
   }
 
-  async importText(token: string, text: string): Promise<IMemoryImportResult> {
-    const { data } = await axios.post(BASE, { action: 'import', text }, { headers: headers(token) });
-    return {
-      processed: data?.processed ?? 0,
-      rejected: data?.rejected ?? 0,
-      total: data?.total ?? 0
-    };
+  async importText(token: string, text: string, options: { signal?: AbortSignal } = {}): Promise<IMemoryImportResult> {
+    const requestedTaskId = uuidv4();
+    let taskId = requestedTaskId;
+    for (let attempt = 0; attempt < 2; attempt++) {
+      try {
+        const { data } = await axios.post(
+          BASE,
+          { action: 'import', id: requestedTaskId, text },
+          { headers: headers(token), signal: options.signal }
+        );
+        taskId = (data?.task_id as string | undefined) || requestedTaskId;
+        break;
+      } catch (error) {
+        if (options.signal?.aborted || attempt === 1) throw error;
+        await wait(500, options.signal);
+      }
+    }
+
+    return this.waitForImport(token, taskId, options);
+  }
+
+  async waitForImport(
+    token: string,
+    taskId: string,
+    options: { signal?: AbortSignal } = {}
+  ): Promise<IMemoryImportResult> {
+    const deadline = Date.now() + IMPORT_TIMEOUT_MS;
+    let pollFailures = 0;
+    while (Date.now() < deadline) {
+      if (options.signal?.aborted) throw abortError();
+      let status: IMemoryImportStatus;
+      try {
+        const { data } = await axios.post(
+          BASE,
+          { action: 'import_status', id: taskId },
+          { headers: headers(token), signal: options.signal }
+        );
+        status = importStatus(data);
+        pollFailures = 0;
+      } catch (error) {
+        if (options.signal?.aborted) throw abortError();
+        pollFailures += 1;
+        if (pollFailures >= MAX_POLL_FAILURES) throw error;
+        await wait(Math.min(IMPORT_POLL_INTERVAL_MS * 2 ** pollFailures, 10_000), options.signal);
+        continue;
+      }
+      if (status.status === 'success') {
+        return {
+          processed: status.processed ?? 0,
+          rejected: status.rejected ?? 0,
+          total: status.total ?? 0
+        };
+      }
+      if (status.status === 'failed') throw new Error(status.error || 'memory import failed');
+      await wait(IMPORT_POLL_INTERVAL_MS, options.signal);
+    }
+    throw new Error('memory import timed out');
   }
 
   async remove(token: string, id: string): Promise<boolean> {


### PR DESCRIPTION
## Incident
- production memory imports hit Kong 504 at exactly 60s while Aichat2 continued and wrote results after about 105s
- backend fix merged first: https://github.com/AceDataCloud/PlatformService/pull/1486

## Fix
- start imports with a client-generated idempotency UUID and poll scoped import_status
- retry transient admission once with the same UUID, back off transient poll failures, and validate status schemas
- cancel frontend polling on unmount, prevent duplicate submits/closing while running, and resume active jobs after reload
- align frontend timeout (8m) with backend orphan expiry (7m)
- add actionable 409 in-progress copy in every locale

## Validation
- 30 operator/component/i18n tests passed after latest-main rebase
- npm run lint:check
- vue-tsc --noEmit
- i18n coverage and Beachball checks passed
- production build passed before commit

## Adversarial review (Explore, 3 rounds)
- added cancellation, retry/backoff, schema validation, timeout alignment, reload resume, idempotent admission, and lifecycle tests
- final frontend review verdict: CLEAN
