### PR TITLE
fix(tasks): query history by actor identity

### DIFF
--- a/change/@acedatacloud-nexior-actor-task-history.json
+++ b/change/@acedatacloud-nexior-actor-task-history.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Query generated task history by the actual actor identity.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/operators/baseTaskOperator.ts
+++ b/src/operators/baseTaskOperator.ts
@@ -11,7 +11,7 @@ import { BASE_URL_API } from '@/constants';
 export interface ITaskListFilter {
   ids?: string[];
   applicationId?: string;
-  userId?: string;
+  actorUserId?: string;
   limit?: number;
   offset?: number;
   createdAtMax?: number;

--- a/src/operators/midjourney.ts
+++ b/src/operators/midjourney.ts
@@ -35,7 +35,7 @@ class MidjourneyOperator {
     filter: {
       ids?: string[];
       applicationId?: string;
-      userId?: string;
+      actorUserId?: string;
       type?: string;
       limit?: number;
       offset?: number;
@@ -58,9 +58,9 @@ class MidjourneyOperator {
               application_id: filter.applicationId
             }
           : {}),
-        ...(filter.userId
+        ...(filter.actorUserId
           ? {
-              user_id: filter.userId
+              actor_user_id: filter.actorUserId
             }
           : {}),
         ...(filter.type

--- a/src/operators/producer.ts
+++ b/src/operators/producer.ts
@@ -37,7 +37,7 @@ class ProducerOperator {
     filter: {
       ids?: string[];
       applicationId?: string;
-      userId?: string;
+      actorUserId?: string;
       type?: string;
       limit?: number;
       offset?: number;
@@ -55,9 +55,9 @@ class ProducerOperator {
               ids: filter.ids
             }
           : {}),
-        ...(filter.userId
+        ...(filter.actorUserId
           ? {
-              user_id: filter.userId
+              actor_user_id: filter.actorUserId
             }
           : {}),
         ...(filter.type

--- a/src/operators/seedream.ts
+++ b/src/operators/seedream.ts
@@ -31,7 +31,7 @@ class SeedreamOperator {
     filter: {
       ids?: string[];
       applicationId?: string;
-      userId?: string;
+      actorUserId?: string;
       type?: string;
       limit?: number;
       offset?: number;
@@ -54,9 +54,9 @@ class SeedreamOperator {
               application_id: filter.applicationId
             }
           : {}),
-        ...(filter.userId
+        ...(filter.actorUserId
           ? {
-              user_id: filter.userId
+              actor_user_id: filter.actorUserId
             }
           : {}),
         ...(filter.type

--- a/src/operators/suno.ts
+++ b/src/operators/suno.ts
@@ -50,7 +50,7 @@ class SunoOperator {
     filter: {
       ids?: string[];
       applicationId?: string;
-      userId?: string;
+      actorUserId?: string;
       type?: string;
       limit?: number;
       offset?: number;
@@ -68,9 +68,9 @@ class SunoOperator {
               ids: filter.ids
             }
           : {}),
-        ...(filter.userId
+        ...(filter.actorUserId
           ? {
-              user_id: filter.userId
+              actor_user_id: filter.actorUserId
             }
           : {}),
         ...(filter.type

--- a/src/store/factories/createTaskActions.ts
+++ b/src/store/factories/createTaskActions.ts
@@ -77,7 +77,7 @@ export function createTaskActions<TConfig, TTask, TFilter>(opts: {
     opts.buildFilter ??
     ((rootState: IRootState, args: IGetTasksArgs): TFilter =>
       ({
-        userId: rootState?.user?.id,
+        actorUserId: rootState?.user?.id,
         ...(opts.paginated ? { offset: args.offset, limit: args.limit } : {}),
         createdAtMin: args.createdAtMin,
         createdAtMax: args.createdAtMax,

--- a/src/store/kling/actions.ts
+++ b/src/store/kling/actions.ts
@@ -13,7 +13,7 @@ const baseActions = createTaskActions<IKlingConfig, IKlingTask, KlingTasksFilter
   serviceId: KLING_SERVICE_ID,
   operator: klingOperator,
   buildFilter: (rootState, args: IGetTasksArgs): KlingTasksFilter => ({
-    userId: rootState?.user?.id,
+    actorUserId: rootState?.user?.id,
     createdAtMin: args.createdAtMin,
     createdAtMax: args.createdAtMax,
     type: rootState?.kling?.taskType

--- a/src/store/midjourney/actions.ts
+++ b/src/store/midjourney/actions.ts
@@ -152,7 +152,7 @@ export const getTasks = async (
     midjourneyOperator
       .tasks(
         {
-          userId: rootState?.user?.id,
+          actorUserId: rootState?.user?.id,
           createdAtMin,
           createdAtMax
         },

--- a/src/store/producer/actions.ts
+++ b/src/store/producer/actions.ts
@@ -155,7 +155,7 @@ export const getTasks = async (
     producerOperator
       .tasks(
         {
-          userId: rootState?.user?.id,
+          actorUserId: rootState?.user?.id,
           createdAtMin,
           createdAtMax,
           type: 'audios'

--- a/src/store/seedream/actions.ts
+++ b/src/store/seedream/actions.ts
@@ -152,7 +152,7 @@ export const getTasks = async (
     seedreamOperator
       .tasks(
         {
-          userId: rootState?.user?.id,
+          actorUserId: rootState?.user?.id,
           offset,
           limit,
           createdAtMin,

--- a/src/store/suno/actions.ts
+++ b/src/store/suno/actions.ts
@@ -157,7 +157,7 @@ export const getTasks = async (
     sunoOperator
       .tasks(
         {
-          userId: rootState?.user?.id,
+          actorUserId: rootState?.user?.id,
           createdAtMin,
           createdAtMax,
           type: 'audios'


### PR DESCRIPTION
## Summary
- send `actor_user_id` for every generated-task history request
- update the generic task operator and the Midjourney, Producer, Seedream, and Suno custom operators
- keep application, credential, persona, and chat identity fields unchanged

## Dependency
Merge/deploy after https://github.com/AceDataCloud/PlatformService/pull/1512.

## Validation
- `npx vue-tsc --noEmit` passed
- `npm run lint:check` passed
- Prettier check passed
- `npm run verify` passed
- `git diff --check` passed

## 🤖 对抗评审 (reviewer: codex attempted, Explore fallback, 2 rounds)
- Verified every generated-task history caller now sends `actor_user_id`
- Verified generic camel-to-snake conversion and four custom operators agree
- Rebutted: refactoring the four custom operators into the base class is unrelated scope expansion; current implementations are typechecked and behaviorally equivalent
- Final verdict: CLEAN
