### PR TITLE
feat(kling): add canonical Omni reference UI

### DIFF
--- a/change/@acedatacloud-nexior-kling-o1-public.json
+++ b/change/@acedatacloud-nexior-kling-o1-public.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add canonical Kling O1 and V3 Omni image/video reference controls.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/kling/ConfigPanel.vue
+++ b/src/components/kling/ConfigPanel.vue
@@ -4,15 +4,16 @@
       <prompt-input class="mb-4" @open-inspiration="inspirationOpen = true" />
       <model-selector class="mb-4" />
       <ratio-selector class="mb-4" />
+      <reference-images v-if="capabilities.referenceImages" class="mb-3" />
       <reference-video v-if="capabilities.referenceVideo" class="mb-2" />
       <start-image class="mb-2" />
       <end-image class="mb-2" />
       <duration-selector class="mb-4" />
       <mode-selector class="mb-4" />
       <generate-audio-selector class="mb-4" />
-      <camera-control-selector class="mb-4" />
-      <cfg-scale-selector class="mb-4" />
-      <negative-prompt-input class="mb-4" />
+      <camera-control-selector v-if="!omniActive" class="mb-4" />
+      <cfg-scale-selector v-if="!omniActive" class="mb-4" />
+      <negative-prompt-input v-if="!omniActive" class="mb-4" />
     </div>
     <div class="flex flex-col items-center justify-center px-5 pb-5">
       <summary-chip />
@@ -47,6 +48,7 @@ import RatioSelector from './config/RatioSelector.vue';
 import StartImage from './config/StartImage.vue';
 import EndImage from './config/EndImage.vue';
 import ReferenceVideo from './config/ReferenceVideo.vue';
+import ReferenceImages from './config/ReferenceImages.vue';
 import Consumption from '../common/Consumption.vue';
 import CfgScaleSelector from './config/CfgScaleSelector.vue';
 import GenerateAudioSelector from './config/GenerateAudioSelector.vue';
