### PR TITLE
Refine Suno variation and Seedance frame spacing

### DIFF
--- a/change/@acedatacloud-nexior-suno-seedance-local-controls.json
+++ b/change/@acedatacloud-nexior-suno-seedance-local-controls.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Improve local Suno variation controls and Seedance frame field spacing.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/seedance/ConfigPanel.vue
+++ b/src/components/seedance/ConfigPanel.vue
@@ -10,8 +10,8 @@
       <camera-fixed-switch class="mb-4" />
       <return-last-frame-switch class="mb-4" />
       <seed-input class="mb-4" />
-      <first-frame-image class="mb-2" />
-      <last-frame-image class="mb-2" />
+      <first-frame-image class="mb-4" />
+      <last-frame-image class="mb-4" />
       <reference-image class="mb-2" />
       <reference-audio class="mb-2" />
       <reference-video class="mb-2" />

--- a/src/components/seedance/config/FirstFrameImage.vue
+++ b/src/components/seedance/config/FirstFrameImage.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="capability.acceptsImage" class="relative">
-    <div class="flex justify-between">
+    <div class="flex min-h-8 items-center pr-20">
       <div class="flex justify-start items-center">
         <span class="text-sm font-bold">{{ $t('seedance.name.firstFrame') }}</span>
         <span v-if="capability.requiresImage" class="required-badge">

--- a/src/components/seedance/config/LastFrameImage.vue
+++ b/src/components/seedance/config/LastFrameImage.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="capability.acceptsLastFrame" class="relative">
-    <div class="flex justify-between">
+    <div class="flex min-h-8 items-center pr-20">
       <div class="flex justify-start items-center">
         <span class="text-sm font-bold">{{ $t('seedance.name.lastFrame') }}</span>
         <info-icon :content="$t('seedance.description.lastFrame')" />

--- a/src/components/suno/config/AdvancedParams.vue
+++ b/src/components/suno/config/AdvancedParams.vue
@@ -40,7 +40,7 @@
         <div class="flex items-center mb-1">
           <span class="text-xs font-bold">{{ $t('suno.name.variationCategory') }}</span>
         </div>
-        <el-radio-group v-model="variationCategory" size="small">
+        <el-radio-group v-model="variationCategory">
           <el-radio-button value="">{{ $t('suno.gender.auto') }}</el-radio-button>
           <el-radio-button value="high">{{ $t('suno.variation.high') }}</el-radio-button>
           <el-radio-button value="low">{{ $t('suno.variation.low') }}</el-radio-button>


### PR DESCRIPTION
## Summary

- restore the implementation to a fresh `origin/main` baseline
- enlarge only Suno Advanced Parameters `Variation Type` by removing its local `size="small"`
- give only Seedance First Frame Image and Last Frame Image title rows enough height and right-side room for their existing upload buttons
- increase spacing only around those two Seedance frame fields

## Explicitly unchanged

- Suno model dropdown and all other selects
- upload button sizes
- ordinary inputs and textareas
- generator panel widths
- shared/global CSS
- Suno Lyrics Mode and other scenarios

## Validation

- `npx vue-tsc --noEmit`
- `npm run lint:check`
- `npx prettier --check` on all touched files
- `npm run verify`
- `npm run build`
- browser geometry: Suno panel 320px, model 32px, upload 24px, footer buttons 32px, Variation Type 32px
- browser geometry: Seedance frame title rows 32px, upload buttons unchanged at 24px, 16px gap between First/Last Frame fields

## 🤖 对抗评审 (reviewer: copilot-explore, 1 round)

- Verified the staged diff is limited to four local components plus one Beachball record.
- Verified Lyrics Mode, upload sizes, shared CSS, generator widths, reference fields, and all other scenarios remain unchanged.
- `VERDICT: CLEAN`
