### PR TITLE
fix: polish Seedream workspace layout

### DIFF
--- a/change/@acedatacloud-nexior-53093c4c-c66f-4617-9790-a7543f262d1a.json
+++ b/change/@acedatacloud-nexior-53093c4c-c66f-4617-9790-a7543f262d1a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Polish Seedream configuration and task history spacing across desktop and mobile.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/seedream/ConfigPanel.vue
+++ b/src/components/seedream/ConfigPanel.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="flex flex-col h-full">
-    <div class="flex-1 overflow-y-auto p-5">
+  <div class="config-panel flex flex-col h-full">
+    <div class="config-scroll flex-1 overflow-y-auto p-5">
       <model-selector class="mb-4" />
       <size-selector class="mb-4" />
       <max-images-selector class="mb-4" />
@@ -11,7 +11,7 @@
       <prompt-input class="mb-4" />
       <image-input v-if="capabilities.image" class="mb-4" />
     </div>
-    <div class="flex flex-col items-center justify-center px-5 pb-5">
+    <div class="config-footer flex flex-col items-center justify-center px-5 pb-5">
       <consumption :value="consumption" :service="service" />
       <el-button type="primary" class="btn w-full" round @click="onGenerate">
         <magic-icon class="mr-2" :size="'1em' as any" aria-hidden="true" focusable="false" />
@@ -98,3 +98,60 @@ export default defineComponent({
   }
 });
 </script>
+
+<style lang="scss" scoped>
+.config-scroll {
+  scrollbar-gutter: stable;
+}
+
+.config-footer {
+  padding-top: 12px;
+  border-top: 1px solid var(--app-border-subtle);
+  background: var(--app-sidebar-bg);
+  box-shadow: 0 -4px 12px rgba(0, 0, 0, 0.04);
+}
+
+.config-panel :deep(.field) {
+  display: grid;
+  grid-template-columns: 148px minmax(140px, 1fr);
+  gap: 12px;
+  align-items: center;
+}
+
+.config-panel :deep(.field .label),
+.config-panel :deep(.field .value) {
+  width: 100%;
+  min-width: 0;
+}
+
+.config-panel :deep(.field .label .box) {
+  min-width: 0;
+}
+
+.config-panel :deep(.field .label .title) {
+  line-height: 1.35;
+}
+
+.config-panel :deep(.field .value) {
+  justify-content: flex-end;
+}
+
+.config-panel :deep(.field .value > *) {
+  max-width: 100%;
+}
+
+@media (max-width: 767px) {
+  .config-panel :deep(.field) {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 6px;
+  }
+
+  .config-panel :deep(.field .value) {
+    justify-content: flex-start;
+  }
+
+  .config-panel :deep(.field .value > *) {
+    width: 100%;
+  }
+}
+</style>

--- a/src/components/seedream/RecentPanel.vue
+++ b/src/components/seedream/RecentPanel.vue
@@ -54,3 +54,17 @@ export default defineComponent({
   }
 });
 </script>
+
+<style lang="scss" scoped>
+.tasks {
+  padding-right: 4px;
+  scrollbar-gutter: stable;
+  scrollbar-width: thin;
+}
+
+@media (max-width: 767px) {
+  .tasks {
+    padding-right: 0;
+  }
+}
+</style>

--- a/src/components/seedream/task/Preview.vue
+++ b/src/components/seedream/task/Preview.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="preview">
+  <article class="preview">
     <div class="left">
       <capability-presentation capability="seedream" part="avatar" class="avatar" />
     </div>
@@ -13,7 +13,7 @@
       <div class="info">
         <div
           v-if="Array.isArray(modelValue?.request?.image) && modelValue?.request?.image.length > 0"
-          class="flex justify-start items-center gap-2 mt-2 w-full overflow-x-auto"
+          class="media-strip mt-2"
         >
           <image-preview
             v-for="(url, idx) in modelValue?.request?.image"
