### PR TITLE
fix(grok): use stable default video duration

### DIFF
--- a/change/@acedatacloud-nexior-grok-duration-default.json
+++ b/change/@acedatacloud-nexior-grok-duration-default.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Use the upstream-recommended 6-second default for Grok video generation.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/change/@acedatacloud-nexior-grok-duration-default.json
+++ b/change/@acedatacloud-nexior-grok-duration-default.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Use the upstream-recommended 6-second default for Grok video generation.",
+  "comment": "Use a stable 6-second default for Grok video generation.",
   "packageName": "@acedatacloud/nexior",
   "email": "dev@acedata.cloud",
   "dependentChangeType": "patch"

--- a/src/constants/grokvideo.ts
+++ b/src/constants/grokvideo.ts
@@ -21,7 +21,7 @@ export const GROKVIDEO_RESOLUTION_720P = '720p';
 export const GROKVIDEO_RESOLUTION_1080P = '1080p';
 export const GROKVIDEO_DEFAULT_RESOLUTION = GROKVIDEO_RESOLUTION_480P;
 
-export const GROKVIDEO_DEFAULT_DURATION = 8;
+export const GROKVIDEO_DEFAULT_DURATION = 6;
 
 // grok-imagine-video (1.0) supports up to 30s; grok-imagine-video-1.5-preview up to 15s.
 export const GROKVIDEO_MAX_DURATION_DEFAULT = 30;


### PR DESCRIPTION
## Summary

- change the Grok video generation default from 8 seconds to the stable 6-second value
- keep the 6-second option flowing through initial state, reset behavior, selector fallback, and request submission
- add the required patch release note using user-facing wording

## Validation

- `npx eslint src/constants/grokvideo.ts`
- `npx prettier --check src/constants/grokvideo.ts change/@acedatacloud-nexior-grok-duration-default.json`
- `npx vue-tsc --noEmit --pretty false`
- `npm run build:web`
- `npx beachball check`
- GitHub build, E2E smoke, and Cloudflare Workers checks passed

## Related rollout

The API runtime and billing changes are tracked in:

- https://github.com/AceDataCloud/PlatformService/pull/1509
- https://github.com/AceDataCloud/PlatformBackend/pull/1013

Nexior sends 6 seconds explicitly, so this PR does not depend on their deployment order.

## 🤖 对抗评审 (reviewer: Explore fallback, 3 rounds)

Codex was unavailable because its account usage limit was reached. The read-only reviewer traced the shared default through initial state, reset behavior, selector fallback, request submission, allowed options, release metadata, API runtime, billing, and documentation.

- RISK: cross-repository Markdown still documented and demonstrated 8 seconds → fixed in PlatformBackend PR 1013
- RISK: display-pricing tests still labeled 8 seconds as the default → fixed in PlatformBackend PR 1013
- Final verdict: CLEAN