### PR TITLE
fix: keep Kling scenario tabs readable

### DIFF
--- a/change/@acedatacloud-nexior-kling-tab-wrap.json
+++ b/change/@acedatacloud-nexior-kling-tab-wrap.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Keep all Kling scenario tab labels readable in narrow parameter panels.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/kling/TabSwitcher.test.ts
+++ b/src/components/kling/TabSwitcher.test.ts
@@ -1,0 +1,23 @@
+// @vitest-environment jsdom
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import TabSwitcher from './TabSwitcher.vue';
+
+describe('KlingTabSwitcher', () => {
+  it('renders all scenario labels without replacing their text', () => {
+    const labels: Record<string, string> = {
+      'kling.tab.videoGeneration': 'Video Generation',
+      'kling.tab.motionControl': 'Motion Control',
+      'kling.tab.talkingPhoto': 'Talking Photo'
+    };
+    const wrapper = mount(TabSwitcher, {
+      global: {
+        mocks: { $t: (key: string) => labels[key] ?? key }
+      }
+    });
+
+    expect(wrapper.text()).toContain('Video Generation');
+    expect(wrapper.text()).toContain('Motion Control');
+    expect(wrapper.text()).toContain('Talking Photo');
+  });
+});

--- a/src/components/kling/TabSwitcher.vue
+++ b/src/components/kling/TabSwitcher.vue
@@ -79,24 +79,33 @@ export default defineComponent({
   }
 
   :deep(.el-tabs__item) {
-    height: 38px;
-    line-height: 38px;
+    height: 48px;
+    line-height: 16px;
     font-size: 13px;
     padding: 0 6px;
+    white-space: normal;
   }
 
   .tab-label {
     display: inline-flex;
     align-items: center;
-    white-space: nowrap;
+    justify-content: center;
+    width: 100%;
+    min-width: 0;
 
     .text {
-      max-width: 100%;
+      display: -webkit-box;
+      flex: 1;
+      min-width: 0;
       overflow: hidden;
-      text-overflow: ellipsis;
+      text-align: center;
+      overflow-wrap: anywhere;
+      -webkit-box-orient: vertical;
+      -webkit-line-clamp: 2;
     }
 
     .badge {
+      flex: none;
       margin-left: 4px;
       font-size: 9px;
       height: 16px;


### PR DESCRIPTION
## 概要

- 修复 Kling 三个顶部 tab 在 320px 参数栏和手机 drawer 中被裁切
- 标签允许两行显示，保持 48px 点击目标
- 稳定 text/badge flex 边界

## 验证

- `TabSwitcher.test.ts` 1 passed
- ESLint、Vue typecheck 通过

## 对抗评审

独立复审 `VERDICT: CLEAN`。

## 说明

- 直接基于 `main`
- 不依赖 N1/N2/N3 或任何 `components/scenario` 抽象
- Ready for review，不启用 auto-merge