### PR TITLE
fix: show failed Suno tasks

### DIFF
--- a/change/@acedatacloud-nexior-236d70e0-645d-474f-ac27-296ffed6a5ef.json
+++ b/change/@acedatacloud-nexior-236d70e0-645d-474f-ac27-296ffed6a5ef.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Show Suno task-level failures when generation returns no audio rows.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/suno/task/Preview.test.ts
+++ b/src/components/suno/task/Preview.test.ts
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+import { mount } from '@vue/test-utils';
+import { ElAlert } from 'element-plus';
+import { describe, expect, it } from 'vitest';
+import type { ISunoTask } from '@/models';
+import Preview from './Preview.vue';
+
+const mountTask = (modelValue: ISunoTask) =>
+  mount(Preview, {
+    props: { modelValue },
+    global: {
+      mocks: {
+        $t: (key: string) => key,
+        $store: {
+          state: {
+            suno: {
+              audio: {},
+              config: {},
+              status: {},
+              tasks: {}
+            }
+          },
+          dispatch: () => undefined,
+          commit: () => undefined
+        }
+      },
+      stubs: {
+        ApiCodeDialog: true,
+        ElDropdown: true,
+        ElTooltip: true
+      }
+    }
+  });
+
+describe('suno/task/Preview', () => {
+  it('renders a task-level failure when no audio rows exist', () => {
+    const wrapper = mountTask({
+      id: 'task-1',
+      map: () => [],
+      response: {
+        success: false,
+        task_id: 'task-1',
+        data: [],
+        error: { message: 'upstream rejected the prompt' },
+        trace_id: 'trace-1'
+      }
+    });
+
+    const alert = wrapper.findComponent(ElAlert);
+    expect(alert.exists()).toBe(true);
+    expect(alert.classes()).toContain('task-failure');
+    expect(wrapper.text()).toContain('suno.name.failure');
+    expect(wrapper.text()).toContain('upstream rejected the prompt');
+    expect(wrapper.text()).toContain('trace-1');
+    expect(wrapper.findAll('.audio')).toHaveLength(0);
+  });
+
+  it('keeps empty successful or pending responses out of failure state', () => {
+    const wrapper = mountTask({
+      id: 'task-2',
+      map: () => [],
+      response: {
+        success: true,
+        task_id: 'task-2',
+        data: []
+      }
+    });
+
+    expect(wrapper.findComponent(ElAlert).exists()).toBe(false);
+  });
+
+  it('renders error-only task responses as failures', () => {
+    const wrapper = mountTask({
+      id: 'task-3',
+      map: () => [],
+      trace_id: 'trace-3',
+      response: {
+        error: 'provider timeout'
+      }
+    });
+
+    const alert = wrapper.findComponent(ElAlert);
+    expect(alert.classes()).toContain('task-failure');
+    expect(wrapper.text()).toContain('provider timeout');
+    expect(wrapper.text()).toContain('trace-3');
+  });
+
+  it('keeps playable partial results instead of showing a task-level failure', () => {
+    const wrapper = mountTask({
+      id: 'task-4',
+      map: () => [],
+      response: {
+        success: false,
+        task_id: 'task-4',
+        data: [{ id: 'audio-1', audio_url: 'https://cdn.example.com/audio.mp3' }],
+        error: { message: 'second variation failed' }
+      }
+    });
+
+    expect(wrapper.findComponent(ElAlert).exists()).toBe(false);
+    expect(wrapper.findAll('.audio')).toHaveLength(1);
+  });
+});

--- a/src/components/suno/task/Preview.vue
+++ b/src/components/suno/task/Preview.vue
@@ -1,5 +1,26 @@
 <template>
   <div class="task">
+    <el-alert v-if="isFailure" :closable="false" class="task-failure">
+      <template #title>
+        <warning-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
+        {{ $t('suno.name.failure') }}
+      </template>
+      <p class="text-[var(--el-text-color-regular)] text-xs mb-2">
+        <magic-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
+        {{ $t('suno.name.taskId') }}: {{ modelValue?.id }}
+        <copy-to-clipboard :content="modelValue?.id" />
+      </p>
+      <p v-if="failureReason" class="text-[var(--el-text-color-regular)] text-xs mb-2">
+        <info-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
+        {{ $t('suno.name.failureReason') }}: {{ failureReason }}
+        <copy-to-clipboard :content="failureReason" />
+      </p>
+      <p v-if="traceId" class="text-[var(--el-text-color-regular)] text-xs mb-0">
+        <channel-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
+        {{ $t('suno.name.traceId') }}: {{ traceId }}
+        <copy-to-clipboard :content="traceId" />
+      </p>
+    </el-alert>
     <div
       v-for="(audio, index) in audios"
       :key="audio.id"
