### PR TITLE
fix: label Flux tasks as pending

### DIFF
--- a/change/@acedatacloud-nexior-d594a1ec-d83b-47af-a628-5a8a8b6619d1.json
+++ b/change/@acedatacloud-nexior-d594a1ec-d83b-47af-a628-5a8a8b6619d1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Label Flux tasks without a response as pending instead of failed.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/flux/task/Preview.test.ts
+++ b/src/components/flux/task/Preview.test.ts
@@ -1,0 +1,32 @@
+// @vitest-environment jsdom
+import { shallowMount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+
+import Preview from './Preview.vue';
+
+describe('flux/task/Preview', () => {
+  it('labels tasks without a response as pending rather than failed', () => {
+    const wrapper = shallowMount(Preview, {
+      props: {
+        modelValue: {
+          id: 'task-1',
+          request: { prompt: 'A lighthouse', model: 'flux-dev' }
+        }
+      },
+      global: {
+        stubs: {
+          ElAlert: { template: '<div><slot name="template" /><slot /></div>' }
+        },
+        mocks: {
+          $t: (key: string) => key,
+          $dayjs: { format: () => '2026-07-19' }
+        }
+      }
+    });
+
+    expect(wrapper.text()).toContain('flux.status.pending');
+    expect(wrapper.text()).not.toContain('flux.name.failure');
+    expect(wrapper.findComponent({ name: 'TimeIcon' }).exists()).toBe(true);
+    expect(wrapper.findComponent({ name: 'WarningIcon' }).exists()).toBe(false);
+  });
+});

--- a/src/components/flux/task/Preview.vue
+++ b/src/components/flux/task/Preview.vue
@@ -82,8 +82,8 @@
       <div v-if="!modelValue?.response" :class="{ content: true }">
         <el-alert :closable="false" class="info">
           <template #template>
-            <warning-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
-            {{ $t('flux.name.failure') }}
+            <time-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
+            {{ $t('flux.status.pending') }}
           </template>
           <p class="text-[var(--el-text-color-regular)] text-xs mb-0">
             <magic-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />


### PR DESCRIPTION
## 改动
- Flux 历史任务在尚未收到 response 时，状态标题从 `Failure` 改为 `Pending`
- 图标从 warning 改为 time，和 pending 语义一致
- 增加回归测试，确保 pending 分支不再出现 failure 文案或 warning icon
- 不修改真实失败分支、成功分支、任务间距、信息块尺寸或 API 请求

## 预期视觉变化
- 页面：`/flux` 历史任务列表
- 状态：仅尚未返回 response 的任务
- 变化：灰色 info alert 内的标题从 Failure 变为 Pending，图标从警告变为时钟
- 不变：失败任务仍显示红色 Failure；成功任务和全部间距不变

## 请重点检查
1. 提交一个 Flux 任务后，在等待期间确认 alert 标题为 Pending
2. 确认等待期间不再出现警告图标或 Failure 文案
3. 确认真实失败任务仍显示原来的 failure reason / task ID / trace ID
4. 确认任务位置、高度、上下间距没有变化

## 验证
- `npx vitest run src/components/flux/task/Preview.test.ts`
- `npx beachball check --branch origin/main`
- ESLint / Prettier
- `npm run build:web`
- `git diff --check origin/main...HEAD`

## 🤖 对抗评审
- Round 1 误读了已合并的 Pixverse PR；变基最新 main 后限定 exact committed diff 复审
- Round 2: `VERDICT: CLEAN`

> 此 PR 仅供检查，不启用 auto-merge，不会由 agent 提前合并。