### PR TITLE
Fix cramped media fields across scenarios

### DIFF
--- a/change/@acedatacloud-nexior-scenario-media-spacing-local.json
+++ b/change/@acedatacloud-nexior-scenario-media-spacing-local.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Improve local media field spacing in Seedance, Kling, and Midjourney.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/kling/ConfigPanel.vue
+++ b/src/components/kling/ConfigPanel.vue
@@ -5,9 +5,9 @@
       <model-selector class="mb-4" />
       <ratio-selector class="mb-4" />
       <reference-images v-if="capabilities.referenceImages" class="mb-3" />
-      <reference-video v-if="capabilities.referenceVideo" class="mb-2" />
-      <start-image class="mb-2" />
-      <end-image class="mb-2" />
+      <reference-video v-if="capabilities.referenceVideo" class="mb-4" />
+      <start-image class="mb-4" />
+      <end-image class="mb-4" />
       <duration-selector class="mb-4" />
       <mode-selector class="mb-4" />
       <generate-audio-selector class="mb-4" />

--- a/src/components/kling/config/EndImage.vue
+++ b/src/components/kling/config/EndImage.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="relative">
-    <div class="flex justify-between">
+    <div class="flex min-h-8 items-center pr-20">
       <div class="flex justify-start items-center">
         <span class="text-sm font-bold">{{ $t('kling.name.endImage') }}</span>
         <info-icon :content="$t('kling.description.uploadEndImage')" />

--- a/src/components/kling/config/ReferenceVideo.vue
+++ b/src/components/kling/config/ReferenceVideo.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="relative">
-    <div class="flex justify-between">
+    <div class="flex min-h-8 items-center pr-20">
       <div class="flex justify-start items-center">
         <span class="text-sm font-bold">{{ $t('kling.name.referenceVideo') }}</span>
         <info-icon :content="$t('kling.description.omniReferenceVideo')" />

--- a/src/components/kling/config/StartImage.vue
+++ b/src/components/kling/config/StartImage.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="relative">
-    <div class="flex justify-between">
+    <div class="flex min-h-8 items-center pr-20">
       <div class="flex justify-start items-center">
         <span class="text-sm font-bold">{{ $t('kling.name.startImage') }}</span>
         <info-icon :content="$t('kling.description.uploadStartImage')" />

--- a/src/components/midjourney/ConfigPanel.vue
+++ b/src/components/midjourney/ConfigPanel.vue
@@ -6,7 +6,7 @@
           <div class="p-5">
             <model-selector class="mb-2" />
             <prompt-input class="mb-4" />
-            <reference-image class="mb-2" />
+            <reference-image class="mb-4" />
             <ratio-selector class="mb-4" />
             <quality-selector class="mb-4" />
             <version-selector v-if="!isNiji" class="mb-4" />
@@ -25,8 +25,8 @@
         <el-tab-pane :label="$t('midjourney.tab.videos')" name="videos">
           <div class="p-5">
             <video-from-input v-show="config?.action === 'extend'" class="mb-4" />
-            <image-url-input class="mb-2" />
-            <end-image-url-input class="mb-2" />
+            <image-url-input class="mb-4" />
+            <end-image-url-input class="mb-4" />
             <loop-selector class="mb-2" />
             <resolution-selector class="mb-4" />
             <prompt-input class="mb-4" />
@@ -34,7 +34,7 @@
         </el-tab-pane>
         <el-tab-pane :label="$t('midjourney.tab.describe')" name="describe">
           <div class="p-5">
-            <image-url-input2 class="mb-2" />
+            <image-url-input2 class="mb-4" />
           </div>
         </el-tab-pane>
       </el-tabs>

--- a/src/components/midjourney/config/EndImageUrlInput.vue
+++ b/src/components/midjourney/config/EndImageUrlInput.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="relative">
-    <div class="flex justify-between">
+    <div class="flex min-h-8 items-center pr-20">
       <div class="flex justify-start items-center">
         <span class="text-sm font-bold">{{ $t('midjourney.name.endImageUrl') }}</span>
         <info-icon :content="$t('midjourney.description.endImageUrl')" />

--- a/src/components/midjourney/config/ImageUrlInput.vue
+++ b/src/components/midjourney/config/ImageUrlInput.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="relative">
-    <div class="flex justify-between">
+    <div class="flex min-h-8 items-center pr-20">
       <div class="flex justify-start items-center">
         <span class="text-sm font-bold">
           {{ $t('midjourney.name.imageUrl') }}

