### PR TITLE
feat(veo): enrich generation task details

### DIFF
--- a/change/@acedatacloud-nexior-19bb8fef-2ba3-43c6-9004-f4b5d473ea97.json
+++ b/change/@acedatacloud-nexior-19bb8fef-2ba3-43c6-9004-f4b5d473ea97.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Improve Veo action labels, reference previews, and task metadata.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/veo/config/ActionSelector.test.ts
+++ b/src/components/veo/config/ActionSelector.test.ts
@@ -1,0 +1,47 @@
+// @vitest-environment jsdom
+import { shallowMount } from '@vue/test-utils';
+import { describe, expect, it, vi } from 'vitest';
+
+import ActionSelector from './ActionSelector.vue';
+
+describe('veo/config/ActionSelector', () => {
+  it('uses explicit video-generation names for every action', () => {
+    const wrapper = shallowMount(ActionSelector, {
+      global: {
+        mocks: {
+          $t: (key: string) => key,
+          $store: {
+            state: { veo: { config: { action: 'text2video' } } },
+            commit: vi.fn()
+          }
+        }
+      }
+    });
+
+    expect((wrapper.vm as unknown as { options: { label: string }[] }).options.map(({ label }) => label)).toEqual([
+      'veo.button.action1',
+      'veo.button.action2',
+      'veo.button.actionIngredients'
+    ]);
+  });
+
+  it('accepts long unbroken translated labels', () => {
+    const wrapper = shallowMount(ActionSelector, {
+      global: {
+        mocks: {
+          $t: () => 'Monikuvayhdistelmävideot',
+          $store: {
+            state: { veo: { config: { action: 'ingredients2video' } } },
+            commit: vi.fn()
+          }
+        }
+      }
+    });
+
+    expect(
+      (wrapper.vm as unknown as { options: { label: string }[] }).options.every(
+        ({ label }) => label === 'Monikuvayhdistelmävideot'
+      )
+    ).toBe(true);
+  });
+});

