### PR TITLE
fix: distinguish failed Fish tasks

### DIFF
--- a/change/@acedatacloud-nexior-beaa290f-541d-4be8-8b70-aa9deb9ad5f7.json
+++ b/change/@acedatacloud-nexior-beaa290f-541d-4be8-8b70-aa9deb9ad5f7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Show failed Fish TTS tasks separately from pending tasks with failure reason and trace details.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/fish/task/Preview.test.ts
+++ b/src/components/fish/task/Preview.test.ts
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+import { mount } from '@vue/test-utils';
+import { ElAlert } from 'element-plus';
+import { describe, expect, it } from 'vitest';
+import type { IFishTask } from '@/models';
+import Preview from './Preview.vue';
+
+const mountTask = (modelValue: IFishTask) =>
+  mount(Preview, {
+    props: { modelValue },
+    global: {
+      mocks: {
+        $t: (key: string) => key,
+        $dayjs: { format: () => '2026-07-19' }
+      },
+      stubs: {
+        'capability-presentation': true
+      }
+    }
+  });
+
+describe('fish/task/Preview', () => {
+  it('renders explicit failures with reason and trace metadata', () => {
+    const wrapper = mountTask({
+      id: 'task-1',
+      request: { text: 'Hello' },
+      response: {
+        success: false,
+        error: { message: 'voice unavailable' },
+        trace_id: 'trace-1'
+      }
+    });
+
+    const alert = wrapper.findComponent(ElAlert);
+    expect(alert.classes()).toContain('failure');
+    expect(wrapper.text()).toContain('fish.name.failure');
+    expect(wrapper.text()).toContain('voice unavailable');
+    expect(wrapper.text()).toContain('trace-1');
+  });
+
+  it('keeps tasks without a response in the pending info state', () => {
+    const wrapper = mountTask({
+      id: 'task-2',
+      request: { text: 'Hello' }
+    });
+
+    const alert = wrapper.findComponent(ElAlert);
+    expect(alert.classes()).toContain('info');
+    expect(alert.classes()).not.toContain('failure');
+    expect(wrapper.text()).toContain('fish.status.pending');
+  });
+
+  it('treats error-only responses as failures', () => {
+    const wrapper = mountTask({
+      id: 'task-3',
+      response: {
+        error: 'upstream timeout',
+        trace_id: 'trace-3'
+      }
+    });
+
+    const alert = wrapper.findComponent(ElAlert);
+    expect(alert.classes()).toContain('failure');
+    expect(wrapper.text()).toContain('fish.name.failure');
+    expect(wrapper.text()).toContain('upstream timeout');
+  });
+});

--- a/src/components/fish/task/Preview.vue
+++ b/src/components/fish/task/Preview.vue
@@ -46,7 +46,35 @@
           </p>
         </el-alert>
       </div>
-      <!-- Pending / no audio yet -->
+      <!-- Failure -->
+      <div v-else-if="isFailure" class="content">
+        <el-alert :closable="false" class="failure">
+          <template #title>
+            <warning-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
+            {{ $t('fish.name.failure') }}
+          </template>
+          <p class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <magic-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
+            {{ $t('fish.name.taskId') }}: {{ modelValue?.id }}
+            <copy-to-clipboard :content="modelValue?.id" />
+          </p>
+          <p v-if="failureReason" class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <info-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
+            {{ $t('fish.name.failureReason') }}: {{ failureReason }}
+            <copy-to-clipboard :content="failureReason" />
+          </p>
+          <p v-if="modelValue?.elapsed" class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <time-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
+            {{ $t('fish.name.elapsed') }}: {{ modelValue?.elapsed?.toFixed(2) }}s
+          </p>
+          <p v-if="modelValue?.response?.trace_id" class="text-[var(--el-text-color-regular)] text-xs mb-0">
+            <channel-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
+            {{ $t('fish.name.traceId') }}: {{ modelValue?.response?.trace_id }}
+            <copy-to-clipboard :content="modelValue?.response?.trace_id" />
+          </p>
+        </el-alert>
+      </div>
+      <!-- Pending / no response yet -->
       <div v-else class="content">
         <el-alert :closable="false" class="info">
           <p class="text-[var(--el-text-color-regular)] text-xs mb-0">
