### PR TITLE
fix: show failed Producer tasks

### DIFF
--- a/change/@acedatacloud-nexior-9db5fb63-b9df-4dca-b534-ecc883506788.json
+++ b/change/@acedatacloud-nexior-9db5fb63-b9df-4dca-b534-ecc883506788.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Show Producer task-level failures when generation returns no audio rows.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/producer/task/Preview.test.ts
+++ b/src/components/producer/task/Preview.test.ts
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+import { mount } from '@vue/test-utils';
+import { ElAlert } from 'element-plus';
+import { describe, expect, it } from 'vitest';
+import type { IProducerTask } from '@/models';
+import Preview from './Preview.vue';
+
+const mountTask = (modelValue: IProducerTask) =>
+  mount(Preview, {
+    props: { modelValue },
+    global: {
+      mocks: {
+        $t: (key: string) => key,
+        $store: {
+          state: {
+            producer: {
+              audio: {},
+              config: {},
+              status: {},
+              tasks: {}
+            }
+          },
+          dispatch: () => undefined,
+          commit: () => undefined
+        }
+      },
+      stubs: {
+        ApiCodeDialog: true,
+        ElDropdown: true,
+        ElTooltip: true
+      }
+    }
+  });
+
+describe('producer/task/Preview', () => {
+  it('renders a task-level failure when no audio rows exist', () => {
+    const wrapper = mountTask({
+      id: 'task-1',
+      map: () => [],
+      response: {
+        success: false,
+        task_id: 'task-1',
+        data: [],
+        error: { message: 'generation rejected' },
+        trace_id: 'trace-1'
+      }
+    });
+
+    const alert = wrapper.findComponent(ElAlert);
+    expect(alert.classes()).toContain('task-failure');
+    expect(wrapper.text()).toContain('producer.name.failure');
+    expect(wrapper.text()).toContain('generation rejected');
+    expect(wrapper.text()).toContain('trace-1');
+    expect(wrapper.findAll('.audio')).toHaveLength(0);
+  });
+
+  it('renders error-only task responses as failures', () => {
+    const wrapper = mountTask({
+      id: 'task-2',
+      map: () => [],
+      trace_id: 'trace-2',
+      response: { error: 'provider timeout' }
+    });
+
+    expect(wrapper.findComponent(ElAlert).classes()).toContain('task-failure');
+    expect(wrapper.text()).toContain('provider timeout');
+    expect(wrapper.text()).toContain('trace-2');
+  });
+
+  it('keeps empty successful responses out of failure state', () => {
+    const wrapper = mountTask({
+      id: 'task-3',
+      map: () => [],
+      response: { success: true, task_id: 'task-3', data: [] }
+    });
+
+    expect(wrapper.findComponent(ElAlert).exists()).toBe(false);
+  });
+
+  it('keeps playable partial results instead of showing a task-level failure', () => {
+    const wrapper = mountTask({
+      id: 'task-4',
+      map: () => [],
+      response: {
+        success: false,
+        task_id: 'task-4',
+        data: [{ id: 'audio-1', audio_url: 'https://cdn.example.com/audio.mp3' }],
+        error: { message: 'second variation failed' }
+      }
+    });
+
+    expect(wrapper.findComponent(ElAlert).exists()).toBe(false);
+    expect(wrapper.findAll('.audio')).toHaveLength(1);
+  });
+});

--- a/src/components/producer/task/Preview.vue
+++ b/src/components/producer/task/Preview.vue
@@ -1,5 +1,26 @@
 <template>
   <div class="task">
+    <el-alert v-if="isFailure" :closable="false" class="task-failure">
+      <template #title>
+        <warning-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
+        {{ $t('producer.name.failure') }}
+      </template>
+      <p class="text-[var(--el-text-color-regular)] text-xs mb-2">
+        <magic-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
+        {{ $t('producer.name.taskId') }}: {{ modelValue?.id }}
+        <copy-to-clipboard :content="modelValue?.id" />
+      </p>
+      <p v-if="failureReason" class="text-[var(--el-text-color-regular)] text-xs mb-2">
+        <info-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
+        {{ $t('producer.name.failureReason') }}: {{ failureReason }}
+        <copy-to-clipboard :content="failureReason" />
+      </p>
+      <p v-if="traceId" class="text-[var(--el-text-color-regular)] text-xs mb-0">
+        <channel-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
+        {{ $t('producer.name.traceId') }}: {{ traceId }}
+        <copy-to-clipboard :content="traceId" />
+      </p>
+    </el-alert>
     <div v-for="audio in audios" :key="audio.id" class="audio" @click.stop="onClick(audio)">
       <div v-loading="!audio?.audio_url" class="left">
         <el-image :src="audio?.image_url" class="cover" fit="cover" lazy />
