### PR TITLE
feat: add task result shell

### DIFF
--- a/change/@acedatacloud-nexior-task-result-shell.json
+++ b/change/@acedatacloud-nexior-task-result-shell.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add a shared task result shell with explicit legacy and missing-output fallbacks.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "minor"
+}

--- a/src/components/scenario/TaskResultShell.test.ts
+++ b/src/components/scenario/TaskResultShell.test.ts
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+import { shallowMount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import TaskResultShell from './TaskResultShell.vue';
+
+const baseProps = {
+  state: 'succeeded' as const,
+  statusLabel: 'Completed',
+  referencesLabel: 'References',
+  outputLabel: 'Output',
+  outputUnavailableLabel: 'Output unavailable',
+  legacyLabel: 'Input details were not saved for this legacy task'
+};
+
+describe('TaskResultShell', () => {
+  it('renders complete intent, references, output, actions and metadata', () => {
+    const wrapper = shallowMount(TaskResultShell, {
+      props: {
+        ...baseProps,
+        metadata: [{ key: 'task', label: 'Task ID', value: 'task-123' }]
+      },
+      slots: {
+        intent: 'A city at night',
+        references: 'reference.png',
+        output: 'result.mp4',
+        actions: 'Download'
+      }
+    });
+
+    expect(wrapper.text()).toContain('A city at night');
+    expect(wrapper.text()).toContain('reference.png');
+    expect(wrapper.text()).toContain('result.mp4');
+    expect(wrapper.text()).toContain('task-123');
+    expect(wrapper.get('.task-result__status').attributes('aria-live')).toBe('off');
+  });
+
+  it('omits empty references and renders an unavailable output placeholder', () => {
+    const wrapper = shallowMount(TaskResultShell, { props: baseProps });
+
+    expect(wrapper.find('.task-result__references').exists()).toBe(false);
+    expect(wrapper.get('.task-result__placeholder').text()).toBe('Output unavailable');
+  });
+
+  it('renders an explicit legacy fallback when metadata is unavailable', () => {
+    const wrapper = shallowMount(TaskResultShell, { props: { ...baseProps, legacy: true } });
+    expect(wrapper.get('.task-result__legacy').text()).toBe(baseProps.legacyLabel);
+    expect(wrapper.find('.task-result__metadata').exists()).toBe(false);
+  });
+
+  it('announces status changes only for active task surfaces', () => {
+    const wrapper = shallowMount(TaskResultShell, { props: { ...baseProps, state: 'running', live: true } });
+    expect(wrapper.get('.task-result__status').attributes('aria-live')).toBe('polite');
+  });
+
+  it('renders failed orphaned tasks with actionable reason and trace ID', () => {
+    const wrapper = shallowMount(TaskResultShell, {
+      props: {
+        ...baseProps,
+        state: 'failed',
+        error: { title: 'Generation failed', reason: 'Reference expired', traceId: 'trace-123' }
+      }
+    });
+
+    expect(wrapper.get('[role="alert"]').text()).toContain('Reference expired');
+    expect(wrapper.get('code').text()).toBe('trace-123');
+  });
+});

--- a/src/components/scenario/TaskResultShell.vue
+++ b/src/components/scenario/TaskResultShell.vue
@@ -1,0 +1,156 @@
+<template>
+  <article class="task-result" :data-state="state">
+    <header v-if="$slots.intent" class="task-result__intent">
+      <slot name="intent" />
+    </header>
+
+    <section v-if="$slots.references" class="task-result__references" role="region" :aria-label="referencesLabel">
+      <slot name="references" />
+    </section>
+
+    <div class="task-result__status" :aria-live="live ? 'polite' : 'off'">
+      <slot name="status">{{ statusLabel }}</slot>
+    </div>
+
+    <section class="task-result__output" role="region" :aria-label="outputLabel">
+      <slot v-if="$slots.output" name="output" />
+      <p v-else class="task-result__placeholder">{{ outputUnavailableLabel }}</p>
+    </section>
+
+    <div v-if="$slots.actions" class="task-result__actions">
+      <slot name="actions" />
+    </div>
+
+    <dl v-if="metadata.length" class="task-result__metadata">
+      <template v-for="item in metadata" :key="item.key">
+        <dt>{{ item.label }}</dt>
+        <dd :title="item.value">{{ item.value }}</dd>
+      </template>
+    </dl>
+    <p v-else-if="legacy" class="task-result__legacy">{{ legacyLabel }}</p>
+
+    <div v-if="error" class="task-result__error" role="alert">
+      <strong>{{ error.title }}</strong>
+      <p>{{ error.reason }}</p>
+      <code v-if="error.traceId">{{ error.traceId }}</code>
+    </div>
+  </article>
+</template>
+
+<script setup lang="ts">
+export type TaskResultState = 'queued' | 'running' | 'succeeded' | 'failed' | 'cancelled';
+
+export interface TaskResultMetadataItem {
+  key: string;
+  label: string;
+  value: string;
+}
+
+export interface TaskResultError {
+  title: string;
+  reason: string;
+  traceId?: string;
+}
+
+withDefaults(
+  defineProps<{
+    state: TaskResultState;
+    statusLabel: string;
+    referencesLabel: string;
+    outputLabel: string;
+    outputUnavailableLabel: string;
+    legacyLabel: string;
+    metadata?: readonly TaskResultMetadataItem[];
+    error?: TaskResultError;
+    legacy?: boolean;
+    live?: boolean;
+  }>(),
+  {
+    metadata: () => [],
+    error: undefined,
+    legacy: false,
+    live: false
+  }
+);
+</script>
+
+<style lang="scss" scoped>
+.task-result {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-width: 0;
+}
+
+.task-result__intent {
+  color: var(--el-text-color-primary);
+  font-size: 14px;
+  line-height: 22px;
+  overflow-wrap: anywhere;
+}
+
+.task-result__references,
+.task-result__output {
+  min-width: 0;
+}
+
+.task-result__status,
+.task-result__legacy,
+.task-result__placeholder {
+  color: var(--el-text-color-secondary);
+  font-size: 12px;
+  line-height: 18px;
+}
+
+.task-result__placeholder,
+.task-result__legacy {
+  margin: 0;
+}
+
+.task-result__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+.task-result__metadata {
+  display: grid;
+  grid-template-columns: max-content minmax(0, 1fr);
+  gap: 6px 12px;
+  margin: 0;
+  padding: 12px;
+  background: var(--el-fill-color-light);
+  border-radius: var(--el-border-radius-base);
+  font-size: 12px;
+  line-height: 18px;
+}
+
+.task-result__metadata dt {
+  max-width: 12rem;
+  color: var(--el-text-color-secondary);
+  overflow-wrap: anywhere;
+}
+
+.task-result__metadata dd {
+  min-width: 0;
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.task-result__error {
+  padding: 12px;
+  color: var(--el-color-danger);
+  background: var(--el-color-danger-light-9);
+  border: 1px solid var(--el-color-danger-light-7);
+  border-radius: var(--el-border-radius-base);
+}
+
+.task-result__error p {
+  margin: 4px 0;
+}
+
+.task-result__error code {
+  overflow-wrap: anywhere;
+}
+</style>

--- a/src/components/scenario/index.ts
+++ b/src/components/scenario/index.ts
@@ -4,5 +4,7 @@ export { default as ScenarioFooter } from './ScenarioFooter.vue';
 export { default as ScenarioPanel } from './ScenarioPanel.vue';
 export { default as ScenarioSection } from './ScenarioSection.vue';
 export { default as ScenarioSegmented } from './ScenarioSegmented.vue';
+export { default as TaskResultShell } from './TaskResultShell.vue';
 export type { MediaInputKind, MediaInputState } from './MediaInputField.vue';
 export type { ScenarioSegmentedOption, ScenarioSegmentedValue } from './ScenarioSegmented.vue';
+export type { TaskResultError, TaskResultMetadataItem, TaskResultState } from './TaskResultShell.vue';


### PR DESCRIPTION
## 概要

- 新增 `TaskResultShell`，统一 intent/references/status/output/actions/metadata/error 信息架构
- 覆盖 complete、partial、legacy、orphaned fallback
- history 默认关闭 live announcement，active task 可显式开启
- 长 metadata label/value 可安全换行

## 验证

- `TaskResultShell.test.ts` 5 passed
- ESLint、Prettier、Vue typecheck 通过

## 对抗评审

修复 region语义、history live-region噪声与长i18n metadata布局；最终 `VERDICT: CLEAN`。

## Stack

Base: N5 `feat/scenario-n5-seedream-action`

Ready for review；不启用 auto-merge。