@@ -43,7 +43,7 @@
         </el-alert>
       </div>
       <div v-else-if="modelValue?.response?.success === true" :class="{ content: true, failed: true }">
-        <div class="flex justify-start items-center gap-4 w-full overflow-x-auto">
+        <div class="media-strip result-media">
           <image-wrapper
             v-for="(image, imageIndex) in images"
             :key="imageIndex"
@@ -51,7 +51,7 @@
             :raw-src="image?.image_url!"
           />
         </div>
-        <div :class="{ operations: true, 'mt-2': true, 'mb-2': true }">
+        <div class="operations">
           <el-tooltip class="box-item" effect="dark" :content="$t('common.button.edit')" placement="top-start">
             <el-button type="info" size="small" class="btn-action" @click.stop="onEdit(images?.[0]?.image_url)">
               {{ $t('common.button.edit') }}
@@ -59,7 +59,7 @@
           </el-tooltip>
           <api-code-button path="/seedream/images" :body="modelValue?.request" />
         </div>
-        <el-alert :closable="false" class="mt-2 success">
+        <el-alert :closable="false" class="metadata success">
           <p v-if="modelValue?.request?.model" class="text-[var(--el-text-color-regular)] text-xs mb-2">
             <application-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
             {{ $t('seedream.name.model') }}:
@@ -94,7 +94,7 @@
         </el-alert>
       </div>
       <div v-else-if="modelValue?.response?.success === false" :class="{ content: true }">
-        <el-alert :closable="false" class="failure">
+        <el-alert :closable="false" class="metadata failure">
           <template #template>
             <warning-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
             {{ $t('seedream.name.failure') }}
@@ -139,7 +139,7 @@
         </el-alert>
       </div>
       <div v-else :class="{ content: true }">
-        <el-alert :closable="false" class="info">
+        <el-alert :closable="false" class="metadata info">
           <template #template>
             <info-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
             {{ $t('seedream.name.status') }}
@@ -159,7 +159,7 @@
         </el-alert>
       </div>
     </div>
-  </div>
+  </article>
 </template>
 
 <script lang="ts">