@@ -61,7 +89,15 @@
 </template>
 
 <script lang="ts">
-import { CpuIcon, MagicIcon, MicrophoneIcon, TimeIcon } from '@acedatacloud/core/icons/components';
+import {
+  ChannelIcon,
+  CpuIcon,
+  InfoIcon,
+  MagicIcon,
+  MicrophoneIcon,
+  TimeIcon,
+  WarningIcon
+} from '@acedatacloud/core/icons/components';
 import { defineComponent } from 'vue';
 import { ElAlert, ElButton } from 'element-plus';
 import { IFishTask } from '@/models';
@@ -71,10 +107,13 @@ import ApiCodeButton from '@/components/common/ApiCodeButton.vue';
 export default defineComponent({
   name: 'FishTaskPreview',
   components: {
+    ChannelIcon,
     CpuIcon,
+    InfoIcon,
     MagicIcon,
     MicrophoneIcon,
     TimeIcon,
+    WarningIcon,
     CopyToClipboard,
     ElAlert,
     ElButton,
@@ -92,6 +131,13 @@ export default defineComponent({
     },
     audioUrl(): string | undefined {
       return this.modelValue?.response?.audio_url;
+    },
+    isFailure(): boolean {
+      return this.modelValue?.response?.success === false || !!this.modelValue?.response?.error;
+    },
+    failureReason(): string | undefined {
+      const error = this.modelValue?.response?.error;
+      return typeof error === 'string' ? error : error?.message;
     }
   },
   methods: {

--- a/src/i18n/ar/fish.json
+++ b/src/i18n/ar/fish.json
@@ -322,5 +322,17 @@
   "script.passage4": {
     "message": "واحد اثنان ثلاثة أربعة خمسة ستة سبعة ثمانية تسعة عشرة، صفر واحد اثنان ثلاثة أربعة خمسة ستة سبعة ثمانية تسعة. اليوم هو الإثنين، الإثنين المقبل عطلة، والإثنين الذي يليه سنبدأ مشروعاً جديداً. يرجى قراءة هذه الفقرة بوضوح، دون التوقف لفترة طويلة.",
     "description": "فقرة نموذجية للتسجيل 4 (الأرقام والنطق)"
+  },
+  "name.failure": {
+    "message": "Generation failed",
+    "description": "Fish task failure title"
+  },
+  "name.failureReason": {
+    "message": "Failure reason",
+    "description": "Fish task failure reason label"
+  },
+  "name.traceId": {
+    "message": "Trace ID",
+    "description": "Fish task trace ID label"
   }
 }

--- a/src/i18n/de/fish.json
+++ b/src/i18n/de/fish.json
@@ -322,5 +322,17 @@
   "script.passage4": {
     "message": "Eins zwei drei vier fünf sechs sieben acht neun zehn, null Punkt eins zwei drei vier fünf sechs sieben acht neun. Heute ist Montag, nächste Woche Montag ist Feiertag, und übernächste Woche Montag beginnt das neue Projekt. Bitte lesen Sie diesen Text klar und deutlich vor, ohne zu lange Pausen zu machen.",
     "description": "Fish Aufnahmebeispielabschnitt 4 (Zahlen und Aussprache)"
+  },
+  "name.failure": {
+    "message": "Generation failed",
+    "description": "Fish task failure title"
+  },
+  "name.failureReason": {
+    "message": "Failure reason",
+    "description": "Fish task failure reason label"
+  },
+  "name.traceId": {
+    "message": "Trace ID",
+    "description": "Fish task trace ID label"
   }
 }

--- a/src/i18n/el/fish.json
+++ b/src/i18n/el/fish.json
@@ -322,5 +322,17 @@
   "script.passage4": {
     "message": "Ένα, δύο, τρία, τέσσερα, πέντε, έξι, επτά, οκτώ, εννέα, δέκα, μηδέν, ένα, δύο, τρία, τέσσερα, πέντε, έξι, επτά, οκτώ, εννέα. Σήμερα είναι Δευτέρα, την επόμενη Δευτέρα είναι αργία, την μεθεπόμενη Δευτέρα θα ξεκινήσει το νέο έργο. Παρακαλώ διαβάστε αυτό το κείμενο καθαρά, χωρίς να σταματήσετε για πολύ.",
     "description": "Δείγμα ηχογράφησης Fish, παράγραφος 4 (αριθμοί και προφορά)"
+  },
+  "name.failure": {
+    "message": "Generation failed",
+    "description": "Fish task failure title"
+  },
+  "name.failureReason": {
+    "message": "Failure reason",
+    "description": "Fish task failure reason label"
+  },
+  "name.traceId": {
+    "message": "Trace ID",
+    "description": "Fish task trace ID label"
   }
 }

--- a/src/i18n/en/fish.json
+++ b/src/i18n/en/fish.json
@@ -27,6 +27,18 @@
     "message": "Elapsed",
     "description": "Fish task elapsed time label"
   },
