### PR TITLE
fix: make audio previews accessible

### DIFF
--- a/change/@acedatacloud-nexior-audio-preview-accessibility.json
+++ b/change/@acedatacloud-nexior-audio-preview-accessibility.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Make shared audio previews keyboard-accessible and show load failures.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/common/AudioPreview.test.ts
+++ b/src/components/common/AudioPreview.test.ts
@@ -1,0 +1,33 @@
+// @vitest-environment jsdom
+import { shallowMount } from '@vue/test-utils';
+import { describe, expect, it, vi } from 'vitest';
+import AudioPreview from './AudioPreview.vue';
+
+describe('AudioPreview', () => {
+  it('uses a native button with an accessible name', () => {
+    const wrapper = shallowMount(AudioPreview, { props: { url: 'track.mp3', name: 'Reference voice' } });
+    expect(wrapper.element.tagName).toBe('BUTTON');
+    expect(wrapper.attributes('aria-label')).toBe('Reference voice');
+  });
+
+  it('plays and pauses from the button action', async () => {
+    const wrapper = shallowMount(AudioPreview, { props: { url: 'track.mp3', name: 'Reference voice' } });
+    const audio = wrapper.get('audio').element as HTMLAudioElement;
+    audio.play = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(audio, 'paused', { configurable: true, value: true });
+
+    await wrapper.trigger('click');
+    expect(audio.play).toHaveBeenCalledOnce();
+  });
+
+  it('disables playback and announces media load failures', async () => {
+    const wrapper = shallowMount(AudioPreview, {
+      props: { url: 'missing.mp3', name: 'Reference voice' },
+      global: { mocks: { $t: () => 'Preview unavailable' } }
+    });
+
+    await wrapper.get('audio').trigger('error');
+    expect(wrapper.attributes('disabled')).toBeDefined();
+    expect(wrapper.attributes('aria-label')).toBe('Reference voice: Preview unavailable');
+  });
+});

--- a/src/components/common/AudioPreview.vue
+++ b/src/components/common/AudioPreview.vue
@@ -1,11 +1,14 @@
 <template>
-  <div
+  <button
+    type="button"
     class="audio-preview w-[50px] h-[50px] relative rounded-[var(--el-border-radius-base)] overflow-hidden shadow-sm cursor-pointer flex items-center justify-center"
-    :title="name"
+    :title="accessibleLabel"
+    :aria-label="accessibleLabel"
+    :disabled="failed"
     @click.stop="onToggle"
   >
     <font-awesome-icon
-      :icon="playing ? 'fa-solid fa-pause' : 'fa-solid fa-music'"
+      :icon="failed ? 'fa-solid fa-triangle-exclamation' : playing ? 'fa-solid fa-pause' : 'fa-solid fa-music'"
       class="icon text-white text-[16px]"
     />
     <audio
@@ -15,8 +18,9 @@
       @play="playing = true"
       @pause="playing = false"
       @ended="playing = false"
+      @error="onError"
     />
-  </div>
+  </button>
 </template>
 
 <script lang="ts">
@@ -41,8 +45,14 @@ export default defineComponent({
   },
   data() {
     return {
-      playing: false
+      playing: false,
+      failed: false
     };
+  },
+  computed: {
+    accessibleLabel(): string {
+      return this.failed ? `${this.name}: ${this.$t('common.message.mediaPreviewUnavailable')}` : this.name;
+    }
   },
   methods: {
     onToggle() {
@@ -55,6 +65,10 @@ export default defineComponent({
       } else {
         audio.pause();
       }
+    },
+    onError() {
+      this.playing = false;
+      this.failed = true;
     }
   }
 });
@@ -62,10 +76,22 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 .audio-preview {
+  padding: 0;
+  border: 0;
   background: linear-gradient(135deg, var(--el-color-primary), var(--el-color-primary-light-3));
   transition: filter 0.15s ease;
   &:hover {
     filter: brightness(1.08);
+  }
+
+  &:focus-visible {
+    outline: 3px solid var(--el-color-primary-light-5);
+    outline-offset: 2px;
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    filter: grayscale(0.5);
   }
 }
 </style>

