### PR TITLE
feat: add scenario panel primitives

### DIFF
--- a/change/@acedatacloud-nexior-scenario-primitives.json
+++ b/change/@acedatacloud-nexior-scenario-primitives.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add shared layout and segmented-control primitives for generation scenario panels.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "minor"
+}

--- a/src/components/scenario/ScenarioField.vue
+++ b/src/components/scenario/ScenarioField.vue
@@ -1,0 +1,99 @@
+<template>
+  <div class="scenario-field" :class="{ 'scenario-field--inline': inline }">
+    <div class="scenario-field__head">
+      <label v-if="label" :for="forId" class="scenario-field__label">
+        {{ label }}<span v-if="required" aria-hidden="true" class="scenario-field__required">*</span>
+      </label>
+      <info-icon v-if="help" :content="help" />
+    </div>
+    <div class="scenario-field__control">
+      <slot />
+    </div>
+    <p v-if="error" class="scenario-field__message scenario-field__message--error" role="alert">
+      {{ error }}
+    </p>
+    <p v-else-if="disabledReason" class="scenario-field__message">
+      {{ disabledReason }}
+    </p>
+  </div>
+</template>
+
+<script setup lang="ts">
+import InfoIcon from '@/components/common/InfoIcon.vue';
+
+withDefaults(
+  defineProps<{
+    label?: string;
+    forId: string;
+    help?: string;
+    error?: string;
+    disabledReason?: string;
+    required?: boolean;
+    inline?: boolean;
+  }>(),
+  {
+    label: undefined,
+    help: undefined,
+    error: undefined,
+    disabledReason: undefined,
+    required: false,
+    inline: false
+  }
+);
+</script>
+
+<style lang="scss" scoped>
+.scenario-field + .scenario-field {
+  margin-top: 16px;
+}
+
+.scenario-field__head {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  margin-bottom: 8px;
+}
+
+.scenario-field__label {
+  min-width: 0;
+  color: var(--el-text-color-primary);
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 20px;
+}
+
+.scenario-field__required,
+.scenario-field__message--error {
+  color: var(--el-color-danger);
+}
+
+.scenario-field__required {
+  margin-left: 2px;
+}
+
+.scenario-field__control {
+  min-width: 0;
+}
+
+.scenario-field__message {
+  margin: 6px 0 0;
+  color: var(--el-text-color-secondary);
+  font-size: 12px;
+  line-height: 18px;
+}
+
+.scenario-field--inline {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 12px;
+  align-items: center;
+}
+
+.scenario-field--inline .scenario-field__head {
+  margin-bottom: 0;
+}
+
+.scenario-field--inline .scenario-field__message {
+  grid-column: 1 / -1;
+}
+</style>

--- a/src/components/scenario/ScenarioFooter.vue
+++ b/src/components/scenario/ScenarioFooter.vue
@@ -1,0 +1,24 @@
+<template>
+  <footer class="scenario-footer">
+    <div v-if="$slots.meta" class="scenario-footer__meta">
+      <slot name="meta" />
+    </div>
+    <slot />
+  </footer>
+</template>
+
+<style lang="scss" scoped>
+.scenario-footer {
+  position: sticky;
+  bottom: 0;
+  z-index: 1;
+  flex: none;
+  padding: 8px 16px calc(16px + env(safe-area-inset-bottom));
+  background: var(--app-sidebar-bg);
+  border-top: 1px solid var(--app-border-subtle);
+}
+
+.scenario-footer__meta {
+  margin-bottom: 8px;
+}
+</style>

