### PR TITLE
fix: align Seedream spacing with Nano Banana

### DIFF
--- a/change/@acedatacloud-nexior-0a17787c-8891-45ca-821f-129516cb20e8.json
+++ b/change/@acedatacloud-nexior-0a17787c-8891-45ca-821f-129516cb20e8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Align Seedream task spacing and result containment with Nano Banana, and add missing spacing above failures without a prompt.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/seedream/task/Preview.test.ts
+++ b/src/components/seedream/task/Preview.test.ts
@@ -30,4 +30,28 @@ describe('seedream/task/Preview', () => {
       async: true
     });
   });
+
+  it('adds request-context spacing only when a failed task has no prompt', () => {
+    const mountFailure = (prompt?: string) =>
+      shallowMount(Preview, {
+        props: {
+          modelValue: {
+            id: 'task-1',
+            request: prompt === undefined ? {} : { prompt },
+            response: { success: false, task_id: 'task-1', error: { message: 'failed' } }
+          }
+        },
+        global: {
+          mocks: {
+            $t: (key: string) => key,
+            $dayjs: { format: () => '2026-07-19' },
+            $store: { state: { seedream: { config: {} } }, commit: () => undefined }
+          }
+        }
+      });
+
+    expect(mountFailure().find('.content').classes()).toContain('mt-[15px]');
+    expect(mountFailure('').find('.content').classes()).toContain('mt-[15px]');
+    expect(mountFailure('A lighthouse').find('.content').classes()).not.toContain('mt-[15px]');
+  });
 });

--- a/src/components/seedream/task/Preview.vue
+++ b/src/components/seedream/task/Preview.vue
@@ -93,7 +93,10 @@
           </p>
         </el-alert>
       </div>
-      <div v-else-if="modelValue?.response?.success === false" :class="{ content: true }">
+      <div
+        v-else-if="modelValue?.response?.success === false"
+        :class="{ content: true, 'mt-[15px]': !modelValue?.request?.prompt }"
+      >
         <el-alert :closable="false" class="failure">
           <template #template>
             <warning-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
@@ -249,7 +252,7 @@ $left-width: 70px;
   text-align: left;
   display: flex;
   flex-direction: row;
-  margin-bottom: 16px;
+  margin-bottom: 10px;
   .left {
     width: $left-width;
     .avatar {

--- a/src/layouts/Seedream.vue
+++ b/src/layouts/Seedream.vue
@@ -5,7 +5,7 @@
     >
       <slot name="config" />
     </div>
-    <div class="result h-full p-6 flex-1 flex flex-col bg-[var(--app-content-bg)]">
+    <div class="result h-full p-6 flex-1 flex flex-col min-w-0 overflow-x-hidden bg-[var(--app-content-bg)]">
       <slot name="result" />
     </div>
     <el-button


### PR DESCRIPTION
## Summary
- restore Seedream task spacing from 16px to Nano Banana's 10px
- restore Nano Banana's `min-w-0 overflow-x-hidden` containment on the Seedream result wrapper
- add 15px between the identity row and failure panel only when the failed task has no rendered prompt
- add regression coverage for undefined, empty, and non-empty prompts
- introduce no new card border, background, shadow, radius, or bespoke visual system

## Validation
- Seedream Preview SCSS matches Nano Banana Preview SCSS after the spacing restoration
- Seedream Layout matches Nano Banana Layout except component identity
- `npx vitest run src/components/seedream/task/Preview.test.ts`
- `npx eslint src/components/seedream/task/Preview.vue src/components/seedream/task/Preview.test.ts src/layouts/Seedream.vue`
- `npx prettier --check ...`
- `npx beachball check --branch origin/main`
- `npm run build:web`

## 🤖 对抗评审 (reviewer: claude-subagent, 2 rounds)
- Round 1 incorrectly treated baseline icon code as part of the PR and confused the layout wrapper with the inner image row; both findings were rebutted by the literal `git diff origin/main`.
- The review note claiming the test file was absent was also rebutted: `Preview.test.ts` is in the PR and its focused Vitest run passes.
- Round 2 exact-diff review: `VERDICT: CLEAN`.