@@ -267,6 +288,7 @@
 <script lang="ts">
 import {
   AudioIcon,
+  ChannelIcon,
   CodeIcon,
   CollectionIcon,
   CutIcon,
@@ -276,6 +298,7 @@ import {
   EditIcon,
   FastForwardIcon,
   GuitarIcon,
+  InfoIcon,
   LinkIcon,
   LoadingIcon as Loading,
   MagicIcon,
@@ -287,7 +310,8 @@ import {
   ShuffleIcon,
   SortIcon,
   TimeIcon,
-  UndoIcon
+  UndoIcon,
+  WarningIcon
 } from '@acedatacloud/core/icons/components';
 import { defineComponent } from 'vue';
 import { useFormatDuring } from '@/utils/number';
@@ -303,7 +327,8 @@ import {
   ElInput,
   ElMessageBox,
   ElProgress,
-  ElCheckbox
+  ElCheckbox,
+  ElAlert
 } from 'element-plus';
 
 import { PauseIcon as VideoPause, PlayIcon as VideoPlay } from '@acedatacloud/core/icons/components';
@@ -311,11 +336,13 @@ import { ISunoMp4Request, ISunoAudioRequest, Status } from '@/models';
 import { saveAs } from 'file-saver';
 import { sunoOperator } from '@/operators';
 import ApiCodeDialog from '@/components/common/ApiCodeDialog.vue';
+import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 import { isMainOfficial } from '@/utils';
 export default defineComponent({
   name: 'TaskPreview',
   components: {
     AudioIcon,
+    ChannelIcon,
     CodeIcon,
     CollectionIcon,
     CutIcon,
@@ -325,6 +352,7 @@ export default defineComponent({
     EditIcon,
     FastForwardIcon,
     GuitarIcon,
+    InfoIcon,
     LinkIcon,
     MagicIcon,
     MicrophoneIcon,
@@ -336,6 +364,7 @@ export default defineComponent({
     SortIcon,
     TimeIcon,
     UndoIcon,
+    WarningIcon,
     ElImage,
     ElIcon,
     ElTooltip,
@@ -347,8 +376,10 @@ export default defineComponent({
     ElInput,
     ElProgress,
     ElCheckbox,
+    ElAlert,
     Loading,
-    ApiCodeDialog
+    ApiCodeDialog,
+    CopyToClipboard
   },
   props: {
     modelValue: {
@@ -389,6 +420,18 @@ export default defineComponent({
       // @ts-ignore
       const action = this.modelValue?.request?.action as ISunoAudio['action'] | undefined;
       return action ? data.map((a) => ({ ...a, action })) : data;
+    },
+    isFailure(): boolean {
+      return (
+        this.audios.length === 0 && (this.modelValue?.response?.success === false || !!this.modelValue?.response?.error)
+      );
+    },
+    failureReason(): string | undefined {
+      const error = this.modelValue?.response?.error;
+      return typeof error === 'string' ? error : error?.message;
+    },
+    traceId(): string | undefined {
+      return this.modelValue?.response?.trace_id || this.modelValue?.trace_id;
     },
     application() {
       return this.$store.state.suno?.application;
@@ -915,6 +958,9 @@ export default defineComponent({
   border-radius: 12px;
   border: 1px solid transparent;
   transition: border-color 0.2s;
+  .task-failure {
+    border-left: 2px solid var(--el-color-danger);
+  }
   &:hover {
     border-color: var(--el-border-color-lighter);
   }

--- a/src/i18n/ar/suno.json
+++ b/src/i18n/ar/suno.json
@@ -938,5 +938,9 @@
   "name.lyricsMode": {
     "message": "وضع الكلمات",
     "description": "تسمية محدد وضع الكلمات (يدوي / تلقائي)"
+  },
+  "name.failure": {
+    "message": "Generation failed",
+    "description": "Suno task failure title"
   }
 }

--- a/src/i18n/de/suno.json
+++ b/src/i18n/de/suno.json
@@ -938,5 +938,9 @@
   "name.lyricsMode": {
     "message": "Lyrics-Modus",
     "description": "Label des Auswahlfeldes für den Lyrics-Modus (manuell / automatisch)"
+  },
+  "name.failure": {
+    "message": "Generation failed",
+    "description": "Suno task failure title"
   }
 }

--- a/src/i18n/el/suno.json
+++ b/src/i18n/el/suno.json
@@ -938,5 +938,9 @@
   "name.lyricsMode": {
     "message": "Λειτουργία στίχων",
     "description": "Ετικέτα επιλογέα λειτουργίας στίχων (Χειροκίνητα / Αυτόματα)"
+  },
+  "name.failure": {
+    "message": "Generation failed",
+    "description": "Suno task failure title"
   }
 }

--- a/src/i18n/en/suno.json
+++ b/src/i18n/en/suno.json
@@ -335,6 +335,10 @@
     "message": "Failure Reason",
     "description": "Reason for task failure"
   },
+  "name.failure": {
+    "message": "Generation failed",
+    "description": "Suno task failure title"
+  },
   "name.status": {
     "message": "Status",
     "description": "Status of the task"

--- a/src/i18n/es/suno.json
+++ b/src/i18n/es/suno.json
@@ -938,5 +938,9 @@
   "name.lyricsMode": {
     "message": "Modo de letras",
     "description": "Etiqueta del selector de modo de letras (manual / automático)"
+  },
+  "name.failure": {
+    "message": "Generation failed",
+    "description": "Suno task failure title"
   }
 }

--- a/src/i18n/fi/suno.json
+++ b/src/i18n/fi/suno.json
@@ -938,5 +938,9 @@
   "name.lyricsMode": {
     "message": "Sanojen tila",
     "description": "Sanojen tilan valitsimen etiketti (manuaalinen / automaattinen)"
+  },
+  "name.failure": {
+    "message": "Generation failed",
+    "description": "Suno task failure title"
   }
 }

--- a/src/i18n/fr/suno.json
+++ b/src/i18n/fr/suno.json
@@ -938,5 +938,9 @@
   "name.lyricsMode": {
     "message": "Mode paroles",
     "description": "Étiquette du sélecteur de mode paroles (manuel / automatique)"
+  },
+  "name.failure": {
+    "message": "Generation failed",
+    "description": "Suno task failure title"
   }
 }

--- a/src/i18n/it/suno.json
+++ b/src/i18n/it/suno.json
@@ -938,5 +938,9 @@
   "name.lyricsMode": {
     "message": "Modalità testi",
     "description": "Etichetta del selettore della modalità testi (manuale / automatica)"
+  },
+  "name.failure": {
+    "message": "Generation failed",
+    "description": "Suno task failure title"
   }
 }

--- a/src/i18n/ja/suno.json
+++ b/src/i18n/ja/suno.json
@@ -938,5 +938,9 @@
   "name.lyricsMode": {
     "message": "歌詞モード",
     "description": "歌詞モード選択器のラベル（手動 / 自動）"
+  },
+  "name.failure": {
+    "message": "Generation failed",
+    "description": "Suno task failure title"
   }
 }

--- a/src/i18n/ko/suno.json
+++ b/src/i18n/ko/suno.json
@@ -938,5 +938,9 @@
   "name.lyricsMode": {
     "message": "가사 모드",
     "description": "가사 모드 선택기 레이블(수동 / 자동)"
+  },
+  "name.failure": {
+    "message": "Generation failed",
+    "description": "Suno task failure title"
   }
 }

--- a/src/i18n/pl/suno.json
+++ b/src/i18n/pl/suno.json
@@ -938,5 +938,9 @@
   "name.lyricsMode": {
     "message": "Tryb tekstów",
     "description": "Etykieta selektora trybu tekstów (ręczny / automatyczny)"
+  },
+  "name.failure": {
+    "message": "Generation failed",
+    "description": "Suno task failure title"
   }
 }

--- a/src/i18n/pt/suno.json
+++ b/src/i18n/pt/suno.json
@@ -938,5 +938,9 @@
   "name.lyricsMode": {
     "message": "Modo de Letras",
     "description": "Rótulo do seletor de modo de letras (manual / automático)"
+  },
+  "name.failure": {
+    "message": "Generation failed",
+    "description": "Suno task failure title"
   }
 }

--- a/src/i18n/ru/suno.json
+++ b/src/i18n/ru/suno.json
@@ -938,5 +938,9 @@
   "name.lyricsMode": {
     "message": "Режим текста",
     "description": "Метка селектора режима текста (ручной / автоматический)"
+  },
+  "name.failure": {
+    "message": "Generation failed",
+    "description": "Suno task failure title"
   }
 }

--- a/src/i18n/sr/suno.json
+++ b/src/i18n/sr/suno.json
@@ -938,5 +938,9 @@
   "name.lyricsMode": {
     "message": "Režim teksta",
     "description": "Oznaka selektora režima teksta (ručno / automatski)"
+  },
+  "name.failure": {
+    "message": "Generation failed",
+    "description": "Suno task failure title"
   }
 }

--- a/src/i18n/sv/suno.json
+++ b/src/i18n/sv/suno.json
@@ -938,5 +938,9 @@
   "name.lyricsMode": {
     "message": "Textläge",
     "description": "Etikett för växlare av textläge (manuell / automatisk)"
+  },
+  "name.failure": {
+    "message": "Generation failed",
+    "description": "Suno task failure title"
   }
 }

--- a/src/i18n/uk/suno.json
+++ b/src/i18n/uk/suno.json
@@ -938,5 +938,9 @@
   "name.lyricsMode": {
     "message": "Режим тексту",
     "description": "Мітка для вибору режиму тексту (ручний / автоматичний)"
+  },
+  "name.failure": {
+    "message": "Generation failed",
+    "description": "Suno task failure title"
   }
 }

--- a/src/i18n/zh-CN/suno.json
+++ b/src/i18n/zh-CN/suno.json
@@ -335,6 +335,10 @@
     "message": "失败原因",
     "description": "任务失败的原因"
   },
