### PR TITLE
Improve generator panel spacing and control sizing

### DIFF
--- a/change/@acedatacloud-nexior-generator-panel-comfort.json
+++ b/change/@acedatacloud-nexior-generator-panel-comfort.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Standardize creative generator panel widths and form control sizing.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/assets/scss/_common.scss
+++ b/src/assets/scss/_common.scss
@@ -195,6 +195,44 @@ w3m-modal {
   overflow: hidden;
 }
 
+.generator-config-panel,
+.el-drawer.generator-drawer {
+  --el-component-size: 40px;
+  --el-component-size-small: 32px;
+
+  .el-button {
+    --el-button-size: 40px;
+    height: var(--el-button-size);
+
+    &.el-button--small {
+      --el-button-size: 32px;
+    }
+  }
+
+  .el-input {
+    --el-input-height: 40px;
+
+    &.el-input--small {
+      --el-input-height: 32px;
+    }
+  }
+
+  .el-select:not(.el-select--small) .el-select__wrapper {
+    min-height: 40px;
+  }
+
+  .el-select.el-select--small .el-select__wrapper {
+    min-height: 32px;
+  }
+
+  .el-radio-button--small .el-radio-button__inner {
+    display: inline-flex;
+    align-items: center;
+    min-height: 32px;
+    padding: 0 11px;
+  }
+}
+
 .el-button {
   font-weight: var(--adc-font-weight-medium);
   letter-spacing: var(--adc-letter-spacing);

--- a/src/layouts/DigitalHuman.vue
+++ b/src/layouts/DigitalHuman.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="main flex flex-row flex-1">
     <div
-      class="config w-[320px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
+      class="config generator-config-panel w-[360px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
     >
       <slot name="config" />
     </div>

--- a/src/layouts/Flux.vue
+++ b/src/layouts/Flux.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="main flex flex-row flex-1">
     <div
-      class="config w-[320px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
+      class="config generator-config-panel w-[360px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
     >
       <slot name="config" />
     </div>

--- a/src/layouts/GrokVideo.vue
+++ b/src/layouts/GrokVideo.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="main flex flex-row flex-1">
     <div
-      class="config w-[320px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
+      class="config generator-config-panel w-[360px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
     >
       <slot name="config" />
     </div>

--- a/src/layouts/Hailuo.vue
+++ b/src/layouts/Hailuo.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="main flex flex-row flex-1">
     <div
-      class="config w-[320px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
+      class="config generator-config-panel w-[360px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
     >
       <slot name="config" />
     </div>

--- a/src/layouts/Kling.vue
+++ b/src/layouts/Kling.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="main flex flex-row flex-1 min-h-0">
     <div
-      class="config w-[320px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
+      class="config generator-config-panel w-[360px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
     >
       <slot name="config" />
     </div>

--- a/src/layouts/Luma.vue
+++ b/src/layouts/Luma.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="main flex flex-row flex-1">
     <div
-      class="config w-[320px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
+      class="config generator-config-panel w-[360px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
     >
       <slot name="config" />
     </div>

--- a/src/layouts/Maestro.vue
+++ b/src/layouts/Maestro.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="main flex flex-row flex-1">
     <div
-      class="config w-[320px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
+      class="config generator-config-panel w-[360px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
     >
       <slot name="config" />
     </div>

--- a/src/layouts/Midjourney.vue
+++ b/src/layouts/Midjourney.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="main flex-1 h-full flex flex-row">
     <div
-      class="config w-[320px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
+      class="config generator-config-panel w-[360px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
     >
       <slot name="config" />
     </div>

--- a/src/layouts/Nanobanana.vue
+++ b/src/layouts/Nanobanana.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="main flex flex-row flex-1">
     <div
-      class="config w-[320px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
+      class="config generator-config-panel w-[360px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
     >
       <slot name="config" />
     </div>

--- a/src/layouts/Omni.vue
+++ b/src/layouts/Omni.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="main flex flex-row flex-1">
     <div
-      class="config w-[320px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
+      class="config generator-config-panel w-[360px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
     >
       <slot name="config" />
     </div>

--- a/src/layouts/OpenAIImage.vue
+++ b/src/layouts/OpenAIImage.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="main flex flex-row flex-1">
     <div
-      class="config w-[320px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
+      class="config generator-config-panel w-[360px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
     >
       <slot name="config" />
     </div>

--- a/src/layouts/Pika.vue
+++ b/src/layouts/Pika.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="main flex flex-row flex-1">
     <div
-      class="config w-[320px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
+      class="config generator-config-panel w-[360px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
     >
       <slot name="config" />
     </div>

--- a/src/layouts/Pixverse.vue
+++ b/src/layouts/Pixverse.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="main flex flex-row flex-1">
     <div
-      class="config w-[320px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
+      class="config generator-config-panel w-[360px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
     >
       <slot name="config" />
     </div>

--- a/src/layouts/Producer.vue
+++ b/src/layouts/Producer.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="main flex flex-row flex-1">
     <div
-      class="config w-[320px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
+      class="config generator-config-panel w-[360px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
     >
       <slot name="config" />
     </div>

--- a/src/layouts/Qrart.vue
+++ b/src/layouts/Qrart.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="main flex flex-row flex-1">
     <div
-      class="config w-[320px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
+      class="config generator-config-panel w-[360px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
     >
       <slot name="config" />
     </div>

--- a/src/layouts/Seedance.vue
+++ b/src/layouts/Seedance.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="main flex flex-row flex-1">
     <div
-      class="config w-[320px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
+      class="config generator-config-panel w-[360px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
     >
       <slot name="config" />
     </div>

--- a/src/layouts/Seedream.vue
+++ b/src/layouts/Seedream.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="main flex flex-row flex-1">
     <div
-      class="config w-[320px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
+      class="config generator-config-panel w-[360px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
     >
       <slot name="config" />
     </div>

--- a/src/layouts/Sora.vue
+++ b/src/layouts/Sora.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="main flex flex-row flex-1">
     <div
-      class="config w-[320px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
+      class="config generator-config-panel w-[360px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
     >
       <slot name="config" />
     </div>

--- a/src/layouts/Suno.vue
+++ b/src/layouts/Suno.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="main flex flex-row flex-1">
     <div
-      class="config w-[320px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
+      class="config generator-config-panel w-[360px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
     >
       <slot name="config" />
     </div>
@@ -49,9 +49,9 @@ export default defineComponent({
   display: none;
 }
 
-// On laptops (≤1180px) the 320 + flex + 300 layout crushes the song list —
+// On laptops (≤1220px) the 360 + flex + 300 layout crushes the song list —
 // drop the detail preview here so the list keeps a usable width.
-@media (max-width: 1180px) {
+@media (max-width: 1220px) {
   .main .preview {
     display: none;
   }

--- a/src/layouts/Veo.vue
+++ b/src/layouts/Veo.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="main flex flex-row flex-1">
     <div
-      class="config w-[320px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
+      class="config generator-config-panel w-[360px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
     >
       <slot name="config" />
     </div>

--- a/src/layouts/Wan.vue
+++ b/src/layouts/Wan.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="main flex flex-row flex-1">
     <div
-      class="config w-[320px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
+      class="config generator-config-panel w-[360px] flex-none h-full min-h-0 overflow-hidden flex flex-col bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
     >
       <slot name="config" />
     </div>


### PR DESCRIPTION
## Summary

- widen 21 creative generator configuration panels from 320px to 360px
- standardize primary form controls at 40px and explicit small controls at 32px across desktop panels and mobile drawers
- move the Suno preview-collapse breakpoint to 1220px so the wider panel does not squeeze the song list

## Validation

- `npm run lint:check`
- `npx prettier --check` on all touched files
- `npx vue-tsc --noEmit`
- `npm run verify`
- `npm run build`
- browser geometry checks on Suno, Kling, and Veo at 1440x900
- mobile drawer check at 390x844: 340px drawer, 40px select/button controls, no horizontal overflow
- Suno breakpoint check: preview visible at 1221px and collapsed at 1220px

## 🤖 对抗评审 (reviewer: copilot-explore, 2 rounds)

- RISK: widening Suno while retaining the 1180px preview breakpoint would squeeze the song list between 1181px and 1220px -> fixed by moving the breakpoint to 1220px and verifying both boundary widths
- Round 2: `VERDICT: CLEAN`
