### PR TITLE
fix: align task identities with services

### DIFF
--- a/change/@acedatacloud-nexior-chat-service-identity.json
+++ b/change/@acedatacloud-nexior-chat-service-identity.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Align task response names and avatars with Service capability presentation overrides.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/common/CapabilityPresentation.test.ts
+++ b/src/components/common/CapabilityPresentation.test.ts
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+import { mount } from '@vue/test-utils';
+import { nextTick, reactive } from 'vue';
+import { describe, expect, it } from 'vitest';
+import { CAPABILITY_ICONS } from '@/constants/capabilities';
+import CapabilityPresentation from './CapabilityPresentation.vue';
+
+function mountPresentation(part: 'avatar' | 'name', site: Record<string, unknown> | undefined) {
+  return mount(CapabilityPresentation, {
+    props: { capability: 'flux', part },
+    global: {
+      mocks: {
+        $store: { state: { site } },
+        $t: (key: string) => (key === 'common.nav.flux' ? 'Flux' : key)
+      }
+    }
+  });
+}
+
+describe('CapabilityPresentation', () => {
+  it('renders the default capability name and icon used by navigation', () => {
+    expect(mountPresentation('name', undefined).text()).toBe('Flux');
+    expect(mountPresentation('avatar', undefined).findComponent({ name: 'ElImage' }).props('src')).toBe(
+      CAPABILITY_ICONS.flux
+    );
+  });
+
+  it('renders the site capability name and icon overrides', () => {
+    const site = {
+      capability_overrides: {
+        flux: {
+          display_name: 'Studio Image',
+          icon_url: 'https://cdn.example.com/studio-image.png'
+        }
+      }
+    };
+
+    expect(mountPresentation('name', site).text()).toBe('Studio Image');
+    expect(mountPresentation('avatar', site).findComponent({ name: 'ElImage' }).props('src')).toBe(
+      'https://cdn.example.com/studio-image.png'
+    );
+  });
+
+  it('falls back after an icon error and retries when the override changes', async () => {
+    const site = reactive({
+      capability_overrides: {
+        flux: { display_name: 'Studio Image', icon_url: 'https://cdn.example.com/broken.png' }
+      }
+    });
+    const wrapper = mountPresentation('avatar', site);
+    const image = () => wrapper.findComponent({ name: 'ElImage' });
+
+    image().vm.$emit('error');
+    await nextTick();
+    expect(image().props('src')).toBe(CAPABILITY_ICONS.flux);
+
+    site.capability_overrides.flux.icon_url = 'https://cdn.example.com/replacement.png';
+    await nextTick();
+    expect(image().props('src')).toBe('https://cdn.example.com/replacement.png');
+  });
+});

--- a/src/components/common/CapabilityPresentation.vue
+++ b/src/components/common/CapabilityPresentation.vue
@@ -1,0 +1,47 @@
+<template>
+  <el-image v-if="part === 'avatar'" :src="iconUrl" @error="iconFailed = true" />
+  <span v-else>{{ presentation.displayName }}</span>
+</template>
+
+<script lang="ts">
+import { defineComponent, type PropType } from 'vue';
+import { ElImage } from 'element-plus';
+import { CAPABILITY_ICONS, type CapabilityKey } from '@/constants/capabilities';
+import { resolveCapabilityPresentation } from '@/utils/capabilityPresentation';
+
+export default defineComponent({
+  name: 'CapabilityPresentation',
+  components: { ElImage },
+  props: {
+    capability: {
+      type: String as PropType<CapabilityKey>,
+      required: true
+    },
+    part: {
+      type: String as PropType<'avatar' | 'name'>,
+      required: true
+    }
+  },
+  data() {
+    return { iconFailed: false };
+  },
+  computed: {
+    presentation() {
+      return resolveCapabilityPresentation(
+        this.$store.state.site,
+        this.capability,
+        this.$t(`common.nav.${this.capability}`),
+        CAPABILITY_ICONS[this.capability]
+      );
+    },
+    iconUrl(): string {
+      return this.iconFailed ? CAPABILITY_ICONS[this.capability] : this.presentation.iconUrl;
+    }
+  },
+  watch: {
+    'presentation.iconUrl'() {
+      this.iconFailed = false;
+    }
+  }
+});
+</script>

--- a/src/components/digitalhuman/task/Preview.vue
+++ b/src/components/digitalhuman/task/Preview.vue
@@ -1,11 +1,11 @@
 <template>
   <div class="preview">
     <div class="left">
