### PR TITLE
feat: add scenario media input field

### DIFF
--- a/change/@acedatacloud-nexior-scenario-media-input.json
+++ b/change/@acedatacloud-nexior-scenario-media-input.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add an accessible media input field for image, video, audio, and file references.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "minor"
+}

--- a/src/components/scenario/MediaInputField.test.ts
+++ b/src/components/scenario/MediaInputField.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+import { shallowMount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import MediaInputField from './MediaInputField.vue';
+
+const baseProps = {
+  name: 'reference.mp4',
+  roleLabel: 'Motion reference',
+  previewLabel: 'Preview motion reference',
+  replaceLabel: 'Replace motion reference',
+  removeLabel: 'Remove motion reference',
+  unavailableLabel: 'Reference unavailable'
+};
+
+describe('MediaInputField', () => {
+  it('renders a visual video preview instead of a generic file row', () => {
+    const wrapper = shallowMount(MediaInputField, {
+      props: { ...baseProps, kind: 'video', url: 'https://cdn.example/reference.mp4' }
+    });
+
+    expect(wrapper.get('video').attributes('src')).toContain('reference.mp4');
+    expect(wrapper.get('.media-input__visual').attributes('aria-label')).toBe(baseProps.previewLabel);
+  });
+
+  it('opens image and video previews from keyboard-accessible buttons', async () => {
+    const image = shallowMount(MediaInputField, {
+      props: { ...baseProps, kind: 'image', url: 'https://cdn.example/reference.png' }
+    });
+    await image.get('.media-input__visual').trigger('click');
+    expect(image.find('el-image-viewer-stub').exists()).toBe(true);
+
+    const video = shallowMount(MediaInputField, {
+      props: { ...baseProps, kind: 'video', url: 'https://cdn.example/reference.mp4' }
+    });
+    await video.get('.media-input__visual').trigger('click');
+    expect(video.get('el-dialog-stub').attributes('modelvalue')).toBe('true');
+  });
+
+  it('exposes upload progress and failure state', async () => {
+    const wrapper = shallowMount(MediaInputField, {
+      props: {
+        ...baseProps,
+        kind: 'image',
+        url: 'https://cdn.example/reference.png',
+        state: 'uploading',
+        progress: 142
+      }
+    });
+    expect(wrapper.attributes('aria-busy')).toBe('true');
+    expect(wrapper.get('.media-input__visual').attributes('disabled')).toBeDefined();
+    expect(wrapper.get('el-progress-stub').attributes('percentage')).toBe('100');
+
+    await wrapper.setProps({ state: 'failed', error: 'Upload failed' });
+    expect(wrapper.get('[role="alert"]').text()).toBe('Upload failed');
+  });
+
+  it('falls back when video thumbnails fail and labels unavailable references', async () => {
+    const wrapper = shallowMount(MediaInputField, {
+      props: {
+        ...baseProps,
+        kind: 'video',
+        url: 'https://cdn.example/missing.mp4',
+        state: 'unavailable'
+      }
+    });
+
+    await wrapper.get('video').trigger('error');
+    expect(wrapper.find('video').exists()).toBe(false);
+    expect(wrapper.text()).toContain(baseProps.unavailableLabel);
+  });
+
+  it('emits explicit replace and remove actions', async () => {
+    const wrapper = shallowMount(MediaInputField, { props: { ...baseProps, kind: 'image' } });
+    const buttons = wrapper.findAll('el-button-stub');
+    await buttons[0].trigger('click');
+    await buttons[1].trigger('click');
+
+    expect(wrapper.emitted('replace')).toHaveLength(1);
+    expect(wrapper.emitted('remove')).toHaveLength(1);
+  });
+});

--- a/src/components/scenario/MediaInputField.vue
+++ b/src/components/scenario/MediaInputField.vue
@@ -1,0 +1,237 @@
+<template>
+  <div class="media-input" :class="`media-input--${kind}`" :aria-busy="state === 'uploading'">
+    <button
+      v-if="kind === 'image' && url"
+      type="button"
+      class="media-input__visual"
+      :aria-label="previewLabel"
+      :disabled="state === 'uploading' || state === 'unavailable'"
+      @click="imageViewerOpen = true"
+    >
+      <img :src="url" :alt="name" />
+    </button>
+    <button
+      v-else-if="kind === 'video' && url && !videoThumbnailFailed"
+      type="button"
+      class="media-input__visual"
+      :aria-label="previewLabel"
+      :disabled="state === 'uploading' || state === 'unavailable'"
+      @click="videoDialogOpen = true"
+    >
+      <video :src="`${url}#t=0.1`" muted preload="metadata" playsinline @error="videoThumbnailFailed = true" />
+      <font-awesome-icon icon="fa-solid fa-play" class="media-input__play" />
+    </button>
+    <div v-else-if="kind === 'audio' && url" class="media-input__audio">
+      <audio :src="url" controls preload="metadata" :aria-label="previewLabel" />
+    </div>
+    <div v-else class="media-input__file" aria-hidden="true">
+      <font-awesome-icon icon="fa-regular fa-file" />
+    </div>
+
+    <div class="media-input__content">
+      <span class="media-input__role">{{ roleLabel }}</span>
+      <strong class="media-input__name" :title="name">{{ name }}</strong>
+      <span v-if="metadata" class="media-input__metadata">{{ metadata }}</span>
+      <el-progress v-if="state === 'uploading'" :percentage="boundedProgress" :show-text="false" :stroke-width="4" />
+      <span v-if="state === 'failed' && error" class="media-input__error" role="alert">{{ error }}</span>
+      <span v-else-if="state === 'unavailable'" class="media-input__metadata">{{ unavailableLabel }}</span>
+    </div>
+
+    <div class="media-input__actions">
+      <el-button v-if="replaceable" circle :aria-label="replaceLabel" @click="$emit('replace')">
+        <font-awesome-icon icon="fa-solid fa-rotate" />
+      </el-button>
+      <el-button v-if="removable" circle :aria-label="removeLabel" @click="$emit('remove')">
+        <font-awesome-icon icon="fa-solid fa-xmark" />
+      </el-button>
+    </div>
+
+    <el-image-viewer
+      v-if="imageViewerOpen && url"
+      :url-list="[url]"
+      teleported
+      hide-on-click-modal
+      @close="imageViewerOpen = false"
+    />
+    <el-dialog v-model="videoDialogOpen" width="640" align-center append-to-body destroy-on-close>
+      <video-player v-if="url" :src="url" />
+    </el-dialog>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, defineAsyncComponent, ref } from 'vue';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import { ElButton, ElDialog, ElImageViewer, ElProgress } from 'element-plus';
+
+const VideoPlayer = defineAsyncComponent(() => import('@/components/common/VideoPlayer.vue'));
+
+export type MediaInputKind = 'image' | 'video' | 'audio' | 'file';
+export type MediaInputState = 'ready' | 'uploading' | 'failed' | 'unavailable';
+
+const props = withDefaults(
+  defineProps<{
+    kind: MediaInputKind;
+    name: string;
+    roleLabel: string;
+    previewLabel: string;
+    replaceLabel: string;
+    removeLabel: string;
+    unavailableLabel: string;
+    url?: string;
+    metadata?: string;
+    error?: string;
+    state?: MediaInputState;
+    progress?: number;
+    replaceable?: boolean;
+    removable?: boolean;
+  }>(),
+  {
+    url: undefined,
+    metadata: undefined,
+    error: undefined,
+    state: 'ready',
+    progress: 0,
+    replaceable: true,
+    removable: true
+  }
+);
+
+defineEmits<{
+  replace: [];
+  remove: [];
+}>();
+
+const imageViewerOpen = ref(false);
+const videoDialogOpen = ref(false);
+const videoThumbnailFailed = ref(false);
+const boundedProgress = computed(() => Math.min(100, Math.max(0, props.progress)));
+</script>
+
+<style lang="scss" scoped>
+.media-input {
+  display: grid;
+  grid-template-columns: 80px minmax(0, 1fr) auto;
+  gap: 12px;
+  align-items: center;
+  min-height: 80px;
+  padding: 8px;
+  background: var(--el-fill-color-lighter);
+  border: 1px solid var(--app-border-subtle);
+  border-radius: var(--el-border-radius-base);
+}
+
+.media-input__visual,
+.media-input__file {
+  position: relative;
+  width: 80px;
+  height: 80px;
+  padding: 0;
+  overflow: hidden;
+  color: var(--el-text-color-secondary);
+  background: var(--el-fill-color-dark);
+  border: 0;
+  border-radius: calc(var(--el-border-radius-base) - 2px);
+}
+
+.media-input__visual:focus-visible {
+  outline: 3px solid var(--el-color-primary-light-5);
+  outline-offset: 2px;
+}
+
+.media-input__visual img,
+.media-input__visual video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.media-input__play {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  color: white;
+  filter: drop-shadow(0 1px 3px rgb(0 0 0 / 70%));
+  transform: translate(-50%, -50%);
+}
+
+.media-input__audio {
+  grid-column: 1 / 3;
+}
+
+.media-input__audio audio {
+  width: 100%;
+  min-width: 0;
+  height: 40px;
+}
+
+.media-input__file {
+  display: grid;
+  place-items: center;
+  font-size: 24px;
+}
+
+.media-input__content {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.media-input__role,
+.media-input__metadata,
+.media-input__error {
+  font-size: 12px;
+  line-height: 18px;
+}
+
+.media-input__role {
+  color: var(--el-color-primary);
+  font-weight: 600;
+}
+
+.media-input__name {
+  overflow: hidden;
+  color: var(--el-text-color-primary);
+  font-size: 14px;
+  line-height: 20px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.media-input__metadata {
+  color: var(--el-text-color-secondary);
+}
+
+.media-input__error {
+  color: var(--el-color-danger);
+}
+
+.media-input__actions {
+  display: flex;
+  gap: 4px;
+}
+
+.media-input__actions :deep(.el-button) {
+  width: 40px;
+  height: 40px;
+  margin: 0;
+}
+
+@media (max-width: 480px) {
+  .media-input {
+    grid-template-columns: 64px minmax(0, 1fr);
+  }
+
+  .media-input__visual,
+  .media-input__file {
+    width: 64px;
+    height: 64px;
+  }
+
+  .media-input__actions {
+    grid-column: 1 / -1;
+    justify-content: flex-end;
+  }
+}
+</style>

--- a/src/components/scenario/index.ts
+++ b/src/components/scenario/index.ts
@@ -1,6 +1,8 @@
+export { default as MediaInputField } from './MediaInputField.vue';
 export { default as ScenarioField } from './ScenarioField.vue';
 export { default as ScenarioFooter } from './ScenarioFooter.vue';
 export { default as ScenarioPanel } from './ScenarioPanel.vue';
 export { default as ScenarioSection } from './ScenarioSection.vue';
 export { default as ScenarioSegmented } from './ScenarioSegmented.vue';
+export type { MediaInputKind, MediaInputState } from './MediaInputField.vue';
 export type { ScenarioSegmentedOption, ScenarioSegmentedValue } from './ScenarioSegmented.vue';


### PR DESCRIPTION
## 概要

- 新增统一 `MediaInputField`，覆盖 image/video/audio/file
- 视频输入默认显示真实画面缩略图与播放 dialog，普通文件才退化为文件行
- 统一 role、文件名、metadata、上传、失败、不可用、替换与移除状态
- 图片/视频预览使用原生 button，操作目标固定 40px
- VideoPlayer 按需异步加载，避免非视频输入加载 Plyr

## 验证

- `MediaInputField.test.ts` 5 passed
- ESLint、Prettier、Vue typecheck、web build 通过

## 对抗评审

修复 unavailable UI、损坏视频缩略图 fallback、progress clamp、preview/disabled interaction tests。复审的其余 findings 均指向未修改的旧 Preview 组件，不扩大本 PR。

## Stack

Base: N2 `feat/scenario-n2-primitives`（Ready for review）

Ready for review；不启用 auto-merge。