--- a/src/components/veo/config/ActionSelector.vue
+++ b/src/components/veo/config/ActionSelector.vue
@@ -24,15 +24,15 @@ export default defineComponent({
       return [
         {
           value: 'text2video',
-          label: this.$t('veo.button.actionTabText')
+          label: this.$t('veo.button.action1')
         },
         {
           value: 'image2video',
-          label: this.$t('veo.button.actionTabImage')
+          label: this.$t('veo.button.action2')
         },
         {
           value: 'ingredients2video',
-          label: this.$t('veo.button.actionTabIngredients')
+          label: this.$t('veo.button.actionIngredients')
         }
       ];
     },
@@ -60,6 +60,7 @@ export default defineComponent({
 .action-tabs {
   :deep(.el-tabs__header) {
     margin: 0;
+    height: 64px;
   }
 
   :deep(.el-tabs__nav-wrap::after) {
@@ -68,11 +69,17 @@ export default defineComponent({
 
   :deep(.el-tabs__nav-scroll) {
     overflow: visible;
+    height: 64px;
   }
 
   :deep(.el-tabs__nav) {
     width: 100%;
+    height: 64px;
     transform: none !important;
+  }
+
+  :deep(.el-tabs__nav-wrap) {
+    height: 64px;
   }
 
   :deep(.el-tabs__nav-prev),
@@ -87,13 +94,18 @@ export default defineComponent({
   :deep(.el-tabs__item) {
     flex: 1;
     min-width: 0;
-    height: 40px;
+    height: 64px;
     padding: 0 6px;
     border-bottom: 2px solid transparent;
     font-size: 12px;
-    line-height: 40px;
+    line-height: 16px;
     letter-spacing: 0;
     text-align: center;
+    white-space: normal;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+    align-items: center;
+    justify-content: center;
   }
 
   :deep(.el-tabs__item.is-active) {

--- a/src/components/veo/task/Preview.test.ts
+++ b/src/components/veo/task/Preview.test.ts
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+import { shallowMount } from '@vue/test-utils';
+import { describe, expect, it, vi } from 'vitest';
+import type { IVeoTask } from '@/models';
+
+vi.mock('@/components/common/VideoPlayer.vue', () => ({
+  default: { name: 'VideoPlayer', template: '<div />' }
+}));
+
+import TaskPreview from './Preview.vue';
+
+const task: IVeoTask = {
+  id: 'veo-task',
+  trace_id: 'task-trace',
+  created_at: 1,
+  elapsed: 42.125,
+  request: {
+    action: 'image2video',
+    model: 'veo31-fast',
+    prompt: 'Walk toward the camera',
+    image_urls: ['https://cdn.example.com/start.jpg', 'https://cdn.example.com/end.jpg'],
+    aspect_ratio: '16:9',
+    translation: true
+  },
+  response: {
+    success: true,
+    task_id: 'veo-task',
+    trace_id: 'response-trace',
+    data: [{ state: 'succeeded', video_url: 'https://cdn.example.com/result.mp4' }]
+  }
+};
+
+const mountPreview = (modelValue = task) =>
+  shallowMount(TaskPreview, {
+    props: { modelValue },
+    global: {
+      stubs: {
+        ElAlert: { template: '<div><slot /><slot name="template" /></div>' }
+      },
+      mocks: {
+        $t: (key: string) => key,
+        $dayjs: { format: () => '' }
+      }
+    }
+  });
+
+describe('veo/task/Preview', () => {
+  it('shows reference images and complete generation metadata', () => {
+    const wrapper = mountPreview();
+
+    expect(wrapper.findAllComponents({ name: 'ImagePreview' }).map((preview) => preview.props('url'))).toEqual([
+      'https://cdn.example.com/start.jpg',
+      'https://cdn.example.com/end.jpg'
+    ]);
+    expect(wrapper.text()).toContain('veo.name.action');
+    expect(wrapper.text()).toContain('veo.button.action2');
+    expect(wrapper.text()).toContain('16:9');
+    expect(wrapper.text()).toContain('seedance.button.on');
+    expect(wrapper.text()).toContain('veo-task');
+    expect(wrapper.text()).toContain('42.13s');
+    expect(wrapper.text()).toContain('response-trace');
+  });
+
+  it('infers image-to-video for legacy tasks with images but no action', () => {
+    const legacyTask = {
+      ...task,
+      request: {
+        ...task.request,
+        action: undefined
+      }
+    };
+
+    expect((mountPreview(legacyTask).vm as unknown as { actionLabel: string }).actionLabel).toBe('veo.button.action2');
+  });
+
+  it('infers ingredients mode for legacy tasks and ignores malformed image lists', () => {
+    const ingredientsTask = {
+      ...task,
+      request: {
+        ...task.request,
+        action: undefined,
+        model: 'veo31-fast-ingredients'
+      }
+    };
+    expect((mountPreview(ingredientsTask).vm as unknown as { actionLabel: string }).actionLabel).toBe(
+      'veo.button.actionIngredients'
+    );
+
+    const malformedTask = {
+      ...task,
+      request: {
+        ...task.request,
+        image_urls: 'https://cdn.example.com/not-an-array.jpg'
+      }
+    } as unknown as IVeoTask;
+    expect(() => mountPreview(malformedTask)).not.toThrow();
+  });
+});

--- a/src/components/veo/task/Preview.vue
+++ b/src/components/veo/task/Preview.vue
@@ -11,6 +11,18 @@
         </span>
       </div>
       <div class="info">
+        <div
+          v-if="referenceImages.length > 0"
+          class="flex justify-start items-center gap-2 mt-2 w-full overflow-x-auto"
+        >
+          <image-preview
+            v-for="(url, idx) in referenceImages"
+            :key="`${idx}-${url}`"
+            :url="url"
+            :name="`reference-${idx + 1}`"
+            :closable="false"
+          />
+        </div>
         <p v-if="modelValue?.request?.prompt" class="prompt mt-2">
           {{ modelValue?.request?.prompt }}
           <span v-if="!modelValue?.response"> - ({{ $t('veo.status.pending') }}) </span>
@@ -19,7 +31,6 @@
           </span>
         </p>
       </div>
-      <!-- Display success message -->
       <div
         v-if="modelValue?.response?.success === true && modelValue?.response?.data"
         :class="{ content: true, failed: true }"
@@ -41,25 +52,7 @@
           </el-tooltip>
           <api-code-button path="/veo/videos" :body="modelValue?.request" />
         </div>
-        <el-alert :closable="false" class="mt-2 success">
-          <p class="text-[var(--el-text-color-regular)] text-xs mb-2">
-            <font-awesome-icon icon="fa-solid fa-hashtag" class="mr-1" />
-            {{ $t('veo.name.model') }}:
-            {{ modelValue?.request?.model }}
-          </p>
-          <p class="text-[var(--el-text-color-regular)] text-xs mb-2">
-            <font-awesome-icon icon="fa-solid fa-magic" class="mr-1" />
-            {{ $t('veo.name.taskId') }}:
-            {{ modelValue?.id }}
-            <copy-to-clipboard :content="modelValue?.id!" />
-          </p>
-          <p v-if="modelValue?.elapsed" class="text-[var(--el-text-color-regular)] text-xs mb-0">
-            <font-awesome-icon icon="fa-solid fa-clock" class="mr-1" />
-            {{ $t('veo.name.elapsed') }}: {{ modelValue?.elapsed?.toFixed(2) }}s
-          </p>
-        </el-alert>
       </div>
-      <!-- Display error message -->
       <div v-if="modelValue?.response?.success === false" :class="{ content: true }">
         <el-alert :closable="false" class="failure">
           <template #template>
@@ -67,47 +60,53 @@
             {{ $t('veo.name.failure') }}
           </template>
           <p class="text-[var(--el-text-color-regular)] text-xs mb-2">
-            <font-awesome-icon icon="fa-solid fa-magic" class="mr-1" />
-            {{ $t('veo.name.taskId') }}:
-            {{ modelValue?.id }}
-            <copy-to-clipboard :content="modelValue?.id!" />
-          </p>
-          <p class="text-[var(--el-text-color-regular)] text-xs mb-2">
             <font-awesome-icon icon="fa-solid fa-circle-info" class="mr-1" />
             {{ $t('veo.name.failureReason') }}:
             {{ modelValue?.response?.error?.message }}
             <copy-to-clipboard :content="modelValue?.response?.error?.message!" />
           </p>
-          <p v-if="modelValue?.elapsed" class="text-[var(--el-text-color-regular)] text-xs mb-2">
-            <font-awesome-icon icon="fa-solid fa-clock" class="mr-1" />
-            {{ $t('veo.name.elapsed') }}: {{ modelValue?.elapsed?.toFixed(2) }}s
-          </p>
-          <p v-if="modelValue?.response?.trace_id" class="text-[var(--el-text-color-regular)] text-xs mb-0">
-            <font-awesome-icon icon="fa-solid fa-hashtag" class="mr-1" />
-            {{ $t('veo.name.traceId') }}:
-            {{ modelValue?.response?.trace_id }}
-            <copy-to-clipboard :content="modelValue?.response?.trace_id" />
-          </p>
         </el-alert>
       </div>
-      <!-- Display error message -->
-      <div v-if="modelValue?.response?.success === undefined" :class="{ content: true }">
-        <el-alert :closable="false" class="info">
-          <template #template>
-            <font-awesome-icon icon="fa-solid fa-exclamation-triangle" class="mr-1" />
-            {{ $t('veo.name.failure') }}
-          </template>
+      <div :class="{ content: true }">
+        <el-alert :closable="false" :class="['mt-2', 'task-metadata', taskInfoClass]">
+          <p v-if="modelValue?.request?.model" class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <font-awesome-icon icon="fa-solid fa-cube" class="mr-1" />
+            {{ $t('veo.name.model') }}:
+            {{ modelValue?.request?.model }}
+          </p>
+          <p class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <font-awesome-icon icon="fa-solid fa-bolt" class="mr-1" />
+            {{ $t('veo.name.action') }}:
+            {{ actionLabel }}
+          </p>
+          <p v-if="modelValue?.request?.aspect_ratio" class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <font-awesome-icon icon="fa-solid fa-up-right-from-square" class="mr-1" />
+            {{ $t('veo.name.ratio') }}:
+            {{ modelValue?.request?.aspect_ratio }}
+          </p>
+          <p
+            v-if="modelValue?.request?.translation !== undefined"
+            class="text-[var(--el-text-color-regular)] text-xs mb-2"
+          >
+            <font-awesome-icon icon="fa-solid fa-language" class="mr-1" />
+            {{ $t('veo.name.translation') }}:
+            {{ $t(modelValue?.request?.translation ? 'seedance.button.on' : 'seedance.button.off') }}
+          </p>
           <p class="text-[var(--el-text-color-regular)] text-xs mb-2">
             <font-awesome-icon icon="fa-solid fa-magic" class="mr-1" />
             {{ $t('veo.name.taskId') }}:
             {{ modelValue?.id }}
-            <copy-to-clipboard :content="modelValue?.id!" />
+            <copy-to-clipboard :content="modelValue?.id!" class="btn-copy inline-block" />
           </p>
-          <p v-if="modelValue?.response?.trace_id" class="text-[var(--el-text-color-regular)] text-xs mb-0">
+          <p v-if="modelValue?.elapsed" class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <font-awesome-icon icon="fa-solid fa-clock" class="mr-1" />
+            {{ $t('veo.name.elapsed') }}: {{ modelValue?.elapsed?.toFixed(2) }}s
+          </p>
+          <p v-if="traceId" class="text-[var(--el-text-color-regular)] text-xs mb-0">
             <font-awesome-icon icon="fa-solid fa-hashtag" class="mr-1" />
             {{ $t('veo.name.traceId') }}:
-            {{ modelValue?.response?.trace_id }}
-            <copy-to-clipboard :content="modelValue?.response?.trace_id" />
+            {{ traceId }}
+            <copy-to-clipboard :content="traceId" class="btn-copy inline-block" />
           </p>
         </el-alert>
       </div>
@@ -122,6 +121,7 @@ import { IVeoTask } from '@/models';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import VideoPlayer from '@/components/common/VideoPlayer.vue';
+import ImagePreview from '@/components/common/ImagePreview.vue';
 import ApiCodeButton from '@/components/common/ApiCodeButton.vue';
 
 export default defineComponent({
@@ -132,6 +132,7 @@ export default defineComponent({
     FontAwesomeIcon,
     ElAlert,
     VideoPlayer,
+    ImagePreview,
     ElTooltip,
     ElButton,
     ApiCodeButton
@@ -146,11 +147,33 @@ export default defineComponent({
     return {};
   },
   computed: {
-    application() {
-      return this.$store.state.veo?.application;
+    referenceImages(): string[] {
+      const imageUrls = this.modelValue?.request?.image_urls;
+      return Array.isArray(imageUrls) ? imageUrls.filter((url): url is string => typeof url === 'string' && !!url) : [];
     },
-    config() {
-      return this.$store.state.veo?.config;
+    actionLabel(): string {
+      const request = this.modelValue?.request;
+      const inferredAction =
+        request?.model === 'veo31-fast-ingredients' || this.referenceImages.length > 2
+          ? 'ingredients2video'
+          : this.referenceImages.length > 0
+            ? 'image2video'
+            : 'text2video';
+      const action = request?.action || inferredAction;
+      const labels: Record<string, string> = {
+        text2video: 'veo.button.action1',
+        image2video: 'veo.button.action2',
+        ingredients2video: 'veo.button.actionIngredients'
+      };
+      return this.$t(labels[action] || 'veo.name.action') as string;
+    },
+    traceId(): string | undefined {
+      return this.modelValue?.response?.trace_id || this.modelValue?.trace_id;
+    },
+    taskInfoClass(): string {
+      if (this.modelValue?.response?.success === true) return 'success';
+      if (this.modelValue?.response?.success === false) return 'failure';
+      return 'info';
     }
   },
   methods: {
@@ -228,6 +251,11 @@ $left-width: 70px;
       .el-alert {
         border-left-width: 2px;
         border-left-style: solid;
+        &.task-metadata {
+          :deep(p) {
+            color: var(--el-text-color-regular);
+          }
+        }
         &.failure {
           border-color: var(--el-color-danger);
         }

--- a/src/models/veo.ts
+++ b/src/models/veo.ts
@@ -44,6 +44,8 @@ export interface IVeoGenerateResponse {
 
 export interface IVeoTask {
   id: string;
+  trace_id?: string;
+  status?: string;
   created_at?: number;
   elapsed?: number;
   request?: IVeoGenerateRequest;


### PR DESCRIPTION
## Summary
- show Veo reference-image thumbnails above each stored task prompt, matching Nano Banana and Seedance history cards
- replace ambiguous Text / Image / Ingredients tabs with localized full generation-mode names
- show a consistent metadata panel for pending, successful, and failed tasks: model, generation mode, aspect ratio, translation, task ID, elapsed time, and trace ID
- keep legacy task history readable by inferring mode from the persisted action/model/reference contract and tolerating malformed stored image lists

## Validation
- `npx vitest run src/components/veo/config/ActionSelector.test.ts src/components/veo/task/Preview.test.ts` (5 tests passed)
- `npx vue-tsc -b --force`
- `npm run build:web`
- `python3 scripts/check_i18n_coverage.py` (17 locales x 44 namespaces)
- `npx beachball check`
- ESLint and Prettier checks on all touched source/test files
- desktop and 390px browser validation with the real production Veo E2E task: no horizontal overflow, complete three-tab labels, reference image visible, metadata/trace ID visible

## Adversarial review
- reviewer: Codex, 2 rounds; final verdict: CLEAN
- RISK: duplicate reference URLs could produce duplicate Vue keys -> fixed with index + URL keys
- RISK: legacy 1-2 image ingredients tasks could be ambiguous -> not accepted: the Veo API/client contract requires `ingredients2video` to use `veo31-fast-ingredients`, and that model is checked before image-count inference; non-ingredients models with references are `image2video`
- prior review fixes retained: malformed `image_urls` are ignored safely, legacy ingredients model is detected, long localized tab labels wrap without clipping, and locale-specific existing strings are reused instead of English placeholders