+  "name.failure": {
+    "message": "Generation failed",
+    "description": "Fish task failure title"
+  },
+  "name.failureReason": {
+    "message": "Failure reason",
+    "description": "Fish task failure reason label"
+  },
+  "name.traceId": {
+    "message": "Trace ID",
+    "description": "Fish task trace ID label"
+  },
   "name.fishBot": {
     "message": "Fish Audio",
     "description": "Fish task card bot name"
@@ -89,7 +101,8 @@
   },
   "message.noVoices": {
     "message": "No voice models yet",
-    "description": "Fish voice picker empty state"  },
+    "description": "Fish voice picker empty state"
+  },
   "name.voiceTitle": {
     "message": "Name",
     "description": "Fish voice model title label"

--- a/src/i18n/es/fish.json
+++ b/src/i18n/es/fish.json
@@ -322,5 +322,17 @@
   "script.passage4": {
     "message": "Uno, dos, tres, cuatro, cinco, seis, siete, ocho, nueve, diez, cero, uno, dos, tres, cuatro, cinco, seis, siete, ocho, nueve. Hoy es lunes, el próximo lunes es festivo, y el lunes siguiente comenzaremos un nuevo proyecto. Por favor, lee este texto claramente, sin pausas demasiado largas.",
     "description": "Ejemplo de grabación de Fish, párrafo 4 (números y pronunciación)."
+  },
+  "name.failure": {
+    "message": "Generation failed",
+    "description": "Fish task failure title"
+  },
+  "name.failureReason": {
+    "message": "Failure reason",
+    "description": "Fish task failure reason label"
+  },
+  "name.traceId": {
+    "message": "Trace ID",
+    "description": "Fish task trace ID label"
   }
 }

--- a/src/i18n/fi/fish.json
+++ b/src/i18n/fi/fish.json
@@ -322,5 +322,17 @@
   "script.passage4": {
     "message": "Yksi, kaksi, kolme, neljä, viisi, kuusi, seitsemän, kahdeksan, yhdeksän, kymmenen, nolla, yksi, kaksi, kolme, neljä, viisi, kuusi, seitsemän, kahdeksan, yhdeksän. Tänään on maanantai, ensi maanantai on lomaa, ja seuraava maanantai alkaa uusi projekti. Ole hyvä ja lue tämä lause selkeästi loppuun, älä pidä liian pitkiä taukoja.",
     "description": "Fish äänitysdemonstraatio kappale 4 (numerot ja ääntämisen kattavuus)"
+  },
+  "name.failure": {
+    "message": "Generation failed",
+    "description": "Fish task failure title"
+  },
+  "name.failureReason": {
+    "message": "Failure reason",
+    "description": "Fish task failure reason label"
+  },
+  "name.traceId": {
+    "message": "Trace ID",
+    "description": "Fish task trace ID label"
   }
 }