--- a/src/i18n/ar/common.json
+++ b/src/i18n/ar/common.json
@@ -1598,5 +1598,9 @@
   "settings.memoryImportInProgress": {
     "message": "A memory import is already running. Keep this dialog open and try again shortly.",
     "description": "Warning shown when another memory import job is active"
+  },
+  "message.mediaPreviewUnavailable": {
+    "message": "Preview unavailable",
+    "description": "Media preview could not be loaded"
   }
 }

--- a/src/i18n/de/common.json
+++ b/src/i18n/de/common.json
@@ -1598,5 +1598,9 @@
   "settings.memoryImportInProgress": {
     "message": "A memory import is already running. Keep this dialog open and try again shortly.",
     "description": "Warning shown when another memory import job is active"
+  },
+  "message.mediaPreviewUnavailable": {
+    "message": "Preview unavailable",
+    "description": "Media preview could not be loaded"
   }
 }

--- a/src/i18n/el/common.json
+++ b/src/i18n/el/common.json
@@ -1598,5 +1598,9 @@
   "settings.memoryImportInProgress": {
     "message": "A memory import is already running. Keep this dialog open and try again shortly.",
     "description": "Warning shown when another memory import job is active"
+  },
+  "message.mediaPreviewUnavailable": {
+    "message": "Preview unavailable",
+    "description": "Media preview could not be loaded"
   }
 }

--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -1,4 +1,8 @@
 {
+  "message.mediaPreviewUnavailable": {
+    "message": "Preview unavailable",
+    "description": "Media preview could not be loaded"
+  },
   "button.setup": {
     "message": "Setup",
     "description": "Text in button for performing setup"

--- a/src/i18n/es/common.json
+++ b/src/i18n/es/common.json
@@ -1598,5 +1598,9 @@
   "settings.memoryImportInProgress": {
     "message": "A memory import is already running. Keep this dialog open and try again shortly.",
     "description": "Warning shown when another memory import job is active"
+  },
+  "message.mediaPreviewUnavailable": {
+    "message": "Preview unavailable",
+    "description": "Media preview could not be loaded"
   }
 }

--- a/src/i18n/fi/common.json
+++ b/src/i18n/fi/common.json
@@ -1598,5 +1598,9 @@
   "settings.memoryImportInProgress": {
     "message": "A memory import is already running. Keep this dialog open and try again shortly.",
     "description": "Warning shown when another memory import job is active"
+  },
+  "message.mediaPreviewUnavailable": {
+    "message": "Preview unavailable",
+    "description": "Media preview could not be loaded"
   }
 }

--- a/src/i18n/fr/common.json
+++ b/src/i18n/fr/common.json
@@ -1598,5 +1598,9 @@
   "settings.memoryImportInProgress": {
     "message": "A memory import is already running. Keep this dialog open and try again shortly.",
     "description": "Warning shown when another memory import job is active"
+  },
+  "message.mediaPreviewUnavailable": {
+    "message": "Preview unavailable",
+    "description": "Media preview could not be loaded"
   }
 }

--- a/src/i18n/it/common.json
+++ b/src/i18n/it/common.json
@@ -1598,5 +1598,9 @@
   "settings.memoryImportInProgress": {
     "message": "A memory import is already running. Keep this dialog open and try again shortly.",
     "description": "Warning shown when another memory import job is active"
+  },
+  "message.mediaPreviewUnavailable": {
+    "message": "Preview unavailable",
+    "description": "Media preview could not be loaded"
   }
 }

--- a/src/i18n/ja/common.json
+++ b/src/i18n/ja/common.json
@@ -1598,5 +1598,9 @@
   "settings.memoryImportInProgress": {
     "message": "A memory import is already running. Keep this dialog open and try again shortly.",
     "description": "Warning shown when another memory import job is active"
+  },
+  "message.mediaPreviewUnavailable": {
+    "message": "Preview unavailable",
+    "description": "Media preview could not be loaded"
   }
 }

--- a/src/i18n/ko/common.json
+++ b/src/i18n/ko/common.json
@@ -1598,5 +1598,9 @@
   "settings.memoryImportInProgress": {
     "message": "A memory import is already running. Keep this dialog open and try again shortly.",
     "description": "Warning shown when another memory import job is active"
+  },
+  "message.mediaPreviewUnavailable": {
+    "message": "Preview unavailable",
+    "description": "Media preview could not be loaded"
   }
 }

