### PR TITLE
feat: make Seedream Generate and Edit explicit

### DIFF
--- a/change/@acedatacloud-nexior-seedream-explicit-action.json
+++ b/change/@acedatacloud-nexior-seedream-explicit-action.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Make Seedream Generate and Edit modes explicit while preserving uploaded references.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/seedream/ConfigPanel.vue
+++ b/src/components/seedream/ConfigPanel.vue
@@ -1,6 +1,19 @@
 <template>
   <div class="flex flex-col h-full">
     <div class="flex-1 overflow-y-auto p-5">
+      <el-radio-group
+        class="action-selector mb-4"
+        :model-value="action"
+        :aria-label="$t('seedream.name.action')"
+        @update:model-value="onActionChange"
+      >
+        <el-radio-button value="generate" :disabled="capabilities.imageRequired">
+          {{ $t('seedream.name.generate') }}
+        </el-radio-button>
+        <el-radio-button value="edit" :disabled="!capabilities.image">
+          {{ $t('seedream.name.edits') }}
+        </el-radio-button>
+      </el-radio-group>
       <model-selector class="mb-4" />
       <size-selector class="mb-4" />
       <max-images-selector class="mb-4" />
@@ -9,7 +22,7 @@
       <guidance-scale-input class="mb-4" />
       <watermark-switch class="mb-4" />
       <prompt-input class="mb-4" />
-      <image-input class="mb-4" />
+      <image-input v-if="action === 'edit'" class="mb-4" />
     </div>
     <div class="flex flex-col items-center justify-center px-5 pb-5">
       <consumption :value="consumption" :service="service" />
@@ -23,7 +36,7 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElButton } from 'element-plus';
+import { ElButton, ElRadioButton, ElRadioGroup } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import PromptInput from './config/PromptInput.vue';
 import ImageInput from './config/ImageInput.vue';
@@ -37,11 +50,15 @@ import SeedInput from './config/SeedInput.vue';
 import GuidanceScaleInput from './config/GuidanceScaleInput.vue';
 import WatermarkSwitch from './config/WatermarkSwitch.vue';
 import { getSeedreamShortModel } from '@/constants';
