### PR TITLE
fix: clarify OpenAI Image task states

### DIFF
--- a/change/@acedatacloud-nexior-07a96f38-524e-498d-8a2f-0831ab220506.json
+++ b/change/@acedatacloud-nexior-07a96f38-524e-498d-8a2f-0831ab220506.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Label OpenAI Image pending and unknown tasks without failure copy.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/openaiimage/task/Preview.test.ts
+++ b/src/components/openaiimage/task/Preview.test.ts
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+import { shallowMount } from '@vue/test-utils';
+import { describe, expect, it, vi } from 'vitest';
+import type { IOpenAIImageTask } from '@/models';
+
+vi.mock('@/components/common/ImageWrapper.vue', () => ({
+  default: { name: 'ImageWrapper', template: '<div />' }
+}));
+
+import Preview from './Preview.vue';
+
+const mountPreview = (response?: IOpenAIImageTask['response']) =>
+  shallowMount(Preview, {
+    props: {
+      modelValue: {
+        id: 'task-1',
+        request: { prompt: 'A lighthouse', model: 'gpt-image-1', size: '1024x1024' },
+        ...(response === undefined ? {} : { response })
+      }
+    },
+    global: {
+      stubs: {
+        ElAlert: { template: '<div><slot name="template" /><slot /></div>' }
+      },
+      mocks: {
+        $t: (key: string) => key,
+        $dayjs: { format: () => '2026-07-19' },
+        $store: { state: { openaiimage: { config: {} } }, commit: () => undefined }
+      }
+    }
+  });
+
+describe('openaiimage/task/Preview', () => {
+  it('labels tasks without a response as pending', () => {
+    const wrapper = mountPreview();
+
+    expect(wrapper.text()).toContain('openaiimage.status.pending');
+    expect(wrapper.text()).not.toContain('openaiimage.name.failure');
+    expect(wrapper.findComponent({ name: 'TimeIcon' }).exists()).toBe(true);
+  });
+
+  it('labels responses without an outcome as status', () => {
+    const wrapper = mountPreview({ task_id: 'task-1' } as IOpenAIImageTask['response']);
+
+    expect(wrapper.text()).toContain('openaiimage.name.status');
+    expect(wrapper.text()).not.toContain('openaiimage.name.failure');
+    expect(wrapper.findComponent({ name: 'InfoIcon' }).exists()).toBe(true);
+  });
+});

--- a/src/components/openaiimage/task/Preview.vue
+++ b/src/components/openaiimage/task/Preview.vue
@@ -132,8 +132,15 @@
       <div v-else :class="{ content: true }">
         <el-alert :closable="false" class="info">
           <template #template>
-            <warning-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
-            {{ $t('openaiimage.name.failure') }}
+            <time-icon
+              v-if="!modelValue?.response"
+              class="mr-1"
+              :size="'1em' as any"
+              aria-hidden="true"
+              focusable="false"
+            />
+            <info-icon v-else class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
+            {{ $t(modelValue?.response ? 'openaiimage.name.status' : 'openaiimage.status.pending') }}
           </template>
           <p v-if="modelValue?.request?.model" class="text-[var(--el-text-color-regular)] text-xs mb-2">
             <application-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />


### PR DESCRIPTION
## Summary
- show a clock icon and Pending title when an OpenAI Image task has no response yet
- show an info icon and Status title for legacy/unknown responses without a success outcome
- keep explicit failure tasks on the existing warning icon and Failure title
- add focused regression coverage for pending and unknown response states

## Expected UI changes
- `/openaiimage`: newly submitted history items waiting for a response display **Pending** instead of **Failure**
- legacy responses that exist but have no `success` outcome display **Status** instead of **Failure**
- explicit `success === false` rows remain visually and semantically unchanged
- spacing, dimensions, output media, action buttons, and metadata layout do not change

## What to review
1. Submit or inspect a task with no response: clock icon + Pending title
2. Inspect a legacy/unknown response: info icon + Status title
3. Inspect a real failed task: warning icon + Failure title remains
4. Confirm no spacing or sizing changed in success/failure rows

## Validation
- `npx vitest run src/components/openaiimage/task/Preview.test.ts`
- `npx eslint src/components/openaiimage/task/Preview.vue src/components/openaiimage/task/Preview.test.ts`
- `npx prettier --check ...`
- `npx beachball check --branch origin/main`
- `npm run build:web`
- `git diff --check origin/main...HEAD`

## 🤖 对抗评审 (reviewer: codex, 1 round)
- `VERDICT: CLEAN`

This PR targets `main`, is independent of the still-open Flux PR, and is intentionally left open for manual review. No auto-merge is enabled.