--- a/src/i18n/pl/common.json
+++ b/src/i18n/pl/common.json
@@ -1598,5 +1598,9 @@
   "settings.memoryImportInProgress": {
     "message": "A memory import is already running. Keep this dialog open and try again shortly.",
     "description": "Warning shown when another memory import job is active"
+  },
+  "message.mediaPreviewUnavailable": {
+    "message": "Preview unavailable",
+    "description": "Media preview could not be loaded"
   }
 }

--- a/src/i18n/pt/common.json
+++ b/src/i18n/pt/common.json
@@ -1598,5 +1598,9 @@
   "settings.memoryImportInProgress": {
     "message": "A memory import is already running. Keep this dialog open and try again shortly.",
     "description": "Warning shown when another memory import job is active"
+  },
+  "message.mediaPreviewUnavailable": {
+    "message": "Preview unavailable",
+    "description": "Media preview could not be loaded"
   }
 }

--- a/src/i18n/ru/common.json
+++ b/src/i18n/ru/common.json
@@ -1598,5 +1598,9 @@
   "settings.memoryImportInProgress": {
     "message": "A memory import is already running. Keep this dialog open and try again shortly.",
     "description": "Warning shown when another memory import job is active"
+  },
+  "message.mediaPreviewUnavailable": {
+    "message": "Preview unavailable",
+    "description": "Media preview could not be loaded"
   }
 }

--- a/src/i18n/sr/common.json
+++ b/src/i18n/sr/common.json
@@ -1598,5 +1598,9 @@
   "settings.memoryImportInProgress": {
     "message": "A memory import is already running. Keep this dialog open and try again shortly.",
     "description": "Warning shown when another memory import job is active"
+  },
+  "message.mediaPreviewUnavailable": {
+    "message": "Preview unavailable",
+    "description": "Media preview could not be loaded"
   }
 }

--- a/src/i18n/sv/common.json
+++ b/src/i18n/sv/common.json
@@ -1598,5 +1598,9 @@
   "settings.memoryImportInProgress": {
     "message": "A memory import is already running. Keep this dialog open and try again shortly.",
     "description": "Warning shown when another memory import job is active"
+  },
+  "message.mediaPreviewUnavailable": {
+    "message": "Preview unavailable",
+    "description": "Media preview could not be loaded"
   }
 }

--- a/src/i18n/uk/common.json
+++ b/src/i18n/uk/common.json
@@ -1598,5 +1598,9 @@
   "settings.memoryImportInProgress": {
     "message": "A memory import is already running. Keep this dialog open and try again shortly.",
     "description": "Warning shown when another memory import job is active"
+  },
+  "message.mediaPreviewUnavailable": {
+    "message": "Preview unavailable",
+    "description": "Media preview could not be loaded"
   }
 }

--- a/src/i18n/zh-CN/common.json
+++ b/src/i18n/zh-CN/common.json
@@ -1,4 +1,8 @@
 {
+  "message.mediaPreviewUnavailable": {
+    "message": "预览不可用",
+    "description": "媒体预览无法加载"
+  },
   "button.setup": {
     "message": "设置",
     "description": "按钮中的文本，用于进行设置"

--- a/src/i18n/zh-TW/common.json
+++ b/src/i18n/zh-TW/common.json
@@ -1598,5 +1598,9 @@
   "settings.memoryImportInProgress": {
     "message": "A memory import is already running. Keep this dialog open and try again shortly.",
     "description": "Warning shown when another memory import job is active"
+  },
+  "message.mediaPreviewUnavailable": {
+    "message": "Preview unavailable",
+    "description": "Media preview could not be loaded"
   }
 }


### PR DESCRIPTION
## 概要

- 将共享 `AudioPreview` 从 clickable div 改为原生 button
- 支持键盘焦点与原生 Enter/Space 激活
- 音频加载失败后显示警告图标、禁用播放并提供本地化 accessible label

## 验证

- `AudioPreview.test.ts` 3 passed
- ESLint、Prettier、Vue typecheck、i18n coverage 通过

## 对抗评审

最终 `VERDICT: CLEAN`。

## Stack

Base: N6 `feat/scenario-n6-result-shell`

Ready for review；不启用 auto-merge。