### PR TITLE
fix: align generator field rhythm

### DIFF
--- a/change/@acedatacloud-nexior-generator-field-rhythm.json
+++ b/change/@acedatacloud-nexior-generator-field-rhythm.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Align top-level generator fields to a consistent 16px vertical rhythm.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/fish/ConfigPanel.vue
+++ b/src/components/fish/ConfigPanel.vue
@@ -4,7 +4,7 @@
       <text-input class="mb-4" />
       <model-selector class="mb-4" />
       <voice-picker class="mb-4" />
-      <div class="field mb-2">
+      <div class="field mb-4">
         <h2 class="title font-bold">{{ $t('fish.name.speed') }}</h2>
         <el-slider v-model="speed" :min="0.5" :max="2" :step="0.1" class="value" show-input />
       </div>

--- a/src/components/grokvideo/ConfigPanel.vue
+++ b/src/components/grokvideo/ConfigPanel.vue
@@ -6,8 +6,8 @@
       <ratio-selector class="mb-4" />
       <resolution-selector class="mb-4" />
       <duration-selector class="mb-4" />
-      <image-input class="mb-2" />
-      <reference-images-input v-if="supportsReferenceImages" class="mb-2" />
+      <image-input class="mb-4" />
+      <reference-images-input v-if="supportsReferenceImages" class="mb-4" />
     </div>
     <div class="flex flex-col items-center justify-center px-5 pb-5">
       <consumption :value="consumption" :service="service" />

--- a/src/components/hailuo/ConfigPanel.vue
+++ b/src/components/hailuo/ConfigPanel.vue
@@ -3,7 +3,7 @@
     <div class="flex-1 overflow-y-auto p-5">
       <prompt-input class="mb-4" />
       <model-selector class="mb-4" />
-      <start-image-url-input v-if="config?.model === 'minimax-i2v'" class="mb-2" />
+      <start-image-url-input v-if="config?.model === 'minimax-i2v'" class="mb-4" />
     </div>
     <div class="flex flex-col items-center justify-center px-5 pb-5">
       <consumption :value="consumption" :service="service" />

--- a/src/components/omni/ConfigPanel.vue
+++ b/src/components/omni/ConfigPanel.vue
@@ -4,8 +4,8 @@
       <prompt-input class="mb-4" />
       <ratio-selector class="mb-4" />
       <resolution-selector class="mb-4" />
-      <reference-images-input class="mb-2" />
-      <video-input class="mb-2" />
+      <reference-images-input class="mb-4" />
+      <video-input class="mb-4" />
     </div>
     <div class="flex flex-col items-center justify-center px-5 pb-5">
       <consumption :value="consumption" :service="service" />

--- a/src/components/pixverse/ConfigPanel.vue
+++ b/src/components/pixverse/ConfigPanel.vue
@@ -7,7 +7,7 @@
       <ratio-selector class="mb-4" />
       <motion-selector class="mb-4" />
       <quality-selector class="mb-4" />
-      <start-image class="mb-2" />
+      <start-image class="mb-4" />
       <seed-selector class="mb-4" />
       <duration-selector class="mb-4" />
     </div>

--- a/src/components/sora/ConfigPanel.vue
+++ b/src/components/sora/ConfigPanel.vue
@@ -7,7 +7,7 @@
       <size-selector class="mb-4" />
       <orientation-selector class="mb-4" />
       <prompt-input class="mb-4" />
-      <start-end-image v-show="config?.action === 'image2video'" class="mb-2" />
+      <start-end-image v-show="config?.action === 'image2video'" class="mb-4" />
     </div>
     <div class="flex flex-col items-center justify-center px-5 pb-5">
       <consumption :value="consumption" :service="service" />

--- a/src/components/veo/ConfigPanel.vue
+++ b/src/components/veo/ConfigPanel.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="flex flex-col h-full">
     <div class="flex-1 overflow-y-auto p-5">
-      <action-selector class="mb-5" />
+      <action-selector class="mb-4" />
 
       <model-selector class="mb-4" />
       <start-end-image
@@ -13,7 +13,7 @@
       />
       <prompt-input class="mb-4" />
       <aspect-ratio-selector class="mb-4" />
-      <translation-selector class="mb-2" />
+      <translation-selector class="mb-4" />
     </div>
     <div class="flex flex-col items-center justify-center px-5 pb-5">
       <consumption :value="consumption" :service="service" />

--- a/src/components/wan/ConfigPanel.vue
+++ b/src/components/wan/ConfigPanel.vue
@@ -5,7 +5,7 @@
       <model-selector class="mb-4" />
       <resolution-selector v-if="supportsResolution" class="mb-4" />
       <duration-selector v-if="supportsDuration" class="mb-4" />
-      <image-url-input v-if="supportsImageUrl" class="mb-2" />
+      <image-url-input v-if="supportsImageUrl" class="mb-4" />
     </div>
     <div class="flex flex-col items-center justify-center px-5 pb-5">
       <consumption :value="consumption" :service="service" />


### PR DESCRIPTION
## 概要

将8个生成器中与相邻一级字段同层、但意外使用 `mb-2/mb-5` 的直属字段统一为 `mb-4`（16px）：

- Fish speed
- Sora start/end image
- Hailuo start image
- Veo action + translation
- Wan image input
- Pixverse start image
- Grok Video image/reference inputs
- Omni image/video references

## 刻意保留

- Kling、Seedance、Midjourney 的 `mb-2/3` 是相关媒体/高级参数密集组，不机械拉开
- DigitalHuman、Maestro 的 `mb-5` 是section间距，不改
- 不新增wrapper或公共抽象

## 运行时验证

管理员真实登录本地分支后检查 Fish、Veo、Grok Video：所有可见直属 `mb-*` 字段 computed `margin-bottom` 均为 `16px`。

## 其他验证

- 8个目标ConfigPanel顶部24行无 `mb-2/3/5` outlier
- ESLint、Prettier、Vue typecheck、web build通过
- 对抗评审：`VERDICT: CLEAN`

Ready for review；不启用auto-merge。