### PR TITLE
Emphasize homepage story headings

### DIFF
--- a/change/@acedatacloud-nexior-home-story-heading-weight.json
+++ b/change/@acedatacloud-nexior-home-story-heading-weight.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Emphasize homepage business-story headings with a stronger visual weight",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/pages/index/Index.vue
+++ b/src/pages/index/Index.vue
@@ -895,6 +895,7 @@ export default defineComponent({
     h3 {
       margin: 10px 0 16px;
       font-size: 34px;
+      font-weight: 800;
       line-height: 1.25;
       letter-spacing: 0;
     }


### PR DESCRIPTION
## Summary

- make homepage business-story headings visibly bolder with an explicit `font-weight: 800`
- keep the existing semantic `h3`, responsive sizes, wrapping, and body-copy weight unchanged
- apply the same hierarchy consistently to headings such as `从获客到登录，每个品牌触点都能配置`

## Validation

- Prettier and ESLint
- `vue-tsc -b`
- `npm run build:web`
- `npm run build:ssg`
- i18n coverage: 17 locales x 44 namespaces
- `npx beachball check`
- Playwright desktop: `34px / 800`, body `400`, zero overflow
- Playwright mobile: `28px / 800`, body `400`, zero overflow

## Adversarial review

`VERDICT: CLEAN`

The review confirmed the loaded typeface includes weight 800, responsive sizing remains intact, the semantic heading structure is unchanged, and the selector is limited to homepage story headings.

## Public preview

https://fix-home-story-heading-weight-nexior.plain-river-2dfc.workers.dev/home

Worker version: `d6409535-d89f-4517-9563-28ee360e3afb`

The deployed zh-CN page was revalidated at 1440×900 and 390×844: the target heading computes to weight 800, body copy remains 400, and horizontal overflow is zero.

## CI follow-up

The initial Node 22 run correctly required a branch-specific Beachball change file. Added a patch change file and verified the exact CI command: `npx beachball check --branch origin/main`. The public page code and preview output are unchanged.