--- a/src/i18n/fr/fish.json
+++ b/src/i18n/fr/fish.json
@@ -322,5 +322,17 @@
   "script.passage4": {
     "message": "Un, deux, trois, quatre, cinq, six, sept, huit, neuf, dix, zéro, un, deux, trois, quatre, cinq, six, sept, huit, neuf. Aujourd'hui, c'est lundi, le lundi prochain est un jour de congé, et le lundi d'après, nous commencerons un nouveau projet. Veuillez lire ce passage clairement, sans trop de pauses.",
     "description": "Fish extrait d'enregistrement exemple 4 (chiffres et couverture de prononciation)"
+  },
+  "name.failure": {
+    "message": "Generation failed",
+    "description": "Fish task failure title"
+  },
+  "name.failureReason": {
+    "message": "Failure reason",
+    "description": "Fish task failure reason label"
+  },
+  "name.traceId": {
+    "message": "Trace ID",
+    "description": "Fish task trace ID label"
   }
 }

--- a/src/i18n/it/fish.json
+++ b/src/i18n/it/fish.json
@@ -322,5 +322,17 @@
   "script.passage4": {
     "message": "Uno due tre quattro cinque sei sette otto nove dieci, zero punto uno due tre quattro cinque sei sette otto nove. Oggi è lunedì, lunedì prossimo è festa, e lunedì dopo inizieremo un nuovo progetto. Per favore, leggi questo passaggio chiaramente, senza pause troppo lunghe.",
     "description": "Fish esempio di registrazione paragrafo 4 (numeri e copertura della pronuncia)"
+  },
+  "name.failure": {
+    "message": "Generation failed",
+    "description": "Fish task failure title"
+  },
+  "name.failureReason": {
+    "message": "Failure reason",
+    "description": "Fish task failure reason label"
+  },
+  "name.traceId": {
+    "message": "Trace ID",
+    "description": "Fish task trace ID label"
   }
 }

--- a/src/i18n/ja/fish.json
+++ b/src/i18n/ja/fish.json
@@ -322,5 +322,17 @@
   "script.passage4": {
     "message": "一二三四五六七八九十、零点一二三四五六七八九。今日は月曜日で、来週の月曜日は休暇、再来週の月曜日には新しいプロジェクトが始まります。この文をはっきりと読んで、あまり長く止まらないでください。",
     "description": "Fish 録音デモ段落 4（数字と発音のカバー）"
+  },
+  "name.failure": {
+    "message": "Generation failed",
+    "description": "Fish task failure title"
+  },
+  "name.failureReason": {
+    "message": "Failure reason",
+    "description": "Fish task failure reason label"
+  },
+  "name.traceId": {
+    "message": "Trace ID",
+    "description": "Fish task trace ID label"
   }
 }

--- a/src/i18n/ko/fish.json
+++ b/src/i18n/ko/fish.json
@@ -322,5 +322,17 @@
   "script.passage4": {
     "message": "일이삼사오육칠팔구십, 영점일이삼사오육칠팔구. 오늘은 월요일이고, 다음 주 월요일은 휴일이며, 그 다음 주 월요일에는 새로운 프로젝트가 시작됩니다. 이 문장을 명확하게 읽어주세요, 너무 오랫동안 멈추지 마세요.",
     "description": "Fish 녹음 시연 단락 4 (숫자 및 발음 커버)"
+  },
+  "name.failure": {
+    "message": "Generation failed",
+    "description": "Fish task failure title"
+  },
+  "name.failureReason": {
+    "message": "Failure reason",
+    "description": "Fish task failure reason label"
+  },
+  "name.traceId": {
+    "message": "Trace ID",
+    "description": "Fish task trace ID label"
   }
 }

--- a/src/i18n/pl/fish.json
+++ b/src/i18n/pl/fish.json
@@ -322,5 +322,17 @@
   "script.passage4": {
     "message": "Jeden, dwa, trzy, cztery, pięć, sześć, siedem, osiem, dziewięć, dziesięć, zero, jeden, dwa, trzy, cztery, pięć, sześć, siedem, osiem, dziewięć. Dzisiaj jest poniedziałek, w przyszły poniedziałek mamy wolne, a za dwa tygodnie zaczynamy nowy projekt. Proszę, przeczytaj ten tekst wyraźnie, nie zatrzymuj się zbyt długo.",
     "description": "Fish fragment nagrania demonstracyjnego 4 (cyfry i wymowa)"
+  },
+  "name.failure": {
+    "message": "Generation failed",
+    "description": "Fish task failure title"
+  },
+  "name.failureReason": {
+    "message": "Failure reason",
+    "description": "Fish task failure reason label"
+  },
+  "name.traceId": {
+    "message": "Trace ID",
+    "description": "Fish task trace ID label"
   }
 }