@@ -77,6 +79,7 @@ export default defineComponent({
     InspirationDrawer,
     SummaryChip,
     EndImage,
+    ReferenceImages,
     ReferenceVideo
   },
   emits: ['generate'],
@@ -91,6 +94,11 @@ export default defineComponent({
     },
     capabilities() {
       return getKlingCapabilities(this.config?.model, this.config?.mode, this.config?.duration);
+    },
+    omniActive(): boolean {
+      return (
+        this.config?.model === 'kling-o1' || Boolean(this.config?.image_list?.length || this.config?.video_list?.length)
+      );
     },
     consumption() {
       return getConsumption(this.config, this.service?.cost);

--- a/src/components/kling/SummaryChip.vue
+++ b/src/components/kling/SummaryChip.vue
@@ -26,7 +26,7 @@ const MODEL_LABELS: Record<string, string> = {
   'kling-v2-master': 'v2-Master',
   'kling-v1-6': 'v1.6',
   'kling-v1': 'v1',
-  'kling-video-o1': 'Video-o1'
+  'kling-o1': 'Kling O1'
 };
 
 const MODE_RESOLUTION: Record<string, string> = {

--- a/src/components/kling/config/DurationSelector.vue
+++ b/src/components/kling/config/DurationSelector.vue
@@ -27,6 +27,7 @@ import { findKlingConflicts, clearKlingConflicts } from '@/utils/kling/capabilit
 
 const V3_VALUES = [3, 5, 8, 10, 12, 15];
 const STANDARD_VALUES = [5, 10];
+const O1_VALUES = [5];
 
 export default defineComponent({
   name: 'DurationSelector',
@@ -51,6 +52,7 @@ export default defineComponent({
       return KLING_V3_MODELS.includes(this.selectedModel);
     },
     allowedDurations(): number[] {
+      if (this.selectedModel === 'kling-o1') return O1_VALUES;
       return this.isV3Model ? V3_VALUES : STANDARD_VALUES;
     },
     value(): number {
@@ -65,7 +67,7 @@ export default defineComponent({
     }
   },
   watch: {
-    isV3Model() {
+    selectedModel() {
       if (!this.allowedDurations.includes(this.value)) {
         this.applyDuration(KLING_DEFAULT_DURATION);
       }

--- a/src/components/kling/config/EndImage.vue
+++ b/src/components/kling/config/EndImage.vue
@@ -29,7 +29,7 @@
           :url="file.url"
           :name="file.name"
           :percentage="file.percentage"
-          @remove="fileList.splice(fileList.indexOf(file), 1)"
+          @remove="onRemove(file)"
         />
       </template>
       <el-tooltip :content="uploadTooltip" :disabled="!uploadDisabled" placement="top">
@@ -155,6 +155,16 @@ export default defineComponent({
         ElMessage.warning(this.$t('kling.message.endImageRequiresStart'));
         return false;
       }
+      if (this.klingConfig.video_list?.[0]?.refer_type === 'base') {
+        ElMessage.warning(this.$t('kling.message.baseVideoFrameConflict'));
+        return false;
+      }
+      const maxImages = this.klingConfig.video_list?.length ? 4 : 7;
+      const total = (this.klingConfig.image_list?.length || 0) + 2;
+      if (total > maxImages) {
+        ElMessage.warning(this.$t('kling.message.referenceImagesTotalLimit', { count: maxImages }));
+        return false;
+      }
       return true;
     },
     onExceed() {
@@ -171,6 +181,10 @@ export default defineComponent({
       });
     },
     async onSuccess() {
+      this.onSetEndImageUrl();
+    },
+    onRemove(file: UploadFile) {
+      this.fileList.splice(this.fileList.indexOf(file), 1);
       this.onSetEndImageUrl();
     }
   }

--- a/src/components/kling/config/ModelSelector.vue
+++ b/src/components/kling/config/ModelSelector.vue
@@ -71,8 +71,8 @@ export default defineComponent({
           label: 'v1'
         },
         {
-          value: 'kling-video-o1',
-          label: 'Video-o1'
+          value: 'kling-o1',
+          label: 'Kling O1'
         }
       ]
     };

--- a/src/components/kling/config/ReferenceImages.vue
+++ b/src/components/kling/config/ReferenceImages.vue
@@ -1,0 +1,166 @@
+<template>
+  <div class="relative">
+    <div class="flex justify-between items-center">
+      <div class="flex justify-start items-center">
+        <span class="text-sm font-bold">{{ $t('kling.name.referenceImages') }}</span>
+        <info-icon :content="$t('kling.description.referenceImages')" />
+      </div>
+      <el-upload
+        v-model:file-list="fileList"
+        accept=".png,.jpg,.jpeg"
+        name="file"
+        :limit="referenceLimit"
+        :multiple="true"
+        :show-file-list="false"
+        :action="uploadUrl"
+        :before-upload="beforeUpload"
+        :on-exceed="onExceed"
+        :on-error="onError"
+        :on-success="onSuccess"
+        :headers="headers"
+      >
+        <el-button round type="primary" size="small" :disabled="remainingSlots === 0">
+          <font-awesome-icon icon="fa-solid fa-upload" class="mr-1" />
+          {{ $t('kling.button.uploadReferenceImages') }}
+        </el-button>
+      </el-upload>
+    </div>
+    <div v-if="fileList.length" class="file-list flex flex-wrap gap-2 mt-2">
+      <image-preview
+        v-for="(file, index) in fileList"
+        :key="file.uid || file.url || index"
+        :url="file.url || (file.response as any)?.file_url"
+        :name="file.name"
+        :percentage="file.percentage"
+        @remove="onRemove(index, file)"
+      />
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElButton, ElMessage, ElUpload, UploadFile, UploadFiles } from 'element-plus';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import ImagePreview from '@/components/common/ImagePreview.vue';
+import InfoIcon from '@/components/common/InfoIcon.vue';
+import { IKlingReferenceImage } from '@/models';
+import { getBaseUrlPlatform, pasteUploadMixin, uploadTrackerMixin } from '@/utils';
+import { stripKlingImageTokens } from '@/utils/kling/capabilities';
+
+interface IData {
+  fileList: UploadFiles;
+  uploadUrl: string;
+}
+
+export default defineComponent({
+  name: 'KlingReferenceImages',
+  components: {
+    ElButton,
+    ElUpload,
+    FontAwesomeIcon,
+    ImagePreview,
+    InfoIcon
+  },
+  mixins: [pasteUploadMixin, uploadTrackerMixin],
+  data(): IData {
+    return {
+      fileList: [],
+      uploadUrl: getBaseUrlPlatform() + '/api/v1/files/'
+    };
+  },
+  computed: {
+    config(): Record<string, any> {
+      return this.$store.state.kling?.config || {};
+    },
+    headers() {
+      return {
+        Authorization: `Bearer ${this.$store.state.token.access}`
+      };
+    },
+    frameCount(): number {
+      return Number(Boolean(this.config.start_image_url)) + Number(Boolean(this.config.end_image_url));
+    },
+    maxImages(): number {
+      return this.config.video_list?.length ? 4 : 7;
+    },
+    referenceLimit(): number {
+      return Math.max(0, this.maxImages - this.frameCount);
+    },
+    remainingSlots(): number {
+      return Math.max(0, this.referenceLimit - this.urls.length);
+    },
+    urls(): string[] {
+      return this.fileList
+        .map((file: UploadFile) => (file.response as any)?.file_url || file.url)
+        .filter(Boolean) as string[];
+    },
+    storeImages(): IKlingReferenceImage[] | undefined {
+      return this.config.image_list;
+    }
+  },
+  watch: {
+    frameCount() {
+      this.syncPromptTokens();
+    },
+    storeImages(value?: IKlingReferenceImage[]) {
+      if (!value?.length && this.fileList.length > 0) {
+        this.fileList = [];
+      }
+    }
+  },
+  methods: {
+    beforeUpload(): boolean {
+      if (this.remainingSlots === 0) {
+        this.onExceed();
+        return false;
+      }
+      return true;
+    },
+    onExceed() {
+      ElMessage.warning(this.$t('kling.message.referenceImagesExceed', { count: this.remainingSlots }));
+    },
+    onError() {
+      ElMessage.error(this.$t('kling.message.referenceImagesError'));
+    },
+    clearOmniConflicts(config: Record<string, any>): Record<string, any> {
+      return {
+        ...config,
+        generate_audio: false,
+        camera_control: undefined,
+        cfg_scale: undefined,
+        negative_prompt: undefined
+      };
+    },
+    syncPromptTokens(configOverride?: Record<string, any>) {
+      const config = configOverride || this.config;
+      const prompt = stripKlingImageTokens(config.prompt);
+      const tokens = this.urls.map((_, index) => `<<<image_${this.frameCount + index + 1}>>>`);
+      const nextPrompt = [prompt, ...tokens].filter(Boolean).join(' ');
+      if (nextPrompt !== config.prompt) {
+        this.$store.commit('kling/setConfig', { ...config, prompt: nextPrompt });
+      }
+    },
+    syncConfig() {
+      const image_list: IKlingReferenceImage[] | undefined = this.urls.length
+        ? this.urls.map((image_url) => ({ image_url }))
+        : undefined;
+      const next = this.clearOmniConflicts({ ...this.config, image_list });
+      this.$store.commit('kling/setConfig', next);
+      this.syncPromptTokens(next);
+    },
+    async onSuccess(response: any, file: UploadFile) {
+      if (response?.file_url) {
+        file.url = response.file_url;
+        file.response = response;
+      }
+      this.syncConfig();
+    },
+    onRemove(index: number, file: UploadFile) {
+      this.fileList.splice(index, 1);
+      if (file.url?.startsWith('blob:')) URL.revokeObjectURL(file.url);
+      this.syncConfig();
+    }
+  }
+});
+</script>

--- a/src/components/kling/config/ReferenceVideo.vue
+++ b/src/components/kling/config/ReferenceVideo.vue
@@ -3,7 +3,7 @@
     <div class="flex justify-between">
       <div class="flex justify-start items-center">
         <span class="text-sm font-bold">{{ $t('kling.name.referenceVideo') }}</span>
-        <info-icon :content="$t('kling.description.referenceVideo')" />
+        <info-icon :content="$t('kling.description.omniReferenceVideo')" />
       </div>
     </div>
     <el-upload
@@ -35,12 +35,34 @@
         {{ $t('kling.button.uploadReferenceVideo') }}
       </el-button>
     </el-upload>
+    <div v-if="hasVideo" class="reference-options mt-3 flex flex-col gap-3">
+      <div class="flex flex-col items-stretch gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <span class="text-sm">{{ $t('kling.name.referenceVideoType') }}</span>
+        <el-radio-group v-model="referenceType" size="small">
+          <el-radio-button value="feature">{{ $t('kling.name.referenceVideoFeature') }}</el-radio-button>
+          <el-radio-button value="base">{{ $t('kling.name.referenceVideoBase') }}</el-radio-button>
+        </el-radio-group>
+      </div>
+      <div class="flex items-center justify-between gap-3">
+        <span class="text-sm">{{ $t('kling.name.keepOriginalSound') }}</span>
+        <el-switch v-model="keepOriginalSound" />
+      </div>
+    </div>
   </div>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElButton, ElUpload, ElMessage, UploadFiles, UploadFile } from 'element-plus';
+import {
+  ElButton,
+  ElMessage,
+  ElRadioButton,
+  ElRadioGroup,
+  ElSwitch,
+  ElUpload,
+  UploadFile,
+  UploadFiles
+} from 'element-plus';
 import { getBaseUrlPlatform, uploadTrackerMixin } from '@/utils';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import FilePreview from '@/components/common/FilePreview.vue';
@@ -58,6 +80,9 @@ export default defineComponent({
   components: {
     ElUpload,
     ElButton,
+    ElRadioButton,
+    ElRadioGroup,
+    ElSwitch,
     InfoIcon,
     FilePreview,
     FontAwesomeIcon
@@ -78,6 +103,28 @@ export default defineComponent({
     urls(): string[] {
       // @ts-ignore
       return this.fileList.map((file: UploadFile) => file?.response?.file_url);
+    },
+    config(): Record<string, any> {
+      return this.$store.state.kling?.config || {};
+    },
+    hasVideo(): boolean {
+      return Boolean(this.urls?.[0]);
+    },
+    referenceType: {
+      get(): 'feature' | 'base' {
+        return this.config.video_list?.[0]?.refer_type || 'feature';
+      },
+      set(value: 'feature' | 'base') {
+        this.updateVideoOptions(value, this.keepOriginalSound);
+      }
+    },
+    keepOriginalSound: {
+      get(): boolean {
+        return this.config.video_list?.[0]?.keep_original_sound === 'yes';
+      },
+      set(value: boolean) {
+        this.updateVideoOptions(this.referenceType, value);
+      }
     }
   },
   methods: {
@@ -88,6 +135,14 @@ export default defineComponent({
       ElMessage.error(this.$t('kling.message.referenceVideoError'));
     },
     beforeUpload(file: File) {
+      const referenceImageCount =
+        (this.config.image_list?.length || 0) +
+        Number(Boolean(this.config.start_image_url)) +
+        Number(Boolean(this.config.end_image_url));
+      if (referenceImageCount > 4) {
+        ElMessage.error(this.$t('kling.message.referenceVideoImageLimit'));
+        return false;
+      }
       const isMP4orMOV = file.type === 'video/mp4' || file.type === 'video/quicktime';
       const isLt200M = file.size / 1024 / 1024 < 200;
       if (!isMP4orMOV) {
@@ -125,13 +180,42 @@ export default defineComponent({
     onSetVideoList() {
       const url = this.urls?.[0];
       const video_list: IKlingReferenceVideo[] | undefined = url
-        ? [{ video_url: url, refer_type: 'base', keep_original_sound: 'no' }]
+        ? [
+            {
+              video_url: url,
+              refer_type: this.referenceType,
+              keep_original_sound: this.keepOriginalSound ? 'yes' : 'no'
+            }
+          ]
         : undefined;
       this.$store.commit('kling/setConfig', {
-        ...this.$store.state.kling?.config,
-        video_list
+        ...this.config,
+        video_list,
+        generate_audio: false,
+        camera_control: undefined,
+        cfg_scale: undefined,
+        negative_prompt: undefined
       });
       this.ensurePromptToken(!!url);
+    },
+    updateVideoOptions(referType: 'feature' | 'base', keepSound: boolean) {
+      const url = this.urls?.[0];
+      if (!url) return;
+      this.$store.commit('kling/setConfig', {
+        ...this.config,
+        video_list: [
+          {
+            video_url: url,
+            refer_type: referType,
+            keep_original_sound: keepSound ? 'yes' : 'no'
+          }
+        ],
+        ...(referType === 'base' ? { start_image_url: undefined, end_image_url: undefined } : {}),
+        generate_audio: false,
+        camera_control: undefined,
+        cfg_scale: undefined,
+        negative_prompt: undefined
+      });
     },
     async onSuccess() {
       this.onSetVideoList();

--- a/src/components/kling/config/StartImage.vue
+++ b/src/components/kling/config/StartImage.vue
@@ -17,6 +17,7 @@
       :multiple="false"
       :action="uploadUrl"
       list-type="picture"
+      :before-upload="onBeforeUpload"
       :on-exceed="onExceed"
       :on-error="onError"
       :on-success="onSuccess"
@@ -28,7 +29,7 @@
           :url="file.url"
           :name="file.name"
           :percentage="file.percentage"
-          @remove="fileList.splice(fileList.indexOf(file), 1)"
+          @remove="onRemove(file)"
         />
       </template>
       <el-tooltip :content="$t('kling.message.uploadReferencesExceed')" :disabled="!reachedLimit" placement="top">
@@ -99,6 +100,13 @@ export default defineComponent({
       }
     }
   },
+  watch: {
+    value(val: string | undefined) {
+      if (!val && this.fileList.length > 0) {
+        this.fileList = [];
+      }
+    }
+  },
   mounted() {
     if (!this.value) {
       this.value = undefined;
@@ -112,6 +120,20 @@ export default defineComponent({
     onError() {
       ElMessage.error(this.$t('kling.message.uploadReferencesError'));
     },
+    onBeforeUpload(): boolean {
+      const config = this.$store.state.kling?.config || {};
+      if (config.video_list?.[0]?.refer_type === 'base') {
+        ElMessage.warning(this.$t('kling.message.baseVideoFrameConflict'));
+        return false;
+      }
+      const maxImages = config.video_list?.length ? 4 : 7;
+      const total = (config.image_list?.length || 0) + Number(Boolean(config.end_image_url)) + 1;
+      if (total > maxImages) {
+        ElMessage.warning(this.$t('kling.message.referenceImagesTotalLimit', { count: maxImages }));
+        return false;
+      }
+      return true;
+    },
     onSetStartImageUrl() {
       const url = this.urls?.[0];
       this.$store.commit('kling/setConfig', {
@@ -120,6 +142,10 @@ export default defineComponent({
       });
     },
     async onSuccess() {
+      this.onSetStartImageUrl();
+    },
+    onRemove(file: UploadFile) {
+      this.fileList.splice(this.fileList.indexOf(file), 1);
       this.onSetStartImageUrl();
     }
   }

--- a/src/i18n/ar/kling.json
+++ b/src/i18n/ar/kling.json
@@ -775,9 +775,53 @@
     "message": "Reference Video",
     "description": "Form field label: reference/editable video for Omni video editing"
   },
-  "description.referenceVideo": {
-    "message": "Only for kling-video-o1. Upload one MP4/MOV (720-2160px, 3-10s, <=200MB) to edit or reference an existing video. The prompt automatically cites it as <<<video_1>>>; keep that token to describe the edit (e.g. 'turn <<<video_1>>> into anime').",
-    "description": "Help text for the reference video uploader"
+  "description.omniReferenceVideo": {
+    "message": "ينطبق على Kling O1 و V3 Omni. قم برفع ملف MP4/MOV (720–2160px، 3–10 ثوانٍ، ≤200MB) للتحرير أو كمرجع لفيديو موجود، وسيتم إضافة علامات الكلمات تلقائيًا <<<video_1>>>.",
+    "description": "نص المساعدة لرفع فيديو المرجع Omni"
+  },
+  "name.referenceImages": {
+    "message": "صور مرجعية",
+    "description": "تسمية حقل صور المرجع Omni"
+  },
+  "description.referenceImages": {
+    "message": "ينطبق على Kling O1 و V3 Omni. يمكنك رفع ما يصل إلى 7 صور مرجعية؛ إذا كان هناك فيديو مرجعي، يمكنك رفع 4 صور كحد أقصى. سيتم إضافة علامات الاقتباس تلقائيًا.",
+    "description": "نص المساعدة لصور المرجع Omni"
+  },
+  "button.uploadReferenceImages": {
+    "message": "رفع الصور",
+    "description": "زر رفع صور المرجع Omni"
+  },
+  "message.referenceImagesExceed": {
+    "message": "يمكنك رفع {count} صورة مرجعية إضافية.",
+    "description": "تنبيه عدد صور المرجع"
+  },
+  "message.referenceImagesError": {
+    "message": "فشل رفع صور المرجع، يرجى المحاولة مرة أخرى.",
+    "description": "خطأ في رفع صور المرجع"
+  },
+  "name.referenceVideoType": {
+    "message": "نوع الفيديو",
+    "description": "تسمية نوع الفيديو المرجعي"
+  },
+  "name.referenceVideoFeature": {
+    "message": "مرجع الميزات",
+    "description": "خيارات فيديو مرجع الميزات"
+  },
+  "name.referenceVideoBase": {
+    "message": "تحرير الفيديو الأصلي",
+    "description": "خيارات تحرير الفيديو الأساسية"
+  },
+  "message.referenceVideoImageLimit": {
+    "message": "عند وجود فيديو مرجعي، يمكنك دعم 4 صور مرجعية كحد أقصى، يرجى إزالة الصور الزائدة أولاً.",
+    "description": "تعارض عدد الفيديو والصور المرجعية"
+  },
+  "message.referenceImagesTotalLimit": {
+    "message": "يدعم هذا الطلب ما يصل إلى {count} صورة مرجعية، حيث يتم احتساب الإطار الأول والإطار الأخير ضمن العدد الإجمالي.",
+    "description": "تنبيه حول الحد الأقصى لعدد الصور المرجعية."
+  },
+  "message.baseVideoFrameConflict": {
+    "message": "لا يمكن استخدام الفيديو الأساسي قيد التحرير مع الإطار الأول أو الإطار الأخير في نفس الوقت.",
+    "description": "تنبيه حول تعارض الفيديو الأساسي مع الإطارين الأول والأخير."
   },
   "button.uploadReferenceVideo": {
     "message": "Upload Video",

--- a/src/i18n/de/kling.json
+++ b/src/i18n/de/kling.json
@@ -775,9 +775,53 @@
     "message": "Reference Video",
     "description": "Form field label: reference/editable video for Omni video editing"
   },
-  "description.referenceVideo": {
-    "message": "Only for kling-video-o1. Upload one MP4/MOV (720-2160px, 3-10s, <=200MB) to edit or reference an existing video. The prompt automatically cites it as <<<video_1>>>; keep that token to describe the edit (e.g. 'turn <<<video_1>>> into anime').",
-    "description": "Help text for the reference video uploader"
+  "description.omniReferenceVideo": {
+    "message": "Für Kling O1 und V3 Omni. Laden Sie ein MP4/MOV (720–2160px, 3–10 Sekunden, ≤200MB) für die Bearbeitung oder als Referenz für vorhandenes Video hoch, Stichwörter werden automatisch hinzugefügt <<<video_1>>>.",
+    "description": "Hilfetext zum Hochladen von Omni Referenzvideos"
+  },
+  "name.referenceImages": {
+    "message": "Referenzbilder",
+    "description": "Feldbezeichnung für Omni Referenzbilder"
+  },
+  "description.referenceImages": {
+    "message": "Für Kling O1 und V3 Omni. Maximal 7 Referenzbilder hochladen; bei vorhandenem Referenzvideo maximal 4 Bilder. Stichwortverweise werden automatisch hinzugefügt.",
+    "description": "Hilfetext zu Omni Referenzbildern"
+  },
+  "button.uploadReferenceImages": {
+    "message": "Bilder hochladen",
+    "description": "Button zum Hochladen von Omni Referenzbildern"
+  },
+  "message.referenceImagesExceed": {
+    "message": "Es können noch {count} Referenzbilder hochgeladen werden.",
+    "description": "Hinweis zur Anzahl der Referenzbilder"
+  },
+  "message.referenceImagesError": {
+    "message": "Hochladen der Referenzbilder fehlgeschlagen, bitte versuchen Sie es erneut.",
+    "description": "Fehler beim Hochladen der Referenzbilder"
+  },
+  "name.referenceVideoType": {
+    "message": "Videonutzung",
+    "description": "Bezeichnung für den Typ des Referenzvideos"
+  },
+  "name.referenceVideoFeature": {
+    "message": "Merkmalsreferenz",
+    "description": "Option für Referenzvideos zu Merkmalen"
+  },
+  "name.referenceVideoBase": {
+    "message": "Originalvideo bearbeiten",
+    "description": "Basisoptionen zur Videobearbeitung"
+  },
+  "message.referenceVideoImageLimit": {
+    "message": "Bei vorhandenem Referenzvideo sind maximal 4 Referenzbilder erlaubt, bitte entfernen Sie überschüssige Bilder.",
+    "description": "Konflikt zwischen Anzahl der Referenzvideos und -bilder"
+  },
+  "message.referenceImagesTotalLimit": {
+    "message": "Diese Anfrage unterstützt maximal {count} Referenzbilder, wobei der erste und letzte Frame ebenfalls in die Gesamtzahl einfließen.",
+    "description": "Hinweis auf die Begrenzung der Gesamtzahl der Referenzbilder."
+  },
+  "message.baseVideoFrameConflict": {
+    "message": "Das zu bearbeitende Basisvideo kann nicht gleichzeitig mit dem ersten oder letzten Frame verwendet werden.",
+    "description": "Hinweis auf Konflikt zwischen Basisvideo und ersten/letzten Frames."
   },
   "button.uploadReferenceVideo": {
     "message": "Upload Video",

--- a/src/i18n/el/kling.json
+++ b/src/i18n/el/kling.json
@@ -775,9 +775,53 @@
     "message": "Reference Video",
     "description": "Form field label: reference/editable video for Omni video editing"
   },
-  "description.referenceVideo": {
-    "message": "Only for kling-video-o1. Upload one MP4/MOV (720-2160px, 3-10s, <=200MB) to edit or reference an existing video. The prompt automatically cites it as <<<video_1>>>; keep that token to describe the edit (e.g. 'turn <<<video_1>>> into anime').",
-    "description": "Help text for the reference video uploader"
+  "description.omniReferenceVideo": {
+    "message": "Ισχύει για Kling O1 και V3 Omni. Ανέβασμα ενός MP4/MOV (720–2160px, 3–10 δευτερόλεπτα, ≤200MB) για επεξεργασία ή αναφορά υπάρχοντος βίντεο, οι ετικέτες θα προστεθούν αυτόματα <<<video_1>>>.",
+    "description": "Βοηθητικό κείμενο για ανέβασμα βίντεο αναφοράς Omni"
+  },
+  "name.referenceImages": {
+    "message": "Εικόνες αναφοράς",
+    "description": "Ετικέτα πεδίου εικόνων αναφοράς Omni"
+  },
+  "description.referenceImages": {
+    "message": "Ισχύει για Kling O1 και V3 Omni. Μπορείτε να ανεβάσετε έως 7 εικόνες αναφοράς; αν υπάρχει βίντεο αναφοράς, έως 4 εικόνες. Οι ετικέτες αναφοράς θα προστεθούν αυτόματα.",
+    "description": "Βοηθητικό κείμενο για εικόνες αναφοράς Omni"
+  },
+  "button.uploadReferenceImages": {
+    "message": "Ανέβασμα εικόνας",
+    "description": "Κουμπί για ανέβασμα αναφοράς εικόνας Omni"
+  },
+  "message.referenceImagesExceed": {
+    "message": "Μπορείτε να ανεβάσετε ακόμη {count} εικόνες αναφοράς.",
+    "description": "Υπόδειξη για τον αριθμό εικόνων αναφοράς"
+  },
+  "message.referenceImagesError": {
+    "message": "Η ανέβασμα εικόνας αναφοράς απέτυχε, παρακαλώ δοκιμάστε ξανά.",
+    "description": "Σφάλμα κατά την ανέβασμα εικόνας αναφοράς"
+  },
+  "name.referenceVideoType": {
+    "message": "Χρήση βίντεο",
+    "description": "Ετικέτα τύπου βίντεο αναφοράς"
+  },
+  "name.referenceVideoFeature": {
+    "message": "Χαρακτηριστικό αναφοράς",
+    "description": "Επιλογές βίντεο χαρακτηριστικού αναφοράς"
+  },
+  "name.referenceVideoBase": {
+    "message": "Επεξεργασία αρχικού βίντεο",
+    "description": "Βασικές επιλογές επεξεργασίας βίντεο"
+  },
+  "message.referenceVideoImageLimit": {
+    "message": "Όταν υπάρχει βίντεο αναφοράς, υποστηρίζονται έως 4 εικόνες αναφοράς, παρακαλώ αφαιρέστε τις επιπλέον εικόνες.",
+    "description": "Σύγκρουση αριθμού βίντεο αναφοράς και εικόνων"
+  },
+  "message.referenceImagesTotalLimit": {
+    "message": "Αυτή η αίτηση υποστηρίζει το πολύ {count} αναφορικές εικόνες, συμπεριλαμβανομένων των αρχικών και τελικών καρέ.",
+    "description": "Ειδοποίηση περιορισμού συνολικού αριθμού αναφορικών εικόνων."
+  },
+  "message.baseVideoFrameConflict": {
+    "message": "Το βασικό βίντεο που περιμένει επεξεργασία δεν μπορεί να χρησιμοποιηθεί ταυτόχρονα με την αρχική ή την τελική καρέ.",
+    "description": "Ειδοποίηση σύγκρουσης μεταξύ του βασικού βίντεο και των αρχικών/τελικών καρέ."
   },
   "button.uploadReferenceVideo": {
     "message": "Upload Video",

--- a/src/i18n/en/kling.json
+++ b/src/i18n/en/kling.json
@@ -32,8 +32,8 @@
     "description": "Character orientation option: Follow Video"
   },
   "name.keepOriginalSound": {
-    "message": "Keep Original Audio",
-    "description": "keep_original_sound toggle"
+    "message": "Keep Original Sound",
+    "description": "Keep reference video audio switch label"
   },
   "description.motionImage": {
     "message": "Upload a character reference image; elements like character and background in the generated video will reference this.",
@@ -775,9 +775,53 @@
     "message": "Reference Video",
     "description": "Form field label: reference/editable video for Omni video editing"
   },
-  "description.referenceVideo": {
-    "message": "Only for kling-video-o1. Upload one MP4/MOV (720-2160px, 3-10s, <=200MB) to edit or reference an existing video. The prompt automatically cites it as <<<video_1>>>; keep that token to describe the edit (e.g. 'turn <<<video_1>>> into anime').",
-    "description": "Help text for the reference video uploader"
+  "description.omniReferenceVideo": {
+    "message": "For Kling O1 and V3 Omni. Upload one MP4/MOV (720-2160px, 3-10s, <=200MB) to edit or reference an existing video. The prompt automatically cites it as <<<video_1>>>.",
+    "description": "Help text for the Omni reference video uploader"
+  },
+  "name.referenceImages": {
+    "message": "Reference Images",
+    "description": "Form field label for Omni reference images"
+  },
+  "description.referenceImages": {
+    "message": "For Kling O1 and V3 Omni. Upload up to 7 reference images, or up to 4 when a reference video is present. Prompt tokens are added automatically.",
+    "description": "Help text for Omni reference images"
+  },
+  "button.uploadReferenceImages": {
+    "message": "Upload Images",
+    "description": "Button to upload Omni reference images"
+  },
+  "message.referenceImagesExceed": {
+    "message": "You can upload {count} more reference images.",
+    "description": "Reference image count warning"
+  },
+  "message.referenceImagesError": {
+    "message": "Reference image upload failed. Please retry.",
+    "description": "Reference image upload error"
+  },
+  "name.referenceVideoType": {
+    "message": "Video Usage",
+    "description": "Reference video type label"
+  },
+  "name.referenceVideoFeature": {
+    "message": "Reference",
+    "description": "Feature reference video option"
+  },
+  "name.referenceVideoBase": {
+    "message": "Edit Source",
+    "description": "Base video editing option"
+  },
+  "message.referenceVideoImageLimit": {
+    "message": "A reference video supports at most 4 reference images. Remove extra images first.",
+    "description": "Reference video image count conflict"
+  },
+  "message.referenceImagesTotalLimit": {
+    "message": "This request supports at most {count} reference images, including first and last frames.",
+    "description": "Total reference image limit warning"
+  },
+  "message.baseVideoFrameConflict": {
+    "message": "An editable base video cannot be combined with first or last frames.",
+    "description": "Base video and frame conflict warning"
   },
   "button.uploadReferenceVideo": {
     "message": "Upload Video",

--- a/src/i18n/es/kling.json
+++ b/src/i18n/es/kling.json
@@ -775,9 +775,53 @@
     "message": "Reference Video",
     "description": "Form field label: reference/editable video for Omni video editing"
   },
-  "description.referenceVideo": {
-    "message": "Only for kling-video-o1. Upload one MP4/MOV (720-2160px, 3-10s, <=200MB) to edit or reference an existing video. The prompt automatically cites it as <<<video_1>>>; keep that token to describe the edit (e.g. 'turn <<<video_1>>> into anime').",
-    "description": "Help text for the reference video uploader"
+  "description.omniReferenceVideo": {
+    "message": "Aplicable a Kling O1 y V3 Omni. Suba un MP4/MOV (720–2160px, 3–10 segundos, ≤200MB) para editar o como referencia de un video existente, la etiqueta de palabras clave se añadirá automáticamente <<<video_1>>>.",
+    "description": "Texto de ayuda para la subida de video de referencia de Omni"
+  },
+  "name.referenceImages": {
+    "message": "Imágenes de referencia",
+    "description": "Etiqueta del campo de imágenes de referencia de Omni"
+  },
+  "description.referenceImages": {
+    "message": "Aplicable a Kling O1 y V3 Omni. Puede subir hasta 7 imágenes de referencia; si hay un video de referencia, se permiten hasta 4. Las etiquetas de palabras clave se añadirán automáticamente.",
+    "description": "Texto de ayuda para las imágenes de referencia de Omni"
+  },
+  "button.uploadReferenceImages": {
+    "message": "Subir imágenes",
+    "description": "Botón para subir imágenes de referencia de Omni"
+  },
+  "message.referenceImagesExceed": {
+    "message": "Puede subir {count} imágenes de referencia más.",
+    "description": "Indicador de cantidad de imágenes de referencia"
+  },
+  "message.referenceImagesError": {
+    "message": "Error al subir imágenes de referencia, por favor intente de nuevo.",
+    "description": "Error en la subida de imágenes de referencia"
+  },
+  "name.referenceVideoType": {
+    "message": "Uso del video",
+    "description": "Etiqueta del tipo de video de referencia"
+  },
+  "name.referenceVideoFeature": {
+    "message": "Referencia de características",
+    "description": "Opciones de video de referencia de características"
+  },
+  "name.referenceVideoBase": {
+    "message": "Editar video original",
+    "description": "Opciones básicas de edición de video"
+  },
+  "message.referenceVideoImageLimit": {
+    "message": "Si hay un video de referencia, se pueden soportar hasta 4 imágenes de referencia, por favor elimine las imágenes adicionales.",
+    "description": "Conflicto entre la cantidad de video de referencia e imágenes"
+  },
+  "message.referenceImagesTotalLimit": {
+    "message": "Esta solicitud admite un máximo de {count} imágenes de referencia, incluyendo el primer y último fotograma en el total.",
+    "description": "Advertencia sobre el límite total de imágenes de referencia."
+  },
+  "message.baseVideoFrameConflict": {
+    "message": "El video base en espera de edición no puede usarse al mismo tiempo que el primer o último fotograma.",
+    "description": "Advertencia sobre el conflicto entre el video base y los fotogramas inicial y final."
   },
   "button.uploadReferenceVideo": {
     "message": "Upload Video",

--- a/src/i18n/fi/kling.json
+++ b/src/i18n/fi/kling.json
@@ -775,9 +775,53 @@
     "message": "Reference Video",
     "description": "Form field label: reference/editable video for Omni video editing"
   },
-  "description.referenceVideo": {
-    "message": "Only for kling-video-o1. Upload one MP4/MOV (720-2160px, 3-10s, <=200MB) to edit or reference an existing video. The prompt automatically cites it as <<<video_1>>>; keep that token to describe the edit (e.g. 'turn <<<video_1>>> into anime').",
-    "description": "Help text for the reference video uploader"
+  "description.omniReferenceVideo": {
+    "message": "Sopii Kling O1:lle ja V3 Omni:lle. Lataa MP4/MOV (720–2160px, 3–10 sekuntia, ≤200MB) muokkausta tai olemassa olevan videon viitteenä varten, avainsanat lisätään automaattisesti <<<video_1>>>.",
+    "description": "Omni-viitevideon lataamisen ohjeet"
+  },
+  "name.referenceImages": {
+    "message": "Viitekuvat",
+    "description": "Omni-viitekuvien kenttälabel"
+  },
+  "description.referenceImages": {
+    "message": "Sopii Kling O1:lle ja V3 Omni:lle. Voit ladata enintään 7 viitekuvaa; jos viitevideo on olemassa, enintään 4 kuvaa. Avainsanat lisätään automaattisesti.",
+    "description": "Omni-viitekuvien ohjeet"
+  },
+  "button.uploadReferenceImages": {
+    "message": "Lataa kuvia",
+    "description": "Omni-viitekuvien latausnappi"
+  },
+  "message.referenceImagesExceed": {
+    "message": "Voit ladata vielä {count} viitekuvaa.",
+    "description": "Viitekuvien määrän ilmoitus"
+  },
+  "message.referenceImagesError": {
+    "message": "Viitekuvien lataaminen epäonnistui, yritä uudelleen.",
+    "description": "Viitekuvien latausvirhe"
+  },
+  "name.referenceVideoType": {
+    "message": "Videon käyttö",
+    "description": "Viitevideon tyyppilabel"
+  },
+  "name.referenceVideoFeature": {
+    "message": "Ominaisuusviite",
+    "description": "Ominaisuusviitevideon vaihtoehto"
+  },
+  "name.referenceVideoBase": {
+    "message": "Muokkaa alkuperäistä videota",
+    "description": "Perusvideon muokkausvaihtoehto"
+  },
+  "message.referenceVideoImageLimit": {
+    "message": "Jos viitevideo on olemassa, voit ladata enintään 4 viitekuvaa, poista ylimääräiset kuvat ensin.",
+    "description": "Viitevideon ja kuvien määrän ristiriita"
+  },
+  "message.referenceImagesTotalLimit": {
+    "message": "Tässä pyynnössä voi olla enintään {count} viitekuvaa, mukaan lukien ensimmäinen ja viimeinen kehys.",
+    "description": "Viitekuvien kokonaismäärän rajoitus."
+  },
+  "message.baseVideoFrameConflict": {
+    "message": "Odottavassa muokkauksessa oleva perusvideo ei voi olla samanaikaisesti käytössä ensimmäisessä tai viimeisessä kehyksessä.",
+    "description": "Perusvideon ja ensimmäisen/viimeisen kehyksen välinen konflikti."
   },
   "button.uploadReferenceVideo": {
     "message": "Upload Video",

--- a/src/i18n/fr/kling.json
+++ b/src/i18n/fr/kling.json
@@ -775,9 +775,53 @@
     "message": "Reference Video",
     "description": "Form field label: reference/editable video for Omni video editing"
   },
-  "description.referenceVideo": {
-    "message": "Only for kling-video-o1. Upload one MP4/MOV (720-2160px, 3-10s, <=200MB) to edit or reference an existing video. The prompt automatically cites it as <<<video_1>>>; keep that token to describe the edit (e.g. 'turn <<<video_1>>> into anime').",
-    "description": "Help text for the reference video uploader"
+  "description.omniReferenceVideo": {
+    "message": "Applicable à Kling O1 et V3 Omni. Téléchargez un MP4/MOV (720–2160px, 3–10 secondes, ≤200 Mo) pour l'édition ou comme référence pour une vidéo existante, les mots-clés seront ajoutés automatiquement <<<video_1>>>.",
+    "description": "Texte d'aide pour le téléchargement de vidéos de référence Omni"
+  },
+  "name.referenceImages": {
+    "message": "Images de référence",
+    "description": "Étiquette du champ d'images de référence Omni"
+  },
+  "description.referenceImages": {
+    "message": "Applicable à Kling O1 et V3 Omni. Téléchargez jusqu'à 7 images de référence ; si une vidéo de référence est présente, un maximum de 4 images. Les balises de mots-clés seront ajoutées automatiquement.",
+    "description": "Texte d'aide pour les images de référence Omni"
+  },
+  "button.uploadReferenceImages": {
+    "message": "Télécharger des images",
+    "description": "Bouton pour télécharger des images de référence Omni"
+  },
+  "message.referenceImagesExceed": {
+    "message": "Vous pouvez encore télécharger {count} images de référence.",
+    "description": "Alerte sur le nombre d'images de référence restantes"
+  },
+  "message.referenceImagesError": {
+    "message": "Échec du téléchargement des images de référence, veuillez réessayer.",
+    "description": "Erreur lors du téléchargement des images de référence"
+  },
+  "name.referenceVideoType": {
+    "message": "Usage de la vidéo",
+    "description": "Étiquette pour le type de vidéo de référence"
+  },
+  "name.referenceVideoFeature": {
+    "message": "Référence de caractéristiques",
+    "description": "Options de vidéo de référence de caractéristiques"
+  },
+  "name.referenceVideoBase": {
+    "message": "Éditer la vidéo originale",
+    "description": "Options d'édition de base pour la vidéo"
+  },
+  "message.referenceVideoImageLimit": {
+    "message": "Un maximum de 4 images de référence est pris en charge lorsqu'une vidéo de référence est présente, veuillez d'abord supprimer les images supplémentaires.",
+    "description": "Conflit entre le nombre de vidéos de référence et d'images"
+  },
+  "message.referenceImagesTotalLimit": {
+    "message": "Cette demande prend en charge un maximum de {count} images de référence, les premières et dernières images comptent également dans le total.",
+    "description": "Alerte de limite du nombre total d'images de référence."
+  },
+  "message.baseVideoFrameConflict": {
+    "message": "La vidéo de base à éditer ne peut pas être utilisée avec la première ou la dernière image en même temps.",
+    "description": "Alerte de conflit entre la vidéo de base et les images de début et de fin."
   },
   "button.uploadReferenceVideo": {
     "message": "Upload Video",

--- a/src/i18n/it/kling.json
+++ b/src/i18n/it/kling.json
@@ -775,9 +775,53 @@
     "message": "Reference Video",
     "description": "Form field label: reference/editable video for Omni video editing"
   },
-  "description.referenceVideo": {
-    "message": "Only for kling-video-o1. Upload one MP4/MOV (720-2160px, 3-10s, <=200MB) to edit or reference an existing video. The prompt automatically cites it as <<<video_1>>>; keep that token to describe the edit (e.g. 'turn <<<video_1>>> into anime').",
-    "description": "Help text for the reference video uploader"
+  "description.omniReferenceVideo": {
+    "message": "Applicabile a Kling O1 e V3 Omni. Carica un MP4/MOV (720–2160px, 3–10 secondi, ≤200MB) per modificare o fare riferimento a un video esistente, le parole chiave verranno aggiunte automaticamente <<<video_1>>>.",
+    "description": "Testo di aiuto per il caricamento di video di riferimento Omni"
+  },
+  "name.referenceImages": {
+    "message": "Immagini di riferimento",
+    "description": "Etichetta del campo immagini di riferimento Omni"
+  },
+  "description.referenceImages": {
+    "message": "Applicabile a Kling O1 e V3 Omni. Puoi caricare fino a 7 immagini di riferimento; se è presente un video di riferimento, massimo 4 immagini. I segnaposto delle parole chiave verranno aggiunti automaticamente.",
+    "description": "Testo di aiuto per le immagini di riferimento Omni"
+  },
+  "button.uploadReferenceImages": {
+    "message": "Carica immagini",
+    "description": "Pulsante per caricare immagini di riferimento Omni"
+  },
+  "message.referenceImagesExceed": {
+    "message": "Puoi caricare ancora {count} immagini di riferimento.",
+    "description": "Messaggio sul numero di immagini di riferimento rimanenti"
+  },
+  "message.referenceImagesError": {
+    "message": "Caricamento delle immagini di riferimento fallito, riprova.",
+    "description": "Errore nel caricamento delle immagini di riferimento"
+  },
+  "name.referenceVideoType": {
+    "message": "Tipo di video",
+    "description": "Etichetta del tipo di video di riferimento"
+  },
+  "name.referenceVideoFeature": {
+    "message": "Riferimento caratteristiche",
+    "description": "Opzione per video di riferimento delle caratteristiche"
+  },
+  "name.referenceVideoBase": {
+    "message": "Modifica video originale",
+    "description": "Opzione di modifica video di base"
+  },
+  "message.referenceVideoImageLimit": {
+    "message": "Se è presente un video di riferimento, puoi supportare al massimo 4 immagini di riferimento, rimuovi prima le immagini in eccesso.",
+    "description": "Conflitto tra il numero di video di riferimento e immagini"
+  },
+  "message.referenceImagesTotalLimit": {
+    "message": "Questa richiesta supporta al massimo {count} immagini di riferimento, inclusi i fotogrammi iniziali e finali nel conteggio totale.",
+    "description": "Avviso sul limite totale delle immagini di riferimento."
+  },
+  "message.baseVideoFrameConflict": {
+    "message": "Il video di base in attesa di modifica non può essere utilizzato contemporaneamente con il fotogramma iniziale o finale.",
+    "description": "Avviso di conflitto tra video di base e fotogrammi iniziali o finali."
   },
   "button.uploadReferenceVideo": {
     "message": "Upload Video",

--- a/src/i18n/ja/kling.json
+++ b/src/i18n/ja/kling.json
@@ -775,9 +775,53 @@
     "message": "Reference Video",
     "description": "Form field label: reference/editable video for Omni video editing"
   },
-  "description.referenceVideo": {
-    "message": "Only for kling-video-o1. Upload one MP4/MOV (720-2160px, 3-10s, <=200MB) to edit or reference an existing video. The prompt automatically cites it as <<<video_1>>>; keep that token to describe the edit (e.g. 'turn <<<video_1>>> into anime').",
-    "description": "Help text for the reference video uploader"
+  "description.omniReferenceVideo": {
+    "message": "Kling O1 と V3 Omni に対応しています。編集または既存の動画の参考用に MP4/MOV（720–2160px、3–10 秒、≤200MB）をアップロードすると、プロンプトが自動的に <<<video_1>>> 追加されます。",
+    "description": "Omni 参考動画アップロードのヘルプテキスト"
+  },
+  "name.referenceImages": {
+    "message": "参考画像",
+    "description": "Omni 参考画像フィールドラベル"
+  },
+  "description.referenceImages": {
+    "message": "Kling O1 と V3 Omni に対応しています。最大 7 枚の参考画像をアップロードできます。参考動画がある場合は最大 4 枚です。プロンプト引用マークが自動的に追加されます。",
+    "description": "Omni 参考画像のヘルプテキスト"
+  },
+  "button.uploadReferenceImages": {
+    "message": "画像をアップロード",
+    "description": "Omni 参考画像をアップロードするボタン"
+  },
+  "message.referenceImagesExceed": {
+    "message": "あと {count} 枚の参考画像をアップロードできます。",
+    "description": "参考画像の数に関するヒント"
+  },
+  "message.referenceImagesError": {
+    "message": "参考画像のアップロードに失敗しました。再試行してください。",
+    "description": "参考画像アップロードエラー"
+  },
+  "name.referenceVideoType": {
+    "message": "動画の用途",
+    "description": "参考動画タイプラベル"
+  },
+  "name.referenceVideoFeature": {
+    "message": "特徴参考",
+    "description": "特徴参考動画オプション"
+  },
+  "name.referenceVideoBase": {
+    "message": "元の動画を編集",
+    "description": "基本的な動画編集オプション"
+  },
+  "message.referenceVideoImageLimit": {
+    "message": "参考動画がある場合、最大 4 枚の参考画像をサポートしています。余分な画像を削除してください。",
+    "description": "参考動画と画像の数の衝突"
+  },
+  "message.referenceImagesTotalLimit": {
+    "message": "このリクエストでは最大 {count} 枚の参考画像をサポートしており、先頭フレームと末尾フレームも総数に含まれます。",
+    "description": "参考画像の総数制限に関する警告"
+  },
+  "message.baseVideoFrameConflict": {
+    "message": "編集中の基本動画は、先頭フレームまたは末尾フレームと同時に使用できません。",
+    "description": "基本動画と先頭・末尾フレームの衝突に関する警告"
   },
   "button.uploadReferenceVideo": {
     "message": "Upload Video",

--- a/src/i18n/ko/kling.json
+++ b/src/i18n/ko/kling.json
@@ -775,9 +775,53 @@
     "message": "Reference Video",
     "description": "Form field label: reference/editable video for Omni video editing"
   },
-  "description.referenceVideo": {
-    "message": "Only for kling-video-o1. Upload one MP4/MOV (720-2160px, 3-10s, <=200MB) to edit or reference an existing video. The prompt automatically cites it as <<<video_1>>>; keep that token to describe the edit (e.g. 'turn <<<video_1>>> into anime').",
-    "description": "Help text for the reference video uploader"
+  "description.omniReferenceVideo": {
+    "message": "Kling O1 및 V3 Omni에 적합합니다. 편집 또는 기존 비디오 참조를 위해 MP4/MOV(720–2160px, 3–10초, ≤200MB)를 업로드하면 자동으로 프롬프트가 추가됩니다 <<<video_1>>>.",
+    "description": "Omni 참조 비디오 업로드 도움말 텍스트"
+  },
+  "name.referenceImages": {
+    "message": "참조 이미지",
+    "description": "Omni 참조 이미지 필드 레이블"
+  },
+  "description.referenceImages": {
+    "message": "Kling O1 및 V3 Omni에 적합합니다. 최대 7개의 참조 이미지를 업로드할 수 있으며, 참조 비디오가 있을 경우 최대 4개까지 가능합니다. 프롬프트 인용 태그가 자동으로 추가됩니다.",
+    "description": "Omni 참조 이미지 도움말 텍스트"
+  },
+  "button.uploadReferenceImages": {
+    "message": "이미지 업로드",
+    "description": "Omni 참조 이미지 업로드 버튼"
+  },
+  "message.referenceImagesExceed": {
+    "message": "아직 {count}개의 참조 이미지를 업로드할 수 있습니다.",
+    "description": "참조 이미지 수량 안내"
+  },
+  "message.referenceImagesError": {
+    "message": "참조 이미지 업로드에 실패했습니다. 다시 시도해주세요.",
+    "description": "참조 이미지 업로드 오류"
+  },
+  "name.referenceVideoType": {
+    "message": "비디오 용도",
+    "description": "참조 비디오 유형 레이블"
+  },
+  "name.referenceVideoFeature": {
+    "message": "특징 참조",
+    "description": "특징 참조 비디오 옵션"
+  },
+  "name.referenceVideoBase": {
+    "message": "원본 비디오 편집",
+    "description": "기본 비디오 편집 옵션"
+  },
+  "message.referenceVideoImageLimit": {
+    "message": "참조 비디오가 있을 경우 최대 4개의 참조 이미지를 지원합니다. 초과 이미지를 먼저 제거해주세요.",
+    "description": "참조 비디오와 이미지 수량 충돌"
+  },
+  "message.referenceImagesTotalLimit": {
+    "message": "이 요청은 최대 {count}장의 참조 이미지를 지원하며, 첫 프레임과 마지막 프레임도 총 수에 포함됩니다.",
+    "description": "참조 이미지 총 수 제한 알림"
+  },
+  "message.baseVideoFrameConflict": {
+    "message": "편집 중인 기본 비디오는 첫 프레임 또는 마지막 프레임과 동시에 사용할 수 없습니다.",
+    "description": "기본 비디오와 첫/마지막 프레임 간의 충돌 알림"
   },
   "button.uploadReferenceVideo": {
     "message": "Upload Video",

--- a/src/i18n/pl/kling.json
+++ b/src/i18n/pl/kling.json
@@ -775,9 +775,53 @@
     "message": "Reference Video",
     "description": "Form field label: reference/editable video for Omni video editing"
   },
-  "description.referenceVideo": {
-    "message": "Only for kling-video-o1. Upload one MP4/MOV (720-2160px, 3-10s, <=200MB) to edit or reference an existing video. The prompt automatically cites it as <<<video_1>>>; keep that token to describe the edit (e.g. 'turn <<<video_1>>> into anime').",
-    "description": "Help text for the reference video uploader"
+  "description.omniReferenceVideo": {
+    "message": "Dla Kling O1 i V3 Omni. Prześlij plik MP4/MOV (720–2160px, 3–10 sekund, ≤200MB) do edycji lub jako odniesienie do istniejącego wideo, słowa kluczowe zostaną automatycznie dodane <<<video_1>>>.",
+    "description": "Pomoc dotycząca przesyłania wideo referencyjnego Omni"
+  },
+  "name.referenceImages": {
+    "message": "Obrazy referencyjne",
+    "description": "Etykieta pola obrazów referencyjnych Omni"
+  },
+  "description.referenceImages": {
+    "message": "Dla Kling O1 i V3 Omni. Możesz przesłać maksymalnie 7 obrazów referencyjnych; w przypadku istniejącego wideo referencyjnego maksymalnie 4 obrazy. Słowa kluczowe będą automatycznie dodawane.",
+    "description": "Pomoc dotycząca obrazów referencyjnych Omni"
+  },
+  "button.uploadReferenceImages": {
+    "message": "Prześlij obrazy",
+    "description": "Przycisk do przesyłania obrazów referencyjnych Omni"
+  },
+  "message.referenceImagesExceed": {
+    "message": "Możesz przesłać jeszcze {count} obrazów referencyjnych.",
+    "description": "Informacja o liczbie dostępnych obrazów referencyjnych do przesłania"
+  },
+  "message.referenceImagesError": {
+    "message": "Przesyłanie obrazów referencyjnych nie powiodło się, spróbuj ponownie.",
+    "description": "Błąd przesyłania obrazów referencyjnych"
+  },
+  "name.referenceVideoType": {
+    "message": "Zastosowanie wideo",
+    "description": "Etykieta typu wideo referencyjnego"
+  },
+  "name.referenceVideoFeature": {
+    "message": "Referencja cech",
+    "description": "Opcje wideo referencyjnego dotyczące cech"
+  },
+  "name.referenceVideoBase": {
+    "message": "Edycja oryginalnego wideo",
+    "description": "Opcje podstawowej edycji wideo"
+  },
+  "message.referenceVideoImageLimit": {
+    "message": "W przypadku istniejącego wideo referencyjnego możesz przesłać maksymalnie 4 obrazy referencyjne, najpierw usuń nadmiarowe obrazy.",
+    "description": "Konflikt liczby wideo referencyjnego i obrazów"
+  },
+  "message.referenceImagesTotalLimit": {
+    "message": "To żądanie obsługuje maksymalnie {count} obrazów referencyjnych, przy czym pierwsza i ostatnia klatka również wliczają się do całkowitej liczby.",
+    "description": "Ograniczenie całkowitej liczby obrazów referencyjnych."
+  },
+  "message.baseVideoFrameConflict": {
+    "message": "Podstawowe wideo do edycji nie może być używane jednocześnie z pierwszą lub ostatnią klatką.",
+    "description": "Wskazanie konfliktu między podstawowym wideo a pierwszą lub ostatnią klatką."
   },
   "button.uploadReferenceVideo": {
     "message": "Upload Video",

--- a/src/i18n/pt/kling.json
+++ b/src/i18n/pt/kling.json
@@ -775,9 +775,53 @@
     "message": "Reference Video",
     "description": "Form field label: reference/editable video for Omni video editing"
   },
-  "description.referenceVideo": {
-    "message": "Only for kling-video-o1. Upload one MP4/MOV (720-2160px, 3-10s, <=200MB) to edit or reference an existing video. The prompt automatically cites it as <<<video_1>>>; keep that token to describe the edit (e.g. 'turn <<<video_1>>> into anime').",
-    "description": "Help text for the reference video uploader"
+  "description.omniReferenceVideo": {
+    "message": "Aplicável ao Kling O1 e V3 Omni. Envie um MP4/MOV (720–2160px, 3–10 segundos, ≤200MB) para edição ou referência de vídeo existente, as palavras-chave serão adicionadas automaticamente <<<video_1>>>.",
+    "description": "Texto de ajuda para o envio de vídeo de referência do Omni"
+  },
+  "name.referenceImages": {
+    "message": "Imagens de Referência",
+    "description": "Rótulo do campo de imagens de referência do Omni"
+  },
+  "description.referenceImages": {
+    "message": "Aplicável ao Kling O1 e V3 Omni. É possível enviar até 7 imagens de referência; se houver um vídeo de referência, no máximo 4 imagens. As marcações de palavras-chave serão adicionadas automaticamente.",
+    "description": "Texto de ajuda para imagens de referência do Omni"
+  },
+  "button.uploadReferenceImages": {
+    "message": "Enviar Imagens",
+    "description": "Botão para enviar imagens de referência do Omni"
+  },
+  "message.referenceImagesExceed": {
+    "message": "Você pode enviar mais {count} imagens de referência.",
+    "description": "Dica sobre a quantidade de imagens de referência"
+  },
+  "message.referenceImagesError": {
+    "message": "Falha ao enviar imagens de referência, por favor, tente novamente.",
+    "description": "Erro ao enviar imagens de referência"
+  },
+  "name.referenceVideoType": {
+    "message": "Uso do Vídeo",
+    "description": "Rótulo do tipo de vídeo de referência"
+  },
+  "name.referenceVideoFeature": {
+    "message": "Referência de Características",
+    "description": "Opção de vídeo de referência de características"
+  },
+  "name.referenceVideoBase": {
+    "message": "Editar Vídeo Original",
+    "description": "Opção de edição de vídeo base"
+  },
+  "message.referenceVideoImageLimit": {
+    "message": "Com um vídeo de referência, é possível suportar no máximo 4 imagens de referência, por favor, remova as imagens extras.",
+    "description": "Conflito entre a quantidade de vídeos de referência e imagens"
+  },
+  "message.referenceImagesTotalLimit": {
+    "message": "Esta solicitação suporta no máximo {count} imagens de referência, incluindo o primeiro e o último quadro no total.",
+    "description": "Aviso sobre o limite total de imagens de referência."
+  },
+  "message.baseVideoFrameConflict": {
+    "message": "O vídeo base a ser editado não pode ser usado com o primeiro ou o último quadro ao mesmo tempo.",
+    "description": "Aviso de conflito entre o vídeo base e os quadros inicial e final."
   },
   "button.uploadReferenceVideo": {
     "message": "Upload Video",

--- a/src/i18n/ru/kling.json
+++ b/src/i18n/ru/kling.json
@@ -775,9 +775,53 @@
     "message": "Reference Video",
     "description": "Form field label: reference/editable video for Omni video editing"
   },
-  "description.referenceVideo": {
-    "message": "Only for kling-video-o1. Upload one MP4/MOV (720-2160px, 3-10s, <=200MB) to edit or reference an existing video. The prompt automatically cites it as <<<video_1>>>; keep that token to describe the edit (e.g. 'turn <<<video_1>>> into anime').",
-    "description": "Help text for the reference video uploader"
+  "description.omniReferenceVideo": {
+    "message": "Подходит для Kling O1 и V3 Omni. Загрузите MP4/MOV (720–2160px, 3–10 секунд, ≤200MB) для редактирования или в качестве ссылки на существующее видео, подсказки будут автоматически добавлены <<<video_1>>>.",
+    "description": "Помощь по загрузке Omni референсного видео"
+  },
+  "name.referenceImages": {
+    "message": "Референсные изображения",
+    "description": "Метка поля для референсных изображений Omni"
+  },
+  "description.referenceImages": {
+    "message": "Подходит для Kling O1 и V3 Omni. Максимум можно загрузить 7 референсных изображений; при наличии референсного видео максимум 4 изображения. Подсказки будут автоматически добавлены.",
+    "description": "Помощь по референсным изображениям Omni"
+  },
+  "button.uploadReferenceImages": {
+    "message": "Загрузить изображения",
+    "description": "Кнопка для загрузки Omni референсных изображений"
+  },
+  "message.referenceImagesExceed": {
+    "message": "Можно загрузить еще {count} референсных изображений.",
+    "description": "Подсказка о количестве референсных изображений"
+  },
+  "message.referenceImagesError": {
+    "message": "Ошибка загрузки референсных изображений, пожалуйста, попробуйте снова.",
+    "description": "Ошибка загрузки референсных изображений"
+  },
+  "name.referenceVideoType": {
+    "message": "Назначение видео",
+    "description": "Метка типа референсного видео"
+  },
+  "name.referenceVideoFeature": {
+    "message": "Референсные характеристики",
+    "description": "Опция референсного видео с характеристиками"
+  },
+  "name.referenceVideoBase": {
+    "message": "Редактировать оригинальное видео",
+    "description": "Основные параметры редактирования видео"
+  },
+  "message.referenceVideoImageLimit": {
+    "message": "При наличии референсного видео поддерживается максимум 4 референсных изображения, пожалуйста, сначала удалите лишние изображения.",
+    "description": "Конфликт количества референсного видео и изображений"
+  },
+  "message.referenceImagesTotalLimit": {
+    "message": "Этот запрос поддерживает максимум {count} референсных изображений, включая первую и последнюю рамки.",
+    "description": "Уведомление о лимите общего количества референсных изображений."
+  },
+  "message.baseVideoFrameConflict": {
+    "message": "Базовое видео не может использоваться одновременно с первой или последней рамкой.",
+    "description": "Уведомление о конфликте между базовым видео и первой/последней рамкой."
   },
   "button.uploadReferenceVideo": {
     "message": "Upload Video",

--- a/src/i18n/sr/kling.json
+++ b/src/i18n/sr/kling.json
@@ -775,9 +775,53 @@
     "message": "Reference Video",
     "description": "Form field label: reference/editable video for Omni video editing"
   },
-  "description.referenceVideo": {
-    "message": "Only for kling-video-o1. Upload one MP4/MOV (720-2160px, 3-10s, <=200MB) to edit or reference an existing video. The prompt automatically cites it as <<<video_1>>>; keep that token to describe the edit (e.g. 'turn <<<video_1>>> into anime').",
-    "description": "Help text for the reference video uploader"
+  "description.omniReferenceVideo": {
+    "message": "Погодно за Kling O1 и V3 Omni. Отпремите MP4/MOV (720–2160px, 3–10 секунди, ≤200MB) за уређивање или референцу постојећег видеа, кључне речи ће бити аутоматски додате <<<video_1>>>.",
+    "description": "Помоћни текст за отпремање Omni референтног видеа"
+  },
+  "name.referenceImages": {
+    "message": "Референтне слике",
+    "description": "Ознака поља за Omni референтне слике"
+  },
+  "description.referenceImages": {
+    "message": "Погодно за Kling O1 и V3 Omni. Можете отпремити до 7 референтних слика; ако постоји референтни видео, максимум је 4 слике. Кључне речи ће бити аутоматски додате.",
+    "description": "Помоћни текст за Omni референтне слике"
+  },
+  "button.uploadReferenceImages": {
+    "message": "Отпремите слике",
+    "description": "Дугме за отпремање Omni референтних слика"
+  },
+  "message.referenceImagesExceed": {
+    "message": "Можете отпремити још {count} референтних слика.",
+    "description": "Индикација о броју преосталих референтних слика"
+  },
+  "message.referenceImagesError": {
+    "message": "Отпремање референтних слика није успело, молимо покушајте поново.",
+    "description": "Грешка при отпремању референтних слика"
+  },
+  "name.referenceVideoType": {
+    "message": "Намена видеа",
+    "description": "Ознака типа референтног видеа"
+  },
+  "name.referenceVideoFeature": {
+    "message": "Референца карактеристика",
+    "description": "Опција за референтни видео карактеристика"
+  },
+  "name.referenceVideoBase": {
+    "message": "Уредите оригинални видео",
+    "description": "Основна опција за уређивање видеа"
+  },
+  "message.referenceVideoImageLimit": {
+    "message": "Када постоји референтни видео, можете подржати максимум 4 референтне слике, молимо уклоните вишак слика.",
+    "description": "Конфликт између броја референтног видеа и слика"
+  },
+  "message.referenceImagesTotalLimit": {
+    "message": "Ovaj zahtev podržava najviše {count} referentnih slika, pri čemu se prvi i poslednji kadar takođe računaju u ukupan broj.",
+    "description": "Obaveštenje o ograničenju ukupnog broja referentnih slika."
+  },
+  "message.baseVideoFrameConflict": {
+    "message": "Osnovni video koji čeka uređivanje ne može se koristiti istovremeno sa prvim ili poslednjim kadrom.",
+    "description": "Obaveštenje o sukobu između osnovnog videa i prvog ili poslednjeg kadra."
   },
   "button.uploadReferenceVideo": {
     "message": "Upload Video",

--- a/src/i18n/sv/kling.json
+++ b/src/i18n/sv/kling.json
@@ -775,9 +775,53 @@
     "message": "Reference Video",
     "description": "Form field label: reference/editable video for Omni video editing"
   },
-  "description.referenceVideo": {
-    "message": "Only for kling-video-o1. Upload one MP4/MOV (720-2160px, 3-10s, <=200MB) to edit or reference an existing video. The prompt automatically cites it as <<<video_1>>>; keep that token to describe the edit (e.g. 'turn <<<video_1>>> into anime').",
-    "description": "Help text for the reference video uploader"
+  "description.omniReferenceVideo": {
+    "message": "Gäller för Kling O1 och V3 Omni. Ladda upp en MP4/MOV (720–2160px, 3–10 sek, ≤200MB) för redigering eller referens av befintligt video, promptord kommer automatiskt att läggas till <<<video_1>>>.",
+    "description": "Hjälptext för att ladda upp Omni referensvideo"
+  },
+  "name.referenceImages": {
+    "message": "Referensbilder",
+    "description": "Fältetikett för Omni referensbilder"
+  },
+  "description.referenceImages": {
+    "message": "Gäller för Kling O1 och V3 Omni. Max 7 referensbilder kan laddas upp; om en referensvideo finns, max 4 bilder. Promptord referensmarkeringar kommer automatiskt att läggas till.",
+    "description": "Hjälptext för Omni referensbilder"
+  },
+  "button.uploadReferenceImages": {
+    "message": "Ladda upp bilder",
+    "description": "Knapp för att ladda upp Omni referensbilder"
+  },
+  "message.referenceImagesExceed": {
+    "message": "Du kan fortfarande ladda upp {count} referensbilder.",
+    "description": "Indikation på antal tillåtna referensbilder"
+  },
+  "message.referenceImagesError": {
+    "message": "Misslyckades med att ladda upp referensbilder, vänligen försök igen.",
+    "description": "Fel vid uppladdning av referensbilder"
+  },
+  "name.referenceVideoType": {
+    "message": "Videons användning",
+    "description": "Etikett för typ av referensvideo"
+  },
+  "name.referenceVideoFeature": {
+    "message": "Funktion referens",
+    "description": "Alternativ för referensvideo av funktion"
+  },
+  "name.referenceVideoBase": {
+    "message": "Redigera originalvideo",
+    "description": "Grundläggande video redigeringsalternativ"
+  },
+  "message.referenceVideoImageLimit": {
+    "message": "Max 4 referensbilder stöds när en referensvideo finns, vänligen ta bort överflödiga bilder först.",
+    "description": "Konflikt mellan antal referensvideo och bilder"
+  },
+  "message.referenceImagesTotalLimit": {
+    "message": "Denna begäran stöder högst {count} referensbilder, där första och sista bildruta också räknas med i totalsumman.",
+    "description": "Meddelande om gräns för det totala antalet referensbilder."
+  },
+  "message.baseVideoFrameConflict": {
+    "message": "Det grundläggande videoklippet kan inte användas samtidigt med första eller sista bildrutan.",
+    "description": "Meddelande om konflikt mellan grundläggande video och första eller sista bildrutan."
   },
   "button.uploadReferenceVideo": {
     "message": "Upload Video",

--- a/src/i18n/uk/kling.json
+++ b/src/i18n/uk/kling.json
@@ -775,9 +775,53 @@
     "message": "Reference Video",
     "description": "Form field label: reference/editable video for Omni video editing"
   },
-  "description.referenceVideo": {
-    "message": "Only for kling-video-o1. Upload one MP4/MOV (720-2160px, 3-10s, <=200MB) to edit or reference an existing video. The prompt automatically cites it as <<<video_1>>>; keep that token to describe the edit (e.g. 'turn <<<video_1>>> into anime').",
-    "description": "Help text for the reference video uploader"
+  "description.omniReferenceVideo": {
+    "message": "Для Kling O1 та V3 Omni. Завантажте MP4/MOV (720–2160px, 3–10 секунд, ≤200MB) для редагування або як посилання на вже існуюче відео, підказки будуть автоматично додані <<<video_1>>>.",
+    "description": "Допоміжний текст для завантаження Omni референсного відео"
+  },
+  "name.referenceImages": {
+    "message": "Референсні зображення",
+    "description": "Мітка поля для референсних зображень Omni"
+  },
+  "description.referenceImages": {
+    "message": "Для Kling O1 та V3 Omni. Максимум можна завантажити 7 референсних зображень; якщо є референсне відео, максимум 4 зображення. Підказки з посиланнями будуть автоматично додані.",
+    "description": "Допоміжний текст для референсних зображень Omni"
+  },
+  "button.uploadReferenceImages": {
+    "message": "Завантажити зображення",
+    "description": "Кнопка для завантаження Omni референсних зображень"
+  },
+  "message.referenceImagesExceed": {
+    "message": "Можна завантажити ще {count} референсних зображень.",
+    "description": "Підказка щодо кількості референсних зображень"
+  },
+  "message.referenceImagesError": {
+    "message": "Не вдалося завантажити референсні зображення, будь ласка, спробуйте ще раз.",
+    "description": "Помилка завантаження референсних зображень"
+  },
+  "name.referenceVideoType": {
+    "message": "Призначення відео",
+    "description": "Мітка типу референсного відео"
+  },
+  "name.referenceVideoFeature": {
+    "message": "Референсні особливості",
+    "description": "Опція для референсного відео з особливостями"
+  },
+  "name.referenceVideoBase": {
+    "message": "Редагувати оригінальне відео",
+    "description": "Основні опції редагування відео"
+  },
+  "message.referenceVideoImageLimit": {
+    "message": "Якщо є референсне відео, підтримується максимум 4 референсних зображення, будь ласка, спочатку видаліть зайві зображення.",
+    "description": "Конфлікт між кількістю референсного відео та зображень"
+  },
+  "message.referenceImagesTotalLimit": {
+    "message": "Цей запит підтримує максимум {count} зображень для посилання, перша та остання рамки також враховуються в загальній кількості.",
+    "description": "Попередження про обмеження загальної кількості зображень для посилання."
+  },
+  "message.baseVideoFrameConflict": {
+    "message": "Базове відео не може використовуватися одночасно з першою або останньою рамкою.",
+    "description": "Попередження про конфлікт між базовим відео та першою або останньою рамкою."
   },
   "button.uploadReferenceVideo": {
     "message": "Upload Video",

--- a/src/i18n/zh-CN/kling.json
+++ b/src/i18n/zh-CN/kling.json
@@ -32,8 +32,8 @@
     "description": "人物朝向选项：跟随视频"
   },
   "name.keepOriginalSound": {
-    "message": "保留原始音频",
-    "description": "keep_original_sound 开关"
+    "message": "保留原声",
+    "description": "保留参考视频原声音频开关标签"
   },
   "description.motionImage": {
     "message": "上传人物参考图，生成视频中的人物、背景等元素均以此为参照",
@@ -775,9 +775,53 @@
     "message": "参考视频",
     "description": "表单字段标签：Omni 视频编辑的参考/待编辑视频"
   },
-  "description.referenceVideo": {
-    "message": "仅 kling-video-o1 支持。上传一个 MP4/MOV（720–2160px、3–10 秒、≤200MB）用于编辑或参考已有视频。提示词会自动以 <<<video_1>>> 引用它，请保留该标记来描述编辑效果（如「把 <<<video_1>>> 改成动漫风格」）。",
-    "description": "参考视频上传的帮助文字"
+  "description.omniReferenceVideo": {
+    "message": "适用于 Kling O1 和 V3 Omni。上传一个 MP4/MOV（720–2160px、3–10 秒、≤200MB）用于编辑或参考已有视频，提示词会自动添加 <<<video_1>>>。",
+    "description": "Omni 参考视频上传的帮助文字"
+  },
+  "name.referenceImages": {
+    "message": "参考图片",
+    "description": "Omni 参考图片字段标签"
+  },
+  "description.referenceImages": {
+    "message": "适用于 Kling O1 和 V3 Omni。最多上传 7 张参考图；存在参考视频时最多 4 张。提示词引用标记会自动添加。",
+    "description": "Omni 参考图片帮助文字"
+  },
+  "button.uploadReferenceImages": {
+    "message": "上传图片",
+    "description": "上传 Omni 参考图片按钮"
+  },
+  "message.referenceImagesExceed": {
+    "message": "还可以上传 {count} 张参考图片。",
+    "description": "参考图片数量提示"
+  },
+  "message.referenceImagesError": {
+    "message": "参考图片上传失败，请重试。",
+    "description": "参考图片上传错误"
+  },
+  "name.referenceVideoType": {
+    "message": "视频用途",
+    "description": "参考视频类型标签"
+  },
+  "name.referenceVideoFeature": {
+    "message": "特征参考",
+    "description": "特征参考视频选项"
+  },
+  "name.referenceVideoBase": {
+    "message": "编辑原视频",
+    "description": "基础视频编辑选项"
+  },
+  "message.referenceVideoImageLimit": {
+    "message": "存在参考视频时最多支持 4 张参考图片，请先移除多余图片。",
+    "description": "参考视频与图片数量冲突"
+  },
+  "message.referenceImagesTotalLimit": {
+    "message": "该请求最多支持 {count} 张参考图片，首帧和尾帧也计入总数。",
+    "description": "参考图片总数限制提示"
+  },
+  "message.baseVideoFrameConflict": {
+    "message": "待编辑的基础视频不能与首帧或尾帧同时使用。",
+    "description": "基础视频与首尾帧冲突提示"
   },
   "button.uploadReferenceVideo": {
     "message": "上传视频",

--- a/src/i18n/zh-TW/kling.json
+++ b/src/i18n/zh-TW/kling.json
@@ -775,9 +775,53 @@
     "message": "Reference Video",
     "description": "Form field label: reference/editable video for Omni video editing"
   },
-  "description.referenceVideo": {
-    "message": "Only for kling-video-o1. Upload one MP4/MOV (720-2160px, 3-10s, <=200MB) to edit or reference an existing video. The prompt automatically cites it as <<<video_1>>>; keep that token to describe the edit (e.g. 'turn <<<video_1>>> into anime').",
-    "description": "Help text for the reference video uploader"
+  "description.omniReferenceVideo": {
+    "message": "適用於 Kling O1 和 V3 Omni。上傳一個 MP4/MOV（720–2160px、3–10 秒、≤200MB）用於編輯或參考已有視頻，提示詞會自動添加 <<<video_1>>>。",
+    "description": "Omni 參考視頻上傳的幫助文字"
+  },
+  "name.referenceImages": {
+    "message": "參考圖片",
+    "description": "Omni 參考圖片字段標籤"
+  },
+  "description.referenceImages": {
+    "message": "適用於 Kling O1 和 V3 Omni。最多上傳 7 張參考圖；存在參考視頻時最多 4 張。提示詞引用標記會自動添加。",
+    "description": "Omni 參考圖片幫助文字"
+  },
+  "button.uploadReferenceImages": {
+    "message": "上傳圖片",
+    "description": "上傳 Omni 參考圖片按鈕"
+  },
+  "message.referenceImagesExceed": {
+    "message": "還可以上傳 {count} 張參考圖片。",
+    "description": "參考圖片數量提示"
+  },
+  "message.referenceImagesError": {
+    "message": "參考圖片上傳失敗，請重試。",
+    "description": "參考圖片上傳錯誤"
+  },
+  "name.referenceVideoType": {
+    "message": "視頻用途",
+    "description": "參考視頻類型標籤"
+  },
+  "name.referenceVideoFeature": {
+    "message": "特徵參考",
+    "description": "特徵參考視頻選項"
+  },
+  "name.referenceVideoBase": {
+    "message": "編輯原視頻",
+    "description": "基礎視頻編輯選項"
+  },
+  "message.referenceVideoImageLimit": {
+    "message": "存在參考視頻時最多支持 4 張參考圖片，請先移除多餘圖片。",
+    "description": "參考視頻與圖片數量衝突"
+  },
+  "message.referenceImagesTotalLimit": {
+    "message": "該請求最多支持 {count} 張參考圖片，首幀和尾幀也計入總數。",
+    "description": "參考圖片總數限制提示"
+  },
+  "message.baseVideoFrameConflict": {
+    "message": "待編輯的基礎視頻不能與首幀或尾幀同時使用。",
+    "description": "基礎視頻與首尾幀衝突提示"
   },
   "button.uploadReferenceVideo": {
     "message": "Upload Video",

--- a/src/models/kling.ts
+++ b/src/models/kling.ts
@@ -20,8 +20,9 @@ export interface IKlingReferenceVideo {
   keep_original_sound?: 'yes' | 'no';
 }
 
-export interface IKlingElementRef {
-  element_id?: string;
+export interface IKlingReferenceImage {
+  image_url: string;
+  type?: 'first_frame' | 'end_frame';
 }
 
 export type IKlingTaskType = 'videos' | 'motion' | 'talking-photo';
@@ -90,7 +91,7 @@ export interface IKlingConfig {
   callback_url?: string;
   async?: boolean;
   generate_audio?: boolean;
-  element_list?: IKlingElementRef[];
+  image_list?: IKlingReferenceImage[];
   video_list?: IKlingReferenceVideo[];
 }
 
@@ -111,7 +112,7 @@ export interface IKlingGenerateRequest {
   callback_url?: string;
   async?: boolean;
   generate_audio?: boolean;
-  element_list?: IKlingElementRef[];
+  image_list?: IKlingReferenceImage[];
   video_list?: IKlingReferenceVideo[];
 }
 export interface IKlingVideo {

--- a/src/pages/kling/Index.vue
+++ b/src/pages/kling/Index.vue
@@ -189,6 +189,20 @@ export default defineComponent({
         ...rest,
         async: true
       } as IKlingGenerateRequest;
+      const frameCount = Number(Boolean(request.start_image_url)) + Number(Boolean(request.end_image_url));
+      const referenceImageCount = request.image_list?.length || 0;
+      const maxReferenceImages = request.video_list?.length ? 4 : 7;
+      if (frameCount + referenceImageCount > maxReferenceImages) {
+        ElMessage.warning(this.$t('kling.message.referenceImagesTotalLimit', { count: maxReferenceImages }));
+        return;
+      }
+      if (
+        request.video_list?.[0]?.refer_type === 'base' &&
+        (request.start_image_url || request.end_image_url || request.image_list?.some(({ type }) => type))
+      ) {
+        ElMessage.warning(this.$t('kling.message.baseVideoFrameConflict'));
+        return;
+      }
       // Reject "only end frame, no start frame" — Kling can't anchor an
       // end-frame without a starting reference.
       if (!request.video_id && !(rest as any).video_url && !request.start_image_url && request.end_image_url) {

--- a/src/utils/kling/capabilities.test.ts
+++ b/src/utils/kling/capabilities.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { clearKlingConflicts, findKlingConflicts, getKlingCapabilities } from './capabilities';
+
+describe('Kling Omni capabilities', () => {
+  it('exposes reference video for the canonical model name', () => {
+    expect(getKlingCapabilities('kling-o1').referenceVideo).toBe(true);
+  });
+
+  it('exposes image and video references for V3 Omni', () => {
+    expect(getKlingCapabilities('kling-v3-omni')).toMatchObject({
+      referenceImages: true,
+      referenceVideo: true
+    });
+  });
+
+  it('clears prompt controls when switching to O1', () => {
+    const config = {
+      model: 'kling-v3',
+      cfg_scale: 0.5,
+      negative_prompt: 'blur',
+      camera_control: { type: 'simple' }
+    };
+    const conflicts = findKlingConflicts(config, { model: 'kling-o1' });
+    expect(conflicts.map(({ field }) => field)).toEqual(['camera_control', 'cfg_scale', 'negative_prompt']);
+    expect(clearKlingConflicts({ ...config, model: 'kling-o1' }, conflicts)).toMatchObject({
+      camera_control: undefined,
+      cfg_scale: undefined,
+      negative_prompt: undefined
+    });
+  });
+});

--- a/src/utils/kling/capabilities.ts
+++ b/src/utils/kling/capabilities.ts
@@ -20,8 +20,10 @@ export interface IKlingCapability {
    *  see findKlingConflicts. */
   motionControl: boolean;
   /** Omni reference video (video_list) — edit/reference an existing video.
-   *  Only kling-video-o1 supports it. */
+   * Kling O1 and V3 Omni support it. */
   referenceVideo: boolean;
+  /** Omni reference images (image_list). */
+  referenceImages: boolean;
 }
 
 const FALLBACK: IKlingCapability = {
@@ -30,7 +32,8 @@ const FALLBACK: IKlingCapability = {
   endImage: false,
   audio: false,
   motionControl: false,
-  referenceVideo: false
+  referenceVideo: false,
+  referenceImages: false
 };
 
 /**
@@ -51,7 +54,8 @@ export function getKlingCapabilities(model?: string, mode?: string, duration?: n
         endImage: d === 5,
         audio: false,
         motionControl: d === 5,
-        referenceVideo: false
+        referenceVideo: false,
+        referenceImages: false
       };
     // v1.6 / v2.5-Turbo / v2.6 / v2.1: end-frame is pro-only.
     case 'kling-v1-6':
@@ -62,7 +66,8 @@ export function getKlingCapabilities(model?: string, mode?: string, duration?: n
         endImage: m === 'pro',
         audio: false,
         motionControl: false,
-        referenceVideo: false
+        referenceVideo: false,
+        referenceImages: false
       };
     case 'kling-v2-6':
       return {
@@ -71,7 +76,8 @@ export function getKlingCapabilities(model?: string, mode?: string, duration?: n
         endImage: m === 'pro',
         audio: m === 'pro',
         motionControl: false,
-        referenceVideo: false
+        referenceVideo: false,
+        referenceImages: false
       };
     // v2-Master / v2.1-Master: single-mode, no end-frame in matrix.
     case 'kling-v2-master':
@@ -82,7 +88,8 @@ export function getKlingCapabilities(model?: string, mode?: string, duration?: n
         endImage: false,
         audio: false,
         motionControl: false,
-        referenceVideo: false
+        referenceVideo: false,
+        referenceImages: false
       };
     // v3 family: end-frame in every mode; motion control on v3 std/pro only.
     case 'kling-v3':
@@ -92,7 +99,8 @@ export function getKlingCapabilities(model?: string, mode?: string, duration?: n
         endImage: true,
         audio: true,
         motionControl: m !== '4k',
-        referenceVideo: false
+        referenceVideo: false,
+        referenceImages: false
       };
     case 'kling-v3-omni':
       return {
@@ -101,16 +109,18 @@ export function getKlingCapabilities(model?: string, mode?: string, duration?: n
         endImage: true,
         audio: true,
         motionControl: false,
-        referenceVideo: false
+        referenceVideo: true,
+        referenceImages: true
       };
-    case 'kling-video-o1':
+    case 'kling-o1':
       return {
         text2video: true,
         image2video: true,
         endImage: true,
         audio: false,
         motionControl: false,
-        referenceVideo: true
+        referenceVideo: true,
+        referenceImages: true
       };
     default:
       return FALLBACK;
@@ -119,7 +129,14 @@ export function getKlingCapabilities(model?: string, mode?: string, duration?: n
 
 export interface IKlingConflict {
   /** Field name in the config object. */
-  field: 'end_image_url' | 'generate_audio' | 'camera_control' | 'video_list';
+  field:
+    | 'end_image_url'
+    | 'generate_audio'
+    | 'camera_control'
+    | 'cfg_scale'
+    | 'negative_prompt'
+    | 'image_list'
+    | 'video_list';
   /** i18n key for the user-facing label of the field. */
   i18nLabel: string;
 }
@@ -128,6 +145,7 @@ export interface IKlingConflict {
 // upstream model ignores it. Shared so the uploader and the model-switch
 // cleanup remove it consistently.
 export const KLING_VIDEO_TOKEN = '<<<video_1>>>';
+export const KLING_IMAGE_TOKEN_PATTERN = /<<<image_\d+>>>/g;
 
 /** Remove every <<<video_1>>> occurrence and collapse the leftover whitespace. */
 export function stripKlingVideoToken(prompt?: string): string {
@@ -135,6 +153,14 @@ export function stripKlingVideoToken(prompt?: string): string {
   return prompt
     .split(KLING_VIDEO_TOKEN)
     .join(' ')
+    .replace(/\s{2,}/g, ' ')
+    .trim();
+}
+
+export function stripKlingImageTokens(prompt?: string): string {
+  if (!prompt) return '';
+  return prompt
+    .replace(KLING_IMAGE_TOKEN_PATTERN, ' ')
     .replace(/\s{2,}/g, ' ')
     .trim();
 }
@@ -173,6 +199,16 @@ export function findKlingConflicts(
   if (config.video_list?.length && !caps.referenceVideo) {
     conflicts.push({ field: 'video_list', i18nLabel: 'kling.name.referenceVideo' });
   }
+  if (config.image_list?.length && !caps.referenceImages) {
+    conflicts.push({ field: 'image_list', i18nLabel: 'kling.name.referenceImages' });
+  }
+  const nextUsesOmni = model === 'kling-o1' || Boolean(config.image_list?.length || config.video_list?.length);
+  if (nextUsesOmni && config.cfg_scale !== undefined) {
+    conflicts.push({ field: 'cfg_scale', i18nLabel: 'kling.name.cfgScale' });
+  }
+  if (nextUsesOmni && config.negative_prompt) {
+    conflicts.push({ field: 'negative_prompt', i18nLabel: 'kling.name.negativePrompt' });
+  }
 
   return conflicts;
 }
@@ -187,9 +223,15 @@ export function clearKlingConflicts(config: Record<string, any>, conflicts: IKli
     if (c.field === 'end_image_url') next.end_image_url = undefined;
     if (c.field === 'generate_audio') next.generate_audio = false;
     if (c.field === 'camera_control') next.camera_control = undefined;
+    if (c.field === 'cfg_scale') next.cfg_scale = undefined;
+    if (c.field === 'negative_prompt') next.negative_prompt = undefined;
     if (c.field === 'video_list') {
       next.video_list = undefined;
       next.prompt = stripKlingVideoToken(next.prompt);
+    }
+    if (c.field === 'image_list') {
+      next.image_list = undefined;
+      next.prompt = stripKlingImageTokens(next.prompt);
     }
   }
   return next;


### PR DESCRIPTION
## Summary
- expose only the canonical `kling-o1` model name and add O1/V3 Omni image and video reference controls
- add multi-image uploads with deterministic prompt-token numbering across first/last frames
- add reference-video `feature`/`base` selection and original-sound control
- enforce O1 five-second duration plus worker-aligned Omni field/count/frame conflicts before submission
- remove Element and legacy O1 surfaces, and translate all new UI keys across 17 locales

## Validation
- ESLint on Kling components, page, models, and capability utilities
- Vitest: Kling capability and task-preview suites (6 tests)
- `vue-tsc -b`
- `scripts/check_i18n_coverage.py` (17 locales x 44 namespaces)
- Vite production build
- Prettier and `git diff --check`

## Rollout dependency
Do not release this UI before PlatformService PR #1500 is deployed, PlatformBackend PR #1007 canonical costs are synced, the worker gates pass the controlled live canary, and the public OpenAPI/docs are synced.

## Adversarial review
Reviewer: Codex attempted, then read-only Explore fallback after a reviewer network disconnect; 2 rounds.
- fixed local preview state after external image-list cleanup
- enforced image limits across reference images, first/last frames, and reference video
- blocked base-video/frame conflicts at upload and submission
- hardened Omni field cleanup when video options change
- improved narrow-screen reference option layout
- preserved user images instead of silently truncating them when adding a video would exceed limits
- final verdict: CLEAN
