### PR TITLE
fix: unify generator panel spacing

### DIFF
--- a/change/@acedatacloud-nexior-generator-panel-spacing.json
+++ b/change/@acedatacloud-nexior-generator-panel-spacing.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Unify generator sidebar scrolling and 20px content padding across services.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/assets/scss/_common.scss
+++ b/src/assets/scss/_common.scss
@@ -190,6 +190,11 @@ w3m-modal {
   padding: 0 !important;
 }
 
+.el-drawer.generator-drawer .el-drawer__body {
+  padding: 0;
+  overflow: hidden;
+}
+
 .el-button {
   font-weight: var(--adc-font-weight-medium);
   letter-spacing: var(--adc-letter-spacing);

--- a/src/components/midjourney/ConfigPanel.vue
+++ b/src/components/midjourney/ConfigPanel.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="flex flex-col h-full">
-    <div class="flex-1 overflow-y-auto p-5">
+    <div class="flex-1 min-h-0 overflow-hidden">
       <el-tabs v-model="type" class="demo-tabs" stretch>
         <el-tab-pane :label="$t('midjourney.tab.images')" name="imagine">
-          <div class="pt-2 px-1">
+          <div class="p-5">
             <model-selector class="mb-2" />
             <prompt-input class="mb-4" />
             <reference-image class="mb-2" />
@@ -23,7 +23,7 @@
           </div>
         </el-tab-pane>
         <el-tab-pane :label="$t('midjourney.tab.videos')" name="videos">
-          <div class="pt-2 px-1">
+          <div class="p-5">
             <video-from-input v-show="config?.action === 'extend'" class="mb-4" />
             <image-url-input class="mb-2" />
             <end-image-url-input class="mb-2" />
@@ -33,7 +33,7 @@
           </div>
         </el-tab-pane>
         <el-tab-pane :label="$t('midjourney.tab.describe')" name="describe">
-          <div class="pt-2 px-1">
+          <div class="p-5">
             <image-url-input2 class="mb-2" />
           </div>
         </el-tab-pane>
@@ -148,3 +148,23 @@ export default defineComponent({
   }
 });
 </script>
+
+<style lang="scss" scoped>
+.demo-tabs {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+
+  :deep(.el-tabs__header) {
+    flex: none;
+    margin: 0;
+    padding: 0 8px;
+  }
+
+  :deep(.el-tabs__content) {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+  }
+}
+</style>

--- a/src/components/producer/ConfigPanel.vue
+++ b/src/components/producer/ConfigPanel.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="flex flex-col h-full">
-    <div class="flex-1 overflow-y-auto p-5">
+    <div class="flex-1 min-h-0 overflow-hidden">
       <el-tabs v-model="mode" class="producer-mode-tabs" stretch>
         <el-tab-pane :label="$t('producer.mode.simple')" name="simple">
-          <div class="pt-2 px-1">
+          <div class="p-5">
             <type-selector class="mb-4" />
             <upload-audio class="mb-4" />
             <prompt-input class="mb-4" />
@@ -14,7 +14,7 @@
           </div>
         </el-tab-pane>
         <el-tab-pane :label="$t('producer.mode.custom')" name="custom">
-          <div class="pt-2 px-1">
+          <div class="p-5">
             <type-selector class="mb-4" />
             <upload-audio class="mb-4" />
             <lyric-input v-if="!config?.instrumental" class="mb-4" />
