### PR TITLE
Auto-select Seedream image mode

### DIFF
--- a/change/@acedatacloud-nexior-seedream-auto-mode.json
+++ b/change/@acedatacloud-nexior-seedream-auto-mode.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Automatically switch Seedream between image creation and editing based on reference images.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/seedream/ConfigPanel.test.ts
+++ b/src/components/seedream/ConfigPanel.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+import { shallowMount } from '@vue/test-utils';
+import { reactive } from 'vue';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import ConfigPanel from './ConfigPanel.vue';
+import ImageInput from './config/ImageInput.vue';
+import ModelSelector from './config/ModelSelector.vue';
+
+const getConsumptionMock = vi.hoisted(() => vi.fn((_request: Record<string, unknown>) => 1));
+
+vi.mock('@/utils', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/utils')>()),
+  getConsumption: getConsumptionMock
+}));
+
+const mountPanel = (image: string[] = [], model = 'doubao-seedream-4-5-251128') => {
+  const config = reactive({
+    model,
+    image
+  });
+  const wrapper = shallowMount(ConfigPanel, {
+    global: {
+      mocks: {
+        $t: (key: string) => key,
+        $store: {
+          state: {
+            seedream: {
+              config,
+              service: { cost: [] }
+            }
+          }
+        }
+      }
+    }
+  });
+  return { config, wrapper };
+};
+
+describe('seedream/ConfigPanel', () => {
+  beforeEach(() => {
+    getConsumptionMock.mockClear();
+  });
+
+  it('shows reference image upload without create/edit tabs', () => {
+    const { wrapper } = mountPanel();
+
+    expect(wrapper.find('.action-selector').exists()).toBe(false);
+    expect(wrapper.findComponent(ImageInput).exists()).toBe(true);
+    expect(wrapper.findComponent(ModelSelector).exists()).toBe(true);
+
+    const { wrapper: textOnlyWrapper } = mountPanel([], 'doubao-seedream-3-0-t2i-250415');
+    expect(textOnlyWrapper.findComponent(ImageInput).exists()).toBe(false);
+  });
+
+  it('automatically switches billing mode when references change', async () => {
+    const { config, wrapper } = mountPanel();
+
+    expect((wrapper.vm as unknown as { action: string }).action).toBe('generate');
+    expect(getConsumptionMock.mock.lastCall?.[0]).toMatchObject({ action: 'generate', input_image_count: 0 });
+
+    config.image = ['https://cdn.example/reference.png'];
+    await wrapper.vm.$nextTick();
+
+    expect((wrapper.vm as unknown as { action: string }).action).toBe('edit');
+    expect(getConsumptionMock.mock.lastCall?.[0]).toMatchObject({ action: 'edit', input_image_count: 1 });
+  });
+});

--- a/src/components/seedream/ConfigPanel.vue
+++ b/src/components/seedream/ConfigPanel.vue
@@ -1,19 +1,6 @@
 <template>
   <div class="flex flex-col h-full">
     <div class="flex-1 overflow-y-auto p-5">
-      <el-radio-group
-        class="action-selector mb-4"
-        :model-value="action"
-        :aria-label="$t('seedream.name.action')"
-        @update:model-value="onActionChange"
-      >
-        <el-radio-button value="generate" :disabled="capabilities.imageRequired">
-          {{ $t('seedream.name.generate') }}
-        </el-radio-button>
-        <el-radio-button value="edit" :disabled="!capabilities.image">
-          {{ $t('seedream.name.edits') }}
-        </el-radio-button>
-      </el-radio-group>
       <model-selector class="mb-4" />
       <size-selector class="mb-4" />
       <max-images-selector class="mb-4" />
@@ -22,7 +9,7 @@
       <guidance-scale-input class="mb-4" />
       <watermark-switch class="mb-4" />
       <prompt-input class="mb-4" />
-      <image-input v-if="action === 'edit'" class="mb-4" />
+      <image-input v-if="capabilities.image" class="mb-4" />
     </div>
     <div class="flex flex-col items-center justify-center px-5 pb-5">
       <consumption :value="consumption" :service="service" />
@@ -37,7 +24,7 @@
 <script lang="ts">
 import { MagicIcon } from '@acedatacloud/core/icons/components';
 import { defineComponent } from 'vue';
-import { ElButton, ElRadioButton, ElRadioGroup } from 'element-plus';
+import { ElButton } from 'element-plus';
 import PromptInput from './config/PromptInput.vue';
 import ImageInput from './config/ImageInput.vue';
 import Consumption from '../common/Consumption.vue';
