### PR TITLE
fix: use failure styling for Pixverse errors

### DIFF
--- a/change/@acedatacloud-nexior-8981dc54-3e74-406a-b00a-a4fd957cf754.json
+++ b/change/@acedatacloud-nexior-8981dc54-3e74-406a-b00a-a4fd957cf754.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Render failed Pixverse tasks with failure alert semantics.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/pixverse/task/Preview.test.ts
+++ b/src/components/pixverse/task/Preview.test.ts
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+import { shallowMount } from '@vue/test-utils';
+import { ElAlert } from 'element-plus';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/components/common/VideoPlayer.vue', () => ({
+  default: { name: 'VideoPlayer', template: '<div />' }
+}));
+
+import Preview from './Preview.vue';
+
+describe('pixverse/task/Preview', () => {
+  it('renders failed tasks with failure semantics', () => {
+    const wrapper = shallowMount(Preview, {
+      props: {
+        modelValue: {
+          id: 'task-1',
+          request: { prompt: 'A lighthouse', model: 'pixverse-v4.5' },
+          response: {
+            success: false,
+            task_id: 'task-1',
+            error: { message: 'generation failed' },
+            trace_id: 'trace-1'
+          }
+        }
+      },
+      global: {
+        mocks: {
+          $t: (key: string) => key,
+          $dayjs: { format: () => '2026-07-19' }
+        }
+      }
+    });
+
+    const alert = wrapper.findComponent(ElAlert);
+    expect(alert.classes()).toContain('failure');
+    expect(alert.classes()).not.toContain('info');
+  });
+});

--- a/src/components/pixverse/task/Preview.vue
+++ b/src/components/pixverse/task/Preview.vue
@@ -72,7 +72,7 @@
       </div>
       <!-- Display error message -->
       <div v-if="modelValue?.response?.success === false" :class="{ content: true }">
-        <el-alert :closable="false" class="info">
+        <el-alert :closable="false" class="failure">
           <template #template>
             <warning-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
             {{ $t('pixverse.name.failure') }}


### PR DESCRIPTION
## 改动
- Pixverse 历史任务在 `response.success === false` 时，`el-alert` 从 `info` 语义改为 `failure` 语义
- 增加组件回归测试，锁定失败任务使用 `failure` class，不能退回 `info`
- 不修改任务间距、尺寸、文案、数据结构或成功/生成中状态

## 预期视觉变化
- 页面：`/pixverse` 历史任务列表
- 状态：仅失败任务
- 变化：失败信息块左侧边界/强调色从 info 色变为 danger/failure 红色，与其他生成场景一致
- 不变：信息块位置、高度、内边距、任务之间距离、成功任务和生成中任务

## 请重点检查
1. 找一条 Pixverse 失败任务，确认错误块左侧为红色 failure 边界
2. 确认 failure reason、task ID、elapsed、trace ID 仍正常显示
3. 确认成功任务和正在生成任务没有视觉变化
4. 分别看 light / dark mode

## 验证
- `npx vitest run src/components/pixverse/task/Preview.test.ts`
- `npx eslint src/components/pixverse/task/Preview.vue src/components/pixverse/task/Preview.test.ts`
- `npx prettier --check ...`
- `npx beachball check --branch origin/main`
- `npm run build:web`
- `git diff --check`

## 🤖 对抗评审
- reviewer: Codex via Ace Data Cloud Responses endpoint
- `VERDICT: CLEAN`

> 此 PR 仅供检查，不启用 auto-merge，不会由 agent 提前合并。