+import { getSeedreamCapabilities } from '@/utils/seedream/capabilities';
+import { buildSeedreamRequest } from '@/utils/seedream/request';
 
 export default defineComponent({
   name: 'SeedreamConfigPanel',
   components: {
     ElButton,
+    ElRadioButton,
+    ElRadioGroup,
     FontAwesomeIcon,
     PromptInput,
     Consumption,
@@ -56,24 +73,30 @@ export default defineComponent({
   },
   emits: ['generate'],
   computed: {
+    action(): 'generate' | 'edit' {
+      return this.config?.action === 'edit' ? 'edit' : 'generate';
+    },
+    capabilities() {
+      return getSeedreamCapabilities(this.config?.model);
+    },
     config() {
       return this.$store.state.seedream?.config;
     },
     consumption() {
-      const cfg: any = { ...(this.config || {}) };
-      const hasReferenceImages = Array.isArray(cfg?.image) && cfg.image.length > 0;
+      const request = buildSeedreamRequest(this.config);
       // Per-image billing: cost/api/86ad30f3-…json multiplies the unit price by
       // `count`. When the user opts into group generation we forward the
       // selected `max_images`; otherwise default to 1 to match the upstream.
       const requestedCount =
-        cfg?.sequential_image_generation === 'auto'
-          ? Math.max(1, Math.floor(cfg?.sequential_image_generation_options?.max_images || 1))
+        request.sequential_image_generation === 'auto'
+          ? Math.max(1, Math.floor(request.sequential_image_generation_options?.max_images || 1))
           : 1;
       return getConsumption(
         {
-          ...cfg,
-          action: hasReferenceImages ? 'edit' : 'generate',
-          model: getSeedreamShortModel(cfg?.model),
+          ...request,
+          action: this.action,
+          model: getSeedreamShortModel(request.model),
+          input_image_count: request.image?.length || 0,
           count: requestedCount
         },
         this.service?.cost
@@ -84,9 +107,29 @@ export default defineComponent({
     }
   },
   methods: {
+    onActionChange(action: string | number | boolean | undefined) {
+      if (action !== 'generate' && action !== 'edit') return;
+      this.$store.commit('seedream/setConfig', { ...this.config, action });
+    },
     onGenerate() {
       this.$emit('generate');
     }
   }
 });
 </script>
+
+<style lang="scss" scoped>
+.action-selector {
+  display: flex;
+  width: 100%;
+}
+
+.action-selector :deep(.el-radio-button) {
+  flex: 1;
+}
+
+.action-selector :deep(.el-radio-button__inner) {
+  width: 100%;
+  min-height: 40px;
+}
+</style>

--- a/src/components/seedream/config/ModelSelector.vue
+++ b/src/components/seedream/config/ModelSelector.vue
@@ -31,7 +31,11 @@ import {
   SEEDREAM_MODEL_5_0_PRO,
   SEEDREAM_MODEL_SEEDEDIT_3_0_I2I
 } from '@/constants';
-import { findSeedreamConflicts, clearSeedreamConflicts } from '@/utils/seedream/capabilities';
+import {
+  findSeedreamConflicts,
+  clearSeedreamConflicts,
+  getCompatibleSeedreamAction
+} from '@/utils/seedream/capabilities';
 
 export default defineComponent({
   name: 'SeedreamModelSelector',
@@ -85,6 +89,7 @@ export default defineComponent({
           }
         );
         const cleared = clearSeedreamConflicts({ ...config, model: val }, conflicts, { model: val });
+        cleared.action = getCompatibleSeedreamAction(cleared.action, val);
         this.$store.commit('seedream/setConfig', cleared);
         ElMessage.success(this.$t('seedream.message.featureRemovedNotice', { fields }));
       } catch {
@@ -95,7 +100,8 @@ export default defineComponent({
     applyModel(val: string) {
       this.$store.commit('seedream/setConfig', {
         ...this.$store.state.seedream?.config,
-        model: val
+        model: val,
+        action: getCompatibleSeedreamAction(this.$store.state.seedream?.config?.action, val)
       });
     }
   }

--- a/src/i18n/ar/seedream.json
+++ b/src/i18n/ar/seedream.json
@@ -218,5 +218,13 @@
   "size.adaptive": {
     "message": "تلقائي (مطابق للصورة المرجعية)",
     "description": "تسمية خيار adaptive"
+  },
+  "name.action": {
+    "message": "Action",
+    "description": "Generate or edit action selector"
+  },
+  "message.referenceImageRequired": {
+    "message": "Upload at least one reference image to use Edit mode.",
+    "description": "Validation shown when Edit mode has no reference image"
   }
 }

--- a/src/i18n/de/seedream.json
+++ b/src/i18n/de/seedream.json
@@ -218,5 +218,13 @@
   "size.adaptive": {
     "message": "Anpassungsfähig (entspricht Referenzbild)",
     "description": "Label für die adaptive Option"
+  },
+  "name.action": {
+    "message": "Action",
+    "description": "Generate or edit action selector"
+  },
+  "message.referenceImageRequired": {
+    "message": "Upload at least one reference image to use Edit mode.",
+    "description": "Validation shown when Edit mode has no reference image"
   }
 }

--- a/src/i18n/el/seedream.json
+++ b/src/i18n/el/seedream.json
@@ -218,5 +218,13 @@
   "size.adaptive": {
     "message": "Προσαρμοστικό (ίδιο με την αναφορά εικόνας)",
     "description": "Ετικέτα επιλογής adaptive"
+  },
+  "name.action": {
+    "message": "Action",
+    "description": "Generate or edit action selector"
+  },
+  "message.referenceImageRequired": {
+    "message": "Upload at least one reference image to use Edit mode.",
+    "description": "Validation shown when Edit mode has no reference image"
   }
 }

--- a/src/i18n/en/seedream.json
+++ b/src/i18n/en/seedream.json
@@ -1,4 +1,8 @@
 {
+  "name.action": {
+    "message": "Action",
+    "description": "Generate or edit action selector"
+  },
   "name.taskId": {
     "message": "Task ID",
     "description": "The ID of the task"
@@ -130,6 +134,10 @@
   "message.uploadImageError": {
     "message": "Image upload failed, please try again later",
     "description": "Upload failure"
+  },
+  "message.referenceImageRequired": {
+    "message": "Upload at least one reference image to use Edit mode.",
+    "description": "Validation shown when Edit mode has no reference image"
   },
   "message.featureNotSupportedTitle": {
     "message": "Confirmation Required",

--- a/src/i18n/es/seedream.json
+++ b/src/i18n/es/seedream.json
@@ -218,5 +218,13 @@
   "size.adaptive": {
     "message": "Adaptativo (igual que la imagen de referencia)",
     "description": "Etiqueta de opción adaptive"
+  },
+  "name.action": {
+    "message": "Action",
+    "description": "Generate or edit action selector"
+  },
+  "message.referenceImageRequired": {
+    "message": "Upload at least one reference image to use Edit mode.",
+    "description": "Validation shown when Edit mode has no reference image"
   }
 }

--- a/src/i18n/fi/seedream.json
+++ b/src/i18n/fi/seedream.json
@@ -218,5 +218,13 @@
   "size.adaptive": {
     "message": "Sovita (sama kuin referenssikuva)",
     "description": "adaptive-vaihtoehdon etiketti"
+  },
+  "name.action": {
+    "message": "Action",
+    "description": "Generate or edit action selector"
+  },
+  "message.referenceImageRequired": {
+    "message": "Upload at least one reference image to use Edit mode.",
+    "description": "Validation shown when Edit mode has no reference image"
   }
 }

--- a/src/i18n/fr/seedream.json
+++ b/src/i18n/fr/seedream.json
@@ -218,5 +218,13 @@
   "size.adaptive": {
     "message": "Adaptatif (comme l'image de référence)",
     "description": "Étiquette de l'option adaptive"
+  },
+  "name.action": {
+    "message": "Action",
+    "description": "Generate or edit action selector"
+  },
+  "message.referenceImageRequired": {
+    "message": "Upload at least one reference image to use Edit mode.",
+    "description": "Validation shown when Edit mode has no reference image"
   }
 }

--- a/src/i18n/it/seedream.json
+++ b/src/i18n/it/seedream.json
@@ -218,5 +218,13 @@
   "size.adaptive": {
     "message": "Adattivo (coerente con l'immagine di riferimento)",
     "description": "Etichetta dell'opzione adattiva"
+  },
+  "name.action": {
+    "message": "Action",
+    "description": "Generate or edit action selector"
+  },
+  "message.referenceImageRequired": {
+    "message": "Upload at least one reference image to use Edit mode.",
+    "description": "Validation shown when Edit mode has no reference image"
   }
 }

--- a/src/i18n/ja/seedream.json
+++ b/src/i18n/ja/seedream.json
@@ -218,5 +218,13 @@
   "size.adaptive": {
     "message": "自適応（参照画像に一致）",
     "description": "adaptive オプションのラベル"
+  },
+  "name.action": {
+    "message": "Action",
+    "description": "Generate or edit action selector"
+  },
+  "message.referenceImageRequired": {
+    "message": "Upload at least one reference image to use Edit mode.",
+    "description": "Validation shown when Edit mode has no reference image"
   }
 }

--- a/src/i18n/ko/seedream.json
+++ b/src/i18n/ko/seedream.json
@@ -218,5 +218,13 @@
   "size.adaptive": {
     "message": "자동 맞춤 (참조 이미지와 동일)",
     "description": "adaptive 옵션 라벨"
+  },
+  "name.action": {
+    "message": "Action",
+    "description": "Generate or edit action selector"
+  },
+  "message.referenceImageRequired": {
+    "message": "Upload at least one reference image to use Edit mode.",
+    "description": "Validation shown when Edit mode has no reference image"
   }
 }

--- a/src/i18n/pl/seedream.json
+++ b/src/i18n/pl/seedream.json
@@ -218,5 +218,13 @@
   "size.adaptive": {
     "message": "Dopasowanie (zgodne z obrazem referencyjnym)",
     "description": "Etykieta opcji adaptive"
+  },
+  "name.action": {
+    "message": "Action",
+    "description": "Generate or edit action selector"
+  },
+  "message.referenceImageRequired": {
+    "message": "Upload at least one reference image to use Edit mode.",
+    "description": "Validation shown when Edit mode has no reference image"
   }
 }

--- a/src/i18n/pt/seedream.json
+++ b/src/i18n/pt/seedream.json
@@ -218,5 +218,13 @@
   "size.adaptive": {
     "message": "Adaptativo (igual à imagem de referência)",
     "description": "Etiqueta da opção adaptive"
+  },
+  "name.action": {
+    "message": "Action",
+    "description": "Generate or edit action selector"
+  },
+  "message.referenceImageRequired": {
+    "message": "Upload at least one reference image to use Edit mode.",
+    "description": "Validation shown when Edit mode has no reference image"
   }
 }

