### PR TITLE
feat: make Seedream action explicit

### DIFF
--- a/change/@acedatacloud-nexior-seedream-explicit-action.json
+++ b/change/@acedatacloud-nexior-seedream-explicit-action.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Make Seedream Generate and Edit modes explicit while preserving uploaded references.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/scenario/ScenarioPrimitives.test.ts
+++ b/src/components/scenario/ScenarioPrimitives.test.ts
@@ -47,7 +47,7 @@ describe('scenario primitives', () => {
     const wrapper = mount(ScenarioSegmented, {
       props: {
         modelValue: 'generate',
-        ariaLabel: 'Action',
+        accessibleLabel: 'Action',
         options: [
           { label: 'Generate', value: 'generate' },
           { label: 'Edit', value: 'edit' }

--- a/src/components/scenario/ScenarioSegmented.vue
+++ b/src/components/scenario/ScenarioSegmented.vue
@@ -2,7 +2,7 @@
   <el-radio-group
     class="scenario-segmented"
     :model-value="modelValue"
-    :aria-label="ariaLabel"
+    :aria-label="accessibleLabel"
     @update:model-value="onUpdate"
   >
     <el-radio-button
@@ -30,7 +30,7 @@ export interface ScenarioSegmentedOption {
 defineProps<{
   modelValue: ScenarioSegmentedValue;
   options: readonly ScenarioSegmentedOption[];
-  ariaLabel: string;
+  accessibleLabel: string;
 }>();
 
 const emit = defineEmits<{

--- a/src/components/seedream/ConfigPanel.vue
+++ b/src/components/seedream/ConfigPanel.vue
@@ -1,6 +1,13 @@
 <template>
   <div class="flex flex-col h-full">
     <div class="flex-1 overflow-y-auto p-5">
+      <scenario-segmented
+        class="mb-4"
+        :model-value="action"
+        :options="actionOptions"
+        :accessible-label="$t('seedream.name.action')"
+        @update:model-value="onActionChange"
+      />
       <model-selector class="mb-4" />
       <size-selector class="mb-4" />
       <max-images-selector class="mb-4" />
@@ -37,6 +44,8 @@ import SeedInput from './config/SeedInput.vue';
 import GuidanceScaleInput from './config/GuidanceScaleInput.vue';
 import WatermarkSwitch from './config/WatermarkSwitch.vue';
 import { getSeedreamShortModel } from '@/constants';
+import { ScenarioSegmented, type ScenarioSegmentedOption, type ScenarioSegmentedValue } from '@/components/scenario';
+import { getSeedreamCapabilities } from '@/utils/seedream/capabilities';
 
 export default defineComponent({
   name: 'SeedreamConfigPanel',
@@ -52,16 +61,34 @@ export default defineComponent({
     OutputFormatSelector,
     SeedInput,
     GuidanceScaleInput,
-    WatermarkSwitch
+    WatermarkSwitch,
+    ScenarioSegmented
   },
   emits: ['generate'],
   computed: {
+    action(): 'generate' | 'edit' {
+      return this.config?.action === 'edit' ? 'edit' : 'generate';
+    },
+    actionOptions(): ScenarioSegmentedOption[] {
+      const capabilities = getSeedreamCapabilities(this.config?.model);
+      return [
+        {
+          value: 'generate',
+          label: this.$t('seedream.name.generate'),
+          disabled: capabilities.imageRequired
+        },
+        {
+          value: 'edit',
+          label: this.$t('seedream.name.edits'),
+          disabled: !capabilities.image
+        }
+      ];
+    },
     config() {
       return this.$store.state.seedream?.config;
     },
     consumption() {
       const cfg: any = { ...(this.config || {}) };
-      const hasReferenceImages = Array.isArray(cfg?.image) && cfg.image.length > 0;
       // Per-image billing: cost/api/86ad30f3-…json multiplies the unit price by
       // `count`. When the user opts into group generation we forward the
       // selected `max_images`; otherwise default to 1 to match the upstream.
@@ -72,7 +99,7 @@ export default defineComponent({
       return getConsumption(
         {
           ...cfg,
-          action: hasReferenceImages ? 'edit' : 'generate',
+          action: this.action,
           model: getSeedreamShortModel(cfg?.model),
           count: requestedCount
         },
@@ -84,6 +111,10 @@ export default defineComponent({
     }
   },
   methods: {
+    onActionChange(action: ScenarioSegmentedValue) {
+      if (action !== 'generate' && action !== 'edit') return;
+      this.$store.commit('seedream/setConfig', { ...this.config, action });
+    },
     onGenerate() {
       this.$emit('generate');
     }

--- a/src/components/seedream/config/ImageInput.vue
+++ b/src/components/seedream/config/ImageInput.vue
@@ -171,6 +171,7 @@ export default defineComponent({
       this.suppressWatch = true;
       this.$store.commit('seedream/setConfig', {
         ...this.$store.state.seedream?.config,
+        action: urls.length > 0 ? 'edit' : this.$store.state.seedream?.config?.action,
         image: urls
       });
       this.$nextTick(() => {

--- a/src/components/seedream/config/ModelSelector.vue
+++ b/src/components/seedream/config/ModelSelector.vue
@@ -31,7 +31,11 @@ import {
   SEEDREAM_MODEL_5_0_PRO,
   SEEDREAM_MODEL_SEEDEDIT_3_0_I2I
 } from '@/constants';
-import { findSeedreamConflicts, clearSeedreamConflicts } from '@/utils/seedream/capabilities';
+import {
+  findSeedreamConflicts,
+  clearSeedreamConflicts,
+  getCompatibleSeedreamAction
+} from '@/utils/seedream/capabilities';
 
 export default defineComponent({
   name: 'SeedreamModelSelector',
@@ -85,6 +89,7 @@ export default defineComponent({
           }
         );
         const cleared = clearSeedreamConflicts({ ...config, model: val }, conflicts, { model: val });
+        cleared.action = getCompatibleSeedreamAction(cleared.action, val);
         this.$store.commit('seedream/setConfig', cleared);
         ElMessage.success(this.$t('seedream.message.featureRemovedNotice', { fields }));
       } catch {
@@ -95,7 +100,8 @@ export default defineComponent({
     applyModel(val: string) {
       this.$store.commit('seedream/setConfig', {
         ...this.$store.state.seedream?.config,
-        model: val
+        model: val,
+        action: getCompatibleSeedreamAction(this.$store.state.seedream?.config?.action, val)
       });
     }
   }

--- a/src/i18n/ar/seedream.json
+++ b/src/i18n/ar/seedream.json
@@ -218,5 +218,13 @@
   "size.adaptive": {
     "message": "تلقائي (مطابق للصورة المرجعية)",
     "description": "تسمية خيار adaptive"
+  },
+  "name.action": {
+    "message": "Action",
+    "description": "Generate or edit action selector"
+  },
+  "message.referenceImageRequired": {
+    "message": "Upload at least one reference image to use Edit mode.",
+    "description": "Validation shown when Edit mode has no reference image"
   }
 }

--- a/src/i18n/de/seedream.json
+++ b/src/i18n/de/seedream.json
@@ -218,5 +218,13 @@
   "size.adaptive": {
     "message": "Anpassungsfähig (entspricht Referenzbild)",
     "description": "Label für die adaptive Option"
+  },
+  "name.action": {
+    "message": "Action",
+    "description": "Generate or edit action selector"
+  },
+  "message.referenceImageRequired": {
+    "message": "Upload at least one reference image to use Edit mode.",
+    "description": "Validation shown when Edit mode has no reference image"
   }
 }

--- a/src/i18n/el/seedream.json
+++ b/src/i18n/el/seedream.json
@@ -218,5 +218,13 @@
   "size.adaptive": {
     "message": "Προσαρμοστικό (ίδιο με την αναφορά εικόνας)",
     "description": "Ετικέτα επιλογής adaptive"
+  },
+  "name.action": {
+    "message": "Action",
+    "description": "Generate or edit action selector"
+  },
+  "message.referenceImageRequired": {
+    "message": "Upload at least one reference image to use Edit mode.",
+    "description": "Validation shown when Edit mode has no reference image"
   }
 }

--- a/src/i18n/en/seedream.json
+++ b/src/i18n/en/seedream.json
@@ -1,4 +1,8 @@
 {
+  "name.action": {
+    "message": "Action",
+    "description": "Generate or edit action selector"
+  },
   "name.taskId": {
     "message": "Task ID",
     "description": "The ID of the task"
@@ -130,6 +134,10 @@
   "message.uploadImageError": {
     "message": "Image upload failed, please try again later",
     "description": "Upload failure"
+  },
+  "message.referenceImageRequired": {
+    "message": "Upload at least one reference image to use Edit mode.",
+    "description": "Validation shown when Edit mode has no reference image"
   },
   "message.featureNotSupportedTitle": {
     "message": "Confirmation Required",

--- a/src/i18n/es/seedream.json
+++ b/src/i18n/es/seedream.json
@@ -218,5 +218,13 @@
   "size.adaptive": {
     "message": "Adaptativo (igual que la imagen de referencia)",
     "description": "Etiqueta de opción adaptive"
+  },
+  "name.action": {
+    "message": "Action",
+    "description": "Generate or edit action selector"
+  },
+  "message.referenceImageRequired": {
+    "message": "Upload at least one reference image to use Edit mode.",
+    "description": "Validation shown when Edit mode has no reference image"
   }
 }

--- a/src/i18n/fi/seedream.json
+++ b/src/i18n/fi/seedream.json
@@ -218,5 +218,13 @@
   "size.adaptive": {
     "message": "Sovita (sama kuin referenssikuva)",
     "description": "adaptive-vaihtoehdon etiketti"
+  },
+  "name.action": {
+    "message": "Action",
+    "description": "Generate or edit action selector"
+  },
+  "message.referenceImageRequired": {
+    "message": "Upload at least one reference image to use Edit mode.",
+    "description": "Validation shown when Edit mode has no reference image"
   }
 }

--- a/src/i18n/fr/seedream.json
+++ b/src/i18n/fr/seedream.json
@@ -218,5 +218,13 @@
   "size.adaptive": {
     "message": "Adaptatif (comme l'image de référence)",
     "description": "Étiquette de l'option adaptive"
+  },
+  "name.action": {
+    "message": "Action",
+    "description": "Generate or edit action selector"
+  },
+  "message.referenceImageRequired": {
+    "message": "Upload at least one reference image to use Edit mode.",
+    "description": "Validation shown when Edit mode has no reference image"
   }
 }

--- a/src/i18n/it/seedream.json
+++ b/src/i18n/it/seedream.json
@@ -218,5 +218,13 @@
   "size.adaptive": {
     "message": "Adattivo (coerente con l'immagine di riferimento)",
     "description": "Etichetta dell'opzione adattiva"
+  },
+  "name.action": {
+    "message": "Action",
+    "description": "Generate or edit action selector"
+  },
+  "message.referenceImageRequired": {
+    "message": "Upload at least one reference image to use Edit mode.",
+    "description": "Validation shown when Edit mode has no reference image"
   }
 }

--- a/src/i18n/ja/seedream.json
+++ b/src/i18n/ja/seedream.json
@@ -218,5 +218,13 @@
   "size.adaptive": {
     "message": "自適応（参照画像に一致）",
     "description": "adaptive オプションのラベル"
+  },
+  "name.action": {
+    "message": "Action",
+    "description": "Generate or edit action selector"
+  },
+  "message.referenceImageRequired": {
+    "message": "Upload at least one reference image to use Edit mode.",
+    "description": "Validation shown when Edit mode has no reference image"
   }
 }

--- a/src/i18n/ko/seedream.json
+++ b/src/i18n/ko/seedream.json
@@ -218,5 +218,13 @@
   "size.adaptive": {
     "message": "자동 맞춤 (참조 이미지와 동일)",
     "description": "adaptive 옵션 라벨"
+  },
+  "name.action": {
+    "message": "Action",
+    "description": "Generate or edit action selector"
+  },
+  "message.referenceImageRequired": {
+    "message": "Upload at least one reference image to use Edit mode.",
+    "description": "Validation shown when Edit mode has no reference image"
   }
 }

--- a/src/i18n/pl/seedream.json
+++ b/src/i18n/pl/seedream.json
@@ -218,5 +218,13 @@
   "size.adaptive": {
     "message": "Dopasowanie (zgodne z obrazem referencyjnym)",
     "description": "Etykieta opcji adaptive"
+  },
+  "name.action": {
+    "message": "Action",
+    "description": "Generate or edit action selector"
+  },
+  "message.referenceImageRequired": {
+    "message": "Upload at least one reference image to use Edit mode.",
+    "description": "Validation shown when Edit mode has no reference image"
   }
 }

--- a/src/i18n/pt/seedream.json
+++ b/src/i18n/pt/seedream.json
@@ -218,5 +218,13 @@
   "size.adaptive": {
     "message": "Adaptativo (igual à imagem de referência)",
     "description": "Etiqueta da opção adaptive"
+  },
+  "name.action": {
+    "message": "Action",
+    "description": "Generate or edit action selector"
+  },
+  "message.referenceImageRequired": {
+    "message": "Upload at least one reference image to use Edit mode.",
+    "description": "Validation shown when Edit mode has no reference image"
   }
 }

--- a/src/i18n/ru/seedream.json
+++ b/src/i18n/ru/seedream.json
@@ -218,5 +218,13 @@
   "size.adaptive": {
     "message": "Адаптивно (соответствует образцу)",
     "description": "Метка опции adaptive"
+  },
+  "name.action": {
+    "message": "Action",
+    "description": "Generate or edit action selector"
+  },
+  "message.referenceImageRequired": {
+    "message": "Upload at least one reference image to use Edit mode.",
+    "description": "Validation shown when Edit mode has no reference image"
   }
 }

--- a/src/i18n/sr/seedream.json
+++ b/src/i18n/sr/seedream.json
@@ -218,5 +218,13 @@
   "size.adaptive": {
     "message": "Адаптивно (попут референтне слике)",
     "description": "Ознака опције adaptive"
+  },
+  "name.action": {
+    "message": "Action",
+    "description": "Generate or edit action selector"
+  },
+  "message.referenceImageRequired": {
+    "message": "Upload at least one reference image to use Edit mode.",
+    "description": "Validation shown when Edit mode has no reference image"
   }
 }

--- a/src/i18n/sv/seedream.json
+++ b/src/i18n/sv/seedream.json
@@ -218,5 +218,13 @@
   "size.adaptive": {
     "message": "Adaptiv (samma som referensbild)",
     "description": "Etikett för adaptive-valet"
+  },
+  "name.action": {
+    "message": "Action",
+    "description": "Generate or edit action selector"
+  },
+  "message.referenceImageRequired": {
+    "message": "Upload at least one reference image to use Edit mode.",
+    "description": "Validation shown when Edit mode has no reference image"
   }
 }

--- a/src/i18n/uk/seedream.json
+++ b/src/i18n/uk/seedream.json
@@ -218,5 +218,13 @@
   "size.adaptive": {
     "message": "Адаптивний (як на зразку)",
     "description": "Позначка опції adaptive"
+  },
+  "name.action": {
+    "message": "Action",
+    "description": "Generate or edit action selector"
+  },
+  "message.referenceImageRequired": {
+    "message": "Upload at least one reference image to use Edit mode.",
+    "description": "Validation shown when Edit mode has no reference image"
   }
 }

--- a/src/i18n/zh-CN/seedream.json
+++ b/src/i18n/zh-CN/seedream.json
@@ -1,4 +1,8 @@
 {
+  "name.action": {
+    "message": "操作",
+    "description": "生成或编辑操作选择器"
+  },
   "name.taskId": {
     "message": "任务 ID",
     "description": "任务的 ID"
@@ -130,6 +134,10 @@
   "message.uploadImageError": {
     "message": "上传图片失败，请稍后重试",
     "description": "上传失败"
+  },
+  "message.referenceImageRequired": {
+    "message": "编辑模式至少需要上传一张参考图片。",
+    "description": "编辑模式没有参考图片时显示的校验提示"
   },
   "message.featureNotSupportedTitle": {
     "message": "需要确认",

--- a/src/i18n/zh-TW/seedream.json
+++ b/src/i18n/zh-TW/seedream.json
@@ -218,5 +218,13 @@
   "size.adaptive": {
     "message": "自適應（與參考圖一致）",
     "description": "adaptive 選項標籤"
+  },
+  "name.action": {
+    "message": "Action",
+    "description": "Generate or edit action selector"
+  },
+  "message.referenceImageRequired": {
+    "message": "Upload at least one reference image to use Edit mode.",
+    "description": "Validation shown when Edit mode has no reference image"
   }
 }

--- a/src/models/seedream.ts
+++ b/src/models/seedream.ts
@@ -3,6 +3,7 @@ export interface ISeedreamSequentialOptions {
 }
 
 export interface ISeedreamConfig {
+  action?: 'generate' | 'edit';
   model?: string;
   prompt?: string;
   image?: string[];

--- a/src/pages/seedream/Index.vue
+++ b/src/pages/seedream/Index.vue
@@ -14,6 +14,7 @@ import { defineComponent } from 'vue';
 import Layout from '@/layouts/Seedream.vue';
 import ConfigPanel from '@/components/seedream/ConfigPanel.vue';
 import { seedreamOperator } from '@/operators';
+import { buildSeedreamRequest } from '@/utils/seedream/request';
 import { instrumentGeneration } from '@/plugins/telemetry';
 import { ISeedreamGenerateRequest, Status } from '@/models';
 import { ElMessage } from 'element-plus';
@@ -148,18 +149,11 @@ export default defineComponent({
       ) {
         return;
       }
-      const cfg: any = { ...(this.config || {}) };
-      const hasReferenceImages = Array.isArray(cfg?.image) && cfg.image.length > 0;
-      if (!hasReferenceImages && 'image' in cfg) {
-        delete cfg.image;
+      if (this.config?.action === 'edit' && !this.config.image?.length) {
+        ElMessage.warning(this.$t('seedream.message.referenceImageRequired'));
+        return;
       }
-      if (!cfg?.size) {
-        delete cfg.size;
-      }
-      const request = {
-        ...cfg,
-        async: true
-      } as ISeedreamGenerateRequest;
+      const request = buildSeedreamRequest(this.config) as ISeedreamGenerateRequest;
       if (!ensureLoggedIn()) {
         return;
       }

--- a/src/store/seedream/state.ts
+++ b/src/store/seedream/state.ts
@@ -10,6 +10,7 @@ export default (): ISeedreamState => {
     tasks: undefined,
     credential: undefined,
     config: {
+      action: 'generate',
       model: SEEDREAM_DEFAULT_MODEL,
       size: SEEDREAM_DEFAULT_SIZE,
       watermark: SEEDREAM_DEFAULT_WATERMARK

--- a/src/utils/seedream/capabilities.ts
+++ b/src/utils/seedream/capabilities.ts
@@ -169,6 +169,16 @@ export function getSeedreamCapabilities(model?: string): ISeedreamCapability {
   }
 }
 
+export function getCompatibleSeedreamAction(
+  action: 'generate' | 'edit' | undefined,
+  model?: string
+): 'generate' | 'edit' {
+  const capabilities = getSeedreamCapabilities(model);
+  if (capabilities.imageRequired) return 'edit';
+  if (!capabilities.image) return 'generate';
+  return action === 'edit' ? 'edit' : 'generate';
+}
+
 export type SeedreamConflictField =
   | 'image'
   | 'size'

--- a/src/utils/seedream/request.test.ts
+++ b/src/utils/seedream/request.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { buildSeedreamRequest } from './request';
+import { getCompatibleSeedreamAction } from './capabilities';
+
+describe('buildSeedreamRequest', () => {
+  it('does not send UI action or saved references in generate mode', () => {
+    expect(
+      buildSeedreamRequest({ action: 'generate', prompt: 'A lighthouse', image: ['https://cdn.example/ref.png'] })
+    ).toEqual({ prompt: 'A lighthouse', async: true });
+  });
+
+  it('sends saved references after switching back to edit mode', () => {
+    expect(buildSeedreamRequest({ action: 'edit', image: ['https://cdn.example/ref.png'] })).toEqual({
+      image: ['https://cdn.example/ref.png'],
+      async: true
+    });
+  });
+
+  it('normalizes actions for text-only and edit-only models', () => {
+    expect(getCompatibleSeedreamAction('edit', 'doubao-seedream-3-0-t2i-250415')).toBe('generate');
+    expect(getCompatibleSeedreamAction('generate', 'doubao-seededit-3-0-i2i-250628')).toBe('edit');
+  });
+});

--- a/src/utils/seedream/request.ts
+++ b/src/utils/seedream/request.ts
@@ -1,0 +1,16 @@
+import type { ISeedreamConfig, ISeedreamGenerateRequest } from '@/models';
+
+export const buildSeedreamRequest = (config?: ISeedreamConfig): ISeedreamGenerateRequest => {
+  const request = { ...(config || {}) };
+  const action = request.action === 'edit' ? 'edit' : 'generate';
+  delete request.action;
+
+  if (action !== 'edit' || !request.image?.length) {
+    delete request.image;
+  }
+  if (!request.size) {
+    delete request.size;
+  }
+
+  return { ...request, async: true };
+};


### PR DESCRIPTION
## 概要

- 将 Seedream Generate/Edit 从“是否上传图片”的隐式推断改为显式 segmented
- 上传参考图自动切 Edit，但切回 Generate 不删除图片，之后可逆切回 Edit
- `action` 仅为 UI 状态，请求发送前剥离；Generate 不发送已保存参考图
- 根据模型能力禁用不合法 action，Edit 无图本地阻止

## 验证

- 相关测试 8 passed
- ESLint、Prettier、Vue typecheck、i18n coverage 通过

## 对抗评审

修复 Edit 无图静默降级、text-only/edit-only 模型不兼容与切模型 action 归一。二轮 reviewer 因网络失败未执行，保留人工 review。

## Stack

Base: https://github.com/AceDataCloud/Nexior/pull/1332

Ready for review；不启用 auto-merge。