@@ -138,6 +138,22 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 .producer-mode-tabs {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+
+  :deep(.el-tabs__header) {
+    flex: none;
+    margin: 0;
+    padding: 0 8px;
+  }
+
+  :deep(.el-tabs__content) {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+  }
+
   :deep(.el-tabs__nav-wrap::after) {
     height: 1px;
   }

--- a/src/components/suno/ConfigPanel.vue
+++ b/src/components/suno/ConfigPanel.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="flex flex-col h-full">
-    <div class="flex-1 overflow-y-auto p-5">
+    <div class="flex-1 min-h-0 overflow-hidden">
       <el-tabs v-model="mode" class="suno-mode-tabs" stretch>
         <el-tab-pane :label="$t('suno.mode.simple')" name="simple">
-          <div class="pt-2 px-1">
+          <div class="p-5">
             <type-selector class="mb-4" />
             <upload-audio class="mb-4" />
             <prompt-input class="mb-4" />
@@ -18,7 +18,7 @@
           </div>
         </el-tab-pane>
         <el-tab-pane :label="$t('suno.mode.custom')" name="custom">
-          <div class="pt-2 px-1">
+          <div class="p-5">
             <type-selector class="mb-4" />
             <upload-audio class="mb-4" />
             <lyric-input v-if="!config?.instrumental" class="mb-4" />
@@ -172,6 +172,24 @@ export default defineComponent({
 </script>
 
 <style lang="scss" scoped>
+.suno-mode-tabs {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+
+  :deep(.el-tabs__header) {
+    flex: none;
+    margin: 0;
+    padding: 0 8px;
+  }
+
+  :deep(.el-tabs__content) {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+  }
+}
+
 .panel {
   height: 100%;
   padding: 20px;

--- a/src/layouts/DigitalHuman.vue
+++ b/src/layouts/DigitalHuman.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="main flex flex-row flex-1">
     <div
-      class="config w-[320px] flex-none h-full overflow-y-auto bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
+      class="config w-[320px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
     >
       <slot name="config" />
     </div>
@@ -11,7 +11,7 @@
     <el-button v-show="!tasksEmpty" circle class="menu" @click="drawer = true">
       <font-awesome-icon icon="fa-solid fa-user" />
     </el-button>
-    <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="350px">
+    <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="340px" class="generator-drawer">
       <slot name="config" />
     </el-drawer>
   </div>

--- a/src/layouts/Flux.vue
+++ b/src/layouts/Flux.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="main flex flex-row flex-1">
     <div
-      class="config w-[320px] flex-none h-full overflow-y-auto bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
+      class="config w-[320px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
     >
       <slot name="config" />
     </div>
@@ -11,7 +11,7 @@
     <el-button v-show="!tasksEmpty" circle class="menu" @click="drawer = true">
       <font-awesome-icon icon="fa-solid fa-magic" />
     </el-button>
-    <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="340px" class="drawer">
+    <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="340px" class="drawer generator-drawer">
       <slot name="config" />
     </el-drawer>
   </div>

--- a/src/layouts/GrokVideo.vue
+++ b/src/layouts/GrokVideo.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="main flex flex-row flex-1">
     <div
-      class="config w-[320px] flex-none h-full overflow-y-auto bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
+      class="config w-[320px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
     >
       <slot name="config" />
     </div>
@@ -11,7 +11,7 @@
     <el-button v-show="!tasksEmpty" circle class="menu" @click="drawer = true">
       <font-awesome-icon icon="fa-solid fa-magic" />
     </el-button>
-    <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="350px">
+    <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="340px" class="generator-drawer">
       <slot name="config" />
     </el-drawer>
   </div>

--- a/src/layouts/Hailuo.vue
+++ b/src/layouts/Hailuo.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="main flex flex-row flex-1">
     <div
-      class="config w-[320px] flex-none h-full overflow-y-auto bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
+      class="config w-[320px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
     >
       <slot name="config" />
     </div>
@@ -11,7 +11,7 @@
     <el-button v-show="!tasksEmpty" circle class="menu" @click="drawer = true">
       <font-awesome-icon icon="fa-solid fa-magic" />
     </el-button>
-    <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="340px">
+    <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="340px" class="generator-drawer">
       <slot name="config" />
     </el-drawer>
   </div>

--- a/src/layouts/Kling.vue
+++ b/src/layouts/Kling.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="main flex flex-row flex-1 min-h-0">
     <div
-      class="config w-[320px] flex-none h-full flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
+      class="config w-[320px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
     >
       <slot name="config" />
     </div>
@@ -11,7 +11,7 @@
     <el-button v-show="!tasksEmpty" circle class="menu" @click="drawer = true">
       <font-awesome-icon icon="fa-solid fa-magic" />
     </el-button>
-    <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="350px">
+    <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="340px" class="generator-drawer">
       <slot name="config" />
     </el-drawer>
   </div>

--- a/src/layouts/Luma.vue
+++ b/src/layouts/Luma.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="main flex flex-row flex-1">
     <div
-      class="config w-[320px] flex-none h-full overflow-y-auto bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
+      class="config w-[320px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
     >
       <slot name="config" />
     </div>
@@ -11,7 +11,7 @@
     <el-button v-show="!tasksEmpty" circle class="menu" @click="drawer = true">
       <font-awesome-icon icon="fa-solid fa-magic" />
     </el-button>
-    <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="350px" class="drawer">
+    <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="340px" class="drawer generator-drawer">
       <slot name="config" />
     </el-drawer>
   </div>

--- a/src/layouts/Maestro.vue
+++ b/src/layouts/Maestro.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="main flex flex-row flex-1">
     <div
-      class="config w-[320px] flex-none h-full overflow-y-auto bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
+      class="config w-[320px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
     >
       <slot name="config" />
     </div>
@@ -11,7 +11,7 @@
     <el-button v-show="!tasksEmpty" circle class="menu" @click="drawer = true">
       <font-awesome-icon icon="fa-solid fa-magic" />
     </el-button>
-    <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="350px">
+    <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="340px" class="generator-drawer">
       <slot name="config" />
     </el-drawer>
   </div>

--- a/src/layouts/Midjourney.vue
+++ b/src/layouts/Midjourney.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="main flex-1 h-full flex flex-row">
     <div
-      class="config w-[320px] flex-none h-full flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
+      class="config w-[320px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
     >
       <slot name="config" />
     </div>
@@ -11,7 +11,7 @@
     <el-button v-show="!tasksEmpty" circle class="menu" @click="drawer = true">
       <font-awesome-icon icon="fa-solid fa-magic" />
     </el-button>
-    <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="350px" class="drawer">
+    <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="340px" class="drawer generator-drawer">
       <slot name="config" />
     </el-drawer>
   </div>

--- a/src/layouts/Nanobanana.vue
+++ b/src/layouts/Nanobanana.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="main flex flex-row flex-1">
     <div
-      class="config w-[320px] flex-none h-full overflow-y-auto bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
+      class="config w-[320px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
     >
       <slot name="config" />
     </div>
@@ -11,7 +11,7 @@
     <el-button v-show="!tasksEmpty" circle class="menu" @click="drawer = true">
       <font-awesome-icon icon="fa-solid fa-magic" />
     </el-button>
-    <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="340px" class="drawer">
+    <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="340px" class="drawer generator-drawer">
       <slot name="config" />
     </el-drawer>
   </div>

--- a/src/layouts/Omni.vue
+++ b/src/layouts/Omni.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="main flex flex-row flex-1">
     <div
-      class="config w-[320px] flex-none h-full overflow-y-auto bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
+      class="config w-[320px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
     >
       <slot name="config" />
     </div>
@@ -11,7 +11,7 @@
     <el-button v-show="!tasksEmpty" circle class="menu" @click="drawer = true">
       <font-awesome-icon icon="fa-solid fa-magic" />
     </el-button>
-    <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="350px">
+    <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="340px" class="generator-drawer">
       <slot name="config" />
     </el-drawer>
   </div>

--- a/src/layouts/OpenAIImage.vue
+++ b/src/layouts/OpenAIImage.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="main flex flex-row flex-1">
     <div
-      class="config w-[320px] flex-none h-full overflow-y-auto bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
+      class="config w-[320px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
     >
       <slot name="config" />
     </div>
@@ -11,7 +11,7 @@
     <el-button v-show="!tasksEmpty" circle class="menu" @click="drawer = true">
       <font-awesome-icon icon="fa-solid fa-magic" />
     </el-button>
-    <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="340px" class="drawer">
+    <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="340px" class="drawer generator-drawer">
       <slot name="config" />
     </el-drawer>
   </div>

--- a/src/layouts/Pika.vue
+++ b/src/layouts/Pika.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="main flex flex-row flex-1">
     <div
-      class="config w-[320px] flex-none h-full overflow-y-auto bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
+      class="config w-[320px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
     >
       <slot name="config" />
     </div>
@@ -11,7 +11,7 @@
     <el-button v-show="!tasksEmpty" circle class="menu" @click="drawer = true">
       <font-awesome-icon icon="fa-solid fa-magic" />
     </el-button>
-    <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="350px">
+    <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="340px" class="generator-drawer">
       <slot name="config" />
     </el-drawer>
   </div>

--- a/src/layouts/Pixverse.vue
+++ b/src/layouts/Pixverse.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="main flex flex-row flex-1">
     <div
-      class="config w-[320px] flex-none h-full overflow-y-auto bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
+      class="config w-[320px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
     >
       <slot name="config" />
     </div>
@@ -11,7 +11,7 @@
     <el-button v-show="!tasksEmpty" circle class="menu" @click="drawer = true">
       <font-awesome-icon icon="fa-solid fa-magic" />
     </el-button>
-    <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="350px">
+    <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="340px" class="generator-drawer">
       <slot name="config" />
     </el-drawer>
   </div>

--- a/src/layouts/Producer.vue
+++ b/src/layouts/Producer.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="main flex flex-row flex-1">
     <div
-      class="config w-[320px] flex-none h-full overflow-y-auto bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
+      class="config w-[320px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
     >
       <slot name="config" />
     </div>
@@ -14,7 +14,7 @@
     <el-button v-show="!tasksEmpty" circle class="menu" @click="drawer = true">
       <font-awesome-icon icon="fa-solid fa-magic" />
     </el-button>
-    <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="340px" class="drawer">
+    <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="340px" class="drawer generator-drawer">
       <slot name="config" />
     </el-drawer>
   </div>

--- a/src/layouts/Qrart.vue
+++ b/src/layouts/Qrart.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="main flex flex-row flex-1">
     <div
-      class="config w-[320px] flex-none h-full overflow-y-auto bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
+      class="config w-[320px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
     >
       <slot name="config" />
     </div>
@@ -11,7 +11,7 @@
     <el-button v-show="!tasksEmpty" circle class="menu" @click="drawer = true">
       <font-awesome-icon icon="fa-solid fa-magic" />
     </el-button>
-    <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="350px">
+    <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="340px" class="generator-drawer">
       <slot name="config" />
     </el-drawer>
   </div>

--- a/src/layouts/Seedance.vue
+++ b/src/layouts/Seedance.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="main flex flex-row flex-1">
     <div
-      class="config w-[320px] flex-none h-full overflow-y-auto bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
+      class="config w-[320px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
     >
       <slot name="config" />
     </div>
@@ -11,7 +11,7 @@
     <el-button v-show="!tasksEmpty" circle class="menu" @click="drawer = true">
       <font-awesome-icon icon="fa-solid fa-magic" />
     </el-button>
-    <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="350px">
+    <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="340px" class="generator-drawer">
       <slot name="config" />
     </el-drawer>
   </div>

--- a/src/layouts/Seedream.vue
+++ b/src/layouts/Seedream.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="main flex flex-row flex-1">
     <div
-      class="config w-[320px] h-full overflow-y-auto bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
+      class="config w-[320px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
     >
       <slot name="config" />
     </div>
@@ -11,7 +11,7 @@
     <el-button v-show="!tasksEmpty" circle class="menu" @click="drawer = true">
       <font-awesome-icon icon="fa-solid fa-magic" />
     </el-button>
-    <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="340px" class="drawer">
+    <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="340px" class="drawer generator-drawer">
       <slot name="config" />
     </el-drawer>
   </div>

--- a/src/layouts/Sora.vue
+++ b/src/layouts/Sora.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="main flex flex-row flex-1">
     <div
-      class="config w-[320px] flex-none h-full overflow-y-auto bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
+      class="config w-[320px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
     >
       <slot name="config" />
     </div>
@@ -11,7 +11,7 @@
     <el-button v-show="!tasksEmpty" circle class="menu" @click="drawer = true">
       <font-awesome-icon icon="fa-solid fa-magic" />
     </el-button>
-    <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="350px">
+    <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="340px" class="generator-drawer">
       <slot name="config" />
     </el-drawer>
   </div>

--- a/src/layouts/Suno.vue
+++ b/src/layouts/Suno.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="main flex flex-row flex-1">
     <div
-      class="config w-[320px] flex-none h-full overflow-y-auto bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
+      class="config w-[320px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
     >
       <slot name="config" />
     </div>
@@ -14,7 +14,7 @@
     <el-button v-show="!tasksEmpty" circle class="menu" @click="drawer = true">
       <font-awesome-icon icon="fa-solid fa-magic" />
     </el-button>
-    <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="340px" class="drawer">
+    <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="340px" class="drawer generator-drawer">
       <slot name="config" />
     </el-drawer>
   </div>

--- a/src/layouts/Veo.vue
+++ b/src/layouts/Veo.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="main flex flex-row flex-1">
     <div
-      class="config w-[320px] flex-none h-full overflow-y-auto bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
+      class="config w-[320px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
     >
       <slot name="config" />
     </div>
@@ -11,7 +11,7 @@
     <el-button v-show="!tasksEmpty" circle class="menu" @click="drawer = true">
       <font-awesome-icon icon="fa-solid fa-magic" />
     </el-button>
-    <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="350px">
+    <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="340px" class="generator-drawer">
       <slot name="config" />
     </el-drawer>
   </div>

--- a/src/layouts/Wan.vue
+++ b/src/layouts/Wan.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="main flex flex-row flex-1">
     <div
-      class="config w-[320px] flex-none h-full overflow-y-auto bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
+      class="config w-[320px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
     >
       <slot name="config" />
     </div>
@@ -11,7 +11,7 @@
     <el-button v-show="!tasksEmpty" circle class="menu" @click="drawer = true">
       <font-awesome-icon icon="fa-solid fa-magic" />
     </el-button>
-    <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="340px">
+    <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="340px" class="generator-drawer">
       <slot name="config" />
     </el-drawer>
   </div>


### PR DESCRIPTION
## 概要

- 统一21个真实生成器左栏外壳：desktop 320px、外层不滚动、ConfigPanel body作为唯一滚动层
- 所有生成器mobile drawer统一为340px
- 清除Element Plus drawer默认20px padding，避免与ConfigPanel `p-5`叠成40px
- Suno、Producer、Midjourney统一为固定tabs header + 单一滚动content + 20px表单padding
- QR Art纳入同一生成器契约
- 不新增ScenarioPanel、wrapper或其他抽象组件

## 运行时验证

管理员真实登录后，在本地分支验证Flux/Suno/Kling：

- desktop shell width=320px，overflow=hidden
- mobile drawer width=340px
- drawer body padding=0px，overflow=hidden
- 表单content padding=20px
- 唯一scroll area overflow-y=auto
- desktop/mobile无断言失败

## 其他验证

- 21个layout shell class完全一致
- 21个drawer均为340px
- Suno/Producer/Midjourney旧 `pt-2 px-1` 已清除
- ESLint、Prettier、Vue typecheck、web build通过

## 对抗评审

首轮补齐QR Art与drawer宽度；真实渲染发现并修复mobile drawer双padding；最终复审 `VERDICT: CLEAN`。

Ready for review；不启用auto-merge。