### PR TITLE
fix: align Pika ingredient fields

### DIFF
--- a/change/@acedatacloud-nexior-pika-field-alignment.json
+++ b/change/@acedatacloud-nexior-pika-field-alignment.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Align Pika ingredient and image labels with their controls without magic offsets.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/pika/config/ImageUrlInput.test.ts
+++ b/src/components/pika/config/ImageUrlInput.test.ts
@@ -1,0 +1,32 @@
+// @vitest-environment jsdom
+import { shallowMount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import ImageUrlInput from './ImageUrlInput.vue';
+
+describe('Pika ImageUrlInput', () => {
+  it('removes a preview URL from the request config', async () => {
+    const commits: Array<{ type: string; payload: { image_url?: string[] } }> = [];
+    const wrapper = shallowMount(ImageUrlInput, {
+      global: {
+        mocks: {
+          $t: (key: string) => key,
+          $store: {
+            state: { token: { access: 'test' }, pika: { config: { ingredients: true } } },
+            commit: (type: string, payload: { image_url?: string[] }) => commits.push({ type, payload })
+          }
+        }
+      }
+    });
+    const first = { response: { file_url: 'https://cdn.example/first.png' } };
+    const second = { response: { file_url: 'https://cdn.example/second.png' } };
+    await wrapper.setData({ fileList: [first, second] });
+    commits.length = 0;
+
+    (wrapper.vm as any).onRemovePreview(first);
+
+    expect(commits.at(-1)).toEqual({
+      type: 'pika/setConfig',
+      payload: { ingredients: true, image_url: ['https://cdn.example/second.png'] }
+    });
+  });
+});

--- a/src/components/pika/config/ImageUrlInput.vue
+++ b/src/components/pika/config/ImageUrlInput.vue
@@ -1,7 +1,10 @@
 <template>
   <div class="field">
-    <h2 class="title font-bold">{{ $t('pika.name.imageUrl') }}</h2>
-    <div class="upload-wrapper">
+    <div class="label">
+      <h2 class="title font-bold">{{ $t('pika.name.imageUrl') }}</h2>
+      <info-icon :content="$t('pika.description.imageUrl')" class="info" />
+    </div>
+    <div class="upload-control">
       <el-upload
         ref="uploader"
         v-model:file-list="fileList"
@@ -23,7 +26,7 @@
             :url="file.url || (file.response as any)?.file_url"
             :name="file.name"
             :percentage="file.percentage"
-            @remove="fileList.splice(fileList.indexOf(file), 1)"
+            @remove="onRemovePreview(file)"
           />
         </template>
         <el-button size="small" type="primary" round>
@@ -32,13 +35,12 @@
         </el-button>
       </el-upload>
     </div>
-    <info-icon :content="$t('pika.description.imageUrl')" class="info" />
   </div>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElButton, ElUpload, ElMessage, UploadFiles } from 'element-plus';
+import { ElButton, ElUpload, ElMessage, UploadFile, UploadFiles } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { getBaseUrlPlatform, pasteUploadMixin, uploadTrackerMixin } from '@/utils';
 import InfoIcon from '@/components/common/InfoIcon.vue';
@@ -73,26 +75,15 @@ export default defineComponent({
       };
     },
     urls(): string[] {
-      // @ts-ignore
-      return this.fileList.map((file: UploadFile) => file?.response?.file_url);
+      return this.fileList
+        .map((file: UploadFile) => (file.response as { file_url?: string } | undefined)?.file_url)
+        .filter((url): url is string => Boolean(url));
     },