@@ -238,20 +238,28 @@ export default defineComponent({
 </script>
 
 <style lang="scss" scoped>
-$left-width: 70px;
+$left-width: 44px;
 .preview {
   width: 100%;
   height: fit-content;
   text-align: left;
   display: flex;
   flex-direction: row;
-  margin-bottom: 16px;
+  gap: 12px;
+  margin-bottom: 12px;
+  padding: 14px;
+  border: 1px solid var(--app-border-subtle);
+  border-radius: 8px;
+  background: var(--app-bg-surface);
+  box-shadow: var(--app-shadow-xs);
+
   .left {
+    flex: 0 0 $left-width;
     width: $left-width;
+
     .avatar {
-      width: 50px;
-      height: 50px;
-      margin: 10px;
+      width: 44px;
+      height: 44px;
       border-radius: 50%;
     }
   }
@@ -260,32 +268,36 @@ $left-width: 70px;
     flex: 1;
     width: calc(100% - $left-width);
     min-width: 0;
-    padding: 10px 10px 0 10px;
 
     .bot {
-      font-size: 16px;
-      font-weight: bold;
+      display: flex;
+      align-items: baseline;
+      gap: 10px;
+      min-width: 0;
+      font-size: 15px;
+      font-weight: 600;
       color: var(--el-color-primary);
-      margin-bottom: 0;
-      margin-top: 0;
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
+
       .datetime {
+        flex: 0 0 auto;
         font-size: 12px;
         font-weight: normal;
         color: var(--el-text-color-secondary);
-        margin-left: 10px;
       }
     }
 
     .info {
       overflow: hidden;
+
       .prompt {
-        font-size: 16px;
-        font-weight: bold;
+        font-size: 14px;
+        line-height: 1.6;
+        font-weight: 400;
         color: var(--el-text-color-regular);
-        margin-bottom: 15px;
+        margin-bottom: 12px;
         white-space: normal;
         word-break: break-word;
         overflow-wrap: anywhere;
@@ -295,9 +307,11 @@ $left-width: 70px;
     .content {
       word-break: break-word;
       overflow-wrap: anywhere;
+
       .el-alert {
         border-left-width: 2px;
         border-left-style: solid;
+
         &.failure {
           border-color: var(--el-color-danger);
         }
@@ -307,27 +321,88 @@ $left-width: 70px;
         &.info {
           border-color: var(--el-color-info);
         }
-        // Drop the trailing `mb-2` on whichever `<p>` ends up rendered
-        // last (trace_id / elapsed are conditional — e.g. pending tasks).
+
         :deep(p:last-child) {
           margin-bottom: 0;
         }
       }
     }
 
+    .media-strip {
+      display: flex;
+      align-items: flex-start;
+      gap: 12px;
+      width: 100%;
+      overflow-x: auto;
+      padding-bottom: 4px;
+      scrollbar-width: thin;
+
+      :deep(.image-wrapper) {
+        flex: 0 0 auto;
+        margin-bottom: 0;
+      }
+    }
+
+    .result-media {
+      margin-bottom: 10px;
+    }
+
     .operations {
       display: flex;
-      justify-content: left;
-      flex-direction: row;
-      width: 100%;
-      align-items: baseline;
+      align-items: center;
       flex-wrap: wrap;
-      overflow: hidden;
-      text-align: center;
+      gap: 8px;
+      margin-bottom: 10px;
       color: var(--el-text-color-regular);
       font-size: 14px;
+
       .btn-action {
-        margin-bottom: 10px;
+        margin: 0;
+      }
+
+      :deep(.el-button + .el-button) {
+        margin-left: 0;
+      }
+    }
+
+    .metadata {
+      border-radius: 6px;
+
+      :deep(.el-alert__content) {
+        min-width: 0;
+        width: 100%;
+      }
+    }
+  }
+}
+
+@media (max-width: 767px) {
+  .preview {
+    gap: 10px;
+    padding: 12px;
+
+    .left {
+      flex-basis: 36px;
+      width: 36px;
+
+      .avatar {
+        width: 36px;
+        height: 36px;
+      }
+    }
+
+    .main {
+      width: calc(100% - 36px);
+
+      .bot {
+        align-items: flex-start;
+        flex-direction: column;
+        gap: 2px;
+        white-space: normal;
+      }
+
+      .info .prompt {
+        font-size: 13px;
       }
     }
   }

--- a/src/layouts/Seedream.vue
+++ b/src/layouts/Seedream.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="main flex flex-row flex-1">
     <div
-      class="config w-[320px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
+      class="config w-[360px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
     >
       <slot name="config" />
     </div>
@@ -46,12 +46,18 @@ export default defineComponent({
   display: none;
 }
 
+.result {
+  min-width: 0;
+  overflow: hidden;
+}
+
 @media (max-width: 767px) {
   .config {
     display: none;
   }
   .result {
     width: 100%;
+    padding: 12px;
   }
   .menu {
     display: block;


### PR DESCRIPTION
## Summary
- align Seedream configuration labels and controls on a wider desktop panel
- stack controls safely in the mobile generator drawer
- give success, failure, and pending history entries consistent card, media, action, and metadata spacing
- contain result scrolling and tighten mobile canvas padding

## Validation
- `npx eslint src/layouts/Seedream.vue src/components/seedream/ConfigPanel.vue src/components/seedream/RecentPanel.vue src/components/seedream/task/Preview.vue`
- `npx prettier --check ...` (touched files)
- `npm run build:web`
- production-account browser audit at 1440x1000 and 390x844

## 🤖 对抗评审 (reviewer: codex, 3 rounds)
- RISK: mobile drawer fields could overflow when a reserved scrollbar gutter reduces the exact 300px content width → 已修 (mobile fields now stack into full-width rows)
- Round 2: `VERDICT: CLEAN`
- Round 3 after rebasing onto latest `main`: `VERDICT: CLEAN`