--- a/src/components/midjourney/config/ImageUrlInput2.vue
+++ b/src/components/midjourney/config/ImageUrlInput2.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="relative">
-    <div class="flex justify-between">
+    <div class="flex min-h-8 items-center pr-20">
       <div class="flex justify-start items-center">
         <span class="text-sm font-bold">{{ $t('midjourney.name.imageUrl2') }}</span>
         <info-icon :content="$t('midjourney.description.imageUrl2')" />

--- a/src/components/midjourney/config/ReferenceImage.vue
+++ b/src/components/midjourney/config/ReferenceImage.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="relative">
-    <div class="flex justify-between">
+    <div class="flex min-h-8 items-center pr-20">
       <div class="flex justify-start items-center">
         <span class="text-sm font-bold">{{ $t('midjourney.name.referenceImage') }}</span>
         <info-icon :content="$t('midjourney.description.uploadReferences')" />

--- a/src/components/seedance/ConfigPanel.vue
+++ b/src/components/seedance/ConfigPanel.vue
@@ -12,9 +12,9 @@
       <seed-input class="mb-4" />
       <first-frame-image class="mb-4" />
       <last-frame-image class="mb-4" />
-      <reference-image class="mb-2" />
-      <reference-audio class="mb-2" />
-      <reference-video class="mb-2" />
+      <reference-image class="mb-4" />
+      <reference-audio class="mb-4" />
+      <reference-video class="mb-4" />
     </div>
     <div class="flex flex-col items-center justify-center px-5 pb-5">
       <consumption :value="consumption" :service="service" />

--- a/src/components/seedance/config/ReferenceAudio.vue
+++ b/src/components/seedance/config/ReferenceAudio.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="capability.acceptsReferenceAudio" class="relative">
-    <div class="flex justify-between">
+    <div class="flex min-h-8 items-center pr-20">
       <div class="flex justify-start items-center">
         <span class="text-sm font-bold">{{ $t('seedance.name.referenceAudio') }}</span>
         <info-icon :content="$t('seedance.description.referenceAudio')" />

--- a/src/components/seedance/config/ReferenceImage.vue
+++ b/src/components/seedance/config/ReferenceImage.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="capability.acceptsReferenceImage" class="relative">
-    <div class="flex justify-between">
+    <div class="flex min-h-8 items-center pr-20">
       <div class="flex justify-start items-center">
         <span class="text-sm font-bold">{{ $t('seedance.name.referenceImage') }}</span>
         <info-icon :content="$t('seedance.description.referenceImage')" />

--- a/src/components/seedance/config/ReferenceVideo.vue
+++ b/src/components/seedance/config/ReferenceVideo.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="capability.acceptsReferenceVideo" class="relative">
-    <div class="flex justify-between">
+    <div class="flex min-h-8 items-center pr-20">
       <div class="flex justify-start items-center">
         <span class="text-sm font-bold">{{ $t('seedance.name.referenceVideo') }}</span>
         <info-icon :content="$t('seedance.description.referenceVideo')" />


### PR DESCRIPTION
## Summary

- add local vertical room around Seedance 2.0 reference image/audio/video fields
- add local vertical room around Kling reference video/start/end frame fields
- add local vertical room around Midjourney reference/video/describe image fields
- preserve all upload button, select, input, sidebar, and shared CSS sizing

## Audit evidence

Measured net distance from each 24px absolute upload button to the following field:

- before: Seedance 2.0 reference fields `-1px`, Kling frame fields `-1px`, Midjourney image fields `-1px`
- after: all touched fields `19px`
- unchanged controls: upload buttons remain `24px`
- intentionally untouched: Luma, GrokVideo, and Pixverse measured `7px`; Flux, Hailuo, Sora, and Wan already use `mb-4`

## Validation

- `npx vue-tsc --noEmit`
- `npm run lint:check`
- `npx prettier --check` on all touched files
- `npm run verify`
- `npm run build`
- browser geometry across Seedance 2.0, Kling, and all Midjourney tabs
- long-label stress test in 320px panel: row expanded from 32px to 80px, `clientHeight == scrollHeight`, no clipping, upload remained 24px

## 🤖 对抗评审 (reviewer: copilot-explore, 3 rounds)

- RISK: First/Last Frame files appeared out of scope -> rejected: they were merged in PR 1349 and are absent from this diff.
- RISK: long localized labels might clip -> rejected with browser stress test showing natural row growth to 80px and visible overflow.
- Round 3: `VERDICT: CLEAN`