--- a/src/components/scenario/ScenarioPanel.vue
+++ b/src/components/scenario/ScenarioPanel.vue
@@ -1,0 +1,48 @@
+<template>
+  <aside class="scenario-panel" :class="{ 'scenario-panel--without-footer': !hasFooter }">
+    <header v-if="$slots.header" class="scenario-panel__header">
+      <slot name="header" />
+    </header>
+    <div class="scenario-panel__body">
+      <slot />
+    </div>
+    <slot name="footer" />
+  </aside>
+</template>
+
+<script setup lang="ts">
+import { computed, useSlots } from 'vue';
+
+const slots = useSlots();
+const hasFooter = computed(() => Boolean(slots.footer));
+</script>
+
+<style lang="scss" scoped>
+.scenario-panel {
+  display: flex;
+  flex: none;
+  flex-direction: column;
+  width: 320px;
+  max-width: 100%;
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
+  background: var(--app-sidebar-bg);
+  border-right: 1px solid var(--app-border-subtle);
+}
+
+.scenario-panel__header {
+  flex: none;
+}
+
+.scenario-panel__body {
+  flex: 1;
+  min-height: 0;
+  padding: 16px;
+  overflow-y: auto;
+}
+
+.scenario-panel--without-footer .scenario-panel__body {
+  padding-bottom: calc(16px + env(safe-area-inset-bottom));
+}
+</style>

--- a/src/components/scenario/ScenarioPrimitives.test.ts
+++ b/src/components/scenario/ScenarioPrimitives.test.ts
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+import { mount, shallowMount } from '@vue/test-utils';
+import { ElRadioGroup } from 'element-plus';
+import { describe, expect, it } from 'vitest';
+import ScenarioField from './ScenarioField.vue';
+import ScenarioPanel from './ScenarioPanel.vue';
+import ScenarioSection from './ScenarioSection.vue';
+import ScenarioSegmented from './ScenarioSegmented.vue';
+
+describe('scenario primitives', () => {
+  it('keeps panel content and footer in separate layout regions', () => {
+    const wrapper = shallowMount(ScenarioPanel, {
+      slots: { default: 'fields', footer: 'generate' }
+    });
+
+    expect(wrapper.find('.scenario-panel__body').text()).toBe('fields');
+    expect(wrapper.text()).toContain('generate');
+    expect(wrapper.classes()).not.toContain('scenario-panel--without-footer');
+  });
+
+  it('lets the scrolling body consume the safe area when there is no footer', () => {
+    const wrapper = shallowMount(ScenarioPanel, { slots: { default: 'fields' } });
+
+    expect(wrapper.classes()).toContain('scenario-panel--without-footer');
+  });
+
+  it('associates labels and exposes validation errors', () => {
+    const wrapper = shallowMount(ScenarioField, {
+      props: { label: 'Prompt', forId: 'prompt', required: true, error: 'Prompt is required' },
+      global: { stubs: { InfoIcon: true } },
+      slots: { default: '<textarea id="prompt" />' }
+    });
+
+    expect(wrapper.get('label').attributes('for')).toBe('prompt');
+    expect(wrapper.get('[role="alert"]').text()).toBe('Prompt is required');
+  });
+
+  it('only labels a section when it renders a title', () => {
+    const titled = shallowMount(ScenarioSection, { props: { title: 'Advanced' } });
+    const untitled = shallowMount(ScenarioSection);
+
+    expect(titled.attributes('aria-labelledby')).toBe(titled.get('h2').attributes('id'));
+    expect(untitled.attributes('aria-labelledby')).toBeUndefined();
+  });
+
+  it('emits the selected short option', async () => {
+    const wrapper = mount(ScenarioSegmented, {
+      props: {
+        modelValue: 'generate',
+        ariaLabel: 'Action',
+        options: [
+          { label: 'Generate', value: 'generate' },
+          { label: 'Edit', value: 'edit' }
+        ]
+      }
+    });
+
+    wrapper.getComponent(ElRadioGroup).vm.$emit('update:modelValue', 'edit');
+    await wrapper.vm.$nextTick();
+    expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual(['edit']);
+  });
+});