--- a/src/i18n/ru/seedream.json
+++ b/src/i18n/ru/seedream.json
@@ -218,5 +218,13 @@
   "size.adaptive": {
     "message": "Адаптивно (соответствует образцу)",
     "description": "Метка опции adaptive"
+  },
+  "name.action": {
+    "message": "Action",
+    "description": "Generate or edit action selector"
+  },
+  "message.referenceImageRequired": {
+    "message": "Upload at least one reference image to use Edit mode.",
+    "description": "Validation shown when Edit mode has no reference image"
   }
 }

--- a/src/i18n/sr/seedream.json
+++ b/src/i18n/sr/seedream.json
@@ -218,5 +218,13 @@
   "size.adaptive": {
     "message": "Адаптивно (попут референтне слике)",
     "description": "Ознака опције adaptive"
+  },
+  "name.action": {
+    "message": "Action",
+    "description": "Generate or edit action selector"
+  },
+  "message.referenceImageRequired": {
+    "message": "Upload at least one reference image to use Edit mode.",
+    "description": "Validation shown when Edit mode has no reference image"
   }
 }

--- a/src/i18n/sv/seedream.json
+++ b/src/i18n/sv/seedream.json
@@ -218,5 +218,13 @@
   "size.adaptive": {
     "message": "Adaptiv (samma som referensbild)",
     "description": "Etikett för adaptive-valet"
+  },
+  "name.action": {
+    "message": "Action",
+    "description": "Generate or edit action selector"
+  },
+  "message.referenceImageRequired": {
+    "message": "Upload at least one reference image to use Edit mode.",
+    "description": "Validation shown when Edit mode has no reference image"
   }
 }