-      <el-image :src="DIGITALHUMAN_LOGO" class="avatar" />
+      <capability-presentation capability="digitalhuman" part="avatar" class="avatar" />
     </div>
     <div class="main">
       <div class="bot">
-        {{ $t('digitalhuman.name.bot') }}
+        <capability-presentation capability="digitalhuman" part="name" />
         <span class="datetime">
           {{ $dayjs.format('' + new Date(parseFloat((modelValue?.created_at || '').toString()) * 1000)) }}
         </span>
@@ -77,9 +77,8 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElImage, ElAlert, ElButton, ElProgress } from 'element-plus';
+import { ElAlert, ElButton, ElProgress } from 'element-plus';
 import { IDigitalHumanTask } from '@/models';
-import { DIGITALHUMAN_LOGO } from '@/constants';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import VideoPlayer from '@/components/common/VideoPlayer.vue';
@@ -88,7 +87,6 @@ import ApiCodeButton from '@/components/common/ApiCodeButton.vue';
 export default defineComponent({
   name: 'TaskPreview',
   components: {
-    ElImage,
     CopyToClipboard,
     FontAwesomeIcon,
     ElAlert,
@@ -102,11 +100,6 @@ export default defineComponent({
       type: Object as () => IDigitalHumanTask | undefined,
       required: true
     }
-  },
-  data() {
-    return {
-      DIGITALHUMAN_LOGO
-    };
   },
   computed: {
     status(): string {

--- a/src/components/fish/task/Preview.vue
+++ b/src/components/fish/task/Preview.vue
@@ -1,11 +1,11 @@
 <template>
   <div class="preview">
     <div class="left">
-      <el-image src="https://cdn.acedata.cloud/e40fccc727.png" class="avatar" />
+      <capability-presentation capability="fish" part="avatar" class="avatar" />
     </div>
     <div class="main">
       <div class="bot">
-        {{ $t('fish.name.fishBot') }}
+        <capability-presentation capability="fish" part="name" />
         <span class="datetime">
           {{ $dayjs.format('' + new Date(parseFloat((modelValue?.created_at || '').toString()) * 1000)) }}
         </span>
@@ -62,7 +62,7 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElImage, ElAlert, ElButton } from 'element-plus';
+import { ElAlert, ElButton } from 'element-plus';
 import { IFishTask } from '@/models';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
@@ -71,7 +71,6 @@ import ApiCodeButton from '@/components/common/ApiCodeButton.vue';
 export default defineComponent({
   name: 'FishTaskPreview',
   components: {
-    ElImage,
     CopyToClipboard,
     FontAwesomeIcon,
     ElAlert,

--- a/src/components/flux/task/Preview.vue
+++ b/src/components/flux/task/Preview.vue
@@ -1,11 +1,11 @@
 <template>
   <div class="preview">
     <div class="left">
-      <el-image src="https://cdn.acedata.cloud/ogm2oa.png" class="avatar" />
+      <capability-presentation capability="flux" part="avatar" class="avatar" />
     </div>
     <div class="main">
       <div class="bot">
-        {{ $t('flux.name.fluxBot') }}
+        <capability-presentation capability="flux" part="name" />
         <span class="datetime">
           {{ $dayjs.format('' + new Date(parseFloat((modelValue?.created_at || '').toString()) * 1000)) }}
         </span>
@@ -99,7 +99,7 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElImage, ElAlert } from 'element-plus';
+import { ElAlert } from 'element-plus';
 import { IFluxTask, IFluxImage } from '@/models';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
@@ -109,7 +109,6 @@ import ApiCodeButton from '@/components/common/ApiCodeButton.vue';
 export default defineComponent({
   name: 'TaskPreview',
   components: {
-    ElImage,
     CopyToClipboard,
     FontAwesomeIcon,
     ElAlert,

--- a/src/components/grokvideo/task/Preview.vue
+++ b/src/components/grokvideo/task/Preview.vue
@@ -1,11 +1,11 @@
 <template>
   <div class="preview">
     <div class="left">
-      <el-image :src="grokVideoLogo" class="avatar" />
+      <capability-presentation capability="grokvideo" part="avatar" class="avatar" />
     </div>
     <div class="main">
       <div class="bot">
-        {{ $t('grokvideo.name.bot') }}
+        <capability-presentation capability="grokvideo" part="name" />
         <span class="datetime">
           {{ $dayjs.format('' + new Date(parseFloat((modelValue?.created_at || '').toString()) * 1000)) }}
         </span>
@@ -137,19 +137,17 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElImage, ElAlert, ElButton, ElTooltip } from 'element-plus';
+import { ElAlert, ElButton, ElTooltip } from 'element-plus';
 import { IGrokVideoTask, IGrokVideoVideo } from '@/models';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import VideoPlayer from '@/components/common/VideoPlayer.vue';
 import ImagePreview from '@/components/common/ImagePreview.vue';
 import ApiCodeButton from '@/components/common/ApiCodeButton.vue';
-import { GROKVIDEO_LOGO } from '@/constants';
 
 export default defineComponent({
   name: 'GrokVideoTaskPreview',
   components: {
-    ElImage,
     CopyToClipboard,
     FontAwesomeIcon,
     ElAlert,
@@ -167,7 +165,6 @@ export default defineComponent({
   },
   data() {
     return {
-      grokVideoLogo: GROKVIDEO_LOGO,
       nowTs: Date.now(),
       timer: 0
     };

--- a/src/components/hailuo/task/Preview.vue
+++ b/src/components/hailuo/task/Preview.vue
@@ -1,11 +1,11 @@
 <template>
   <div class="preview">
     <div class="left">
-      <el-image src="https://cdn.acedata.cloud/0qg4gp.png" class="avatar" />
+      <capability-presentation capability="hailuo" part="avatar" class="avatar" />
     </div>
     <div class="main">
       <div class="bot">
-        {{ $t('hailuo.name.hailuoBot') }}
+        <capability-presentation capability="hailuo" part="name" />
         <span class="datetime">
           {{ $dayjs.format('' + new Date(parseFloat((modelValue?.created_at || '').toString()) * 1000)) }}
         </span>
@@ -114,7 +114,7 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElImage, ElAlert, ElButton, ElTooltip } from 'element-plus';
+import { ElAlert, ElButton, ElTooltip } from 'element-plus';
 import { IHailuoTask, IHailuoVideo } from '@/models';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
@@ -124,7 +124,6 @@ import ApiCodeButton from '@/components/common/ApiCodeButton.vue';
 export default defineComponent({
   name: 'TaskPreview',
   components: {
-    ElImage,
     CopyToClipboard,
     FontAwesomeIcon,
     ElAlert,

--- a/src/components/kling/task/Preview.vue
+++ b/src/components/kling/task/Preview.vue
@@ -1,11 +1,11 @@
 <template>
   <div class="preview">
     <div class="left">
-      <el-image src="https://cdn.acedata.cloud/qpbbbb.jpg" class="avatar" />
+      <capability-presentation capability="kling" part="avatar" class="avatar" />
     </div>
     <div class="main">
       <div class="bot">
-        {{ $t('kling.name.klingBot') }}
+        <capability-presentation capability="kling" part="name" />
         <span class="datetime">
           {{ $dayjs.format('' + new Date(parseFloat((modelValue?.created_at || '').toString()) * 1000)) }}
         </span>
@@ -145,7 +145,7 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElImage, ElAlert, ElButton, ElTooltip } from 'element-plus';
+import { ElAlert, ElButton, ElTooltip } from 'element-plus';
 import { IKlingTask } from '@/models';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
@@ -158,7 +158,6 @@ import ApiCodeButton from '@/components/common/ApiCodeButton.vue';
 export default defineComponent({
   name: 'TaskPreview',
   components: {
-    ElImage,
     CopyToClipboard,
     FontAwesomeIcon,
     ElAlert,

--- a/src/components/luma/task/Preview.vue
+++ b/src/components/luma/task/Preview.vue
@@ -1,11 +1,11 @@
 <template>
   <div class="preview">
     <div class="left">
-      <el-image src="https://cdn.acedata.cloud/ahjfwi.png" class="avatar" />
+      <capability-presentation capability="luma" part="avatar" class="avatar" />
     </div>
     <div class="main">
       <div class="bot">
-        {{ $t('luma.name.lumaBot') }}
+        <capability-presentation capability="luma" part="name" />
         <span class="datetime">
           {{ $dayjs.format('' + new Date(parseFloat((modelValue?.created_at || '').toString()) * 1000)) }}
         </span>
@@ -117,7 +117,7 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElImage, ElAlert, ElButton, ElTooltip } from 'element-plus';
+import { ElAlert, ElButton, ElTooltip } from 'element-plus';
 import { ILumaTask, ILumaGenerateResponse } from '@/models';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
@@ -127,7 +127,6 @@ import ApiCodeButton from '@/components/common/ApiCodeButton.vue';
 export default defineComponent({
   name: 'TaskPreview',
   components: {
-    ElImage,
     CopyToClipboard,
     FontAwesomeIcon,
     ElAlert,

--- a/src/components/maestro/task/Preview.vue
+++ b/src/components/maestro/task/Preview.vue
@@ -1,11 +1,11 @@
 <template>
   <div class="preview">
     <div class="left">
-      <el-image :src="MAESTRO_LOGO" class="avatar" />
+      <capability-presentation capability="maestro" part="avatar" class="avatar" />
     </div>
     <div class="main">
       <div class="bot">
-        {{ $t('maestro.name.maestroBot') }}
+        <capability-presentation capability="maestro" part="name" />
         <span class="datetime">
           {{ $dayjs.format('' + new Date(parseFloat((modelValue?.created_at || '').toString()) * 1000)) }}
         </span>
@@ -174,9 +174,9 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElImage, ElAlert, ElButton, ElMessage } from 'element-plus';
+import { ElAlert, ElButton, ElMessage } from 'element-plus';
 import { IMaestroTask, IMaestroVariant } from '@/models';
-import { MAESTRO_ACTION_REMIX, MAESTRO_LOGO } from '@/constants';
+import { MAESTRO_ACTION_REMIX } from '@/constants';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import VideoPlayer from '@/components/common/VideoPlayer.vue';
@@ -203,7 +203,6 @@ interface IMaestroInputFile {
 export default defineComponent({
   name: 'TaskPreview',
   components: {
-    ElImage,
     CopyToClipboard,
     FontAwesomeIcon,
     ElAlert,
@@ -224,7 +223,6 @@ export default defineComponent({
   },
   data() {
     return {
-      MAESTRO_LOGO,
       fetchedReferenceTask: undefined as IMaestroTask | undefined,
       fetchedReferenceKey: undefined as string | undefined,
       referenceLoadAttempt: 0,

--- a/src/components/midjourney/tasks/TaskItem.vue
+++ b/src/components/midjourney/tasks/TaskItem.vue
@@ -1,11 +1,11 @@
 <template>
   <div v-if="modelValue?.type === 'imagine'" class="item">
     <div class="left">
-      <el-image src="https://cdn.acedata.cloud/wto43b.png" class="avatar" />
+      <capability-presentation capability="midjourney" part="avatar" class="avatar" />
     </div>
     <div class="preview">
       <div class="bot">
-        {{ $t('midjourney.name.midjourneyBot') }}
+        <capability-presentation capability="midjourney" part="name" />
         <span class="datetime">
           {{ $dayjs.format('' + new Date(parseFloat((modelValue?.created_at || '').toString()) * 1000)) }}
         </span>
@@ -120,11 +120,11 @@
   </div>
   <div v-if="modelValue?.type === 'videos'" class="item">
     <div class="left">
-      <el-image src="https://cdn.acedata.cloud/wto43b.png" class="avatar" />
+      <capability-presentation capability="midjourney" part="avatar" class="avatar" />
     </div>
     <div class="preview">
       <div class="bot">
-        {{ $t('midjourney.name.midjourneyBot') }}
+        <capability-presentation capability="midjourney" part="name" />
         <span class="datetime">
           {{ $dayjs.format('' + new Date(parseFloat((modelValue?.created_at || '').toString()) * 1000)) }}
         </span>
@@ -314,11 +314,11 @@
   </div>
   <div v-if="modelValue?.type === 'describe'" class="item">
     <div class="left">
-      <el-image src="https://cdn.acedata.cloud/wto43b.png" class="avatar" />
+      <capability-presentation capability="midjourney" part="avatar" class="avatar" />
     </div>
     <div class="preview">
       <div class="bot">
-        {{ $t('midjourney.name.midjourneyBot') }}
+        <capability-presentation capability="midjourney" part="name" />
         <span class="datetime">
           {{ $dayjs.format('' + new Date(parseFloat((modelValue?.created_at || '').toString()) * 1000)) }}
         </span>
@@ -421,7 +421,7 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElImage, ElButton, ElTooltip, ElAlert, ElTag } from 'element-plus';
+import { ElButton, ElTooltip, ElAlert, ElTag } from 'element-plus';
 import { IMidjourneyTask, MidjourneyImagineAction, MidjourneyImagineState, IMidjourneyVideosResponse } from '@/models';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
@@ -439,7 +439,6 @@ interface IData {
 export default defineComponent({
   name: 'TaskPreview',
   components: {
-    ElImage,
     ImageWrapper,
     ImagePreview,
     ElButton,

--- a/src/components/nanobanana/task/Preview.vue
+++ b/src/components/nanobanana/task/Preview.vue
@@ -1,11 +1,11 @@
 <template>
   <div class="preview">
     <div class="left">
-      <el-image src="https://cdn.acedata.cloud/859plc.jpg" class="avatar" />
+      <capability-presentation capability="nanobanana" part="avatar" class="avatar" />
     </div>
     <div class="main">
       <div class="bot">
-        {{ $t('nanobanana.name.nanobananaBot') }}
+        <capability-presentation capability="nanobanana" part="name" />
         <span class="datetime">
           {{ $dayjs.format('' + new Date(parseFloat((modelValue?.created_at || '').toString()) * 1000)) }}
         </span>
@@ -180,7 +180,7 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElImage, ElAlert, ElButton, ElTooltip } from 'element-plus';
+import { ElAlert, ElButton, ElTooltip } from 'element-plus';
 import { INanobananaTask, INanobananaImage } from '@/models';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
@@ -191,7 +191,6 @@ import ApiCodeButton from '@/components/common/ApiCodeButton.vue';
 export default defineComponent({
   name: 'TaskPreview',
   components: {
-    ElImage,
     CopyToClipboard,
     FontAwesomeIcon,
     ElAlert,

--- a/src/components/omni/task/Preview.vue
+++ b/src/components/omni/task/Preview.vue
@@ -1,11 +1,11 @@
 <template>
   <div class="preview">
     <div class="left">
-      <el-image :src="omniLogo" class="avatar" />
+      <capability-presentation capability="omni" part="avatar" class="avatar" />
     </div>
     <div class="main">
       <div class="bot">
-        {{ $t('omni.name.bot') }}
+        <capability-presentation capability="omni" part="name" />
         <span class="datetime">
           {{ $dayjs.format('' + new Date(parseFloat((modelValue?.created_at || '').toString()) * 1000)) }}
         </span>
@@ -128,19 +128,17 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElImage, ElAlert, ElButton, ElTooltip } from 'element-plus';
+import { ElAlert, ElButton, ElTooltip } from 'element-plus';
 import { IOmniTask, IOmniVideo } from '@/models';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import VideoPlayer from '@/components/common/VideoPlayer.vue';
 import ImagePreview from '@/components/common/ImagePreview.vue';
 import ApiCodeButton from '@/components/common/ApiCodeButton.vue';
-import { OMNI_LOGO } from '@/constants';
 
 export default defineComponent({
   name: 'OmniTaskPreview',
   components: {
-    ElImage,
     CopyToClipboard,
     FontAwesomeIcon,
     ElAlert,
@@ -158,7 +156,6 @@ export default defineComponent({
   },
   data() {
     return {
-      omniLogo: OMNI_LOGO,
       nowTs: Date.now(),
       timer: 0
     };

--- a/src/components/openaiimage/task/Preview.vue
+++ b/src/components/openaiimage/task/Preview.vue
@@ -1,11 +1,11 @@
 <template>
   <div class="preview">
     <div class="left">
-      <el-image :src="OPENAIIMAGE_LOGO" class="avatar" />
+      <capability-presentation capability="openaiimage" part="avatar" class="avatar" />
     </div>
     <div class="main">
       <div class="bot">
-        {{ $t('openaiimage.name.openaiimageBot') }}
+        <capability-presentation capability="openaiimage" part="name" />
         <span class="datetime">
           {{ $dayjs.format('' + new Date(parseFloat((modelValue?.created_at || '').toString()) * 1000)) }}
         </span>
@@ -164,9 +164,8 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElImage, ElAlert, ElButton, ElTooltip } from 'element-plus';
+import { ElAlert, ElButton, ElTooltip } from 'element-plus';
 import { IOpenAIImageTask, IOpenAIImageImage } from '@/models';
-import { OPENAIIMAGE_LOGO } from '@/constants/openaiimage';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import ImageWrapper from '@/components/common/ImageWrapper.vue';
@@ -176,7 +175,6 @@ import ApiCodeButton from '@/components/common/ApiCodeButton.vue';
 export default defineComponent({
   name: 'TaskPreview',
   components: {
-    ElImage,
     CopyToClipboard,
     FontAwesomeIcon,
     ElAlert,
@@ -191,9 +189,6 @@ export default defineComponent({
       type: Object as () => IOpenAIImageTask | undefined,
       required: true
     }
-  },
-  setup() {
-    return { OPENAIIMAGE_LOGO };
   },
   computed: {
     isEditRequest(): boolean {

--- a/src/components/pika/task/Preview.vue
+++ b/src/components/pika/task/Preview.vue
@@ -1,11 +1,11 @@
 <template>
   <div v-for="(video, videoIndex) in videos" :key="videoIndex" class="preview">
     <div class="left">
-      <el-image src="https://cdn.acedata.cloud/i80tgn.png" class="avatar" />
+      <capability-presentation capability="pika" part="avatar" class="avatar" />
     </div>
     <div class="main">
       <div class="bot">
-        {{ $t('pika.name.pikaBot') }}
+        <capability-presentation capability="pika" part="name" />
         <span class="datetime">
           {{ $dayjs.format('' + new Date(parseFloat((modelValue?.created_at || '').toString()) * 1000)) }}
         </span>
@@ -111,7 +111,7 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElImage, ElAlert, ElButton, ElTooltip } from 'element-plus';
+import { ElAlert, ElButton, ElTooltip } from 'element-plus';
 import { IPikaTask, IPikaVideo } from '@/models';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
@@ -120,7 +120,6 @@ import ApiCodeButton from '@/components/common/ApiCodeButton.vue';
 export default defineComponent({
   name: 'TaskPreview',
   components: {
-    ElImage,
     CopyToClipboard,
     FontAwesomeIcon,
     ElAlert,

--- a/src/components/pixverse/task/Preview.vue
+++ b/src/components/pixverse/task/Preview.vue
@@ -1,11 +1,11 @@
 <template>
   <div class="preview">
     <div class="left">
-      <el-image src="https://cdn.acedata.cloud/viy61r.jpg" class="avatar" />
+      <capability-presentation capability="pixverse" part="avatar" class="avatar" />
     </div>
     <div class="main">
       <div class="bot">
-        {{ $t('pixverse.name.pixverseBot') }}
+        <capability-presentation capability="pixverse" part="name" />
         <span class="datetime">
           {{ $dayjs.format('' + new Date(parseFloat((modelValue?.created_at || '').toString()) * 1000)) }}
         </span>
@@ -107,7 +107,7 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElImage, ElAlert, ElButton, ElTooltip } from 'element-plus';
+import { ElAlert, ElButton, ElTooltip } from 'element-plus';
 import { IPixverseTask } from '@/models';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
@@ -117,7 +117,6 @@ import ApiCodeButton from '@/components/common/ApiCodeButton.vue';
 export default defineComponent({
   name: 'TaskPreview',
   components: {
-    ElImage,
     CopyToClipboard,
     FontAwesomeIcon,
     ElAlert,

--- a/src/components/qrart/task/Preview.vue
+++ b/src/components/qrart/task/Preview.vue
@@ -1,8 +1,9 @@
 <template>
   <div class="preview w-full h-fit text-left flex flex-row mb-[15px]">
     <div class="left">
-      <el-image
-        src="https://cdn.acedata.cloud/bcml67.png"
+      <capability-presentation
+        capability="qrart"
+        part="avatar"
         class="avatar bg-[var(--el-bg-color)] p-[2px] w-[50px] h-[50px] m-[10px] rounded-full"
       />
     </div>
@@ -10,7 +11,7 @@
       <div
         class="bot text-[16px] font-bold text-[var(--el-color-primary)] overflow-hidden text-ellipsis whitespace-nowrap"
       >
-        {{ $t('qrart.name.qrartBot') }}
+        <capability-presentation capability="qrart" part="name" />
         <span class="datetime text-[12px] font-normal text-[var(--el-text-color-secondary)] ml-[10px]">
           {{ $dayjs.format('' + new Date(parseFloat((modelValue?.created_at || '').toString()) * 1000)) }}
         </span>
@@ -126,7 +127,7 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElImage, ElAlert } from 'element-plus';
+import { ElAlert } from 'element-plus';
 import { IQrartTask } from '@/models';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
@@ -136,7 +137,6 @@ import ApiCodeButton from '@/components/common/ApiCodeButton.vue';
 export default defineComponent({
   name: 'TaskPreview',
   components: {
-    ElImage,
     CopyToClipboard,
     FontAwesomeIcon,
     ElAlert,

--- a/src/components/seedance/task/Preview.vue
+++ b/src/components/seedance/task/Preview.vue
@@ -1,11 +1,11 @@
 <template>
   <div class="preview">
     <div class="left">
-      <el-image :src="seedanceLogo" class="avatar" />
+      <capability-presentation capability="seedance" part="avatar" class="avatar" />
     </div>
     <div class="main">
       <div class="bot">
-        {{ $t('seedance.name.seedanceBot') }}
+        <capability-presentation capability="seedance" part="name" />
         <span class="datetime">
           {{ $dayjs.format('' + new Date(parseFloat((modelValue?.created_at || '').toString()) * 1000)) }}
         </span>
@@ -173,7 +173,7 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElImage, ElAlert, ElButton, ElTooltip } from 'element-plus';
+import { ElAlert, ElButton, ElTooltip } from 'element-plus';
 import { ISeedanceTask, ISeedanceVideo, SeedanceImageRole } from '@/models';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
@@ -183,12 +183,10 @@ import ImagePreview from '@/components/common/ImagePreview.vue';
 import AudioPreview from '@/components/common/AudioPreview.vue';
 import VideoPreview from '@/components/common/VideoPreview.vue';
 import ApiCodeButton from '@/components/common/ApiCodeButton.vue';
-import { SEEDANCE_LOGO } from '@/constants';
 
 export default defineComponent({
   name: 'SeedanceTaskPreview',
   components: {
-    ElImage,
     CopyToClipboard,
     FontAwesomeIcon,
     ElAlert,
@@ -206,11 +204,6 @@ export default defineComponent({
       type: Object as () => ISeedanceTask | undefined,
       required: true
     }
-  },
-  data() {
-    return {
-      seedanceLogo: SEEDANCE_LOGO
-    };
   },
   computed: {
     video(): ISeedanceVideo | undefined {

--- a/src/components/seedream/task/Preview.vue
+++ b/src/components/seedream/task/Preview.vue
@@ -1,11 +1,11 @@
 <template>
   <div class="preview">
     <div class="left">
-      <el-image src="https://cdn.acedata.cloud/9egrbn.png" class="avatar" />
+      <capability-presentation capability="seedream" part="avatar" class="avatar" />
     </div>
     <div class="main">
       <div class="bot">
-        {{ $t('seedream.name.seedreamBot') }}
+        <capability-presentation capability="seedream" part="name" />
         <span class="datetime">
           {{ $dayjs.format('' + new Date(parseFloat((modelValue?.created_at || '').toString()) * 1000)) }}
         </span>
@@ -164,7 +164,7 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElImage, ElAlert, ElButton, ElTooltip } from 'element-plus';
+import { ElAlert, ElButton, ElTooltip } from 'element-plus';
 import { ISeedreamTask, ISeedreamImage } from '@/models';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
@@ -176,7 +176,6 @@ import { getSeedreamShortModel } from '@/constants';
 export default defineComponent({
   name: 'SeedreamTaskPreview',
   components: {
-    ElImage,
     CopyToClipboard,
     FontAwesomeIcon,
     ElAlert,

--- a/src/components/sora/task/Preview.vue
+++ b/src/components/sora/task/Preview.vue
@@ -1,11 +1,11 @@
 <template>
   <div class="preview">
     <div class="left">
-      <el-image src="https://cdn.acedata.cloud/z5id1u.png" class="avatar" />
+      <capability-presentation capability="sora" part="avatar" class="avatar" />
     </div>
     <div class="main">
       <div class="bot">
-        {{ $t('sora.name.soraBot') }}
+        <capability-presentation capability="sora" part="name" />
         <span class="datetime">
           {{ $dayjs.format('' + new Date(parseFloat((modelValue?.created_at || '').toString()) * 1000)) }}
         </span>
@@ -117,7 +117,7 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElImage, ElAlert, ElButton, ElTooltip } from 'element-plus';
+import { ElAlert, ElButton, ElTooltip } from 'element-plus';
 import { ISoraTask } from '@/models';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
@@ -127,7 +127,6 @@ import ApiCodeButton from '@/components/common/ApiCodeButton.vue';
 export default defineComponent({
   name: 'TaskPreview',
   components: {
-    ElImage,
     CopyToClipboard,
     FontAwesomeIcon,
     ElAlert,

--- a/src/components/veo/task/Preview.vue
+++ b/src/components/veo/task/Preview.vue
@@ -1,11 +1,11 @@
 <template>
   <div class="preview">
     <div class="left">
-      <el-image src="https://cdn.acedata.cloud/8nxyy9.jpg" class="avatar" />
+      <capability-presentation capability="veo" part="avatar" class="avatar" />
     </div>
     <div class="main">
       <div class="bot">
-        {{ $t('veo.name.veoBot') }}
+        <capability-presentation capability="veo" part="name" />
         <span class="datetime">
           {{ $dayjs.format('' + new Date(parseFloat((modelValue?.created_at || '').toString()) * 1000)) }}
         </span>
@@ -116,7 +116,7 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElImage, ElAlert, ElButton, ElTooltip } from 'element-plus';
+import { ElAlert, ElButton, ElTooltip } from 'element-plus';
 import { IVeoTask } from '@/models';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
@@ -127,7 +127,6 @@ import ApiCodeButton from '@/components/common/ApiCodeButton.vue';
 export default defineComponent({
   name: 'TaskPreview',
   components: {
-    ElImage,
     CopyToClipboard,
     FontAwesomeIcon,
     ElAlert,

--- a/src/components/wan/task/Preview.vue
+++ b/src/components/wan/task/Preview.vue
@@ -1,11 +1,11 @@
 <template>
   <div class="preview">
     <div class="left">
-      <el-image :src="WAN_LOGO" class="avatar" />
+      <capability-presentation capability="wan" part="avatar" class="avatar" />
     </div>
     <div class="main">
       <div class="bot">
-        {{ $t('wan.name.wanBot') }}
+        <capability-presentation capability="wan" part="name" />
         <span class="datetime">
           {{ $dayjs.format('' + new Date(parseFloat((modelValue?.created_at || '').toString()) * 1000)) }}
         </span>
@@ -109,18 +109,16 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElImage, ElAlert, ElButton, ElTooltip } from 'element-plus';
+import { ElAlert, ElButton, ElTooltip } from 'element-plus';
 import { IWanTask } from '@/models';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import VideoPlayer from '@/components/common/VideoPlayer.vue';
 import ApiCodeButton from '@/components/common/ApiCodeButton.vue';
-import { WAN_LOGO } from '@/constants/wan';
 
 export default defineComponent({
   name: 'TaskPreview',
   components: {
-    ElImage,
     CopyToClipboard,
     FontAwesomeIcon,
     ElAlert,
@@ -134,9 +132,6 @@ export default defineComponent({
       type: Object as () => IWanTask | undefined,
       required: true
     }
-  },
-  setup() {
-    return { WAN_LOGO };
   },
   computed: {
     application() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,6 +16,7 @@ import dayjs from './plugins/dayjs';
 import './plugins/font-awesome';
 import { MotionPlugin } from '@vueuse/motion';
 import { vLoading } from 'element-plus';
+import CapabilityPresentation from '@/components/common/CapabilityPresentation.vue';
 import { getSurface, isNative, isDesktop, isMacOS, isWindows } from '@/utils/surface';
 import { resolveDeferredInviterId } from '@/utils/attribution';
 import { syncFeaturesFromUrl } from '@/utils/featureFlag';
@@ -47,6 +48,7 @@ export const createApp = ViteSSG(App, { routes, base: import.meta.env.BASE_URL }
   app.use(i18n);
   app.use(MotionPlugin);
   app.use(dayjs, { formatString: 'YYYY-MM-DD HH:mm:ss' });
+  app.component('CapabilityPresentation', CapabilityPresentation);
   app.directive('loading', vLoading);
   setupRouterGuards(router);
   setActiveRouter(router);


### PR DESCRIPTION
## Summary
- use each capability's Service name instead of legacy `XXX Bot` labels in task responses
- resolve task avatars and names from the same capability presentation source as the sidebar
- honor site capability `display_name` and `icon_url` overrides, with bundled-icon fallback on load errors

## Validation
- `npx vitest run src/components/common/CapabilityPresentation.test.ts src/components/common/Navigator.capabilityOverride.test.ts src/utils/capabilityPresentation.test.ts src/components/kling/task/Preview.test.ts src/components/maestro/task/Preview.test.ts src/components/veo/task/Preview.test.ts` (18 passed)
- `npm run lint:check`
- `git diff --cached --name-only --diff-filter=ACM | xargs npx prettier --check`
- `npm run build:web`

## 🤖 对抗评审 (reviewer: claude-subagent, 2 rounds)
- RISK: add `fit="cover"` to task avatars → 未采纳，理由: sidebar and existing task cards both use Element Plus default fit; changing it would diverge from the requested sidebar-equivalent presentation.
- RISK: explicitly forward avatar classes → 未采纳，理由: Vue class fallthrough already lands on the root `ElImage` wrapper, preserving the prior direct `<el-image class="avatar">` DOM contract.
- RISK: retry an unchanged failed icon URL after site replacement → 未采纳，理由: identical URLs provide no content-change signal; actual override URL changes reset the fallback and are covered by test.
- RISK: add separate SSG hydration coverage → 未采纳，理由: registration occurs before the SSG/client split, the component uses no browser APIs, and the production Vue typecheck/build passed.
- Round 2: `VERDICT: CLEAN`.