@@ -141,30 +162,49 @@
 
 <script lang="ts">
 import {
+  ChannelIcon,
   CodeIcon,
   DownloadIcon,
+  InfoIcon,
   LoadingIcon as Loading,
+  MagicIcon,
   MoreIcon,
   PauseIcon as VideoPause,
-  PlayIcon as VideoPlay
+  PlayIcon as VideoPlay,
+  WarningIcon
 } from '@acedatacloud/core/icons/components';
 import { defineComponent } from 'vue';
 import { useFormatDuring } from '@/utils/number';
 import { IProducerAudio, IProducerTask } from '@/models';
-import { ElImage, ElIcon, ElTooltip, ElDropdown, ElDropdownMenu, ElDropdownItem, ElMessage } from 'element-plus';
+import {
+  ElAlert,
+  ElImage,
+  ElIcon,
+  ElTooltip,
+  ElDropdown,
+  ElDropdownMenu,
+  ElDropdownItem,
+  ElMessage
+} from 'element-plus';
 
 import { IProducerVideoRequest, IProducerAudioRequest, Status } from '@/models';
 import { saveAs } from 'file-saver';
 import { producerOperator } from '@/operators';
 import ApiCodeDialog from '@/components/common/ApiCodeDialog.vue';
+import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 import { isMainOfficial } from '@/utils';
 
 export default defineComponent({
   name: 'TaskPreview',
   components: {
+    ChannelIcon,
     CodeIcon,
     DownloadIcon,
+    InfoIcon,
+    MagicIcon,
     MoreIcon,
+    WarningIcon,
+    ElAlert,
     ElImage,
     ElIcon,
     ElTooltip,
@@ -174,7 +214,8 @@ export default defineComponent({
     ElDropdownMenu,
     ElDropdownItem,
     Loading,
-    ApiCodeDialog
+    ApiCodeDialog,
+    CopyToClipboard
   },
   props: {
     modelValue: {
@@ -212,6 +253,18 @@ export default defineComponent({
       // @ts-ignore
       const action = this.modelValue?.request?.action as IProducerAudio['action'] | undefined;
       return action ? data.map((a) => ({ ...a, action })) : data;
+    },
+    isFailure(): boolean {
+      return (
+        this.audios.length === 0 && (this.modelValue?.response?.success === false || !!this.modelValue?.response?.error)
+      );
+    },
+    failureReason(): string | undefined {
+      const error = this.modelValue?.response?.error;
+      return typeof error === 'string' ? error : error?.message;
+    },
+    traceId(): string | undefined {
+      return this.modelValue?.response?.trace_id || this.modelValue?.trace_id;
     },
     application() {
       return this.$store.state.producer?.application;
@@ -465,6 +518,9 @@ export default defineComponent({
   display: flex;
   flex-direction: column;
   cursor: pointer;
+  .task-failure {
+    border-left: 2px solid var(--el-color-danger);
+  }
   .audio {
     display: flex;
     margin-bottom: 10px;

--- a/src/i18n/ar/producer.json
+++ b/src/i18n/ar/producer.json
@@ -438,5 +438,9 @@
   "message.noTasks": {
     "message": "لا توجد مهام تاريخية، يرجى توليد الموسيقى من الشريط الجانبي الأيسر",
     "description": "رسالة عند عدم وجود مهام"
+  },
+  "name.failure": {
+    "message": "Generation failed",
+    "description": "Producer task failure title"
   }
 }

--- a/src/i18n/de/producer.json
+++ b/src/i18n/de/producer.json
@@ -438,5 +438,9 @@
   "message.noTasks": {
     "message": "Keine historischen Aufgaben, bitte Musik im linken Konfigurationsbereich generieren",
     "description": "Nachricht, wenn keine Aufgaben vorhanden sind"
+  },
+  "name.failure": {
+    "message": "Generation failed",
+    "description": "Producer task failure title"
   }
 }

--- a/src/i18n/el/producer.json
+++ b/src/i18n/el/producer.json
@@ -438,5 +438,9 @@
   "message.noTasks": {
     "message": "Δεν υπάρχουν ιστορικά καθήκοντα, παρακαλώ δημιουργήστε μουσική από την αριστερή ρύθμιση",
     "description": "Μήνυμα όταν δεν υπάρχουν καθήκοντα"
+  },
+  "name.failure": {
+    "message": "Generation failed",
+    "description": "Producer task failure title"
   }
 }

--- a/src/i18n/en/producer.json
+++ b/src/i18n/en/producer.json
@@ -215,6 +215,10 @@
     "message": "Failure Reason",
     "description": "Reason for task failure"
   },
+  "name.failure": {
+    "message": "Generation failed",
+    "description": "Producer task failure title"
+  },
   "name.status": {
     "message": "Status",
     "description": "Status of the task"

--- a/src/i18n/es/producer.json
+++ b/src/i18n/es/producer.json
@@ -438,5 +438,9 @@
   "message.noTasks": {
     "message": "No hay tareas históricas, por favor genera música en la barra de configuración a la izquierda",
     "description": "Mensaje cuando no hay tareas"
+  },
+  "name.failure": {
+    "message": "Generation failed",
+    "description": "Producer task failure title"
   }
 }

--- a/src/i18n/fi/producer.json
+++ b/src/i18n/fi/producer.json
@@ -438,5 +438,9 @@
   "message.noTasks": {
     "message": "Ei historiallisia tehtäviä, luo musiikkia vasemmalla olevasta asetuspaneelista",
     "description": "Viesti, kun ei ole tehtäviä"
+  },
+  "name.failure": {
+    "message": "Generation failed",
+    "description": "Producer task failure title"
   }
 }

--- a/src/i18n/fr/producer.json
+++ b/src/i18n/fr/producer.json
@@ -438,5 +438,9 @@
   "message.noTasks": {
     "message": "Aucune tâche historique, veuillez générer de la musique dans la barre de configuration à gauche",
     "description": "Message lorsqu'il n'y a pas de tâches"
+  },
+  "name.failure": {
+    "message": "Generation failed",
+    "description": "Producer task failure title"
   }
 }

--- a/src/i18n/it/producer.json
+++ b/src/i18n/it/producer.json
@@ -438,5 +438,9 @@
   "message.noTasks": {
     "message": "Nessun compito storico, genera musica nel pannello di configurazione a sinistra",
     "description": "Messaggio quando non ci sono compiti"
+  },
+  "name.failure": {
+    "message": "Generation failed",
+    "description": "Producer task failure title"
   }
 }

--- a/src/i18n/ja/producer.json
+++ b/src/i18n/ja/producer.json
@@ -438,5 +438,9 @@
   "message.noTasks": {
     "message": "履歴タスクはありません。左側の設定バーで音楽を生成してください",
     "description": "タスクがない際のメッセージ"
+  },
+  "name.failure": {
+    "message": "Generation failed",
+    "description": "Producer task failure title"
   }
 }

--- a/src/i18n/ko/producer.json
+++ b/src/i18n/ko/producer.json
@@ -438,5 +438,9 @@
   "message.noTasks": {
     "message": "이력 작업이 없습니다. 왼쪽 구성 패널에서 음악을 생성하세요",
     "description": "작업이 없을 때의 메시지"
+  },
+  "name.failure": {
+    "message": "Generation failed",
+    "description": "Producer task failure title"
   }
 }

--- a/src/i18n/pl/producer.json
+++ b/src/i18n/pl/producer.json
@@ -438,5 +438,9 @@
   "message.noTasks": {
     "message": "Brak historii zadań, proszę wygenerować muzykę w lewym panelu konfiguracyjnym",
     "description": "Wiadomość, gdy brak zadań"
+  },
+  "name.failure": {
+    "message": "Generation failed",
+    "description": "Producer task failure title"
   }
 }

--- a/src/i18n/pt/producer.json
+++ b/src/i18n/pt/producer.json
@@ -438,5 +438,9 @@
   "message.noTasks": {
     "message": "Nenhuma tarefa histórica, por favor, gere música na barra de configuração à esquerda",
     "description": "Mensagem quando não há tarefas"
+  },
+  "name.failure": {
+    "message": "Generation failed",
+    "description": "Producer task failure title"
   }
 }