--- a/src/components/scenario/ScenarioSection.vue
+++ b/src/components/scenario/ScenarioSection.vue
@@ -1,0 +1,30 @@
+<template>
+  <section class="scenario-section" :aria-labelledby="title ? titleId : undefined">
+    <h2 v-if="title" :id="titleId" class="scenario-section__title">{{ title }}</h2>
+    <slot />
+  </section>
+</template>
+
+<script setup lang="ts">
+import { useId } from 'vue';
+
+defineProps<{
+  title?: string;
+}>();
+
+const titleId = `scenario-section-${useId()}`;
+</script>
+
+<style lang="scss" scoped>
+.scenario-section + .scenario-section {
+  margin-top: 24px;
+}
+
+.scenario-section__title {
+  margin: 0 0 12px;
+  color: var(--el-text-color-primary);
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 20px;
+}
+</style>

--- a/src/components/scenario/ScenarioSegmented.vue
+++ b/src/components/scenario/ScenarioSegmented.vue
@@ -1,0 +1,67 @@
+<template>
+  <el-radio-group
+    class="scenario-segmented"
+    :model-value="modelValue"
+    :aria-label="ariaLabel"
+    @update:model-value="onUpdate"
+  >
+    <el-radio-button
+      v-for="option in options"
+      :key="String(option.value)"
+      :value="option.value"
+      :disabled="option.disabled"
+    >
+      {{ option.label }}
+    </el-radio-button>
+  </el-radio-group>
+</template>
+
+<script setup lang="ts">
+import { ElRadioButton, ElRadioGroup } from 'element-plus';
+
+export type ScenarioSegmentedValue = string | number;
+
+export interface ScenarioSegmentedOption {
+  label: string;
+  value: ScenarioSegmentedValue;
+  disabled?: boolean;
+}
+
+defineProps<{
+  modelValue: ScenarioSegmentedValue;
+  options: readonly ScenarioSegmentedOption[];
+  ariaLabel: string;
+}>();
+
+const emit = defineEmits<{
+  'update:modelValue': [value: ScenarioSegmentedValue];
+}>();
+
+const onUpdate = (value: string | number | boolean | undefined) => {
+  if (typeof value === 'string' || typeof value === 'number') {
+    emit('update:modelValue', value);
+  }
+};
+</script>
+
+<style lang="scss" scoped>
+.scenario-segmented {
+  display: flex;
+  width: 100%;
+}
+
+.scenario-segmented :deep(.el-radio-button) {
+  flex: 1;
+  min-width: 0;
+}
+
+.scenario-segmented :deep(.el-radio-button__inner) {
+  width: 100%;
+  min-height: 40px;
+  padding: 8px 12px;
+  overflow: hidden;
+  line-height: 22px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+</style>

--- a/src/components/scenario/index.ts
+++ b/src/components/scenario/index.ts
@@ -1,0 +1,6 @@
+export { default as ScenarioField } from './ScenarioField.vue';
+export { default as ScenarioFooter } from './ScenarioFooter.vue';
+export { default as ScenarioPanel } from './ScenarioPanel.vue';
+export { default as ScenarioSection } from './ScenarioSection.vue';
+export { default as ScenarioSegmented } from './ScenarioSegmented.vue';
+export type { ScenarioSegmentedOption, ScenarioSegmentedValue } from './ScenarioSegmented.vue';


### PR DESCRIPTION
## 概要

- 新增 ScenarioPanel/Section/Field/Footer，统一参数栏布局、字段节奏与 sticky footer
- 新增 ScenarioSegmented，统一短互斥选项
- 原语不持有业务值、不读写 store、不接管上传
- 增加 5 个组件契约测试

## 验证

- 组件测试 5 passed
- ESLint、Prettier、Vue typecheck、web build 通过

## 对抗评审

修复 forId 必填、safe-area 单一归属、宽事件过滤与无标题 section ARIA；最终 VERDICT: CLEAN。

## Stack

Base: https://github.com/AceDataCloud/Nexior/pull/1328

Ready for review；不启用 auto-merge。