--- a/src/i18n/uk/seedream.json
+++ b/src/i18n/uk/seedream.json
@@ -218,5 +218,13 @@
   "size.adaptive": {
     "message": "Адаптивний (як на зразку)",
     "description": "Позначка опції adaptive"
+  },
+  "name.action": {
+    "message": "Action",
+    "description": "Generate or edit action selector"
+  },
+  "message.referenceImageRequired": {
+    "message": "Upload at least one reference image to use Edit mode.",
+    "description": "Validation shown when Edit mode has no reference image"
   }
 }

--- a/src/i18n/zh-CN/seedream.json
+++ b/src/i18n/zh-CN/seedream.json
@@ -1,4 +1,8 @@
 {
+  "name.action": {
+    "message": "操作",
+    "description": "生成或编辑操作选择器"
+  },
   "name.taskId": {
     "message": "任务 ID",
     "description": "任务的 ID"
@@ -130,6 +134,10 @@
   "message.uploadImageError": {
     "message": "上传图片失败，请稍后重试",
     "description": "上传失败"
+  },
+  "message.referenceImageRequired": {
+    "message": "编辑模式至少需要上传一张参考图片。",
+    "description": "编辑模式没有参考图片时显示的校验提示"
   },
   "message.featureNotSupportedTitle": {
     "message": "需要确认",

--- a/src/i18n/zh-TW/seedream.json
+++ b/src/i18n/zh-TW/seedream.json
@@ -218,5 +218,13 @@
   "size.adaptive": {
     "message": "自適應（與參考圖一致）",
     "description": "adaptive 選項標籤"
+  },
+  "name.action": {
+    "message": "Action",
+    "description": "Generate or edit action selector"
+  },
+  "message.referenceImageRequired": {
+    "message": "Upload at least one reference image to use Edit mode.",
+    "description": "Validation shown when Edit mode has no reference image"
   }
 }

--- a/src/models/seedream.ts
+++ b/src/models/seedream.ts
@@ -3,6 +3,7 @@ export interface ISeedreamSequentialOptions {
 }
 
 export interface ISeedreamConfig {
+  action?: 'generate' | 'edit';
   model?: string;
   prompt?: string;
   image?: string[];

--- a/src/pages/seedream/Index.vue
+++ b/src/pages/seedream/Index.vue
@@ -14,6 +14,7 @@ import { defineComponent } from 'vue';
 import Layout from '@/layouts/Seedream.vue';
 import ConfigPanel from '@/components/seedream/ConfigPanel.vue';
 import { seedreamOperator } from '@/operators';
+import { buildSeedreamRequest } from '@/utils/seedream/request';
 import { instrumentGeneration } from '@/plugins/telemetry';
 import { ISeedreamGenerateRequest, Status } from '@/models';
 import { ElMessage } from 'element-plus';
@@ -148,18 +149,11 @@ export default defineComponent({
       ) {
         return;
       }
-      const cfg: any = { ...(this.config || {}) };
-      const hasReferenceImages = Array.isArray(cfg?.image) && cfg.image.length > 0;
-      if (!hasReferenceImages && 'image' in cfg) {
-        delete cfg.image;
+      if (this.config?.action === 'edit' && !this.config.image?.length) {
+        ElMessage.warning(this.$t('seedream.message.referenceImageRequired'));
+        return;
       }
-      if (!cfg?.size) {
-        delete cfg.size;
-      }
-      const request = {
-        ...cfg,
-        async: true
-      } as ISeedreamGenerateRequest;
+      const request = buildSeedreamRequest(this.config) as ISeedreamGenerateRequest;
       if (!ensureLoggedIn()) {
         return;
       }

--- a/src/store/seedream/state.ts
+++ b/src/store/seedream/state.ts
@@ -10,6 +10,7 @@ export default (): ISeedreamState => {
     tasks: undefined,
     credential: undefined,
     config: {
+      action: 'generate',
       model: SEEDREAM_DEFAULT_MODEL,
       size: SEEDREAM_DEFAULT_SIZE,
       watermark: SEEDREAM_DEFAULT_WATERMARK

--- a/src/utils/seedream/capabilities.ts
+++ b/src/utils/seedream/capabilities.ts
@@ -169,6 +169,16 @@ export function getSeedreamCapabilities(model?: string): ISeedreamCapability {
   }
 }
 
+export function getCompatibleSeedreamAction(
+  action: 'generate' | 'edit' | undefined,
+  model?: string
+): 'generate' | 'edit' {
+  const capabilities = getSeedreamCapabilities(model);
+  if (capabilities.imageRequired) return 'edit';
+  if (!capabilities.image) return 'generate';
+  return action === 'edit' ? 'edit' : 'generate';
+}
+
 export type SeedreamConflictField =
   | 'image'
   | 'size'

--- a/src/utils/seedream/request.test.ts
+++ b/src/utils/seedream/request.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { buildSeedreamRequest } from './request';
+import { getCompatibleSeedreamAction } from './capabilities';
+
+describe('buildSeedreamRequest', () => {
+  it('does not send UI action or saved references in generate mode', () => {
+    expect(
+      buildSeedreamRequest({ action: 'generate', prompt: 'A lighthouse', image: ['https://cdn.example/ref.png'] })
+    ).toEqual({ prompt: 'A lighthouse', async: true });
+  });
+
+  it('sends saved references after switching back to edit mode', () => {
+    expect(buildSeedreamRequest({ action: 'edit', image: ['https://cdn.example/ref.png'] })).toEqual({
+      image: ['https://cdn.example/ref.png'],
+      async: true
+    });
+  });
+
+  it('normalizes actions for text-only and edit-only models', () => {
+    expect(getCompatibleSeedreamAction('edit', 'doubao-seedream-3-0-t2i-250415')).toBe('generate');
+    expect(getCompatibleSeedreamAction('generate', 'doubao-seededit-3-0-i2i-250628')).toBe('edit');
+  });
+
+  it('removes group options when group generation is inactive', () => {
+    expect(
+      buildSeedreamRequest({
+        sequential_image_generation: 'disabled',
+        sequential_image_generation_options: { max_images: 4 }
+      })
+    ).toEqual({ sequential_image_generation: 'disabled', async: true });
+  });
+
+  it('counts only references included by the selected action', () => {
+    const image = ['one.png', 'two.png'];
+    expect(buildSeedreamRequest({ action: 'generate', image }).image).toBeUndefined();
+    expect(buildSeedreamRequest({ action: 'edit', image }).image).toHaveLength(2);
+  });
+});

--- a/src/utils/seedream/request.ts
+++ b/src/utils/seedream/request.ts
@@ -1,0 +1,19 @@
+import type { ISeedreamConfig, ISeedreamGenerateRequest } from '@/models';
+
+export const buildSeedreamRequest = (config?: ISeedreamConfig): ISeedreamGenerateRequest => {
+  const request = { ...(config || {}) };
+  const action = request.action === 'edit' ? 'edit' : 'generate';
+  delete request.action;
+
+  if (action !== 'edit' || !request.image?.length) {
+    delete request.image;
+  }
+  if (!request.size) {
+    delete request.size;
+  }
+  if (request.sequential_image_generation !== 'auto') {
+    delete request.sequential_image_generation_options;
+  }
+
+  return { ...request, async: true };
+};


### PR DESCRIPTION
## 概要

- 在 Seedream 页面内直接使用 Element Plus radio buttons，显式区分 Generate/Edit
- Edit 才显示参考图输入；切换 Generate 不删除已上传图片，切回 Edit 可继续使用
- 根据模型能力禁用不合法 action，Edit 无图本地阻止
- UI-only `action` 不进入 API；请求和价格预估共用同一 normalizer
- 清理 inactive group-generation options，避免上游 400

## 验证

- request tests 5 passed
- ESLint、Vue typecheck、i18n coverage 通过

## 对抗评审

两轮评审后修复模式/模型不兼容、隐藏图片价格漂移和 input image count；无未处置本PR风险。

## 说明

- 直接基于 `main`
- 使用页面内 Element Plus，不新增 `components/scenario`
- Ready for review，不启用 auto-merge