--- a/src/i18n/ru/producer.json
+++ b/src/i18n/ru/producer.json
@@ -438,5 +438,9 @@
   "message.noTasks": {
     "message": "Нет историй задач, пожалуйста, создайте музыку в левой панели конфигурации",
     "description": "Сообщение при отсутствии задач"
+  },
+  "name.failure": {
+    "message": "Generation failed",
+    "description": "Producer task failure title"
   }
 }

--- a/src/i18n/sr/producer.json
+++ b/src/i18n/sr/producer.json
@@ -438,5 +438,9 @@
   "message.noTasks": {
     "message": "Nema istorijskih zadataka, molimo generišite muziku u levom konfiguracionom panelu",
     "description": "Poruka kada nema zadataka"
+  },
+  "name.failure": {
+    "message": "Generation failed",
+    "description": "Producer task failure title"
   }
 }

--- a/src/i18n/sv/producer.json
+++ b/src/i18n/sv/producer.json
@@ -438,5 +438,9 @@
   "message.noTasks": {
     "message": "Inga historiska uppgifter, vänligen generera musik i konfigurationspanelen till vänster",
     "description": "Meddelande när det inte finns några uppgifter"
+  },
+  "name.failure": {
+    "message": "Generation failed",
+    "description": "Producer task failure title"
   }
 }