--- a/src/i18n/pt/fish.json
+++ b/src/i18n/pt/fish.json
@@ -322,5 +322,17 @@
   "script.passage4": {
     "message": "Um dois três quatro cinco seis sete oito nove dez, zero um dois três quatro cinco seis sete oito nove. Hoje é segunda-feira, na próxima segunda é feriado, na outra segunda começaremos um novo projeto. Por favor, leia este trecho claramente, sem pausas longas.",
     "description": "Trecho de gravação de demonstração 4 (números e cobertura de pronúncia)."
+  },
+  "name.failure": {
+    "message": "Generation failed",
+    "description": "Fish task failure title"
+  },
+  "name.failureReason": {
+    "message": "Failure reason",
+    "description": "Fish task failure reason label"
+  },
+  "name.traceId": {
+    "message": "Trace ID",
+    "description": "Fish task trace ID label"
   }
 }

--- a/src/i18n/ru/fish.json
+++ b/src/i18n/ru/fish.json
@@ -322,5 +322,17 @@
   "script.passage4": {
     "message": "Один два три четыре пять шесть семь восемь девять десять, ноль один два три четыре пять шесть семь восемь девять. Сегодня понедельник, в следующем понедельнике выходной, а через понедельник начнётся новый проект. Пожалуйста, прочитайте этот текст чётко, не делая слишком долгих пауз.",
     "description": "Fish запись демонстрационного абзаца 4 (цифры и произношение)"
+  },
+  "name.failure": {
+    "message": "Generation failed",
+    "description": "Fish task failure title"
+  },
+  "name.failureReason": {
+    "message": "Failure reason",
+    "description": "Fish task failure reason label"
+  },
+  "name.traceId": {
+    "message": "Trace ID",
+    "description": "Fish task trace ID label"
   }
 }

--- a/src/i18n/sr/fish.json
+++ b/src/i18n/sr/fish.json
@@ -322,5 +322,17 @@
   "script.passage4": {
     "message": "Jedan, dva, tri, četiri, pet, šest, sedam, osam, devet, deset, nula, jedan, dva, tri, četiri, pet, šest, sedam, osam, devet. Danas je ponedeljak, sledeći ponedeljak je praznik, a sledeći ponedeljak počinjemo novi projekat. Molim vas, pročitajte ovaj deo jasno, ne pravite preduge pauze.",
     "description": "Fish snimak demonstracionog pasusa 4 (brojevi i izgovor)"
+  },
+  "name.failure": {
+    "message": "Generation failed",
+    "description": "Fish task failure title"
+  },
+  "name.failureReason": {
+    "message": "Failure reason",
+    "description": "Fish task failure reason label"
+  },
+  "name.traceId": {
+    "message": "Trace ID",
+    "description": "Fish task trace ID label"
   }
 }

--- a/src/i18n/sv/fish.json
+++ b/src/i18n/sv/fish.json
@@ -322,5 +322,17 @@
   "script.passage4": {
     "message": "Ett, två, tre, fyra, fem, sex, sju, åtta, nio, tio, noll, ett, två, tre, fyra, fem, sex, sju, åtta, nio. Idag är det måndag, nästa måndag är det ledigt, och måndagen därpå börjar vi med ett nytt projekt. Vänligen läs denna text tydligt utan att pausa för länge.",
     "description": "Fish inspelningsdemopassage 4 (nummer och uttalstäckning)"
+  },
+  "name.failure": {
+    "message": "Generation failed",
+    "description": "Fish task failure title"
+  },
+  "name.failureReason": {
+    "message": "Failure reason",
+    "description": "Fish task failure reason label"
+  },
+  "name.traceId": {
+    "message": "Trace ID",
+    "description": "Fish task trace ID label"
   }
 }