-    value: {
-      get() {
-        return this.$store.state.pika?.config?.image_url;
-      },
-      set() {
-        const url = this.urls?.[0];
-        this.$store.commit('pika/setConfig', {
-          ...this.$store.state.pika?.config,
-          image_url: url
-        });
-      }
+    value(): string[] | undefined {
+      return this.$store.state.pika?.config?.image_url;
     }
   },
   mounted() {
-    if (!this.value) {
-      this.value = undefined;
-    }
     this.onSetStartImageUrl();
   },
   methods: {
@@ -102,8 +93,8 @@ export default defineComponent({
     onError() {
       ElMessage.error(this.$t('pika.message.uploadStartImageError'));
     },
-    async onRemove() {
-      ElMessage.error(this.$t('pika.message.uploadStartImageError'));
+    onRemove() {
+      this.onSetStartImageUrl();
     },
     onSetStartImageUrl() {
       this.$store.commit('pika/setConfig', {
@@ -111,7 +102,12 @@ export default defineComponent({
         image_url: this.urls
       });
     },
-    async onSuccess() {
+    onSuccess() {
+      this.onSetStartImageUrl();
+    },
+    onRemovePreview(file: UploadFiles[number]) {
+      const index = this.fileList.indexOf(file);
+      if (index >= 0) this.fileList.splice(index, 1);
       this.onSetStartImageUrl();
     }
   }
@@ -120,27 +116,39 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 .field {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: space-between; // Distribute space evenly
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 160px;
+  gap: 8px;
+  align-items: start;
+
+  .label {
+    display: flex;
+    gap: 6px;
+    align-items: center;
+    min-width: 0;
+  }
+
+  .info {
+    flex: none;
+  }
+
   .title {
-    font-size: 14px;
+    min-width: 0;
     margin: 0;
-    width: 30%;
+    font-size: 14px;
   }
-  .value {
-    flex: 1;
-    margin-left: 60px; // Adjust this value as needed
+
+  .upload-control {
+    width: 160px;
+    min-width: 0;
   }
+
   .upload-wrapper {
     display: flex;
     flex-direction: column;
     align-items: flex-start;
+    width: 100%;
     gap: 8px;
-  }
-  .info {
-    margin-left: auto; // Pushes the info icon to the right
   }
 }
 </style>

--- a/src/components/pika/config/IngredientsSelector.vue
+++ b/src/components/pika/config/IngredientsSelector.vue
@@ -1,8 +1,10 @@
 <template>
   <div class="field">
-    <h2 class="title font-bold">{{ $t('pika.name.ingredients') }}</h2>
+    <div class="label">
+      <h2 class="title font-bold">{{ $t('pika.name.ingredients') }}</h2>
+      <info-icon :content="$t('pika.description.ingredients')" class="info" />
+    </div>
     <el-switch v-model="value" class="value" />
-    <info-icon :content="$t('pika.description.ingredients')" class="info" />
   </div>
 </template>
 
@@ -22,8 +24,7 @@ export default defineComponent({
       get() {
         return this.$store.state.pika?.config?.ingredients;
       },
-      set(val: string) {
-        console.debug('set ingredients', val);
+      set(val: boolean) {
         if (!val) {
           this.$store.commit('pika/setConfig', {
             ...this.$store.state.pika?.config,
@@ -31,6 +32,7 @@ export default defineComponent({
             ingredients_mode: undefined,
             image_url: undefined
           });
+          return;
         }
         this.$store.commit('pika/setConfig', {
           ...this.$store.state.pika?.config,
@@ -50,18 +52,22 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 .field {
-  display: flex;
-  flex-direction: row;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 8px;
   align-items: center;
 
-  .title {
-    font-size: 14px;
-    margin: 0;
-    width: 30%;
+  .label {
+    display: flex;
+    gap: 6px;
+    align-items: center;
+    min-width: 0;
   }
-  .value {
-    flex: 1;
-    margin-left: 60px; // Adjust this value as needed
+
+  .title {
+    min-width: 0;
+    margin: 0;
+    font-size: 14px;
   }
 }
 </style>


### PR DESCRIPTION
## 概要

- 移除Pika Ingredients与Image字段的60px魔法偏移
- label与InfoIcon归为同一左列，固定6px间距
- Switch保持语义auto宽度；三图Upload使用160px右列
- 修复图片预览移除后未同步Vuex request config的问题
- 修复el-upload remove误报上传失败和computed setter类型/数组问题
- 不新增公共组件或scenario抽象

## 真实渲染验证

管理员登录本地分支，打开Ingredients并拦截上传接口注入3张PNG（未发送真实上传）：

- Ingredients grid 231px/40px
- Image grid 111px/160px
- label/help gap 6px
- control右边缘0
- 3个预览均渲染
- 无横向overflow

## 自动验证

- ImageUrlInput removal regression test 1 passed
- ESLint、Prettier、Vue typecheck、web build通过

## 对抗评审

修复remove同步、setter early return、upload列约束与info icon收缩；最终 `VERDICT: CLEAN`。

Ready for review；不启用auto-merge。