@@ -50,7 +37,7 @@ import SeedInput from './config/SeedInput.vue';
 import GuidanceScaleInput from './config/GuidanceScaleInput.vue';
 import WatermarkSwitch from './config/WatermarkSwitch.vue';
 import { getSeedreamShortModel } from '@/constants';
-import { getSeedreamCapabilities } from '@/utils/seedream/capabilities';
+import { getSeedreamAction, getSeedreamCapabilities } from '@/utils/seedream/capabilities';
 import { buildSeedreamRequest } from '@/utils/seedream/request';
 
 export default defineComponent({
@@ -58,8 +45,6 @@ export default defineComponent({
   components: {
     MagicIcon,
     ElButton,
-    ElRadioButton,
-    ElRadioGroup,
     PromptInput,
     Consumption,
     ImageInput,
@@ -74,7 +59,7 @@ export default defineComponent({
   emits: ['generate'],
   computed: {
     action(): 'generate' | 'edit' {
-      return this.config?.action === 'edit' ? 'edit' : 'generate';
+      return getSeedreamAction(this.config?.model, this.config?.image);
     },
     capabilities() {
       return getSeedreamCapabilities(this.config?.model);
@@ -107,29 +92,9 @@ export default defineComponent({
     }
   },
   methods: {
-    onActionChange(action: string | number | boolean | undefined) {
-      if (action !== 'generate' && action !== 'edit') return;
-      this.$store.commit('seedream/setConfig', { ...this.config, action });
-    },
     onGenerate() {
       this.$emit('generate');
     }
   }
 });
 </script>
-
-<style lang="scss" scoped>
-.action-selector {
-  display: flex;
-  width: 100%;
-}
-
-.action-selector :deep(.el-radio-button) {
-  flex: 1;
-}
-
-.action-selector :deep(.el-radio-button__inner) {
-  width: 100%;
-  min-height: 40px;
-}
-</style>

--- a/src/components/seedream/config/ModelSelector.vue
+++ b/src/components/seedream/config/ModelSelector.vue
@@ -31,11 +31,7 @@ import {
   SEEDREAM_MODEL_5_0_PRO,
   SEEDREAM_MODEL_SEEDEDIT_3_0_I2I
 } from '@/constants';
-import {
-  findSeedreamConflicts,
-  clearSeedreamConflicts,
-  getCompatibleSeedreamAction
-} from '@/utils/seedream/capabilities';
+import { findSeedreamConflicts, clearSeedreamConflicts } from '@/utils/seedream/capabilities';
 
 export default defineComponent({
   name: 'SeedreamModelSelector',
@@ -89,7 +85,6 @@ export default defineComponent({
           }
         );
         const cleared = clearSeedreamConflicts({ ...config, model: val }, conflicts, { model: val });
-        cleared.action = getCompatibleSeedreamAction(cleared.action, val);
         this.$store.commit('seedream/setConfig', cleared);
         ElMessage.success(this.$t('seedream.message.featureRemovedNotice', { fields }));
       } catch {
@@ -100,8 +95,7 @@ export default defineComponent({
     applyModel(val: string) {
       this.$store.commit('seedream/setConfig', {
         ...this.$store.state.seedream?.config,
-        model: val,
-        action: getCompatibleSeedreamAction(this.$store.state.seedream?.config?.action, val)
+        model: val
       });
     }
   }

--- a/src/pages/seedream/Index.vue
+++ b/src/pages/seedream/Index.vue
@@ -15,6 +15,7 @@ import Layout from '@/layouts/Seedream.vue';
 import ConfigPanel from '@/components/seedream/ConfigPanel.vue';
 import { seedreamOperator } from '@/operators';
 import { buildSeedreamRequest } from '@/utils/seedream/request';
+import { getSeedreamCapabilities } from '@/utils/seedream/capabilities';
 import { instrumentGeneration } from '@/plugins/telemetry';
 import { ISeedreamGenerateRequest, Status } from '@/models';
 import { ElMessage } from 'element-plus';
@@ -149,7 +150,7 @@ export default defineComponent({
       ) {
         return;
       }
-      if (this.config?.action === 'edit' && !this.config.image?.length) {
+      if (getSeedreamCapabilities(this.config?.model).imageRequired && !this.config?.image?.length) {
         ElMessage.warning(this.$t('seedream.message.referenceImageRequired'));
         return;
       }

--- a/src/utils/seedream/capabilities.ts
+++ b/src/utils/seedream/capabilities.ts
@@ -179,6 +179,12 @@ export function getCompatibleSeedreamAction(
   return action === 'edit' ? 'edit' : 'generate';
 }
 
+export function getSeedreamAction(model?: string, image?: string[]): 'generate' | 'edit' {
+  const capabilities = getSeedreamCapabilities(model);
+  if (capabilities.imageRequired) return 'edit';
+  return capabilities.image && image?.length ? 'edit' : 'generate';
+}
+
 export type SeedreamConflictField =
   | 'image'
   | 'size'

--- a/src/utils/seedream/request.test.ts
+++ b/src/utils/seedream/request.test.ts
@@ -1,17 +1,17 @@
 import { describe, expect, it } from 'vitest';
 import { buildSeedreamRequest } from './request';
-import { getCompatibleSeedreamAction } from './capabilities';
+import { getCompatibleSeedreamAction, getSeedreamAction } from './capabilities';
 
 describe('buildSeedreamRequest', () => {
-  it('does not send UI action or saved references in generate mode', () => {
+  it('automatically sends references in edit mode', () => {
     expect(
       buildSeedreamRequest({ action: 'generate', prompt: 'A lighthouse', image: ['https://cdn.example/ref.png'] })
-    ).toEqual({ prompt: 'A lighthouse', async: true });
+    ).toEqual({ prompt: 'A lighthouse', image: ['https://cdn.example/ref.png'], async: true });
   });
 
-  it('sends saved references after switching back to edit mode', () => {
-    expect(buildSeedreamRequest({ action: 'edit', image: ['https://cdn.example/ref.png'] })).toEqual({
-      image: ['https://cdn.example/ref.png'],
+  it('automatically returns to generate mode after references are removed', () => {
+    expect(buildSeedreamRequest({ action: 'edit', prompt: 'A lighthouse', image: [] })).toEqual({
+      prompt: 'A lighthouse',
       async: true
     });
   });
@@ -30,9 +30,11 @@ describe('buildSeedreamRequest', () => {
     ).toEqual({ sequential_image_generation: 'disabled', async: true });
   });
 
-  it('counts only references included by the selected action', () => {
+  it('derives the action from model capabilities and references', () => {
     const image = ['one.png', 'two.png'];
-    expect(buildSeedreamRequest({ action: 'generate', image }).image).toBeUndefined();
-    expect(buildSeedreamRequest({ action: 'edit', image }).image).toHaveLength(2);
+    expect(getSeedreamAction('doubao-seedream-4-5-251128', [])).toBe('generate');
+    expect(getSeedreamAction('doubao-seedream-4-5-251128', image)).toBe('edit');
+    expect(getSeedreamAction('doubao-seededit-3-0-i2i-250628', [])).toBe('edit');
+    expect(getSeedreamAction('doubao-seedream-3-0-t2i-250415', image)).toBe('generate');
   });
 });

--- a/src/utils/seedream/request.ts
+++ b/src/utils/seedream/request.ts
@@ -1,8 +1,9 @@
 import type { ISeedreamConfig, ISeedreamGenerateRequest } from '@/models';
+import { getSeedreamAction } from './capabilities';
 
 export const buildSeedreamRequest = (config?: ISeedreamConfig): ISeedreamGenerateRequest => {
   const request = { ...(config || {}) };
-  const action = request.action === 'edit' ? 'edit' : 'generate';
+  const action = getSeedreamAction(request.model, request.image);
   delete request.action;
 
   if (action !== 'edit' || !request.image?.length) {


### PR DESCRIPTION
## Summary

- remove the manual create/edit tabs from Seedream
- derive generate vs edit mode from model capabilities and uploaded reference images, matching OpenAI Image behavior
- keep edit-only model validation and hide the uploader entirely for text-only models
- add request and component regression coverage for automatic mode changes

## Validation

- `npx vitest run src/utils/seedream/request.test.ts src/components/seedream/ConfigPanel.test.ts` (7 passed)
- `npx eslint src/components/seedream/ConfigPanel.vue src/components/seedream/ConfigPanel.test.ts src/components/seedream/config/ModelSelector.vue src/pages/seedream/Index.vue src/utils/seedream/capabilities.ts src/utils/seedream/request.ts src/utils/seedream/request.test.ts`
- `npx vue-tsc -b --pretty false`
- `npm run build:web`

## 🤖 对抗评审 (reviewer: codex, 2 rounds)

- RISK: hidden image uploader could swallow clipboard image pastes on text-only models → 已修 (gate `ImageInput` mounting by model image capability and add regression coverage)
- Round 2: `VERDICT: CLEAN`
