### PR TITLE
test: guard scenario media inputs

### DIFF
--- a/change/@acedatacloud-nexior-scenario-media-guard.json
+++ b/change/@acedatacloud-nexior-scenario-media-guard.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Prevent new raw audio or video previews in generation input panels.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "none"
+}

--- a/src/components/scenario/mediaInputGuard.test.ts
+++ b/src/components/scenario/mediaInputGuard.test.ts
@@ -1,0 +1,56 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { SCENARIO_ROUTES } from '@/constants/scenarioRoutes';
+
+const COMPONENTS_ROOT = path.resolve(import.meta.dirname, '..');
+const LEGACY_RAW_MEDIA_INPUTS = [
+  'fish/model/Card.vue',
+  'fish/model/Recorder.vue',
+  'fish/ModelConfigPanel.vue',
+  'kling/TalkingPhotoPanel.vue',
+  'pika/VideoPlayer.vue',
+  'producer/config/UploadAudio.vue',
+  'suno/config/UploadAudio.vue'
+];
+const RESULT_PATH_SEGMENTS = new Set(['task', 'tasks']);
+const RESULT_FILE_NAMES = new Set(['Preview.vue', 'RecentPanel.vue', 'ResultPanel.vue']);
+const AUDITED_SERVICE_ROOTS = new Set(
+  SCENARIO_ROUTES.map(({ name }) => name.replace(/-model$/, '').replaceAll('-', ''))
+);
+
+const listVueFiles = (directory: string): string[] =>
+  readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const absolutePath = path.join(directory, entry.name);
+    if (entry.isDirectory()) return listVueFiles(absolutePath);
+    return entry.isFile() && entry.name.endsWith('.vue') ? [absolutePath] : [];
+  });
+
+describe('scenario media input guard', () => {
+  it('does not add raw audio or video elements to generation input panels', () => {
+    const rawMediaInputs = listVueFiles(COMPONENTS_ROOT)
+      .filter((filePath) => {
+        const relativePath = path.relative(COMPONENTS_ROOT, filePath);
+        const segments = relativePath.split(path.sep);
+        return (
+          AUDITED_SERVICE_ROOTS.has(segments[0]) &&
+          !segments.some((segment) => RESULT_PATH_SEGMENTS.has(segment)) &&
+          !RESULT_FILE_NAMES.has(path.basename(filePath))
+        );
+      })
+      .filter((filePath) => {
+        const source = readFileSync(filePath, 'utf8');
+        const templateStart = source.search(/<template(?:\s[^>]*)?>/i);
+        const templateOpenEnd = templateStart < 0 ? -1 : source.indexOf('>', templateStart);
+        const templateEnd = source.toLowerCase().lastIndexOf('</template>');
+        const template =
+          templateOpenEnd >= 0 && templateEnd > templateOpenEnd ? source.slice(templateOpenEnd + 1, templateEnd) : '';
+        const withoutComments = template.replace(/<!--[\s\S]*?-->/g, '');
+        return /<(?:audio|video)(?:\s|\/?\s*>)/i.test(withoutComments);
+      })
+      .map((filePath) => path.relative(COMPONENTS_ROOT, filePath).split(path.sep).join('/'))
+      .sort();
+
+    expect(rawMediaInputs).toEqual([...LEGACY_RAW_MEDIA_INPUTS].sort());
+  });
+});

--- a/src/constants/scenarioRoutes.test.ts
+++ b/src/constants/scenarioRoutes.test.ts
@@ -5,9 +5,9 @@ describe('scenario route manifest', () => {
   it('tracks the audited generation routes without duplicate names or paths', () => {
     // Keep this explicit: adding or removing an audited product surface must
     // update the review manifest, not silently change screenshot coverage.
-    expect(SCENARIO_ROUTES).toHaveLength(20);
-    expect(new Set(SCENARIO_ROUTES.map(({ name }) => name))).toHaveLength(20);
-    expect(new Set(SCENARIO_ROUTES.map(({ path }) => path))).toHaveLength(20);
+    expect(SCENARIO_ROUTES).toHaveLength(22);
+    expect(new Set(SCENARIO_ROUTES.map(({ name }) => name))).toHaveLength(22);
+    expect(new Set(SCENARIO_ROUTES.map(({ path }) => path))).toHaveLength(22);
     expect(SCENARIO_ROUTES.every(({ path }) => path.startsWith('/'))).toBe(true);
   });
 

--- a/src/constants/scenarioRoutes.ts
+++ b/src/constants/scenarioRoutes.ts
@@ -22,6 +22,7 @@ export const SCENARIO_ROUTES = [
     output: 'audio',
     auditVariants: ['text-to-speech', 'voice-cloning']
   },
+  { name: 'fish-model', path: '/fish/model', output: 'audio' },
   {
     name: 'suno',
     path: '/suno',
@@ -64,6 +65,7 @@ export const SCENARIO_ROUTES = [
   { name: 'pika', path: '/pika', output: 'video' },
   { name: 'pixverse', path: '/pixverse', output: 'video' },
   { name: 'grok-video', path: '/grok-video', output: 'video' },
+  { name: 'omni', path: '/omni', output: 'video' },
   {
     name: 'digital-human',
     path: '/digital-human',


### PR DESCRIPTION
## 概要

- 冻结审计服务输入侧当前7个裸 audio/video legacy实现，阻止数量继续增加
- 扫描范围由 scenario route manifest 派生，排除 task/result输出组件
- template扫描支持 nested slots、注释、大小写与自闭合标签
- manifest补 Fish Model与Omni，共22个审计路由

## 验证

- media guard + route manifest tests 5 passed
- ESLint、Prettier、Vue typecheck 通过

## 对抗评审

修复真实基线遗漏、nested template截断、大小写/自闭合绕过、服务根目录过滤；无未处置产品风险。

## Stack

Base: N7 `fix/scenario-n7-audio-preview`

Ready for review；不启用 auto-merge。