### PR TITLE
fix: keep Kling scenario tabs readable

### DIFF
--- a/change/@acedatacloud-nexior-kling-tab-wrap.json
+++ b/change/@acedatacloud-nexior-kling-tab-wrap.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Keep all Kling scenario tab labels readable in narrow parameter panels.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/kling/TabSwitcher.test.ts
+++ b/src/components/kling/TabSwitcher.test.ts
@@ -1,0 +1,23 @@
+// @vitest-environment jsdom
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import TabSwitcher from './TabSwitcher.vue';
+
+describe('KlingTabSwitcher', () => {
+  it('renders all scenario labels without replacing their text', () => {
+    const labels: Record<string, string> = {
+      'kling.tab.videoGeneration': 'Video Generation',
+      'kling.tab.motionControl': 'Motion Control',
+      'kling.tab.talkingPhoto': 'Talking Photo'
+    };
+    const wrapper = mount(TabSwitcher, {
+      global: {
+        mocks: { $t: (key: string) => labels[key] ?? key }
+      }
+    });
+
+    expect(wrapper.text()).toContain('Video Generation');
+    expect(wrapper.text()).toContain('Motion Control');
+    expect(wrapper.text()).toContain('Talking Photo');
+  });
+});

--- a/src/components/kling/TabSwitcher.vue
+++ b/src/components/kling/TabSwitcher.vue
@@ -79,24 +79,33 @@ export default defineComponent({
   }
 
   :deep(.el-tabs__item) {
-    height: 38px;
-    line-height: 38px;
+    height: 48px;
+    line-height: 16px;
     font-size: 13px;
     padding: 0 6px;
+    white-space: normal;
   }
 
   .tab-label {
     display: inline-flex;
     align-items: center;
-    white-space: nowrap;
+    justify-content: center;
+    width: 100%;
+    min-width: 0;
 
     .text {
-      max-width: 100%;
+      display: -webkit-box;
+      flex: 1;
+      min-width: 0;
       overflow: hidden;
-      text-overflow: ellipsis;
+      text-align: center;
+      overflow-wrap: anywhere;
+      -webkit-box-orient: vertical;
+      -webkit-line-clamp: 2;
     }
 
     .badge {
+      flex: none;
       margin-left: 4px;
       font-size: 9px;
       height: 16px;


### PR DESCRIPTION
## 概要

- 修复 Kling 三个 scenario tab 在 320px 参数栏与 390px drawer 中被裁切
- tab 高度提升为 48px，标签允许两行居中显示
- text 与可选 badge 使用稳定 flex 边界，避免互相挤压

## 验证

- `TabSwitcher.test.ts` 1 passed
- ESLint、Prettier、Vue typecheck 通过

## 对抗评审

采纳 text/badge flex 稳定性建议；viewport 像素回归由 N1 harness 后续消费，不用 jsdom 假装验证 CSS。无未处置产品缺陷。

## Stack

Base: https://github.com/AceDataCloud/Nexior/pull/1331

Ready for review；不启用 auto-merge。