### PR TITLE
fix: align generator select widths

### DIFF
--- a/change/@acedatacloud-nexior-generator-control-widths.json
+++ b/change/@acedatacloud-nexior-generator-control-widths.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Align horizontal generator select controls to a consistent 160px grid.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/fish/ConfigPanel.vue
+++ b/src/components/fish/ConfigPanel.vue
@@ -77,7 +77,7 @@ export default defineComponent({
 </script>
 
 <style lang="scss" scoped>
-.field {
+.field:has(> .el-slider) {
   display: flex;
   flex-direction: row;
   align-items: center;

--- a/src/components/fish/config/ModelSelector.vue
+++ b/src/components/fish/config/ModelSelector.vue
@@ -48,17 +48,18 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 .field {
-  display: flex;
-  flex-direction: row;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 160px;
+  gap: 8px;
   align-items: center;
 
   .title {
     font-size: 14px;
     margin: 0;
-    width: 30%;
+    min-width: 0;
   }
   .value {
-    flex: 1;
+    width: 100%;
   }
 }
 </style>

--- a/src/components/fish/config/VoicePicker.vue
+++ b/src/components/fish/config/VoicePicker.vue
@@ -87,17 +87,18 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 .field {
-  display: flex;
-  flex-direction: row;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 160px;
+  gap: 8px;
   align-items: center;
 
   .title {
     font-size: 14px;
     margin: 0;
-    width: 30%;
+    min-width: 0;
   }
   .value {
-    flex: 1;
+    width: 100%;
   }
 }
 </style>

--- a/src/components/grokvideo/config/DurationSelector.vue
+++ b/src/components/grokvideo/config/DurationSelector.vue
@@ -66,13 +66,13 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 .field {
-  display: flex;
-  flex-direction: row;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 160px;
+  gap: 8px;
   align-items: center;
-  justify-content: space-between;
 
   .label {
-    width: 30%;
+    min-width: 0;
     display: flex;
     align-items: center;
 
@@ -80,6 +80,7 @@ export default defineComponent({
       display: flex;
       flex-direction: row;
       align-items: center;
+      min-width: 0;
 
       .title {
         font-size: 14px;
@@ -93,7 +94,7 @@ export default defineComponent({
   }
 
   .value {
-    width: 80px;
+    width: 100%;
   }
 }
 </style>

--- a/src/components/grokvideo/config/ModelSelector.vue
+++ b/src/components/grokvideo/config/ModelSelector.vue
@@ -6,7 +6,12 @@
         <info-icon :content="$t('grokvideo.description.model')" class="info" />
       </div>
     </div>
-    <el-select v-model="value" class="value" :placeholder="$t('grokvideo.placeholder.select')">
+    <el-select
+      v-model="value"
+      class="value"
+      :title="selectedModelLabel"
+      :placeholder="$t('grokvideo.placeholder.select')"
+    >
       <el-option v-for="item in options" :key="item.value" :label="item.label" :value="item.value" />
     </el-select>
   </div>
@@ -34,6 +39,9 @@ export default defineComponent({
     };
   },
   computed: {
+    selectedModelLabel(): string {
+      return this.options.find((item) => item.value === this.value)?.label || '';
+    },
     value: {
       get() {
         return this.$store.state.grokvideo?.config?.model;
@@ -56,13 +64,13 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 .field {
-  display: flex;
-  flex-direction: row;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 160px;
+  gap: 8px;
   align-items: center;
-  justify-content: space-between;
 
   .label {
-    width: 30%;
+    min-width: 0;
     display: flex;
     align-items: center;
 
@@ -70,6 +78,7 @@ export default defineComponent({
       display: flex;
       flex-direction: row;
       align-items: center;
+      min-width: 0;
 
       .title {
         font-size: 14px;
@@ -83,7 +92,7 @@ export default defineComponent({
   }
 
   .value {
-    width: 200px;
+    width: 100%;
   }
 }
 </style>

--- a/src/components/hailuo/config/ModelSelector.vue
+++ b/src/components/hailuo/config/ModelSelector.vue
@@ -62,17 +62,18 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 .field {
-  display: flex;
-  flex-direction: row;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 160px;
+  gap: 8px;
   align-items: center;
 
   .title {
     font-size: 14px;
     margin: 0;
-    width: 30%;
+    min-width: 0;
   }
   .value {
-    flex: 1;
+    width: 100%;
   }
 }
 </style>

--- a/src/components/kling/config/DurationSelector.vue
+++ b/src/components/kling/config/DurationSelector.vue
@@ -121,12 +121,13 @@ export default defineComponent({
   flex-direction: column;
 }
 .control {
-  display: flex;
-  flex-direction: row;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 160px;
+  gap: 8px;
   align-items: center;
-  justify-content: space-between;
 }
 .label {
+  min-width: 0;
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -136,6 +137,6 @@ export default defineComponent({
   margin: 0;
 }
 .value {
-  width: 120px;
+  width: 100%;
 }
 </style>

--- a/src/components/kling/config/ModeSelector.vue
+++ b/src/components/kling/config/ModeSelector.vue
@@ -138,16 +138,16 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 .field {
-  display: flex;
-  flex-direction: row;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 160px;
+  gap: 8px;
   align-items: center;
-  justify-content: space-between;
 
   .header {
     display: flex;
     flex-direction: row;
     align-items: center;
-    width: 50%;
+    min-width: 0;
 
     .title {
       font-size: 14px;
@@ -155,7 +155,7 @@ export default defineComponent({
     }
   }
   .value {
-    width: 120px;
+    width: 100%;
   }
 }
 .opt-disabled {

--- a/src/components/kling/config/ModelSelector.vue
+++ b/src/components/kling/config/ModelSelector.vue
@@ -126,18 +126,18 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 .field {
-  display: flex;
-  flex-direction: row;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 160px;
+  gap: 8px;
   align-items: center;
-  justify-content: space-between;
 
   .title {
     font-size: 14px;
     margin: 0;
-    width: 30%;
+    min-width: 0;
   }
   .value {
-    width: 120px;
+    width: 100%;
   }
 }
 </style>

--- a/src/components/midjourney/config/ResolutionSelector.vue
+++ b/src/components/midjourney/config/ResolutionSelector.vue
@@ -62,18 +62,18 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 .field {
-  display: flex;
-  flex-direction: row;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 160px;
+  gap: 8px;
   align-items: center;
-  justify-content: space-between;
 
   .title {
     font-size: 14px;
     margin: 0;
-    width: 30%;
+    min-width: 0;
   }
   .value {
-    width: 80px;
+    width: 100%;
   }
 }
 </style>

--- a/src/components/midjourney/config/VersionSelector.vue
+++ b/src/components/midjourney/config/VersionSelector.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="field">
-    <span class="text-sm font-bold">{{ $t('midjourney.name.version') }}</span>
+    <span class="title text-sm font-bold">{{ $t('midjourney.name.version') }}</span>
     <el-select v-model="value" class="value" :placeholder="$t('midjourney.placeholder.select')">
       <el-option v-for="item in options" :key="item.value" :label="item.label" :value="item.value" />
     </el-select>
@@ -103,18 +103,18 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 .field {
-  display: flex;
-  flex-direction: row;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 160px;
+  gap: 8px;
   align-items: center;
-  justify-content: space-between;
 
   .title {
     font-size: 14px;
     margin: 0;
-    width: 30%;
+    min-width: 0;
   }
   .value {
-    width: 80px;
+    width: 100%;
   }
 }
 </style>

--- a/src/components/pika/config/EffectSelector.vue
+++ b/src/components/pika/config/EffectSelector.vue
@@ -97,17 +97,18 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 .field {
-  display: flex;
-  flex-direction: row;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 160px;
+  gap: 8px;
   align-items: center;
 
   .title {
     font-size: 14px;
     margin: 0;
-    width: 30%;
+    min-width: 0;
   }
   .value {
-    flex: 1;
+    width: 100%;
   }
 }
 </style>

--- a/src/components/pika/config/ModelSelector.vue
+++ b/src/components/pika/config/ModelSelector.vue
@@ -62,18 +62,18 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 .field {
-  display: flex;
-  flex-direction: row;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 160px;
+  gap: 8px;
   align-items: center;
-  justify-content: space-between;
 
   .title {
     font-size: 14px;
     margin: 0;
-    width: 30%;
+    min-width: 0;
   }
   .value {
-    width: 80px;
+    width: 100%;
   }
 }
 </style>

--- a/src/components/pixverse/config/DurationSelector.vue
+++ b/src/components/pixverse/config/DurationSelector.vue
@@ -62,18 +62,18 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 .field {
-  display: flex;
-  flex-direction: row;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 160px;
+  gap: 8px;
   align-items: center;
-  justify-content: space-between;
 
   .title {
     font-size: 14px;
     margin: 0;
-    width: 30%;
+    min-width: 0;
   }
   .value {
-    width: 80px;
+    width: 100%;
   }
 }
 </style>

--- a/src/components/pixverse/config/ModelSelector.vue
+++ b/src/components/pixverse/config/ModelSelector.vue
@@ -66,18 +66,18 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 .field {
-  display: flex;
-  flex-direction: row;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 160px;
+  gap: 8px;
   align-items: center;
-  justify-content: space-between;
 
   .title {
     font-size: 14px;
     margin: 0;
-    width: 30%;
+    min-width: 0;
   }
   .value {
-    width: 80px;
+    width: 100%;
   }
 }
 </style>

--- a/src/components/pixverse/config/MotionSelector.vue
+++ b/src/components/pixverse/config/MotionSelector.vue
@@ -62,18 +62,18 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 .field {
-  display: flex;
-  flex-direction: row;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 160px;
+  gap: 8px;
   align-items: center;
-  justify-content: space-between;
 
   .title {
     font-size: 14px;
     margin: 0;
-    width: 30%;
+    min-width: 0;
   }
   .value {
-    width: 80px;
+    width: 100%;
   }
 }
 </style>

--- a/src/components/pixverse/config/QualitySelector.vue
+++ b/src/components/pixverse/config/QualitySelector.vue
@@ -70,18 +70,18 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 .field {
-  display: flex;
-  flex-direction: row;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 160px;
+  gap: 8px;
   align-items: center;
-  justify-content: space-between;
 
   .title {
     font-size: 14px;
     margin: 0;
-    width: 30%;
+    min-width: 0;
   }
   .value {
-    width: 80px;
+    width: 100%;
   }
 }
 </style>

--- a/src/components/pixverse/config/StyleSelector.vue
+++ b/src/components/pixverse/config/StyleSelector.vue
@@ -78,18 +78,18 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 .field {
-  display: flex;
-  flex-direction: row;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 160px;
+  gap: 8px;
   align-items: center;
-  justify-content: space-between;
 
   .title {
     font-size: 14px;
     margin: 0;
-    width: 30%;
+    min-width: 0;
   }
   .value {
-    width: 120px;
+    width: 100%;
   }
 }
 </style>

--- a/src/components/producer/config/ExtendFromInput.vue
+++ b/src/components/producer/config/ExtendFromInput.vue
@@ -143,19 +143,19 @@ export default defineComponent({
 <style lang="scss" scoped>
 .field {
   .box {
-    display: flex;
-    flex-direction: row;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 160px;
+    gap: 8px;
     align-items: center;
-    justify-content: space-between;
     position: relative;
     margin-bottom: 10px;
     .title {
       font-size: 14px;
-      margin-bottom: 10px;
+      margin: 0;
+      min-width: 0;
     }
     .input-wrapper {
-      width: 150px;
-      margin-left: 30px;
+      width: 160px;
     }
   }
 }

--- a/src/components/seedance/config/DurationSelector.vue
+++ b/src/components/seedance/config/DurationSelector.vue
@@ -83,13 +83,13 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 .field {
-  display: flex;
-  flex-direction: row;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 160px;
+  gap: 8px;
   align-items: center;
-  justify-content: space-between;
 
   .label {
-    width: 30%;
+    min-width: 0;
     display: flex;
     align-items: center;
 
@@ -97,6 +97,7 @@ export default defineComponent({
       display: flex;
       flex-direction: row;
       align-items: center;
+      min-width: 0;
 
       .title {
         font-size: 14px;
@@ -110,7 +111,7 @@ export default defineComponent({
   }
 
   .value {
-    width: 80px;
+    width: 100%;
   }
 }
 </style>

--- a/src/components/sora/config/ActionSelector.vue
+++ b/src/components/sora/config/ActionSelector.vue
@@ -58,17 +58,18 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 .field {
-  display: flex;
-  flex-direction: row;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 160px;
+  gap: 8px;
   align-items: center;
 
   .title {
     font-size: 14px;
     margin: 0;
-    width: 30%;
+    min-width: 0;
   }
   .value {
-    flex: 1;
+    width: 100%;
   }
 }
 </style>

--- a/src/components/sora/config/DurationSelector.vue
+++ b/src/components/sora/config/DurationSelector.vue
@@ -70,19 +70,19 @@ export default defineComponent({
 }
 
 .control {
-  display: flex;
-  flex-direction: row;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 160px;
+  gap: 8px;
   align-items: center;
-  justify-content: space-between;
 }
 
 .title {
   font-size: 14px;
   margin: 0;
-  width: 30%;
+  min-width: 0;
 }
 
 .value {
-  width: 120px;
+  width: 100%;
 }
 </style>

--- a/src/components/sora/config/ModelSelector.vue
+++ b/src/components/sora/config/ModelSelector.vue
@@ -82,18 +82,18 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 .field {
-  display: flex;
-  flex-direction: row;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 160px;
+  gap: 8px;
   align-items: center;
-  justify-content: space-between;
 
   .title {
     font-size: 14px;
     margin: 0;
-    width: 30%;
+    min-width: 0;
   }
   .value {
-    width: 120px;
+    width: 100%;
   }
 }
 </style>

--- a/src/components/sora/config/SizeSelector.vue
+++ b/src/components/sora/config/SizeSelector.vue
@@ -64,19 +64,19 @@ export default defineComponent({
 }
 
 .control {
-  display: flex;
-  flex-direction: row;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 160px;
+  gap: 8px;
   align-items: center;
-  justify-content: space-between;
 }
 
 .title {
   font-size: 14px;
   margin: 0;
-  width: 30%;
+  min-width: 0;
 }
 
 .value {
-  width: 120px;
+  width: 100%;
 }
 </style>

--- a/src/components/suno/config/ExtendFromInput.vue
+++ b/src/components/suno/config/ExtendFromInput.vue
@@ -145,19 +145,19 @@ export default defineComponent({
 <style lang="scss" scoped>
 .field {
   .box {
-    display: flex;
-    flex-direction: row;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 160px;
+    gap: 8px;
     align-items: center;
-    justify-content: space-between;
     position: relative;
     margin-bottom: 10px;
     .title {
       font-size: 14px;
-      margin-bottom: 10px;
+      margin: 0;
+      min-width: 0;
     }
     .input-wrapper {
-      width: 150px; // 根据需要调整宽度
-      margin-left: 30px; // 增加左边距
+      width: 160px;
     }
   }
 }

--- a/src/components/veo/config/ModelSelector.vue
+++ b/src/components/veo/config/ModelSelector.vue
@@ -51,18 +51,18 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 .field {
-  display: flex;
-  flex-direction: row;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 160px;
+  gap: 8px;
   align-items: center;
-  justify-content: space-between;
 
   .title {
     font-size: 14px;
     margin: 0;
-    width: 30%;
+    min-width: 0;
   }
   .value {
-    flex: 1;
+    width: 100%;
   }
 }
 </style>

--- a/src/components/wan/config/DurationSelector.vue
+++ b/src/components/wan/config/DurationSelector.vue
@@ -60,17 +60,18 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 .field {
-  display: flex;
-  flex-direction: row;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 160px;
+  gap: 8px;
   align-items: center;
 
   .title {
     font-size: 14px;
     margin: 0;
-    width: 30%;
+    min-width: 0;
   }
   .value {
-    flex: 1;
+    width: 100%;
   }
 }
 </style>

--- a/src/components/wan/config/ModelSelector.vue
+++ b/src/components/wan/config/ModelSelector.vue
@@ -66,17 +66,18 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 .field {
-  display: flex;
-  flex-direction: row;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 160px;
+  gap: 8px;
   align-items: center;
 
   .title {
     font-size: 14px;
     margin: 0;
-    width: 30%;
+    min-width: 0;
   }
   .value {
-    flex: 1;
+    width: 100%;
   }
 }
 </style>

--- a/src/components/wan/config/ResolutionSelector.vue
+++ b/src/components/wan/config/ResolutionSelector.vue
@@ -60,17 +60,18 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 .field {
-  display: flex;
-  flex-direction: row;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 160px;
+  gap: 8px;
   align-items: center;
 
   .title {
     font-size: 14px;
     margin: 0;
-    width: 30%;
+    min-width: 0;
   }
   .value {
-    flex: 1;
+    width: 100%;
   }
 }
 </style>


### PR DESCRIPTION
## 概要

- 统一26个普通横排Select控件（25个Selector + Fish VoicePicker），并对齐Suno/Producer两个Extend InputNumber
- 每行使用本地grid `minmax(0, 1fr) 160px`，gap 8px
- label允许收缩/换行，control统一160px且右对齐
- 修复Fish父级scoped `.field`规则泄漏，避免覆盖Model/Voice子组件grid
- Grok长模型名保留完整native title，避免统一宽度后信息不可发现
- 不新增公共组件或scenario抽象
- Switch、Slider、上传、比例卡和rich/custom selector保持语义宽度

## 真实渲染验证

- 22个生成器页面逐页DOM审计：普通横排Select已全部160px
- Kling 3、Pixverse 5、Seedance 1：容器279px，grid 111px/160px，control起点一致、右边缘0、无overflow
- Fish、Grok Video、Veo、Sora、Pika、Midjourney截图检查通过
- Grok完整选中模型名通过title可见
- 剩余非160仅为明确例外：Suno/Producer rich full-width、Seedream custom Size、Kling Camera Control、Maestro workflow、QR Art dense fields

## 其他验证

- ESLint、Prettier、Vue typecheck、web build通过

## 对抗评审

修复Seedance nested label收缩边界；扩展后用最长模型名复验；修复Fish scoped CSS泄漏；最终复审 `VERDICT: CLEAN`。

Ready for review；不启用auto-merge。