+  "name.failure": {
+    "message": "生成失败",
+    "description": "Suno 任务失败标题"
+  },
   "name.status": {
     "message": "状态",
     "description": "任务的状态"

--- a/src/i18n/zh-TW/suno.json
+++ b/src/i18n/zh-TW/suno.json
@@ -938,5 +938,9 @@
   "name.lyricsMode": {
     "message": "歌詞模式",
     "description": "歌詞模式選擇器的標籤（手動 / 自動）"
+  },
+  "name.failure": {
+    "message": "Generation failed",
+    "description": "Suno task failure title"
   }
 }

--- a/src/models/suno.ts
+++ b/src/models/suno.ts
@@ -254,14 +254,23 @@ export interface ISunoMP4 {
   video_url?: string;
 }
 
-export interface ISunoAudioResponse {
+export interface ISunoTaskResultMeta {
   success?: boolean;
-  task_id: string;
-  data: ISunoAudio[];
+  trace_id?: string;
+  error?:
+    | string
+    | {
+        code?: string;
+        message?: string;
+      };
 }
 
-export interface ISunoLyricResponse {
-  success?: boolean;
+export interface ISunoAudioResponse extends ISunoTaskResultMeta {
+  task_id?: string;
+  data?: ISunoAudio[];
+}
+
+export interface ISunoLyricResponse extends ISunoTaskResultMeta {
   task_id: string;
   data: ISunoAudioLyric;
 }
@@ -282,6 +291,7 @@ export interface ISunoTask {
   map(arg0: (song: any) => any): any;
   id: string;
   created_at?: number;
+  trace_id?: string;
   request?: ISunoAudioRequest | ISunoLyricRequest;
   response?: ISunoAudioResponse | ISunoLyricResponse;
 }


### PR DESCRIPTION
## Summary
- add a task-level Suno failure fallback when a failed generation returns no audio rows
- show Task ID, failure reason, and Trace ID for failed Suno tasks
- support both `success: false` and error-only task responses
- keep playable partial results visible without showing an incorrect whole-task failure banner
- extend the shared Suno audio/lyric response metadata contract
- add one zh-CN/en failure-title key and mechanically backfill it to other locales
- do not change successful audio rows, player behavior, task spacing, search/filter UI, or other scenarios

## Expected UI change
- `/suno` failed tasks that previously disappeared because `response.data` was empty now render one red task-level failure block
- failed tasks show Task ID, failure reason when available, and Trace ID when available
- a partial result with at least one playable audio row continues to show that row and does not show a whole-task failure banner
- empty successful/pending responses remain unchanged in this PR

## Please check before merge
1. A failed Suno generation with no tracks no longer disappears from history.
2. The failure reason and Trace ID are readable and copyable.
3. A partial result with a playable track still displays the track without a failure banner.
4. Successful track playback/download/action menus are unchanged.
5. Search, filters, player, task density, and spacing are unchanged.

## Validation
- `npx vitest run src/components/suno/task/Preview.test.ts` — 4/4 passed
- focused ESLint and Prettier checks
- `python3 scripts/check_i18n_coverage.py`
- `npx beachball check --branch origin/main`
- `npm run build:web` on the rebased head
- `git diff --check`

## 🤖 对抗评审 (reviewer: codex, 3 rounds)
- Round 1 found the partial-result false failure risk; fixed with an audio-row gate and regression test.
- Round 2 found an unavailable elapsed translation; the nonessential elapsed row was removed to keep scope minimal.
- Round 3: `VERDICT: CLEAN`.