--- a/src/i18n/uk/producer.json
+++ b/src/i18n/uk/producer.json
@@ -438,5 +438,9 @@
   "message.noTasks": {
     "message": "Немає історичних завдань, будь ласка, згенеруйте музику в лівій панелі налаштувань",
     "description": "Повідомлення, коли немає завдань"
+  },
+  "name.failure": {
+    "message": "Generation failed",
+    "description": "Producer task failure title"
   }
 }

--- a/src/i18n/zh-CN/producer.json
+++ b/src/i18n/zh-CN/producer.json
@@ -215,6 +215,10 @@
     "message": "失败原因",
     "description": "任务失败的原因"
   },
+  "name.failure": {
+    "message": "生成失败",
+    "description": "Producer 任务失败标题"
+  },
   "name.status": {
     "message": "状态",
     "description": "任务的状态"

--- a/src/i18n/zh-TW/producer.json
+++ b/src/i18n/zh-TW/producer.json
@@ -438,5 +438,9 @@
   "message.noTasks": {
     "message": "沒有歷史任務，請在左側配置欄生成音樂",
     "description": "沒有任務時的消息"
+  },
+  "name.failure": {
+    "message": "Generation failed",
+    "description": "Producer task failure title"
   }
 }

--- a/src/models/producer.ts
+++ b/src/models/producer.ts
@@ -89,14 +89,23 @@ export interface IProducerVideo {
   video_url?: string;
 }
 
-export interface IProducerAudioResponse {
+export interface IProducerTaskResultMeta {
   success?: boolean;
-  task_id: string;
-  data: IProducerAudio[];
+  trace_id?: string;
+  error?:
+    | string
+    | {
+        code?: string;
+        message?: string;
+      };
 }
 
-export interface IProducerLyricResponse {
-  success?: boolean;
+export interface IProducerAudioResponse extends IProducerTaskResultMeta {
+  task_id?: string;
+  data?: IProducerAudio[];
+}
+
+export interface IProducerLyricResponse extends IProducerTaskResultMeta {
   task_id: string;
   data: IProducerAudioLyric;
 }
@@ -117,6 +126,7 @@ export interface IProducerTask {
   map(arg0: (song: any) => any): any;
   id: string;
   created_at?: number;
+  trace_id?: string;
   request?: IProducerAudioRequest | IProducerLyricRequest;
   response?: IProducerAudioResponse | IProducerLyricResponse;
 }


### PR DESCRIPTION
## 变更说明
- Producer 任务失败且没有音频结果时，显示任务级失败提示，不再让任务静默消失
- 展示并支持复制任务 ID、失败原因和 trace ID
- 保留 partial result：存在音频行时继续显示可用结果，不用整任务失败提示覆盖
- 补齐 Producer response 的失败元数据类型和 18 个 locale 的 failure 标题

## 验证
- `npx vitest run src/components/producer/task/Preview.test.ts`（4/4）
- `npx eslint src/components/producer/task/Preview.vue src/components/producer/task/Preview.test.ts src/models/producer.ts`
- `npx prettier --check ...`
- `python3 scripts/check_i18n_coverage.py`
- `npm run verify`
- `npm run build:web`

## 对抗评审（reviewer: codex, 2 rounds）
- RISK: 分支落后于已发布的 `3.329.35`，可能导致版本回退和重复发布 → 已修：提交后 rebase 到最新 `origin/main` 的 package update commit `fd070fcd8`
- 第二轮：`VERDICT: CLEAN`