### PR TITLE
Customize capability app names and icons

### DIFF
--- a/change/@acedatacloud-nexior-5fa8a9a7-7f8f-4335-bfb2-51c8f73d0ef2.json
+++ b/change/@acedatacloud-nexior-5fa8a9a7-7f8f-4335-bfb2-51c8f73d0ef2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add per-site custom names and icons for capability apps",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/common/Navigator.capabilityOverride.test.ts
+++ b/src/components/common/Navigator.capabilityOverride.test.ts
@@ -1,0 +1,41 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import Navigator from './Navigator.vue';
+import { CHAT_MODEL_ICON_CHATGPT } from '@/constants';
+
+function buildLinks(failed = false) {
+  const computed = Navigator.computed as unknown as { links: () => Array<Record<string, unknown>> };
+  return computed.links.call({
+    $t: (key: string) => (key === 'common.nav.chatgpt' ? 'ChatGPT' : key),
+    $store: {
+      state: {
+        site: {
+          features: { chatgpt: { enabled: true } },
+          capability_overrides: {
+            chatgpt: {
+              display_name: 'My Assistant',
+              icon_url: 'https://cdn.example.com/chatgpt.png'
+            }
+          }
+        }
+      }
+    },
+    failedCapabilityIcons: failed ? { chatgpt: true } : {}
+  });
+}
+
+describe('Navigator capability overrides', () => {
+  it('uses the localized custom name and icon without changing the route', () => {
+    const [link] = buildLinks();
+    expect(link.displayName).toBe('My Assistant');
+    expect(link.logo).toBe('https://cdn.example.com/chatgpt.png');
+    expect(link.defaultLogo).toBe(CHAT_MODEL_ICON_CHATGPT);
+    expect(link.capability).toBe('chatgpt');
+  });
+
+  it('falls back to the bundled icon after a custom icon load failure', () => {
+    const [link] = buildLinks(true);
+    expect(link.displayName).toBe('My Assistant');
+    expect(link.logo).toBe(CHAT_MODEL_ICON_CHATGPT);
+  });
+});

--- a/src/components/common/Navigator.vue
+++ b/src/components/common/Navigator.vue
@@ -14,7 +14,13 @@
           :class="{ link: true, active: link.routes.includes($route.name as string) }"
         >
           <el-tooltip effect="dark" :content="link.displayName" :placement="direction === 'row' ? 'top' : 'right'">
-            <el-image v-if="link.logo" :src="link.logo" class="avatar" @click="$router.push(link.route)" />
+            <el-image
+              v-if="link.logo"
+              :src="link.logo"
+              class="avatar"
+              @error="onCapabilityIconError(link)"
+              @click="$router.push(link.route)"
+            />
           </el-tooltip>
         </div>
         <div v-if="overflowLinks.length > 0" :class="{ link: true, active: isOverflowActive }">
@@ -35,6 +41,7 @@
                     :src="link.logo"
                     class="folder-icon"
                     fit="cover"
+                    @error="onCapabilityIconError(link)"
                   />
                 </div>
               </div>
@@ -46,7 +53,13 @@
                 :class="{ 'overflow-item': true, active: link.routes.includes($route.name as string) }"
                 @click="onOverflowItemClick(link)"
               >
-                <el-image v-if="link.logo" :src="link.logo" class="overflow-avatar" fit="cover" />
+                <el-image
+                  v-if="link.logo"
+                  :src="link.logo"
+                  class="overflow-avatar"
+                  fit="cover"
+                  @error="onCapabilityIconError(link)"
+                />
                 <span class="overflow-name">{{ link.displayName }}</span>
               </div>
             </div>
@@ -144,6 +157,8 @@ import Logo from './Logo.vue';
 import UserCenter from '@/components/user/Center.vue';
 import { isMacOS } from '@/utils/surface';
 import { desktopBridge } from '@/utils/desktop';