--- a/src/i18n/uk/fish.json
+++ b/src/i18n/uk/fish.json
@@ -322,5 +322,17 @@
   "script.passage4": {
     "message": "Один, два, три, чотири, п’ять, шість, сім, вісім, дев’ять, десять, нуль, один, два, три, чотири, п’ять, шість, сім, вісім, дев’ять. Сьогодні понеділок, наступного понеділка — вихідний, а через понеділок почнеться новий проект. Будь ласка, прочитайте цей текст чітко, не роблячи занадто довгих пауз.",
     "description": "Fish запис демонстраційного абзацу 4 (числа та вимова)"
+  },
+  "name.failure": {
+    "message": "Generation failed",
+    "description": "Fish task failure title"
+  },
+  "name.failureReason": {
+    "message": "Failure reason",
+    "description": "Fish task failure reason label"
+  },
+  "name.traceId": {
+    "message": "Trace ID",
+    "description": "Fish task trace ID label"
   }
 }

--- a/src/i18n/zh-CN/fish.json
+++ b/src/i18n/zh-CN/fish.json
@@ -27,6 +27,18 @@
     "message": "耗时",
     "description": "Fish 任务耗时标签"
   },
+  "name.failure": {
+    "message": "生成失败",
+    "description": "Fish 任务失败标题"
+  },
+  "name.failureReason": {
+    "message": "失败原因",
+    "description": "Fish 任务失败原因标签"
+  },
+  "name.traceId": {
+    "message": "追踪 ID",
+    "description": "Fish 任务追踪 ID 标签"
+  },
   "name.fishBot": {
     "message": "Fish Audio",
     "description": "Fish 任务卡片机器人标签"

--- a/src/i18n/zh-TW/fish.json
+++ b/src/i18n/zh-TW/fish.json
@@ -322,5 +322,17 @@
   "script.passage4": {
     "message": "一二三四五六七八九十，零點一二三四五六七八九。今天是星期一，下週一是放假，再下週一就要開始新的項目了。請把這段話清晰地讀完，不要停頓太久。",
     "description": "Fish 錄音示範段落 4（數字與發音覆蓋）"
+  },
+  "name.failure": {
+    "message": "Generation failed",
+    "description": "Fish task failure title"
+  },
+  "name.failureReason": {
+    "message": "Failure reason",
+    "description": "Fish task failure reason label"
+  },
+  "name.traceId": {
+    "message": "Trace ID",
+    "description": "Fish task trace ID label"
   }
 }

--- a/src/models/fish.ts
+++ b/src/models/fish.ts
@@ -24,6 +24,13 @@ export interface IFishTtsResponse {
   trace_id?: string;
   started_at?: number;
   audio_url?: string;
+  success?: boolean;
+  error?:
+    | string
+    | {
+        code?: string;
+        message?: string;
+      };
 }
 
 export interface IFishTtsConfig {


### PR DESCRIPTION
## Summary
- split Fish task history into success, explicit failure, and pending branches
- show failure reason, elapsed time, and trace ID for failed Fish TTS tasks
- treat both `success: false` and error-only legacy responses as failures
- extend the Fish response type with the platform task failure contract
- add real zh-CN/en strings and mechanically backfill the three keys to all other locales
- do not change task spacing, success rendering, pending layout, or any other scenario

## Expected UI change
- `/fish` failed history items: the previous gray/info task block becomes a red failure block titled “Generation failed / 生成失败”
- failed items show Task ID, failure reason when available, elapsed time when available, and Trace ID when available
- pending items with no response remain the existing info block
- successful items with `audio_url` remain unchanged

## Please check before merge
1. A failed Fish history item is visibly failure-styled and no longer looks pending.
2. Failure reason and trace ID are readable and copyable when present.
3. A task with no response still appears pending, not failed.
4. Existing successful audio playback/download remains unchanged.
5. Spacing and card dimensions do not change in this PR.

## Validation
- `npx vitest run src/components/fish/task/Preview.test.ts` — 3/3 passed
- focused ESLint and Prettier checks
- `python3 scripts/check_i18n_coverage.py`
- `npx beachball check --branch origin/main`
- `npm run build:web`
- `git diff --check`

## 🤖 对抗评审 (reviewer: codex, 2 rounds)
- Round 1 found the unsupported alert slot and error-only legacy response gap; both fixed with regression coverage.
- Round 2: `VERDICT: CLEAN`.