+import { type CapabilityKey } from '@/constants/capabilities';
+import { resolveCapabilityPresentation } from '@/utils/capabilityPresentation';
 
 interface NavLink {
   route: { name: string };
@@ -152,7 +167,41 @@ interface NavLink {
   icon?: string;
   routes: string[];
   category: string;
+  capability?: CapabilityKey;
+  defaultLogo?: string;
 }
+
+const NAV_CAPABILITY_BY_ROUTE: Partial<Record<string, CapabilityKey>> = {
+  [ROUTE_CHATGPT_CONVERSATION_NEW]: 'chatgpt',
+  [ROUTE_DEEPSEEK_CONVERSATION_NEW]: 'deepseek',
+  [ROUTE_GROK_CONVERSATION_NEW]: 'grok',
+  [ROUTE_GEMINI_CONVERSATION_NEW]: 'gemini',
+  [ROUTE_CLAUDE_CONVERSATION_NEW]: 'claude',
+  [ROUTE_KIMI_CONVERSATION_NEW]: 'kimi',
+  [ROUTE_MIDJOURNEY_INDEX]: 'midjourney',
+  [ROUTE_FLUX_INDEX]: 'flux',
+  [ROUTE_NANOBANANA_INDEX]: 'nanobanana',
+  [ROUTE_OPENAIIMAGE_INDEX]: 'openaiimage',
+  [ROUTE_SEEDREAM_INDEX]: 'seedream',
+  [ROUTE_SUNO_INDEX]: 'suno',
+  [ROUTE_PRODUCER_INDEX]: 'producer',
+  [ROUTE_FISH_TTS_INDEX]: 'fish',
+  [ROUTE_SEEDANCE_INDEX]: 'seedance',
+  [ROUTE_GROKVIDEO_INDEX]: 'grokvideo',
+  [ROUTE_OMNI_INDEX]: 'omni',
+  [ROUTE_LUMA_INDEX]: 'luma',
+  [ROUTE_HAILUO_INDEX]: 'hailuo',
+  [ROUTE_KLING_INDEX]: 'kling',
+  [ROUTE_VEO_INDEX]: 'veo',
+  [ROUTE_MAESTRO_INDEX]: 'maestro',
+  [ROUTE_DIGITALHUMAN_INDEX]: 'digitalhuman',
+  [ROUTE_SORA_INDEX]: 'sora',
+  [ROUTE_PIXVERSE_INDEX]: 'pixverse',
+  [ROUTE_WAN_INDEX]: 'wan',
+  [ROUTE_SERP_INDEX]: 'serp',
+  [ROUTE_WEBEXTRATOR_INDEX]: 'webextrator',
+  [ROUTE_CODING_BRIDGE_INDEX]: 'codingBridge'
+};
 
 export default defineComponent({
   name: 'Navigator',
@@ -179,6 +228,7 @@ export default defineComponent({
       containerHeight: 0,
       showOverflow: false,
       resizeObserver: null as ResizeObserver | null,
+      failedCapabilityIcons: {} as Partial<Record<CapabilityKey, boolean>>,
       // macOS native fullscreen hides the traffic lights, so the brand inset
       // must be dropped there. Fed by the Electron main fullscreen events.
       isFullscreen: false,
@@ -454,7 +504,24 @@ export default defineComponent({
           category: 'data'
         });
       }
-      return result;
+      return result.map((link) => {
+        const capability = NAV_CAPABILITY_BY_ROUTE[link.route.name];
+        if (!capability || !link.logo) return link;
+        const defaultLogo = link.logo;
+        const presentation = resolveCapabilityPresentation(
+          this.$store.state.site,
+          capability,
+          link.displayName,
+          defaultLogo
+        );
+        return {
+          ...link,
+          capability,
+          defaultLogo,
+          displayName: presentation.displayName,
+          logo: this.failedCapabilityIcons[capability] ? defaultLogo : presentation.iconUrl
+        };
+      });
     },
     authenticated() {
       return !!this.$store.state.token.access;
@@ -515,6 +582,11 @@ export default defineComponent({
     }
   },
   methods: {
+    onCapabilityIconError(link: NavLink): void {
+      if (link.capability && link.defaultLogo && link.logo !== link.defaultLogo) {
+        this.failedCapabilityIcons[link.capability] = true;
+      }
+    },
     // Frameless macOS desktop: the traffic lights sit over the top-left, so the
     // column rail insets its brand logo to clear them. isMacOS() reads the
     // Electron preload bridge, which only exists in the desktop shell.

--- a/src/components/setting/Auth.vue
+++ b/src/components/setting/Auth.vue
@@ -222,6 +222,7 @@ import {
 import SectionNotice from '@/components/setting/SectionNotice.vue';
 import { siteOperator, smsWebhookOperator } from '@/operators';
 import type { ISiteAuth, ISiteAuthProvider } from '@/models';
+import { toWritableSitePayload } from '@/utils';
 
 // Provider IDs we surface in this tab. The IDs match
 // ``IUserPublicRegistrationMethod`` in ``src/models/user.ts`` so the
@@ -521,7 +522,7 @@ export default defineComponent({
     },
     persistAuth(nextAuth: ISiteAuth) {
       const payload = {
-        ...this.site,
+        ...toWritableSitePayload(this.site),
         auth: nextAuth
       };
       siteOperator.update(this.site?.id, payload).then(() => {

--- a/src/components/setting/CapabilityOverrideDialog.test.ts
+++ b/src/components/setting/CapabilityOverrideDialog.test.ts
@@ -1,0 +1,134 @@
+// @vitest-environment jsdom
+import { flushPromises, shallowMount } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  create: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+  success: vi.fn(),
+  error: vi.fn(),
+  warning: vi.fn(),
+  confirm: vi.fn()
+}));
+
+vi.mock('@/operators', () => ({
+  siteCapabilityOverrideOperator: {
+    create: mocks.create,
+    update: mocks.update,
+    delete: mocks.delete
+  }
+}));
+
+vi.mock('element-plus', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('element-plus')>();
+  return {
+    ...actual,
+    ElMessage: { success: mocks.success, error: mocks.error, warning: mocks.warning },
+    ElMessageBox: { confirm: mocks.confirm }
+  };
+});
+
+import CapabilityOverrideDialog from './CapabilityOverrideDialog.vue';
+
+const translate = (key: string) => key;
+
+const mountDialog = (override: Record<string, unknown> | null = null) =>
+  shallowMount(CapabilityOverrideDialog, {
+    props: {
+      modelValue: true,
+      siteId: 'site-1',
+      capability: 'chatgpt',
+      defaultName: 'ChatGPT',
+      defaultIcon: '/chatgpt.png',
+      override
+    },
+    global: {
+      mocks: { $t: translate },
+      stubs: {
+        ElDialog: { template: '<div><slot /><slot name="footer" /></div>' },
+        ElForm: { template: '<form><slot /></form>' },
+        ElFormItem: { template: '<div><slot /></div>' },
+        ElInput: { template: '<div><slot name="suffix" /></div>' },
+        ElButton: { template: '<button><slot /></button>' },
+        AutoTranslateToggle: true,
+        ImageCropper: true
+      }
+    }
+  });
+
+describe('CapabilityOverrideDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.confirm.mockResolvedValue(undefined);
+  });
+
+  it('hydrates the source name and icon when first opened', async () => {
+    const wrapper = mountDialog({
+      id: 'override-1',
+      display_name: 'English name',
+      display_name_source: '源名称',
+      icon_url: 'https://cdn.example.com/icon.png',
+      auto_translated_fields: ['display_name']
+    });
+    await flushPromises();
+
+    const vm = wrapper.vm as unknown as {
+      displayName: string;
+      iconUrl: string;
+      autoTranslatedFields: string[];
+    };
+    expect(vm.displayName).toBe('源名称');
+    expect(vm.iconUrl).toBe('https://cdn.example.com/icon.png');
+    expect(vm.autoTranslatedFields).toEqual(['display_name']);
+  });
+
+  it('creates an override and stays open so translation can be enabled', async () => {
+    mocks.create.mockResolvedValue({
+      data: {
+        id: 'override-1',
+        display_name: 'My Assistant',
+        display_name_source: 'My Assistant',
+        icon_url: null,
+        auto_translated_fields: []
+      }
+    });
+    const wrapper = mountDialog();
+    await wrapper.setData({ displayName: '  My Assistant  ' });
+
+    await (wrapper.vm as unknown as { onSave: () => Promise<void> }).onSave();
+
+    expect(mocks.create).toHaveBeenCalledWith({
+      site: 'site-1',
+      capability: 'chatgpt',
+      display_name: 'My Assistant',
+      icon_url: null
+    });
+    expect((wrapper.vm as unknown as { record: { id?: string } }).record.id).toBe('override-1');
+    expect(wrapper.emitted('saved')).toHaveLength(1);
+    expect(wrapper.emitted('update:modelValue')).toBeUndefined();
+  });
+
+  it('updates an override and closes the dialog', async () => {
+    mocks.update.mockResolvedValue({ data: { id: 'override-1', display_name: 'Updated', icon_url: null } });
+    const wrapper = mountDialog({ id: 'override-1', display_name_source: 'Old', icon_url: null });
+    await wrapper.setData({ displayName: 'Updated' });
+
+    await (wrapper.vm as unknown as { onSave: () => Promise<void> }).onSave();
+
+    expect(mocks.update).toHaveBeenCalledWith('override-1', { display_name: 'Updated', icon_url: null });
+    expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual([false]);
+  });
+
+  it('deletes the row to restore both defaults', async () => {
+    mocks.delete.mockResolvedValue({ data: undefined });
+    const wrapper = mountDialog({ id: 'override-1', display_name_source: 'Old', icon_url: null });
+
+    await (wrapper.vm as unknown as { onReset: () => Promise<void> }).onReset();
+
+    expect(mocks.confirm).toHaveBeenCalled();
+    expect(mocks.delete).toHaveBeenCalledWith('override-1');
+    expect(wrapper.emitted('saved')).toHaveLength(1);
+    expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual([false]);
+  });
+});

--- a/src/components/setting/CapabilityOverrideDialog.vue
+++ b/src/components/setting/CapabilityOverrideDialog.vue
@@ -1,0 +1,318 @@
+<template>
+  <el-dialog
+    v-model="visible"
+    :title="$t('site.capabilityOverride.dialogTitle', { name: defaultName })"
+    :width="mobile ? '94vw' : '520px'"
+    :close-on-click-modal="false"
+    append-to-body
+  >
+    <el-form label-position="top" @submit.prevent>
+      <el-form-item :label="$t('site.capabilityOverride.displayName')">
+        <el-input v-model="displayName" maxlength="120" show-word-limit clearable>
+          <template #suffix>
+            <auto-translate-toggle
+              model="site_capability_override"
+              field="display_name"
+              :object-id="record?.id"
+              :enabled="autoTranslatedFields.includes('display_name')"
+              :current-value="displayName"
+              @enabled-success="onTranslationEnabled"
+              @disabled-success="onTranslationDisabled"
+            />
+          </template>
+        </el-input>
+        <div class="field-tip">{{ $t('site.capabilityOverride.displayNameTip', { name: defaultName }) }}</div>
+      </el-form-item>
+
+      <el-form-item :label="$t('site.capabilityOverride.icon')">
+        <div class="icon-comparison">
+          <div class="icon-preview-block">
+            <span class="preview-label">{{ $t('site.capabilityOverride.defaultIcon') }}</span>
+            <img :src="defaultIcon" class="icon-preview" alt="" />
+          </div>
+          <div class="icon-preview-block">
+            <span class="preview-label">{{ $t('site.capabilityOverride.currentIcon') }}</span>
+            <img :src="iconUrl || defaultIcon" class="icon-preview" alt="" />
+          </div>
+          <div class="icon-actions">
+            <el-button :icon="Upload" @click="iconEditorVisible = true">
+              {{ iconUrl ? $t('site.capabilityOverride.replaceIcon') : $t('site.capabilityOverride.uploadIcon') }}
+            </el-button>
+            <el-button v-if="iconUrl" link type="primary" @click="iconUrl = ''">
+              {{ $t('site.capabilityOverride.useDefaultIcon') }}
+            </el-button>
+          </div>
+        </div>
+        <div class="field-tip">{{ $t('site.capabilityOverride.iconTip') }}</div>
+      </el-form-item>
+    </el-form>
+
+    <image-cropper
+      v-model="iconEditorVisible"
+      :title="$t('site.capabilityOverride.editIcon')"
+      :format-hint="$t('site.capabilityOverride.iconTip')"
+      :aspect-ratio="1"
+      :output-width="512"
+      accept="image/png,image/jpeg,image/webp"
+      shape="rectangle"
+      @uploaded="iconUrl = $event"
+    />
+
+    <template #footer>
+      <div class="dialog-footer">
+        <el-button v-if="record?.id" type="danger" plain :loading="resetting" @click="onReset">
+          {{ $t('site.capabilityOverride.resetAll') }}
+        </el-button>
+        <span class="footer-spacer" />
+        <el-button @click="visible = false">{{ $t('common.button.cancel') }}</el-button>
+        <el-button type="primary" :loading="submitting" @click="onSave">
+          {{ $t('common.button.confirm') }}
+        </el-button>
+      </div>
+    </template>
+  </el-dialog>
+</template>
+
+<script lang="ts">
+import { defineComponent, type PropType } from 'vue';
+import { ElButton, ElDialog, ElForm, ElFormItem, ElInput, ElMessage, ElMessageBox } from 'element-plus';
+import { Upload } from '@element-plus/icons-vue';
+import AutoTranslateToggle from '@/components/site/AutoTranslateToggle.vue';
+import ImageCropper from '@/components/common/ImageCropper.vue';
+import { siteCapabilityOverrideOperator } from '@/operators';
+import type { ISiteCapabilityOverride } from '@/models';
+import type { CapabilityKey } from '@/constants/capabilities';
+
+export default defineComponent({
+  name: 'CapabilityOverrideDialog',
+  components: {
+    AutoTranslateToggle,
+    ElButton,
+    ElDialog,
+    ElForm,
+    ElFormItem,
+    ElInput,
+    ImageCropper
+  },
+  props: {
+    modelValue: { type: Boolean, default: false },
+    siteId: { type: String, required: true },
+    capability: { type: String as PropType<CapabilityKey>, required: true },
+    defaultName: { type: String, required: true },
+    defaultIcon: { type: String, required: true },
+    override: { type: Object as PropType<ISiteCapabilityOverride | null>, default: null }
+  },
+  emits: ['update:modelValue', 'saved'],
+  data() {
+    return {
+      record: null as ISiteCapabilityOverride | null,
+      displayName: '',
+      iconUrl: '',
+      autoTranslatedFields: [] as string[],
+      iconEditorVisible: false,
+      submitting: false,
+      resetting: false,
+      Upload
+    };
+  },
+  computed: {
+    visible: {
+      get(): boolean {
+        return this.modelValue;
+      },
+      set(value: boolean) {
+        this.$emit('update:modelValue', value);
+      }
+    },
+    mobile(): boolean {
+      return typeof window !== 'undefined' && window.innerWidth < 640;
+    }
+  },
+  watch: {
+    modelValue(open: boolean) {
+      if (open) this.hydrate();
+    },
+    override() {
+      if (this.modelValue) this.hydrate();
+    }
+  },
+  mounted() {
+    if (this.modelValue) this.hydrate();
+  },
+  methods: {
+    hydrate(): void {
+      this.record = this.override ? { ...this.override } : null;
+      this.displayName = this.override?.display_name_source ?? this.override?.display_name ?? '';
+      this.iconUrl = this.override?.icon_url ?? '';
+      this.autoTranslatedFields = [...(this.override?.auto_translated_fields ?? [])];
+      this.iconEditorVisible = false;
+    },
+    extractError(error: unknown): string {
+      const data = (error as { response?: { data?: Record<string, unknown> } })?.response?.data;
+      if (!data) return '';
+      const detail = data.detail;
+      if (typeof detail === 'string') return detail;
+      return Object.values(data)
+        .flat()
+        .filter((value) => typeof value === 'string')
+        .join(' ');
+    },
+    async onSave(): Promise<void> {
+      const displayName = this.displayName.trim() || null;
+      const iconUrl = this.iconUrl.trim() || null;
+      if (!displayName && !iconUrl) {
+        if (this.record?.id) {
+          await this.onReset();
+        } else {
+          ElMessage.warning(this.$t('site.capabilityOverride.empty') as string);
+        }
+        return;
+      }
+
+      this.submitting = true;
+      try {
+        if (this.record?.id) {
+          const { data } = await siteCapabilityOverrideOperator.update(this.record.id, {
+            display_name: displayName,
+            icon_url: iconUrl
+          });
+          this.record = data;
+          ElMessage.success(this.$t('site.capabilityOverride.saved') as string);
+          this.$emit('saved');
+          this.visible = false;
+        } else {
+          const { data } = await siteCapabilityOverrideOperator.create({
+            site: this.siteId,
+            capability: this.capability,
+            display_name: displayName,
+            icon_url: iconUrl
+          });
+          this.record = data;
+          this.displayName = data.display_name_source ?? data.display_name ?? '';
+          this.iconUrl = data.icon_url ?? '';
+          this.autoTranslatedFields = [...(data.auto_translated_fields ?? [])];
+          ElMessage.success(this.$t('site.capabilityOverride.savedEnableTranslation') as string);
+          this.$emit('saved');
+        }
+      } catch (error) {
+        ElMessage.error(this.extractError(error) || (this.$t('site.capabilityOverride.saveFailed') as string));
+      } finally {
+        this.submitting = false;
+      }
+    },
+    async onReset(): Promise<void> {
+      if (!this.record?.id) return;
+      try {
+        await ElMessageBox.confirm(
+          this.$t('site.capabilityOverride.resetConfirm', { name: this.defaultName }) as string,
+          this.$t('site.capabilityOverride.resetAll') as string,
+          {
+            type: 'warning',
+            confirmButtonText: this.$t('site.capabilityOverride.resetAll') as string,
+            cancelButtonText: this.$t('common.button.cancel') as string
+          }
+        );
+      } catch {
+        return;
+      }
+      this.resetting = true;
+      try {
+        await siteCapabilityOverrideOperator.delete(this.record.id);
+        ElMessage.success(this.$t('site.capabilityOverride.resetDone') as string);
+        this.$emit('saved');
+        this.visible = false;
+      } catch (error) {
+        ElMessage.error(this.extractError(error) || (this.$t('site.capabilityOverride.saveFailed') as string));
+      } finally {
+        this.resetting = false;
+      }
+    },
+    async onTranslationEnabled(payload: { source: string; fieldValue: string }): Promise<void> {
+      this.displayName = payload.source;
+      this.autoTranslatedFields = ['display_name'];
+      if (this.record) {
+        this.record.display_name = payload.fieldValue;
+        this.record.display_name_source = payload.source;
+        this.record.auto_translated_fields = ['display_name'];
+      }
+      ElMessage.success(this.$t('site.capabilityOverride.saved') as string);
+      this.$emit('saved');
+    },
+    async onTranslationDisabled(payload: { fieldValue: string | null }): Promise<void> {
+      this.displayName = payload.fieldValue ?? '';
+      this.autoTranslatedFields = [];
+      if (this.record) {
+        this.record.display_name = payload.fieldValue;
+        this.record.display_name_source = payload.fieldValue;
+        this.record.auto_translated_fields = [];
+      }
+      ElMessage.success(this.$t('site.capabilityOverride.saved') as string);
+      this.$emit('saved');
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.field-tip {
+  margin-top: 6px;
+  color: var(--el-text-color-secondary);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.icon-comparison {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  width: 100%;
+  flex-wrap: wrap;
+}
+
+.icon-preview-block {
+  display: grid;
+  justify-items: center;
+  gap: 6px;
+}
+
+.preview-label {
+  color: var(--el-text-color-secondary);
+  font-size: 12px;
+}
+
+.icon-preview {
+  width: 48px;
+  height: 48px;
+  border: 1px solid var(--el-border-color-lighter);
+  border-radius: 8px;
+  object-fit: cover;
+  background: var(--el-fill-color-lighter);
+}
+
+.icon-actions {
+  display: flex;
+  align-items: flex-start;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.dialog-footer {
+  display: flex;
+  align-items: center;
+  width: 100%;
+}
+
+.footer-spacer {
+  flex: 1;
+}
+
+@media (max-width: 479px) {
+  .icon-comparison {
+    gap: 14px;
+  }
+
+  .icon-actions {
+    flex-basis: 100%;
+  }
+}
+</style>

--- a/src/components/setting/Distribution.vue
+++ b/src/components/setting/Distribution.vue
@@ -57,6 +57,7 @@ import EditUser from '@/components/site/EditUser.vue';
 import UserChip from '@/components/site/UserChip.vue';
 import SectionNotice from '@/components/setting/SectionNotice.vue';
 import { siteOperator } from '@/operators';
+import { toWritableSitePayload } from '@/utils';
 
 export default defineComponent({
   name: 'DistributionSetting',
@@ -73,7 +74,7 @@ export default defineComponent({
   methods: {
     onSave(data: any) {
       const payload = {
-        ...this.site,
+        ...toWritableSitePayload(this.site),
         ...data
       };
       siteOperator.update(this.site?.id, payload).then(() => {

--- a/src/components/setting/Function.test.ts
+++ b/src/components/setting/Function.test.ts
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+import { shallowMount } from '@vue/test-utils';
+import { describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  updateSite: vi.fn().mockResolvedValue({ data: {} }),
+  getOverrides: vi.fn().mockResolvedValue({ data: { count: 0, items: [] } })
+}));
+
+vi.mock('@/operators', () => ({
+  siteOperator: { update: mocks.updateSite },
+  siteCapabilityOverrideOperator: { getAll: mocks.getOverrides }
+}));
+
+import FunctionSetting from './Function.vue';
+
+describe('FunctionSetting', () => {
+  it('does not echo the read-only capability override mapping in Site PUTs', async () => {
+    const site = {
+      id: 'site-1',
+      title: 'Demo',
+      features: { chatgpt: { enabled: true } },
+      capability_overrides: {
+        chatgpt: { display_name: 'Custom Chat', icon_url: 'https://cdn.example.com/chat.png' }
+      }
+    };
+    const dispatch = vi.fn().mockResolvedValue(undefined);
+    const wrapper = shallowMount(FunctionSetting, {
+      global: {
+        mocks: {
+          $store: {
+            getters: { site },
+            dispatch
+          },
+          $t: (key: string) => key
+        },
+        stubs: {
+          CapabilityOverrideDialog: true,
+          ElButton: true,
+          ElSwitch: true,
+          ElTooltip: true,
+          SectionNotice: true
+        }
+      }
+    });
+
+    (wrapper.vm as unknown as { onToggleFeature: (feature: string, enabled: boolean) => void }).onToggleFeature(
+      'chatgpt',
+      false
+    );
+    await Promise.resolve();
+
+    expect(mocks.updateSite).toHaveBeenCalledWith('site-1', {
+      id: 'site-1',
+      title: 'Demo',
+      features: { chatgpt: { enabled: false } }
+    });
+    expect(dispatch).toHaveBeenCalledWith('getSite');
+  });
+});

--- a/src/components/setting/Function.vue
+++ b/src/components/setting/Function.vue
@@ -4,7 +4,7 @@
     <section v-for="feature in featureKeys" :key="feature" class="settings-item">
       <div class="settings-label">
         <div class="capability-heading">
-          <img :src="featureIcon(feature)" class="capability-favicon" alt="" />
+          <img :src="featureIcon(feature)" class="capability-favicon" alt="" @error="failedIcons[feature] = true" />
           <p class="settings-title">{{ featureLabel(feature) }}</p>
         </div>
         <p class="settings-tip">
@@ -12,6 +12,15 @@
         </p>
       </div>
       <div class="settings-content">
+        <el-tooltip :content="$t('site.capabilityOverride.edit')" placement="top">
+          <el-button
+            circle
+            size="small"
+            :icon="Edit"
+            :aria-label="$t('site.capabilityOverride.edit')"
+            @click="onEdit(feature as CapabilityKey)"
+          />
+        </el-tooltip>
         <el-switch
           :model-value="site.features?.[feature]?.enabled || false"
           inline-prompt
@@ -21,39 +30,106 @@
         />
       </div>
     </section>
+    <capability-override-dialog
+      v-if="editingCapability && site.id"
+      v-model="dialogVisible"
+      :site-id="site.id"
+      :capability="editingCapability"
+      :default-name="defaultFeatureLabel(editingCapability)"
+      :default-icon="CAPABILITY_ICONS[editingCapability]"
+      :override="overrides[editingCapability] || null"
+      @saved="onOverrideSaved"
+    />
   </div>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElSwitch } from 'element-plus';
+import { ElButton, ElMessage, ElSwitch, ElTooltip } from 'element-plus';
+import { Edit } from '@element-plus/icons-vue';
 import SectionNotice from '@/components/setting/SectionNotice.vue';
-import { siteOperator } from '@/operators';
+import CapabilityOverrideDialog from '@/components/setting/CapabilityOverrideDialog.vue';
+import { siteCapabilityOverrideOperator, siteOperator } from '@/operators';
 import { CAPABILITY_ICONS, CAPABILITY_KEYS, type CapabilityKey } from '@/constants/capabilities';
+import type { ISiteCapabilityOverride } from '@/models';
+import { resolveCapabilityPresentation } from '@/utils/capabilityPresentation';
+import { toWritableSitePayload } from '@/utils';
 
 export default defineComponent({
   name: 'FunctionSetting',
   components: {
+    CapabilityOverrideDialog,
+    ElButton,
     ElSwitch,
+    ElTooltip,
     SectionNotice
+  },
+  data() {
+    return {
+      overrides: {} as Partial<Record<CapabilityKey, ISiteCapabilityOverride>>,
+      editingCapability: null as CapabilityKey | null,
+      dialogVisible: false,
+      failedIcons: {} as Partial<Record<CapabilityKey, boolean>>,
+      Edit,
+      CAPABILITY_ICONS
+    };
   },
   computed: {
     site() {
       return this.$store.getters.site || { features: {} };
     },
-    featureKeys(): string[] {
+    featureKeys(): CapabilityKey[] {
       return [...CAPABILITY_KEYS];
     }
   },
+  watch: {
+    'site.id': {
+      immediate: true,
+      handler(siteId?: string) {
+        if (siteId) void this.fetchOverrides();
+      }
+    }
+  },
   methods: {
-    featureLabel(feature: string) {
+    defaultFeatureLabel(feature: CapabilityKey): string {
       return this.$t('site.field.features' + feature.charAt(0).toUpperCase() + feature.slice(1));
     },
-    featureTip(feature: string) {
+    featureLabel(feature: CapabilityKey): string {
+      return resolveCapabilityPresentation(
+        this.site,
+        feature,
+        this.defaultFeatureLabel(feature),
+        CAPABILITY_ICONS[feature]
+      ).displayName;
+    },
+    featureTip(feature: CapabilityKey) {
       return this.$t('site.message.features' + feature.charAt(0).toUpperCase() + feature.slice(1));
     },
-    featureIcon(feature: string): string {
-      return CAPABILITY_ICONS[feature as CapabilityKey];
+    featureIcon(feature: CapabilityKey): string {
+      if (this.failedIcons[feature]) return CAPABILITY_ICONS[feature];
+      return resolveCapabilityPresentation(
+        this.site,
+        feature,
+        this.defaultFeatureLabel(feature),
+        CAPABILITY_ICONS[feature]
+      ).iconUrl;
+    },
+    async fetchOverrides(): Promise<void> {
+      if (!this.site.id) return;
+      try {
+        const { data } = await siteCapabilityOverrideOperator.getAll({ site: this.site.id, limit: 100 });
+        this.overrides = Object.fromEntries((data.items || []).map((item) => [item.capability as CapabilityKey, item]));
+      } catch {
+        ElMessage.error(this.$t('site.capabilityOverride.fetchFailed') as string);
+      }
+    },
+    onEdit(feature: CapabilityKey): void {
+      this.editingCapability = feature;
+      this.dialogVisible = true;
+    },
+    async onOverrideSaved(): Promise<void> {
+      this.failedIcons = {};
+      await Promise.all([this.fetchOverrides(), this.$store.dispatch('getSite')]);
     },
     updateFeature(feature: string, updates: Record<string, unknown>) {
       this.onSave({
@@ -71,7 +147,7 @@ export default defineComponent({
     },
     onSave(data: any) {
       const payload = {
-        ...this.site,
+        ...toWritableSitePayload(this.site),
         ...data
       };
       siteOperator.update(this.site?.id, payload).then(() => {

--- a/src/components/setting/Seo.vue
+++ b/src/components/setting/Seo.vue
@@ -58,6 +58,7 @@ import EditArray from '@/components/site/EditArray.vue';
 import AutoTranslateToggle from '@/components/site/AutoTranslateToggle.vue';
 import SectionNotice from '@/components/setting/SectionNotice.vue';
 import { siteOperator } from '@/operators';
+import { toWritableSitePayload } from '@/utils';
 
 export default defineComponent({
   name: 'SettingSeo',
@@ -84,7 +85,7 @@ export default defineComponent({
   methods: {
     onSave(data: any) {
       const payload = {
-        ...this.site,
+        ...toWritableSitePayload(this.site),
         ...data
       };
       siteOperator.update(this.site?.id, payload).then(() => {

--- a/src/components/setting/Site.vue
+++ b/src/components/setting/Site.vue
@@ -157,7 +157,7 @@ import UserChip from '@/components/site/UserChip.vue';
 import AutoTranslateToggle from '@/components/site/AutoTranslateToggle.vue';
 import SectionNotice from '@/components/setting/SectionNotice.vue';
 import { siteOperator } from '@/operators';
-import { getBrandContacts, hasBrandContacts } from '@/utils';
+import { getBrandContacts, hasBrandContacts, toWritableSitePayload } from '@/utils';
 import { contactIcon, contactBrand, contactTypeI18nKey } from '@/utils/contactTypes';
 import { ISiteContact } from '@/models';
 import { DEFAULT_PRIMARY_COLOR, applyAccentColor } from '@/utils/theme';
@@ -246,7 +246,7 @@ export default defineComponent({
     },
     onSave(data: any) {
       const payload = {
-        ...this.site,
+        ...toWritableSitePayload(this.site),
         ...data
       };
       siteOperator.update(this.site?.id, payload).then(() => {

--- a/src/components/setting/SiteServices.vue
+++ b/src/components/setting/SiteServices.vue
@@ -256,7 +256,7 @@ import { serviceOperator, siteOperator, siteServiceOverrideOperator } from '@/op
 import type { IService, ISite, ISiteServiceOverride } from '@/models';
 import SectionNotice from '@/components/setting/SectionNotice.vue';
 import AutoTranslateToggle from '@/components/site/AutoTranslateToggle.vue';
-import { getSiteMarkupRatio, isRechargeDisabled, MARKUP_RATIO_MAX } from '@/utils';
+import { getSiteMarkupRatio, isRechargeDisabled, MARKUP_RATIO_MAX, toWritableSitePayload } from '@/utils';
 
 // Pre-fetch the whole catalog once so each override row can show the
 // service title/alias without an N+1 per-row GET. If a tenant ever
@@ -422,7 +422,7 @@ export default defineComponent({
       try {
         const metadata = (this.site.metadata || {}) as Record<string, unknown>;
         await siteOperator.update(this.siteId, {
-          ...this.site,
+          ...toWritableSitePayload(this.site),
           metadata: {
             ...metadata,
             disable_recharge: enabled
@@ -453,7 +453,7 @@ export default defineComponent({
           if (!siteId) break;
           const metadata = (this.site.metadata || {}) as Record<string, unknown>;
           await siteOperator.update(siteId, {
-            ...this.site,
+            ...toWritableSitePayload(this.site),
             metadata: {
               ...metadata,
               pricing: {

--- a/src/i18n/ar/site.json
+++ b/src/i18n/ar/site.json
@@ -889,5 +889,85 @@
   "message.featuresOmni": {
     "message": "أنشئ مقاطع فيديو أو حرّرها باستخدام نماذج Omni انطلاقًا من النصوص والصور ومراجع الفيديو.",
     "description": "أنشئ مقاطع فيديو أو حرّرها باستخدام نماذج Omni انطلاقًا من النصوص والصور ومراجع الفيديو."
+  },
+  "capabilityOverride.edit": {
+    "message": "Customize app",
+    "description": "Tooltip and accessible label for editing a capability app name and icon"
+  },
+  "capabilityOverride.dialogTitle": {
+    "message": "Customize {name}",
+    "description": "Dialog title; {name} is the platform-default capability app name"
+  },
+  "capabilityOverride.displayName": {
+    "message": "Custom name",
+    "description": "Field label for a per-site capability app display name"
+  },
+  "capabilityOverride.displayNameTip": {
+    "message": "Leave blank to use {name}. Save once before enabling automatic translation.",
+    "description": "Help text; {name} is the platform-default capability app name"
+  },
+  "capabilityOverride.icon": {
+    "message": "Custom icon",
+    "description": "Field label for a per-site capability app icon"
+  },
+  "capabilityOverride.defaultIcon": {
+    "message": "Default",
+    "description": "Label above the platform-default capability icon preview"
+  },
+  "capabilityOverride.currentIcon": {
+    "message": "Current",
+    "description": "Label above the effective capability icon preview"
+  },
+  "capabilityOverride.replaceIcon": {
+    "message": "Replace icon",
+    "description": "Command to upload a replacement capability icon"
+  },
+  "capabilityOverride.uploadIcon": {
+    "message": "Upload icon",
+    "description": "Command to upload the first custom capability icon"
+  },
+  "capabilityOverride.useDefaultIcon": {
+    "message": "Use default icon",
+    "description": "Command to clear the custom icon draft"
+  },
+  "capabilityOverride.iconTip": {
+    "message": "PNG, JPEG, or WebP. The image is cropped to a square; transparent PNG is preserved.",
+    "description": "Capability icon upload requirements"
+  },
+  "capabilityOverride.editIcon": {
+    "message": "Edit app icon",
+    "description": "Title of the capability icon cropper dialog"
+  },
+  "capabilityOverride.resetAll": {
+    "message": "Restore defaults",
+    "description": "Command that removes both custom name and icon"
+  },
+  "capabilityOverride.empty": {
+    "message": "Enter a custom name or upload an icon first.",
+    "description": "Warning when attempting to create an empty override"
+  },
+  "capabilityOverride.saved": {
+    "message": "App customization saved",
+    "description": "Success message after saving a capability override"
+  },
+  "capabilityOverride.savedEnableTranslation": {
+    "message": "Saved. You can now enable automatic translation for the custom name.",
+    "description": "Success message after first save creates an override ID"
+  },
+  "capabilityOverride.saveFailed": {
+    "message": "Failed to save app customization",
+    "description": "Fallback error for capability override writes"
+  },
+  "capabilityOverride.resetConfirm": {
+    "message": "Restore the default name and icon for {name}?",
+    "description": "Confirmation message; {name} is the platform-default capability app name"
+  },
+  "capabilityOverride.resetDone": {
+    "message": "Default name and icon restored",
+    "description": "Success message after deleting a capability override"
+  },
+  "capabilityOverride.fetchFailed": {
+    "message": "Failed to load app customizations",
+    "description": "Error shown when capability override management rows cannot be loaded"
   }
 }

--- a/src/i18n/de/site.json
+++ b/src/i18n/de/site.json
@@ -889,5 +889,85 @@
   "message.featuresOmni": {
     "message": "Erstelle oder bearbeite Videos mit Omni-Modellen aus Texten, Bildern und Videoreferenzen.",
     "description": "Erstelle oder bearbeite Videos mit Omni-Modellen aus Texten, Bildern und Videoreferenzen."
+  },
+  "capabilityOverride.edit": {
+    "message": "Customize app",
+    "description": "Tooltip and accessible label for editing a capability app name and icon"
+  },
+  "capabilityOverride.dialogTitle": {
+    "message": "Customize {name}",
+    "description": "Dialog title; {name} is the platform-default capability app name"
+  },
+  "capabilityOverride.displayName": {
+    "message": "Custom name",
+    "description": "Field label for a per-site capability app display name"
+  },
+  "capabilityOverride.displayNameTip": {
+    "message": "Leave blank to use {name}. Save once before enabling automatic translation.",
+    "description": "Help text; {name} is the platform-default capability app name"
+  },
+  "capabilityOverride.icon": {
+    "message": "Custom icon",
+    "description": "Field label for a per-site capability app icon"
+  },
+  "capabilityOverride.defaultIcon": {
+    "message": "Default",
+    "description": "Label above the platform-default capability icon preview"
+  },
+  "capabilityOverride.currentIcon": {
+    "message": "Current",
+    "description": "Label above the effective capability icon preview"
+  },
+  "capabilityOverride.replaceIcon": {
+    "message": "Replace icon",
+    "description": "Command to upload a replacement capability icon"
+  },
+  "capabilityOverride.uploadIcon": {
+    "message": "Upload icon",
+    "description": "Command to upload the first custom capability icon"
+  },
+  "capabilityOverride.useDefaultIcon": {
+    "message": "Use default icon",
+    "description": "Command to clear the custom icon draft"
+  },
+  "capabilityOverride.iconTip": {
+    "message": "PNG, JPEG, or WebP. The image is cropped to a square; transparent PNG is preserved.",
+    "description": "Capability icon upload requirements"
+  },
+  "capabilityOverride.editIcon": {
+    "message": "Edit app icon",
+    "description": "Title of the capability icon cropper dialog"
+  },
+  "capabilityOverride.resetAll": {
+    "message": "Restore defaults",
+    "description": "Command that removes both custom name and icon"
+  },
+  "capabilityOverride.empty": {
+    "message": "Enter a custom name or upload an icon first.",
+    "description": "Warning when attempting to create an empty override"
+  },
+  "capabilityOverride.saved": {
+    "message": "App customization saved",
+    "description": "Success message after saving a capability override"
+  },
+  "capabilityOverride.savedEnableTranslation": {
+    "message": "Saved. You can now enable automatic translation for the custom name.",
+    "description": "Success message after first save creates an override ID"
+  },
+  "capabilityOverride.saveFailed": {
+    "message": "Failed to save app customization",
+    "description": "Fallback error for capability override writes"
+  },
+  "capabilityOverride.resetConfirm": {
+    "message": "Restore the default name and icon for {name}?",
+    "description": "Confirmation message; {name} is the platform-default capability app name"
+  },
+  "capabilityOverride.resetDone": {
+    "message": "Default name and icon restored",
+    "description": "Success message after deleting a capability override"
+  },
+  "capabilityOverride.fetchFailed": {
+    "message": "Failed to load app customizations",
+    "description": "Error shown when capability override management rows cannot be loaded"
   }
 }

--- a/src/i18n/el/site.json
+++ b/src/i18n/el/site.json
@@ -889,5 +889,85 @@
   "message.featuresOmni": {
     "message": "Δημιουργήστε ή επεξεργαστείτε βίντεο με μοντέλα Omni από κείμενο, εικόνες και αναφορές βίντεο.",
     "description": "Δημιουργήστε ή επεξεργαστείτε βίντεο με μοντέλα Omni από κείμενο, εικόνες και αναφορές βίντεο."
+  },
+  "capabilityOverride.edit": {
+    "message": "Customize app",
+    "description": "Tooltip and accessible label for editing a capability app name and icon"
+  },
+  "capabilityOverride.dialogTitle": {
+    "message": "Customize {name}",
+    "description": "Dialog title; {name} is the platform-default capability app name"
+  },
+  "capabilityOverride.displayName": {
+    "message": "Custom name",
+    "description": "Field label for a per-site capability app display name"
+  },
+  "capabilityOverride.displayNameTip": {
+    "message": "Leave blank to use {name}. Save once before enabling automatic translation.",
+    "description": "Help text; {name} is the platform-default capability app name"
+  },
+  "capabilityOverride.icon": {
+    "message": "Custom icon",
+    "description": "Field label for a per-site capability app icon"
+  },
+  "capabilityOverride.defaultIcon": {
+    "message": "Default",
+    "description": "Label above the platform-default capability icon preview"
+  },
+  "capabilityOverride.currentIcon": {
+    "message": "Current",
+    "description": "Label above the effective capability icon preview"
+  },
+  "capabilityOverride.replaceIcon": {
+    "message": "Replace icon",
+    "description": "Command to upload a replacement capability icon"
+  },
+  "capabilityOverride.uploadIcon": {
+    "message": "Upload icon",
+    "description": "Command to upload the first custom capability icon"
+  },
+  "capabilityOverride.useDefaultIcon": {
+    "message": "Use default icon",
+    "description": "Command to clear the custom icon draft"
+  },
+  "capabilityOverride.iconTip": {
+    "message": "PNG, JPEG, or WebP. The image is cropped to a square; transparent PNG is preserved.",
+    "description": "Capability icon upload requirements"
+  },
+  "capabilityOverride.editIcon": {
+    "message": "Edit app icon",
+    "description": "Title of the capability icon cropper dialog"
+  },
+  "capabilityOverride.resetAll": {
+    "message": "Restore defaults",
+    "description": "Command that removes both custom name and icon"
+  },
+  "capabilityOverride.empty": {
+    "message": "Enter a custom name or upload an icon first.",
+    "description": "Warning when attempting to create an empty override"
+  },
+  "capabilityOverride.saved": {
+    "message": "App customization saved",
+    "description": "Success message after saving a capability override"
+  },
+  "capabilityOverride.savedEnableTranslation": {
+    "message": "Saved. You can now enable automatic translation for the custom name.",
+    "description": "Success message after first save creates an override ID"
+  },
+  "capabilityOverride.saveFailed": {
+    "message": "Failed to save app customization",
+    "description": "Fallback error for capability override writes"
+  },
+  "capabilityOverride.resetConfirm": {
+    "message": "Restore the default name and icon for {name}?",
+    "description": "Confirmation message; {name} is the platform-default capability app name"
+  },
+  "capabilityOverride.resetDone": {
+    "message": "Default name and icon restored",
+    "description": "Success message after deleting a capability override"
+  },
+  "capabilityOverride.fetchFailed": {
+    "message": "Failed to load app customizations",
+    "description": "Error shown when capability override management rows cannot be loaded"
   }
 }

--- a/src/i18n/en/site.json
+++ b/src/i18n/en/site.json
@@ -890,5 +890,85 @@
   },
   "services.message.fetchFailed": {
     "message": "Failed to load service overrides"
+  },
+  "capabilityOverride.edit": {
+    "message": "Customize app",
+    "description": "Tooltip and accessible label for editing a capability app name and icon"
+  },
+  "capabilityOverride.dialogTitle": {
+    "message": "Customize {name}",
+    "description": "Dialog title; {name} is the platform-default capability app name"
+  },
+  "capabilityOverride.displayName": {
+    "message": "Custom name",
+    "description": "Field label for a per-site capability app display name"
+  },
+  "capabilityOverride.displayNameTip": {
+    "message": "Leave blank to use {name}. Save once before enabling automatic translation.",
+    "description": "Help text; {name} is the platform-default capability app name"
+  },
+  "capabilityOverride.icon": {
+    "message": "Custom icon",
+    "description": "Field label for a per-site capability app icon"
+  },
+  "capabilityOverride.defaultIcon": {
+    "message": "Default",
+    "description": "Label above the platform-default capability icon preview"
+  },
+  "capabilityOverride.currentIcon": {
+    "message": "Current",
+    "description": "Label above the effective capability icon preview"
+  },
+  "capabilityOverride.replaceIcon": {
+    "message": "Replace icon",
+    "description": "Command to upload a replacement capability icon"
+  },
+  "capabilityOverride.uploadIcon": {
+    "message": "Upload icon",
+    "description": "Command to upload the first custom capability icon"
+  },
+  "capabilityOverride.useDefaultIcon": {
+    "message": "Use default icon",
+    "description": "Command to clear the custom icon draft"
+  },
+  "capabilityOverride.iconTip": {
+    "message": "PNG, JPEG, or WebP. The image is cropped to a square; transparent PNG is preserved.",
+    "description": "Capability icon upload requirements"
+  },
+  "capabilityOverride.editIcon": {
+    "message": "Edit app icon",
+    "description": "Title of the capability icon cropper dialog"
+  },
+  "capabilityOverride.resetAll": {
+    "message": "Restore defaults",
+    "description": "Command that removes both custom name and icon"
+  },
+  "capabilityOverride.empty": {
+    "message": "Enter a custom name or upload an icon first.",
+    "description": "Warning when attempting to create an empty override"
+  },
+  "capabilityOverride.saved": {
+    "message": "App customization saved",
+    "description": "Success message after saving a capability override"
+  },
+  "capabilityOverride.savedEnableTranslation": {
+    "message": "Saved. You can now enable automatic translation for the custom name.",
+    "description": "Success message after first save creates an override ID"
+  },
+  "capabilityOverride.saveFailed": {
+    "message": "Failed to save app customization",
+    "description": "Fallback error for capability override writes"
+  },
+  "capabilityOverride.resetConfirm": {
+    "message": "Restore the default name and icon for {name}?",
+    "description": "Confirmation message; {name} is the platform-default capability app name"
+  },
+  "capabilityOverride.resetDone": {
+    "message": "Default name and icon restored",
+    "description": "Success message after deleting a capability override"
+  },
+  "capabilityOverride.fetchFailed": {
+    "message": "Failed to load app customizations",
+    "description": "Error shown when capability override management rows cannot be loaded"
   }
 }

--- a/src/i18n/es/site.json
+++ b/src/i18n/es/site.json
@@ -889,5 +889,85 @@
   "message.featuresOmni": {
     "message": "Genera o edita vídeos con modelos Omni a partir de texto, imágenes y referencias de vídeo.",
     "description": "Genera o edita vídeos con modelos Omni a partir de texto, imágenes y referencias de vídeo."
+  },
+  "capabilityOverride.edit": {
+    "message": "Customize app",
+    "description": "Tooltip and accessible label for editing a capability app name and icon"
+  },
+  "capabilityOverride.dialogTitle": {
+    "message": "Customize {name}",
+    "description": "Dialog title; {name} is the platform-default capability app name"
+  },
+  "capabilityOverride.displayName": {
+    "message": "Custom name",
+    "description": "Field label for a per-site capability app display name"
+  },
+  "capabilityOverride.displayNameTip": {
+    "message": "Leave blank to use {name}. Save once before enabling automatic translation.",
+    "description": "Help text; {name} is the platform-default capability app name"
+  },
+  "capabilityOverride.icon": {
+    "message": "Custom icon",
+    "description": "Field label for a per-site capability app icon"
+  },
+  "capabilityOverride.defaultIcon": {
+    "message": "Default",
+    "description": "Label above the platform-default capability icon preview"
+  },
+  "capabilityOverride.currentIcon": {
+    "message": "Current",
+    "description": "Label above the effective capability icon preview"
+  },
+  "capabilityOverride.replaceIcon": {
+    "message": "Replace icon",
+    "description": "Command to upload a replacement capability icon"
+  },
+  "capabilityOverride.uploadIcon": {
+    "message": "Upload icon",
+    "description": "Command to upload the first custom capability icon"
+  },
+  "capabilityOverride.useDefaultIcon": {
+    "message": "Use default icon",
+    "description": "Command to clear the custom icon draft"
+  },
+  "capabilityOverride.iconTip": {
+    "message": "PNG, JPEG, or WebP. The image is cropped to a square; transparent PNG is preserved.",
+    "description": "Capability icon upload requirements"
+  },
+  "capabilityOverride.editIcon": {
+    "message": "Edit app icon",
+    "description": "Title of the capability icon cropper dialog"
+  },
+  "capabilityOverride.resetAll": {
+    "message": "Restore defaults",
+    "description": "Command that removes both custom name and icon"
+  },
+  "capabilityOverride.empty": {
+    "message": "Enter a custom name or upload an icon first.",
+    "description": "Warning when attempting to create an empty override"
+  },
+  "capabilityOverride.saved": {
+    "message": "App customization saved",
+    "description": "Success message after saving a capability override"
+  },
+  "capabilityOverride.savedEnableTranslation": {
+    "message": "Saved. You can now enable automatic translation for the custom name.",
+    "description": "Success message after first save creates an override ID"
+  },
+  "capabilityOverride.saveFailed": {
+    "message": "Failed to save app customization",
+    "description": "Fallback error for capability override writes"
+  },
+  "capabilityOverride.resetConfirm": {
+    "message": "Restore the default name and icon for {name}?",
+    "description": "Confirmation message; {name} is the platform-default capability app name"
+  },
+  "capabilityOverride.resetDone": {
+    "message": "Default name and icon restored",
+    "description": "Success message after deleting a capability override"
+  },
+  "capabilityOverride.fetchFailed": {
+    "message": "Failed to load app customizations",
+    "description": "Error shown when capability override management rows cannot be loaded"
   }
 }

--- a/src/i18n/fi/site.json
+++ b/src/i18n/fi/site.json
@@ -889,5 +889,85 @@
   "message.featuresOmni": {
     "message": "Luo tai muokkaa videoita Omni-malleilla tekstin, kuvien ja videoviitteiden pohjalta.",
     "description": "Luo tai muokkaa videoita Omni-malleilla tekstin, kuvien ja videoviitteiden pohjalta."
+  },
+  "capabilityOverride.edit": {
+    "message": "Customize app",
+    "description": "Tooltip and accessible label for editing a capability app name and icon"
+  },
+  "capabilityOverride.dialogTitle": {
+    "message": "Customize {name}",
+    "description": "Dialog title; {name} is the platform-default capability app name"
+  },
+  "capabilityOverride.displayName": {
+    "message": "Custom name",
+    "description": "Field label for a per-site capability app display name"
+  },
+  "capabilityOverride.displayNameTip": {
+    "message": "Leave blank to use {name}. Save once before enabling automatic translation.",
+    "description": "Help text; {name} is the platform-default capability app name"
+  },
+  "capabilityOverride.icon": {
+    "message": "Custom icon",
+    "description": "Field label for a per-site capability app icon"
+  },
+  "capabilityOverride.defaultIcon": {
+    "message": "Default",
+    "description": "Label above the platform-default capability icon preview"
+  },
+  "capabilityOverride.currentIcon": {
+    "message": "Current",
+    "description": "Label above the effective capability icon preview"
+  },
+  "capabilityOverride.replaceIcon": {
+    "message": "Replace icon",
+    "description": "Command to upload a replacement capability icon"
+  },
+  "capabilityOverride.uploadIcon": {
+    "message": "Upload icon",
+    "description": "Command to upload the first custom capability icon"
+  },
+  "capabilityOverride.useDefaultIcon": {
+    "message": "Use default icon",
+    "description": "Command to clear the custom icon draft"
+  },
+  "capabilityOverride.iconTip": {
+    "message": "PNG, JPEG, or WebP. The image is cropped to a square; transparent PNG is preserved.",
+    "description": "Capability icon upload requirements"
+  },
+  "capabilityOverride.editIcon": {
+    "message": "Edit app icon",
+    "description": "Title of the capability icon cropper dialog"
+  },
+  "capabilityOverride.resetAll": {
+    "message": "Restore defaults",
+    "description": "Command that removes both custom name and icon"
+  },
+  "capabilityOverride.empty": {
+    "message": "Enter a custom name or upload an icon first.",
+    "description": "Warning when attempting to create an empty override"
+  },
+  "capabilityOverride.saved": {
+    "message": "App customization saved",
+    "description": "Success message after saving a capability override"
+  },
+  "capabilityOverride.savedEnableTranslation": {
+    "message": "Saved. You can now enable automatic translation for the custom name.",
+    "description": "Success message after first save creates an override ID"
+  },
+  "capabilityOverride.saveFailed": {
+    "message": "Failed to save app customization",
+    "description": "Fallback error for capability override writes"
+  },
+  "capabilityOverride.resetConfirm": {
+    "message": "Restore the default name and icon for {name}?",
+    "description": "Confirmation message; {name} is the platform-default capability app name"
+  },
+  "capabilityOverride.resetDone": {
+    "message": "Default name and icon restored",
+    "description": "Success message after deleting a capability override"
+  },
+  "capabilityOverride.fetchFailed": {
+    "message": "Failed to load app customizations",
+    "description": "Error shown when capability override management rows cannot be loaded"
   }
 }

--- a/src/i18n/fr/site.json
+++ b/src/i18n/fr/site.json
@@ -889,5 +889,85 @@
   "message.featuresOmni": {
     "message": "Générez ou modifiez des vidéos avec les modèles Omni à partir de texte, d’images et de références vidéo.",
     "description": "Générez ou modifiez des vidéos avec les modèles Omni à partir de texte, d’images et de références vidéo."
+  },
+  "capabilityOverride.edit": {
+    "message": "Customize app",
+    "description": "Tooltip and accessible label for editing a capability app name and icon"
+  },
+  "capabilityOverride.dialogTitle": {
+    "message": "Customize {name}",
+    "description": "Dialog title; {name} is the platform-default capability app name"
+  },
+  "capabilityOverride.displayName": {
+    "message": "Custom name",
+    "description": "Field label for a per-site capability app display name"
+  },
+  "capabilityOverride.displayNameTip": {
+    "message": "Leave blank to use {name}. Save once before enabling automatic translation.",
+    "description": "Help text; {name} is the platform-default capability app name"
+  },
+  "capabilityOverride.icon": {
+    "message": "Custom icon",
+    "description": "Field label for a per-site capability app icon"
+  },
+  "capabilityOverride.defaultIcon": {
+    "message": "Default",
+    "description": "Label above the platform-default capability icon preview"
+  },
+  "capabilityOverride.currentIcon": {
+    "message": "Current",
+    "description": "Label above the effective capability icon preview"
+  },
+  "capabilityOverride.replaceIcon": {
+    "message": "Replace icon",
+    "description": "Command to upload a replacement capability icon"
+  },
+  "capabilityOverride.uploadIcon": {
+    "message": "Upload icon",
+    "description": "Command to upload the first custom capability icon"
+  },
+  "capabilityOverride.useDefaultIcon": {
+    "message": "Use default icon",
+    "description": "Command to clear the custom icon draft"
+  },
+  "capabilityOverride.iconTip": {
+    "message": "PNG, JPEG, or WebP. The image is cropped to a square; transparent PNG is preserved.",
+    "description": "Capability icon upload requirements"
+  },
+  "capabilityOverride.editIcon": {
+    "message": "Edit app icon",
+    "description": "Title of the capability icon cropper dialog"
+  },
+  "capabilityOverride.resetAll": {
+    "message": "Restore defaults",
+    "description": "Command that removes both custom name and icon"
+  },
+  "capabilityOverride.empty": {
+    "message": "Enter a custom name or upload an icon first.",
+    "description": "Warning when attempting to create an empty override"
+  },
+  "capabilityOverride.saved": {
+    "message": "App customization saved",
+    "description": "Success message after saving a capability override"
+  },
+  "capabilityOverride.savedEnableTranslation": {
+    "message": "Saved. You can now enable automatic translation for the custom name.",
+    "description": "Success message after first save creates an override ID"
+  },
+  "capabilityOverride.saveFailed": {
+    "message": "Failed to save app customization",
+    "description": "Fallback error for capability override writes"
+  },
+  "capabilityOverride.resetConfirm": {
+    "message": "Restore the default name and icon for {name}?",
+    "description": "Confirmation message; {name} is the platform-default capability app name"
+  },
+  "capabilityOverride.resetDone": {
+    "message": "Default name and icon restored",
+    "description": "Success message after deleting a capability override"
+  },
+  "capabilityOverride.fetchFailed": {
+    "message": "Failed to load app customizations",
+    "description": "Error shown when capability override management rows cannot be loaded"
   }
 }

--- a/src/i18n/it/site.json
+++ b/src/i18n/it/site.json
@@ -889,5 +889,85 @@
   "message.featuresOmni": {
     "message": "Genera o modifica video con i modelli Omni a partire da testo, immagini e riferimenti video.",
     "description": "Genera o modifica video con i modelli Omni a partire da testo, immagini e riferimenti video."
+  },
+  "capabilityOverride.edit": {
+    "message": "Customize app",
+    "description": "Tooltip and accessible label for editing a capability app name and icon"
+  },
+  "capabilityOverride.dialogTitle": {
+    "message": "Customize {name}",
+    "description": "Dialog title; {name} is the platform-default capability app name"
+  },
+  "capabilityOverride.displayName": {
+    "message": "Custom name",
+    "description": "Field label for a per-site capability app display name"
+  },
+  "capabilityOverride.displayNameTip": {
+    "message": "Leave blank to use {name}. Save once before enabling automatic translation.",
+    "description": "Help text; {name} is the platform-default capability app name"
+  },
+  "capabilityOverride.icon": {
+    "message": "Custom icon",
+    "description": "Field label for a per-site capability app icon"
+  },
+  "capabilityOverride.defaultIcon": {
+    "message": "Default",
+    "description": "Label above the platform-default capability icon preview"
+  },
+  "capabilityOverride.currentIcon": {
+    "message": "Current",
+    "description": "Label above the effective capability icon preview"
+  },
+  "capabilityOverride.replaceIcon": {
+    "message": "Replace icon",
+    "description": "Command to upload a replacement capability icon"
+  },
+  "capabilityOverride.uploadIcon": {
+    "message": "Upload icon",
+    "description": "Command to upload the first custom capability icon"
+  },
+  "capabilityOverride.useDefaultIcon": {
+    "message": "Use default icon",
+    "description": "Command to clear the custom icon draft"
+  },
+  "capabilityOverride.iconTip": {
+    "message": "PNG, JPEG, or WebP. The image is cropped to a square; transparent PNG is preserved.",
+    "description": "Capability icon upload requirements"
+  },
+  "capabilityOverride.editIcon": {
+    "message": "Edit app icon",
+    "description": "Title of the capability icon cropper dialog"
+  },
+  "capabilityOverride.resetAll": {
+    "message": "Restore defaults",
+    "description": "Command that removes both custom name and icon"
+  },
+  "capabilityOverride.empty": {
+    "message": "Enter a custom name or upload an icon first.",
+    "description": "Warning when attempting to create an empty override"
+  },
+  "capabilityOverride.saved": {
+    "message": "App customization saved",
+    "description": "Success message after saving a capability override"
+  },
+  "capabilityOverride.savedEnableTranslation": {
+    "message": "Saved. You can now enable automatic translation for the custom name.",
+    "description": "Success message after first save creates an override ID"
+  },
+  "capabilityOverride.saveFailed": {
+    "message": "Failed to save app customization",
+    "description": "Fallback error for capability override writes"
+  },
+  "capabilityOverride.resetConfirm": {
+    "message": "Restore the default name and icon for {name}?",
+    "description": "Confirmation message; {name} is the platform-default capability app name"
+  },
+  "capabilityOverride.resetDone": {
+    "message": "Default name and icon restored",
+    "description": "Success message after deleting a capability override"
+  },
+  "capabilityOverride.fetchFailed": {
+    "message": "Failed to load app customizations",
+    "description": "Error shown when capability override management rows cannot be loaded"
   }
 }

--- a/src/i18n/ja/site.json
+++ b/src/i18n/ja/site.json
@@ -889,5 +889,85 @@
   "message.featuresOmni": {
     "message": "Omniモデルを使い、テキスト、画像、動画参照から動画を生成・編集します。",
     "description": "Omniモデルを使い、テキスト、画像、動画参照から動画を生成・編集します。"
+  },
+  "capabilityOverride.edit": {
+    "message": "Customize app",
+    "description": "Tooltip and accessible label for editing a capability app name and icon"
+  },
+  "capabilityOverride.dialogTitle": {
+    "message": "Customize {name}",
+    "description": "Dialog title; {name} is the platform-default capability app name"
+  },
+  "capabilityOverride.displayName": {
+    "message": "Custom name",
+    "description": "Field label for a per-site capability app display name"
+  },
+  "capabilityOverride.displayNameTip": {
+    "message": "Leave blank to use {name}. Save once before enabling automatic translation.",
+    "description": "Help text; {name} is the platform-default capability app name"
+  },
+  "capabilityOverride.icon": {
+    "message": "Custom icon",
+    "description": "Field label for a per-site capability app icon"
+  },
+  "capabilityOverride.defaultIcon": {
+    "message": "Default",
+    "description": "Label above the platform-default capability icon preview"
+  },
+  "capabilityOverride.currentIcon": {
+    "message": "Current",
+    "description": "Label above the effective capability icon preview"
+  },
+  "capabilityOverride.replaceIcon": {
+    "message": "Replace icon",
+    "description": "Command to upload a replacement capability icon"
+  },
+  "capabilityOverride.uploadIcon": {
+    "message": "Upload icon",
+    "description": "Command to upload the first custom capability icon"
+  },
+  "capabilityOverride.useDefaultIcon": {
+    "message": "Use default icon",
+    "description": "Command to clear the custom icon draft"
+  },
+  "capabilityOverride.iconTip": {
+    "message": "PNG, JPEG, or WebP. The image is cropped to a square; transparent PNG is preserved.",
+    "description": "Capability icon upload requirements"
+  },
+  "capabilityOverride.editIcon": {
+    "message": "Edit app icon",
+    "description": "Title of the capability icon cropper dialog"
+  },
+  "capabilityOverride.resetAll": {
+    "message": "Restore defaults",
+    "description": "Command that removes both custom name and icon"
+  },
+  "capabilityOverride.empty": {
+    "message": "Enter a custom name or upload an icon first.",
+    "description": "Warning when attempting to create an empty override"
+  },
+  "capabilityOverride.saved": {
+    "message": "App customization saved",
+    "description": "Success message after saving a capability override"
+  },
+  "capabilityOverride.savedEnableTranslation": {
+    "message": "Saved. You can now enable automatic translation for the custom name.",
+    "description": "Success message after first save creates an override ID"
+  },
+  "capabilityOverride.saveFailed": {
+    "message": "Failed to save app customization",
+    "description": "Fallback error for capability override writes"
+  },
+  "capabilityOverride.resetConfirm": {
+    "message": "Restore the default name and icon for {name}?",
+    "description": "Confirmation message; {name} is the platform-default capability app name"
+  },
+  "capabilityOverride.resetDone": {
+    "message": "Default name and icon restored",
+    "description": "Success message after deleting a capability override"
+  },
+  "capabilityOverride.fetchFailed": {
+    "message": "Failed to load app customizations",
+    "description": "Error shown when capability override management rows cannot be loaded"
   }
 }

--- a/src/i18n/ko/site.json
+++ b/src/i18n/ko/site.json
@@ -889,5 +889,85 @@
   "message.featuresOmni": {
     "message": "Omni 모델로 텍스트, 이미지, 동영상 참조를 바탕으로 동영상을 생성하거나 편집합니다.",
     "description": "Omni 모델로 텍스트, 이미지, 동영상 참조를 바탕으로 동영상을 생성하거나 편집합니다."
+  },
+  "capabilityOverride.edit": {
+    "message": "Customize app",
+    "description": "Tooltip and accessible label for editing a capability app name and icon"
+  },
+  "capabilityOverride.dialogTitle": {
+    "message": "Customize {name}",
+    "description": "Dialog title; {name} is the platform-default capability app name"
+  },
+  "capabilityOverride.displayName": {
+    "message": "Custom name",
+    "description": "Field label for a per-site capability app display name"
+  },
+  "capabilityOverride.displayNameTip": {
+    "message": "Leave blank to use {name}. Save once before enabling automatic translation.",
+    "description": "Help text; {name} is the platform-default capability app name"
+  },
+  "capabilityOverride.icon": {
+    "message": "Custom icon",
+    "description": "Field label for a per-site capability app icon"
+  },
+  "capabilityOverride.defaultIcon": {
+    "message": "Default",
+    "description": "Label above the platform-default capability icon preview"
+  },
+  "capabilityOverride.currentIcon": {
+    "message": "Current",
+    "description": "Label above the effective capability icon preview"
+  },
+  "capabilityOverride.replaceIcon": {
+    "message": "Replace icon",
+    "description": "Command to upload a replacement capability icon"
+  },
+  "capabilityOverride.uploadIcon": {
+    "message": "Upload icon",
+    "description": "Command to upload the first custom capability icon"
+  },
+  "capabilityOverride.useDefaultIcon": {
+    "message": "Use default icon",
+    "description": "Command to clear the custom icon draft"
+  },
+  "capabilityOverride.iconTip": {
+    "message": "PNG, JPEG, or WebP. The image is cropped to a square; transparent PNG is preserved.",
+    "description": "Capability icon upload requirements"
+  },
+  "capabilityOverride.editIcon": {
+    "message": "Edit app icon",
+    "description": "Title of the capability icon cropper dialog"
+  },
+  "capabilityOverride.resetAll": {
+    "message": "Restore defaults",
+    "description": "Command that removes both custom name and icon"
+  },
+  "capabilityOverride.empty": {
+    "message": "Enter a custom name or upload an icon first.",
+    "description": "Warning when attempting to create an empty override"
+  },
+  "capabilityOverride.saved": {
+    "message": "App customization saved",
+    "description": "Success message after saving a capability override"
+  },
+  "capabilityOverride.savedEnableTranslation": {
+    "message": "Saved. You can now enable automatic translation for the custom name.",
+    "description": "Success message after first save creates an override ID"
+  },
+  "capabilityOverride.saveFailed": {
+    "message": "Failed to save app customization",
+    "description": "Fallback error for capability override writes"
+  },
+  "capabilityOverride.resetConfirm": {
+    "message": "Restore the default name and icon for {name}?",
+    "description": "Confirmation message; {name} is the platform-default capability app name"
+  },
+  "capabilityOverride.resetDone": {
+    "message": "Default name and icon restored",
+    "description": "Success message after deleting a capability override"
+  },
+  "capabilityOverride.fetchFailed": {
+    "message": "Failed to load app customizations",
+    "description": "Error shown when capability override management rows cannot be loaded"
   }
 }

--- a/src/i18n/pl/site.json
+++ b/src/i18n/pl/site.json
@@ -889,5 +889,85 @@
   "message.featuresOmni": {
     "message": "Twórz lub edytuj filmy za pomocą modeli Omni na podstawie tekstu, obrazów i materiałów wideo.",
     "description": "Twórz lub edytuj filmy za pomocą modeli Omni na podstawie tekstu, obrazów i materiałów wideo."
+  },
+  "capabilityOverride.edit": {
+    "message": "Customize app",
+    "description": "Tooltip and accessible label for editing a capability app name and icon"
+  },
+  "capabilityOverride.dialogTitle": {
+    "message": "Customize {name}",
+    "description": "Dialog title; {name} is the platform-default capability app name"
+  },
+  "capabilityOverride.displayName": {
+    "message": "Custom name",
+    "description": "Field label for a per-site capability app display name"
+  },
+  "capabilityOverride.displayNameTip": {
+    "message": "Leave blank to use {name}. Save once before enabling automatic translation.",
+    "description": "Help text; {name} is the platform-default capability app name"
+  },
+  "capabilityOverride.icon": {
+    "message": "Custom icon",
+    "description": "Field label for a per-site capability app icon"
+  },
+  "capabilityOverride.defaultIcon": {
+    "message": "Default",
+    "description": "Label above the platform-default capability icon preview"
+  },
+  "capabilityOverride.currentIcon": {
+    "message": "Current",
+    "description": "Label above the effective capability icon preview"
+  },
+  "capabilityOverride.replaceIcon": {
+    "message": "Replace icon",
+    "description": "Command to upload a replacement capability icon"
+  },
+  "capabilityOverride.uploadIcon": {
+    "message": "Upload icon",
+    "description": "Command to upload the first custom capability icon"
+  },
+  "capabilityOverride.useDefaultIcon": {
+    "message": "Use default icon",
+    "description": "Command to clear the custom icon draft"
+  },
+  "capabilityOverride.iconTip": {
+    "message": "PNG, JPEG, or WebP. The image is cropped to a square; transparent PNG is preserved.",
+    "description": "Capability icon upload requirements"
+  },
+  "capabilityOverride.editIcon": {
+    "message": "Edit app icon",
+    "description": "Title of the capability icon cropper dialog"
+  },
+  "capabilityOverride.resetAll": {
+    "message": "Restore defaults",
+    "description": "Command that removes both custom name and icon"
+  },
+  "capabilityOverride.empty": {
+    "message": "Enter a custom name or upload an icon first.",
+    "description": "Warning when attempting to create an empty override"
+  },
+  "capabilityOverride.saved": {
+    "message": "App customization saved",
+    "description": "Success message after saving a capability override"
+  },
+  "capabilityOverride.savedEnableTranslation": {
+    "message": "Saved. You can now enable automatic translation for the custom name.",
+    "description": "Success message after first save creates an override ID"
+  },
+  "capabilityOverride.saveFailed": {
+    "message": "Failed to save app customization",
+    "description": "Fallback error for capability override writes"
+  },
+  "capabilityOverride.resetConfirm": {
+    "message": "Restore the default name and icon for {name}?",
+    "description": "Confirmation message; {name} is the platform-default capability app name"
+  },
+  "capabilityOverride.resetDone": {
+    "message": "Default name and icon restored",
+    "description": "Success message after deleting a capability override"
+  },
+  "capabilityOverride.fetchFailed": {
+    "message": "Failed to load app customizations",
+    "description": "Error shown when capability override management rows cannot be loaded"
   }
 }

--- a/src/i18n/pt/site.json
+++ b/src/i18n/pt/site.json
@@ -889,5 +889,85 @@
   "message.featuresOmni": {
     "message": "Gere ou edite vídeos com modelos Omni a partir de texto, imagens e referências de vídeo.",
     "description": "Gere ou edite vídeos com modelos Omni a partir de texto, imagens e referências de vídeo."
+  },
+  "capabilityOverride.edit": {
+    "message": "Customize app",
+    "description": "Tooltip and accessible label for editing a capability app name and icon"
+  },
+  "capabilityOverride.dialogTitle": {
+    "message": "Customize {name}",
+    "description": "Dialog title; {name} is the platform-default capability app name"
+  },
+  "capabilityOverride.displayName": {
+    "message": "Custom name",
+    "description": "Field label for a per-site capability app display name"
+  },
+  "capabilityOverride.displayNameTip": {
+    "message": "Leave blank to use {name}. Save once before enabling automatic translation.",
+    "description": "Help text; {name} is the platform-default capability app name"
+  },
+  "capabilityOverride.icon": {
+    "message": "Custom icon",
+    "description": "Field label for a per-site capability app icon"
+  },
+  "capabilityOverride.defaultIcon": {
+    "message": "Default",
+    "description": "Label above the platform-default capability icon preview"
+  },
+  "capabilityOverride.currentIcon": {
+    "message": "Current",
+    "description": "Label above the effective capability icon preview"
+  },
+  "capabilityOverride.replaceIcon": {
+    "message": "Replace icon",
+    "description": "Command to upload a replacement capability icon"
+  },
+  "capabilityOverride.uploadIcon": {
+    "message": "Upload icon",
+    "description": "Command to upload the first custom capability icon"
+  },
+  "capabilityOverride.useDefaultIcon": {
+    "message": "Use default icon",
+    "description": "Command to clear the custom icon draft"
+  },
+  "capabilityOverride.iconTip": {
+    "message": "PNG, JPEG, or WebP. The image is cropped to a square; transparent PNG is preserved.",
+    "description": "Capability icon upload requirements"
+  },
+  "capabilityOverride.editIcon": {
+    "message": "Edit app icon",
+    "description": "Title of the capability icon cropper dialog"
+  },
+  "capabilityOverride.resetAll": {
+    "message": "Restore defaults",
+    "description": "Command that removes both custom name and icon"
+  },
+  "capabilityOverride.empty": {
+    "message": "Enter a custom name or upload an icon first.",
+    "description": "Warning when attempting to create an empty override"
+  },
+  "capabilityOverride.saved": {
+    "message": "App customization saved",
+    "description": "Success message after saving a capability override"
+  },
+  "capabilityOverride.savedEnableTranslation": {
+    "message": "Saved. You can now enable automatic translation for the custom name.",
+    "description": "Success message after first save creates an override ID"
+  },
+  "capabilityOverride.saveFailed": {
+    "message": "Failed to save app customization",
+    "description": "Fallback error for capability override writes"
+  },
+  "capabilityOverride.resetConfirm": {
+    "message": "Restore the default name and icon for {name}?",
+    "description": "Confirmation message; {name} is the platform-default capability app name"
+  },
+  "capabilityOverride.resetDone": {
+    "message": "Default name and icon restored",
+    "description": "Success message after deleting a capability override"
+  },
+  "capabilityOverride.fetchFailed": {
+    "message": "Failed to load app customizations",
+    "description": "Error shown when capability override management rows cannot be loaded"
   }
 }

--- a/src/i18n/ru/site.json
+++ b/src/i18n/ru/site.json
@@ -889,5 +889,85 @@
   "message.featuresOmni": {
     "message": "Создавайте и редактируйте видео с помощью моделей Omni на основе текста, изображений и видеореференсов.",
     "description": "Создавайте и редактируйте видео с помощью моделей Omni на основе текста, изображений и видеореференсов."
+  },
+  "capabilityOverride.edit": {
+    "message": "Customize app",
+    "description": "Tooltip and accessible label for editing a capability app name and icon"
+  },
+  "capabilityOverride.dialogTitle": {
+    "message": "Customize {name}",
+    "description": "Dialog title; {name} is the platform-default capability app name"
+  },
+  "capabilityOverride.displayName": {
+    "message": "Custom name",
+    "description": "Field label for a per-site capability app display name"
+  },
+  "capabilityOverride.displayNameTip": {
+    "message": "Leave blank to use {name}. Save once before enabling automatic translation.",
+    "description": "Help text; {name} is the platform-default capability app name"
+  },
+  "capabilityOverride.icon": {
+    "message": "Custom icon",
+    "description": "Field label for a per-site capability app icon"
+  },
+  "capabilityOverride.defaultIcon": {
+    "message": "Default",
+    "description": "Label above the platform-default capability icon preview"
+  },
+  "capabilityOverride.currentIcon": {
+    "message": "Current",
+    "description": "Label above the effective capability icon preview"
+  },
+  "capabilityOverride.replaceIcon": {
+    "message": "Replace icon",
+    "description": "Command to upload a replacement capability icon"
+  },
+  "capabilityOverride.uploadIcon": {
+    "message": "Upload icon",
+    "description": "Command to upload the first custom capability icon"
+  },
+  "capabilityOverride.useDefaultIcon": {
+    "message": "Use default icon",
+    "description": "Command to clear the custom icon draft"
+  },
+  "capabilityOverride.iconTip": {
+    "message": "PNG, JPEG, or WebP. The image is cropped to a square; transparent PNG is preserved.",
+    "description": "Capability icon upload requirements"
+  },
+  "capabilityOverride.editIcon": {
+    "message": "Edit app icon",
+    "description": "Title of the capability icon cropper dialog"
+  },
+  "capabilityOverride.resetAll": {
+    "message": "Restore defaults",
+    "description": "Command that removes both custom name and icon"
+  },
+  "capabilityOverride.empty": {
+    "message": "Enter a custom name or upload an icon first.",
+    "description": "Warning when attempting to create an empty override"
+  },
+  "capabilityOverride.saved": {
+    "message": "App customization saved",
+    "description": "Success message after saving a capability override"
+  },
+  "capabilityOverride.savedEnableTranslation": {
+    "message": "Saved. You can now enable automatic translation for the custom name.",
+    "description": "Success message after first save creates an override ID"
+  },
+  "capabilityOverride.saveFailed": {
+    "message": "Failed to save app customization",
+    "description": "Fallback error for capability override writes"
+  },
+  "capabilityOverride.resetConfirm": {
+    "message": "Restore the default name and icon for {name}?",
+    "description": "Confirmation message; {name} is the platform-default capability app name"
+  },
+  "capabilityOverride.resetDone": {
+    "message": "Default name and icon restored",
+    "description": "Success message after deleting a capability override"
+  },
+  "capabilityOverride.fetchFailed": {
+    "message": "Failed to load app customizations",
+    "description": "Error shown when capability override management rows cannot be loaded"
   }
 }

--- a/src/i18n/sr/site.json
+++ b/src/i18n/sr/site.json
@@ -889,5 +889,85 @@
   "message.featuresOmni": {
     "message": "Креирајте или уређујте видео-записе помоћу Omni модела на основу текста, слика и видео-референци.",
     "description": "Креирајте или уређујте видео-записе помоћу Omni модела на основу текста, слика и видео-референци."
+  },
+  "capabilityOverride.edit": {
+    "message": "Customize app",
+    "description": "Tooltip and accessible label for editing a capability app name and icon"
+  },
+  "capabilityOverride.dialogTitle": {
+    "message": "Customize {name}",
+    "description": "Dialog title; {name} is the platform-default capability app name"
+  },
+  "capabilityOverride.displayName": {
+    "message": "Custom name",
+    "description": "Field label for a per-site capability app display name"
+  },
+  "capabilityOverride.displayNameTip": {
+    "message": "Leave blank to use {name}. Save once before enabling automatic translation.",
+    "description": "Help text; {name} is the platform-default capability app name"
+  },
+  "capabilityOverride.icon": {
+    "message": "Custom icon",
+    "description": "Field label for a per-site capability app icon"
+  },
+  "capabilityOverride.defaultIcon": {
+    "message": "Default",
+    "description": "Label above the platform-default capability icon preview"
+  },
+  "capabilityOverride.currentIcon": {
+    "message": "Current",
+    "description": "Label above the effective capability icon preview"
+  },
+  "capabilityOverride.replaceIcon": {
+    "message": "Replace icon",
+    "description": "Command to upload a replacement capability icon"
+  },
+  "capabilityOverride.uploadIcon": {
+    "message": "Upload icon",
+    "description": "Command to upload the first custom capability icon"
+  },
+  "capabilityOverride.useDefaultIcon": {
+    "message": "Use default icon",
+    "description": "Command to clear the custom icon draft"
+  },
+  "capabilityOverride.iconTip": {
+    "message": "PNG, JPEG, or WebP. The image is cropped to a square; transparent PNG is preserved.",
+    "description": "Capability icon upload requirements"
+  },
+  "capabilityOverride.editIcon": {
+    "message": "Edit app icon",
+    "description": "Title of the capability icon cropper dialog"
+  },
+  "capabilityOverride.resetAll": {
+    "message": "Restore defaults",
+    "description": "Command that removes both custom name and icon"
+  },
+  "capabilityOverride.empty": {
+    "message": "Enter a custom name or upload an icon first.",
+    "description": "Warning when attempting to create an empty override"
+  },
+  "capabilityOverride.saved": {
+    "message": "App customization saved",
+    "description": "Success message after saving a capability override"
+  },
+  "capabilityOverride.savedEnableTranslation": {
+    "message": "Saved. You can now enable automatic translation for the custom name.",
+    "description": "Success message after first save creates an override ID"
+  },
+  "capabilityOverride.saveFailed": {
+    "message": "Failed to save app customization",
+    "description": "Fallback error for capability override writes"
+  },
+  "capabilityOverride.resetConfirm": {
+    "message": "Restore the default name and icon for {name}?",
+    "description": "Confirmation message; {name} is the platform-default capability app name"
+  },
+  "capabilityOverride.resetDone": {
+    "message": "Default name and icon restored",
+    "description": "Success message after deleting a capability override"
+  },
+  "capabilityOverride.fetchFailed": {
+    "message": "Failed to load app customizations",
+    "description": "Error shown when capability override management rows cannot be loaded"
   }
 }

--- a/src/i18n/sv/site.json
+++ b/src/i18n/sv/site.json
@@ -889,5 +889,85 @@
   "message.featuresOmni": {
     "message": "Skapa eller redigera videor med Omni-modeller utifrån text, bilder och videoreferenser.",
     "description": "Skapa eller redigera videor med Omni-modeller utifrån text, bilder och videoreferenser."
+  },
+  "capabilityOverride.edit": {
+    "message": "Customize app",
+    "description": "Tooltip and accessible label for editing a capability app name and icon"
+  },
+  "capabilityOverride.dialogTitle": {
+    "message": "Customize {name}",
+    "description": "Dialog title; {name} is the platform-default capability app name"
+  },
+  "capabilityOverride.displayName": {
+    "message": "Custom name",
+    "description": "Field label for a per-site capability app display name"
+  },
+  "capabilityOverride.displayNameTip": {
+    "message": "Leave blank to use {name}. Save once before enabling automatic translation.",
+    "description": "Help text; {name} is the platform-default capability app name"
+  },
+  "capabilityOverride.icon": {
+    "message": "Custom icon",
+    "description": "Field label for a per-site capability app icon"
+  },
+  "capabilityOverride.defaultIcon": {
+    "message": "Default",
+    "description": "Label above the platform-default capability icon preview"
+  },
+  "capabilityOverride.currentIcon": {
+    "message": "Current",
+    "description": "Label above the effective capability icon preview"
+  },
+  "capabilityOverride.replaceIcon": {
+    "message": "Replace icon",
+    "description": "Command to upload a replacement capability icon"
+  },
+  "capabilityOverride.uploadIcon": {
+    "message": "Upload icon",
+    "description": "Command to upload the first custom capability icon"
+  },
+  "capabilityOverride.useDefaultIcon": {
+    "message": "Use default icon",
+    "description": "Command to clear the custom icon draft"
+  },
+  "capabilityOverride.iconTip": {
+    "message": "PNG, JPEG, or WebP. The image is cropped to a square; transparent PNG is preserved.",
+    "description": "Capability icon upload requirements"
+  },
+  "capabilityOverride.editIcon": {
+    "message": "Edit app icon",
+    "description": "Title of the capability icon cropper dialog"
+  },
+  "capabilityOverride.resetAll": {
+    "message": "Restore defaults",
+    "description": "Command that removes both custom name and icon"
+  },
+  "capabilityOverride.empty": {
+    "message": "Enter a custom name or upload an icon first.",
+    "description": "Warning when attempting to create an empty override"
+  },
+  "capabilityOverride.saved": {
+    "message": "App customization saved",
+    "description": "Success message after saving a capability override"
+  },
+  "capabilityOverride.savedEnableTranslation": {
+    "message": "Saved. You can now enable automatic translation for the custom name.",
+    "description": "Success message after first save creates an override ID"
+  },
+  "capabilityOverride.saveFailed": {
+    "message": "Failed to save app customization",
+    "description": "Fallback error for capability override writes"
+  },
+  "capabilityOverride.resetConfirm": {
+    "message": "Restore the default name and icon for {name}?",
+    "description": "Confirmation message; {name} is the platform-default capability app name"
+  },
+  "capabilityOverride.resetDone": {
+    "message": "Default name and icon restored",
+    "description": "Success message after deleting a capability override"
+  },
+  "capabilityOverride.fetchFailed": {
+    "message": "Failed to load app customizations",
+    "description": "Error shown when capability override management rows cannot be loaded"
   }
 }

--- a/src/i18n/uk/site.json
+++ b/src/i18n/uk/site.json
@@ -889,5 +889,85 @@
   "message.featuresOmni": {
     "message": "Створюйте або редагуйте відео за допомогою моделей Omni на основі тексту, зображень і відеореференсів.",
     "description": "Створюйте або редагуйте відео за допомогою моделей Omni на основі тексту, зображень і відеореференсів."
+  },
+  "capabilityOverride.edit": {
+    "message": "Customize app",
+    "description": "Tooltip and accessible label for editing a capability app name and icon"
+  },
+  "capabilityOverride.dialogTitle": {
+    "message": "Customize {name}",
+    "description": "Dialog title; {name} is the platform-default capability app name"
+  },
+  "capabilityOverride.displayName": {
+    "message": "Custom name",
+    "description": "Field label for a per-site capability app display name"
+  },
+  "capabilityOverride.displayNameTip": {
+    "message": "Leave blank to use {name}. Save once before enabling automatic translation.",
+    "description": "Help text; {name} is the platform-default capability app name"
+  },
+  "capabilityOverride.icon": {
+    "message": "Custom icon",
+    "description": "Field label for a per-site capability app icon"
+  },
+  "capabilityOverride.defaultIcon": {
+    "message": "Default",
+    "description": "Label above the platform-default capability icon preview"
+  },
+  "capabilityOverride.currentIcon": {
+    "message": "Current",
+    "description": "Label above the effective capability icon preview"
+  },
+  "capabilityOverride.replaceIcon": {
+    "message": "Replace icon",
+    "description": "Command to upload a replacement capability icon"
+  },
+  "capabilityOverride.uploadIcon": {
+    "message": "Upload icon",
+    "description": "Command to upload the first custom capability icon"
+  },
+  "capabilityOverride.useDefaultIcon": {
+    "message": "Use default icon",
+    "description": "Command to clear the custom icon draft"
+  },
+  "capabilityOverride.iconTip": {
+    "message": "PNG, JPEG, or WebP. The image is cropped to a square; transparent PNG is preserved.",
+    "description": "Capability icon upload requirements"
+  },
+  "capabilityOverride.editIcon": {
+    "message": "Edit app icon",
+    "description": "Title of the capability icon cropper dialog"
+  },
+  "capabilityOverride.resetAll": {
+    "message": "Restore defaults",
+    "description": "Command that removes both custom name and icon"
+  },
+  "capabilityOverride.empty": {
+    "message": "Enter a custom name or upload an icon first.",
+    "description": "Warning when attempting to create an empty override"
+  },
+  "capabilityOverride.saved": {
+    "message": "App customization saved",
+    "description": "Success message after saving a capability override"
+  },
+  "capabilityOverride.savedEnableTranslation": {
+    "message": "Saved. You can now enable automatic translation for the custom name.",
+    "description": "Success message after first save creates an override ID"
+  },
+  "capabilityOverride.saveFailed": {
+    "message": "Failed to save app customization",
+    "description": "Fallback error for capability override writes"
+  },
+  "capabilityOverride.resetConfirm": {
+    "message": "Restore the default name and icon for {name}?",
+    "description": "Confirmation message; {name} is the platform-default capability app name"
+  },
+  "capabilityOverride.resetDone": {
+    "message": "Default name and icon restored",
+    "description": "Success message after deleting a capability override"
+  },
+  "capabilityOverride.fetchFailed": {
+    "message": "Failed to load app customizations",
+    "description": "Error shown when capability override management rows cannot be loaded"
   }
 }

--- a/src/i18n/zh-CN/site.json
+++ b/src/i18n/zh-CN/site.json
@@ -890,5 +890,85 @@
   },
   "services.message.fetchFailed": {
     "message": "加载服务覆盖失败"
+  },
+  "capabilityOverride.edit": {
+    "message": "自定义应用",
+    "description": "编辑能力应用名称和图标的提示与无障碍标签"
+  },
+  "capabilityOverride.dialogTitle": {
+    "message": "自定义 {name}",
+    "description": "弹窗标题，{name} 为平台默认应用名称"
+  },
+  "capabilityOverride.displayName": {
+    "message": "自定义名称",
+    "description": "子站能力应用显示名称字段"
+  },
+  "capabilityOverride.displayNameTip": {
+    "message": "留空则使用 {name}。首次保存后可开启自动翻译。",
+    "description": "名称说明，{name} 为平台默认应用名称"
+  },
+  "capabilityOverride.icon": {
+    "message": "自定义图标",
+    "description": "子站能力应用图标字段"
+  },
+  "capabilityOverride.defaultIcon": {
+    "message": "默认",
+    "description": "平台默认图标预览标签"
+  },
+  "capabilityOverride.currentIcon": {
+    "message": "当前效果",
+    "description": "当前生效图标预览标签"
+  },
+  "capabilityOverride.replaceIcon": {
+    "message": "替换图标",
+    "description": "上传替换图标的命令"
+  },
+  "capabilityOverride.uploadIcon": {
+    "message": "上传图标",
+    "description": "首次上传自定义图标的命令"
+  },
+  "capabilityOverride.useDefaultIcon": {
+    "message": "使用默认图标",
+    "description": "清除自定义图标草稿的命令"
+  },
+  "capabilityOverride.iconTip": {
+    "message": "支持 PNG、JPEG 或 WebP，将裁剪为正方形；透明 PNG 会保留透明背景。",
+    "description": "能力应用图标上传要求"
+  },
+  "capabilityOverride.editIcon": {
+    "message": "编辑应用图标",
+    "description": "图标裁剪弹窗标题"
+  },
+  "capabilityOverride.resetAll": {
+    "message": "恢复默认",
+    "description": "同时删除自定义名称和图标的命令"
+  },
+  "capabilityOverride.empty": {
+    "message": "请先输入自定义名称或上传图标。",
+    "description": "尝试创建空覆盖时的提示"
+  },
+  "capabilityOverride.saved": {
+    "message": "应用自定义已保存",
+    "description": "保存能力应用覆盖后的成功提示"
+  },
+  "capabilityOverride.savedEnableTranslation": {
+    "message": "已保存，现在可以为自定义名称开启自动翻译。",
+    "description": "首次保存并获得覆盖记录 ID 后的提示"
+  },
+  "capabilityOverride.saveFailed": {
+    "message": "保存应用自定义失败",
+    "description": "能力应用覆盖写入失败的兜底错误"
+  },
+  "capabilityOverride.resetConfirm": {
+    "message": "恢复 {name} 的默认名称和图标？",
+    "description": "恢复确认文案，{name} 为平台默认应用名称"
+  },
+  "capabilityOverride.resetDone": {
+    "message": "已恢复默认名称和图标",
+    "description": "删除能力应用覆盖后的成功提示"
+  },
+  "capabilityOverride.fetchFailed": {
+    "message": "加载应用自定义失败",
+    "description": "无法读取能力应用覆盖管理记录时的错误"
   }
 }

--- a/src/i18n/zh-TW/site.json
+++ b/src/i18n/zh-TW/site.json
@@ -889,5 +889,85 @@
   "message.featuresOmni": {
     "message": "使用 Omni 模型，根據文字、圖片和影片參考生成或編輯影片。",
     "description": "使用 Omni 模型，根據文字、圖片和影片參考生成或編輯影片。"
+  },
+  "capabilityOverride.edit": {
+    "message": "Customize app",
+    "description": "Tooltip and accessible label for editing a capability app name and icon"
+  },
+  "capabilityOverride.dialogTitle": {
+    "message": "Customize {name}",
+    "description": "Dialog title; {name} is the platform-default capability app name"
+  },
+  "capabilityOverride.displayName": {
+    "message": "Custom name",
+    "description": "Field label for a per-site capability app display name"
+  },
+  "capabilityOverride.displayNameTip": {
+    "message": "Leave blank to use {name}. Save once before enabling automatic translation.",
+    "description": "Help text; {name} is the platform-default capability app name"
+  },
+  "capabilityOverride.icon": {
+    "message": "Custom icon",
+    "description": "Field label for a per-site capability app icon"
+  },
+  "capabilityOverride.defaultIcon": {
+    "message": "Default",
+    "description": "Label above the platform-default capability icon preview"
+  },
+  "capabilityOverride.currentIcon": {
+    "message": "Current",
+    "description": "Label above the effective capability icon preview"
+  },
+  "capabilityOverride.replaceIcon": {
+    "message": "Replace icon",
+    "description": "Command to upload a replacement capability icon"
+  },
+  "capabilityOverride.uploadIcon": {
+    "message": "Upload icon",
+    "description": "Command to upload the first custom capability icon"
+  },
+  "capabilityOverride.useDefaultIcon": {
+    "message": "Use default icon",
+    "description": "Command to clear the custom icon draft"
+  },
+  "capabilityOverride.iconTip": {
+    "message": "PNG, JPEG, or WebP. The image is cropped to a square; transparent PNG is preserved.",
+    "description": "Capability icon upload requirements"
+  },
+  "capabilityOverride.editIcon": {
+    "message": "Edit app icon",
+    "description": "Title of the capability icon cropper dialog"
+  },
+  "capabilityOverride.resetAll": {
+    "message": "Restore defaults",
+    "description": "Command that removes both custom name and icon"
+  },
+  "capabilityOverride.empty": {
+    "message": "Enter a custom name or upload an icon first.",
+    "description": "Warning when attempting to create an empty override"
+  },
+  "capabilityOverride.saved": {
+    "message": "App customization saved",
+    "description": "Success message after saving a capability override"
+  },
+  "capabilityOverride.savedEnableTranslation": {
+    "message": "Saved. You can now enable automatic translation for the custom name.",
+    "description": "Success message after first save creates an override ID"
+  },
+  "capabilityOverride.saveFailed": {
+    "message": "Failed to save app customization",
+    "description": "Fallback error for capability override writes"
+  },
+  "capabilityOverride.resetConfirm": {
+    "message": "Restore the default name and icon for {name}?",
+    "description": "Confirmation message; {name} is the platform-default capability app name"
+  },
+  "capabilityOverride.resetDone": {
+    "message": "Default name and icon restored",
+    "description": "Success message after deleting a capability override"
+  },
+  "capabilityOverride.fetchFailed": {
+    "message": "Failed to load app customizations",
+    "description": "Error shown when capability override management rows cannot be loaded"
   }
 }

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -35,6 +35,7 @@ export * from './webextrator';
 export * from './fish';
 export * from './site';
 export * from './siteServiceOverride';
+export * from './siteCapabilityOverride';
 export * from './site_domain';
 export * from './exchange';
 export * from './error';

--- a/src/models/site.ts
+++ b/src/models/site.ts
@@ -1,3 +1,10 @@
+import type { CapabilityKey } from '@/constants/capabilities';
+
+export interface ISiteCapabilityFeature {
+  enabled?: boolean;
+  [key: string]: unknown;
+}
+
 export interface ISiteFeatures {
   chatgpt?: any;
   deepseek?: any;
@@ -32,6 +39,11 @@ export interface ISiteFeatures {
   codingBridge?: any;
   support?: any;
   subsite?: ISiteSubsiteFeature;
+}
+
+export interface ISiteCapabilityPresentation {
+  display_name?: string | null;
+  icon_url?: string | null;
 }
 
 export interface ISiteSubsiteFeature {
@@ -184,6 +196,7 @@ export interface ISite {
   title_source?: string;
   description_source?: string;
   auto_translated_fields?: string[];
+  capability_overrides?: Partial<Record<CapabilityKey, ISiteCapabilityPresentation>>;
 }
 
 export interface ISiteListResponse {

--- a/src/models/siteCapabilityOverride.ts
+++ b/src/models/siteCapabilityOverride.ts
@@ -1,0 +1,31 @@
+export interface ISiteCapabilityOverride {
+  id?: string;
+  site?: string;
+  capability?: string;
+  display_name?: string | null;
+  display_name_source?: string | null;
+  icon_url?: string | null;
+  auto_translated_fields?: string[];
+  user_id?: string | null;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface ISiteCapabilityOverrideListResponse {
+  count: number;
+  items: ISiteCapabilityOverride[];
+}
+
+export type ISiteCapabilityOverrideDetailResponse = ISiteCapabilityOverride;
+
+export interface ISiteCapabilityOverrideCreateRequest {
+  site: string;
+  capability: string;
+  display_name?: string | null;
+  icon_url?: string | null;
+}
+
+export interface ISiteCapabilityOverrideUpdateRequest {
+  display_name?: string | null;
+  icon_url?: string | null;
+}

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -24,6 +24,7 @@ export * from './flux';
 export * from './hailuo';
 export * from './site';
 export * from './siteServiceOverride';
+export * from './siteCapabilityOverride';
 export * from './site_domain';
 export * from './smsWebhook';
 export * from './translation';

--- a/src/operators/siteCapabilityOverride.test.ts
+++ b/src/operators/siteCapabilityOverride.test.ts
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const http = vi.hoisted(() => ({ get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() }));
+
+vi.mock('./common', () => ({ httpClient: http }));
+
+import { siteCapabilityOverrideOperator } from './siteCapabilityOverride';
+
+describe('siteCapabilityOverrideOperator', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('uses the site capability override endpoints', async () => {
+    http.get.mockResolvedValue({ data: { count: 0, items: [] } });
+    http.post.mockResolvedValue({ data: { id: 'override-1' } });
+    http.patch.mockResolvedValue({ data: { id: 'override-1' } });
+    http.delete.mockResolvedValue({ data: undefined });
+
+    await siteCapabilityOverrideOperator.getAll({ site: 'site-1' });
+    await siteCapabilityOverrideOperator.create({ site: 'site-1', capability: 'chatgpt', display_name: 'Assistant' });
+    await siteCapabilityOverrideOperator.update('override-1', { icon_url: 'https://cdn.example.com/icon.png' });
+    await siteCapabilityOverrideOperator.delete('override-1');
+
+    expect(http.get).toHaveBeenCalledWith('/site-capability-overrides/', { params: { site: 'site-1' } });
+    expect(http.post).toHaveBeenCalledWith('/site-capability-overrides/', {
+      site: 'site-1',
+      capability: 'chatgpt',
+      display_name: 'Assistant'
+    });
+    expect(http.patch).toHaveBeenCalledWith('/site-capability-overrides/override-1/', {
+      icon_url: 'https://cdn.example.com/icon.png'
+    });
+    expect(http.delete).toHaveBeenCalledWith('/site-capability-overrides/override-1/');
+  });
+});

--- a/src/operators/siteCapabilityOverride.ts
+++ b/src/operators/siteCapabilityOverride.ts
@@ -1,0 +1,42 @@
+import type { AxiosResponse } from 'axios';
+import { httpClient } from './common';
+import type {
+  ISiteCapabilityOverrideCreateRequest,
+  ISiteCapabilityOverrideDetailResponse,
+  ISiteCapabilityOverrideListResponse,
+  ISiteCapabilityOverrideUpdateRequest
+} from '@/models';
+
+export interface ISiteCapabilityOverrideQuery {
+  site?: string;
+  capability?: string;
+  offset?: number;
+  limit?: number;
+}
+
+class SiteCapabilityOverrideOperator {
+  key = 'site-capability-overrides';
+
+  async getAll(query?: ISiteCapabilityOverrideQuery): Promise<AxiosResponse<ISiteCapabilityOverrideListResponse>> {
+    return await httpClient.get(`/${this.key}/`, { params: query });
+  }
+
+  async create(
+    data: ISiteCapabilityOverrideCreateRequest
+  ): Promise<AxiosResponse<ISiteCapabilityOverrideDetailResponse>> {
+    return await httpClient.post(`/${this.key}/`, data);
+  }
+
+  async update(
+    id: string,
+    data: ISiteCapabilityOverrideUpdateRequest
+  ): Promise<AxiosResponse<ISiteCapabilityOverrideDetailResponse>> {
+    return await httpClient.patch(`/${this.key}/${id}/`, data);
+  }
+
+  async delete(id: string): Promise<AxiosResponse<void>> {
+    return await httpClient.delete(`/${this.key}/${id}/`);
+  }
+}
+
+export const siteCapabilityOverrideOperator = new SiteCapabilityOverrideOperator();

--- a/src/utils/capabilityPresentation.test.ts
+++ b/src/utils/capabilityPresentation.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { resolveCapabilityPresentation } from './capabilityPresentation';
+
+describe('resolveCapabilityPresentation', () => {
+  it('uses platform defaults when no override exists', () => {
+    expect(resolveCapabilityPresentation(undefined, 'chatgpt', 'ChatGPT', '/chatgpt.png')).toEqual({
+      displayName: 'ChatGPT',
+      iconUrl: '/chatgpt.png',
+      isOverridden: false
+    });
+  });
+
+  it('resolves name and icon independently', () => {
+    expect(
+      resolveCapabilityPresentation(
+        { capability_overrides: { chatgpt: { display_name: '  My Assistant  ', icon_url: null } } },
+        'chatgpt',
+        'ChatGPT',
+        '/chatgpt.png'
+      )
+    ).toEqual({ displayName: 'My Assistant', iconUrl: '/chatgpt.png', isOverridden: true });
+
+    expect(
+      resolveCapabilityPresentation(
+        { capability_overrides: { grok: { display_name: '', icon_url: 'https://cdn.example.com/grok.png' } } },
+        'grok',
+        'Grok',
+        '/grok.png'
+      )
+    ).toEqual({ displayName: 'Grok', iconUrl: 'https://cdn.example.com/grok.png', isOverridden: true });
+  });
+});

--- a/src/utils/capabilityPresentation.ts
+++ b/src/utils/capabilityPresentation.ts
@@ -1,0 +1,24 @@
+import type { CapabilityKey } from '@/constants/capabilities';
+import type { ISite } from '@/models';
+
+export interface CapabilityPresentation {
+  displayName: string;
+  iconUrl: string;
+  isOverridden: boolean;
+}
+
+export function resolveCapabilityPresentation(
+  site: ISite | null | undefined,
+  capability: CapabilityKey,
+  defaultDisplayName: string,
+  defaultIconUrl: string
+): CapabilityPresentation {
+  const override = site?.capability_overrides?.[capability];
+  const displayName = override?.display_name?.trim() || defaultDisplayName;
+  const iconUrl = override?.icon_url?.trim() || defaultIconUrl;
+  return {
+    displayName,
+    iconUrl,
+    isOverridden: displayName !== defaultDisplayName || iconUrl !== defaultIconUrl
+  };
+}

--- a/src/utils/site.ts
+++ b/src/utils/site.ts
@@ -28,6 +28,17 @@ import { isNative, isDesktop } from './surface';
  */
 const STUDIO_HOST = 'studio.acedata.cloud';
 
+export const toWritableSitePayload = (site: ISite): ISite => {
+  const {
+    capability_overrides: _capabilityOverrides,
+    title_source: _titleSource,
+    description_source: _descriptionSource,
+    auto_translated_fields: _autoTranslatedFields,
+    ...writableSite
+  } = site;
+  return writableSite;
+};
+
 export const getSiteOrigin = (site?: ISite) => {
   // If we already have a Site row, trust its stored origin.
   if (site?.origin) {

--- a/src/utils/site.writablePayload.test.ts
+++ b/src/utils/site.writablePayload.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { toWritableSitePayload } from './site';
+
+describe('toWritableSitePayload', () => {
+  it('keeps writable Site data and removes server-derived fields', () => {
+    expect(
+      toWritableSitePayload({
+        id: 'site-1',
+        title: 'Demo',
+        title_source: '源标题',
+        description_source: '源描述',
+        auto_translated_fields: ['title'],
+        features: { chatgpt: { enabled: true } },
+        capability_overrides: {
+          chatgpt: { display_name: 'Custom Chat', icon_url: 'https://cdn.example.com/chat.png' }
+        }
+      })
+    ).toEqual({
+      id: 'site-1',
+      title: 'Demo',
+      features: { chatgpt: { enabled: true } }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add a compact edit action to every Settings > Capabilities row for per-site app names and square icons.
- Reuse the existing image crop/upload flow and per-field auto-translation toggle, including create, edit, partial fallback, and restore-default behavior.
- Apply the effective presentation to Settings and every Navigator surface, with bundled-icon fallback on image load failure.
- Keep all Site PUT paths from echoing server-derived localization and capability override fields.
- Add typed CRUD operators, shared presentation/payload helpers, full locale coverage, and focused tests.

Depends on https://github.com/AceDataCloud/PlatformBackend/pull/997 and must deploy after it.

## Validation

- full Vitest: **51 files / 465 tests passed**
- focused capability/write-contract Vitest: **6 files / 11 tests passed**
- ESLint on all touched TypeScript/Vue files
- `vue-tsc -b --force`
- production Vite web build
- i18n coverage: **17 locales × 44 namespaces**
- `beachball check`
- standalone Playwright at 1280×800 and 390×844: custom long name, translated source, icon preview, reset action, no body/dialog/row horizontal overflow

## Adversarial review

Independent Explore review, 3 rounds. Fixed the valid findings by stripping all server-derived Site fields from every full Site PUT through one tested helper. Rebutted retry amplification on override-fetch failure (toast + safe defaults is the intended fallback), URL text validation (icons are upload-only), speculative >100 pagination (registry is fixed at 31), and optimistic locking (site settings remain last-write-wins). Final verdict: **CLEAN**.