### PR TITLE
test: cover null Seedream prompt spacing

### DIFF
--- a/change/@acedatacloud-nexior-8a7cdbd1-0c57-4d3a-85e0-a2080f655f63.json
+++ b/change/@acedatacloud-nexior-8a7cdbd1-0c57-4d3a-85e0-a2080f655f63.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Cover Seedream failure spacing when legacy requests contain a null prompt.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/seedream/task/Preview.test.ts
+++ b/src/components/seedream/task/Preview.test.ts
@@ -32,12 +32,12 @@ describe('seedream/task/Preview', () => {
   });
 
   it('adds request-context spacing only when a failed task has no prompt', () => {
-    const mountFailure = (prompt?: string) =>
+    const mountFailure = (prompt?: string | null) =>
       shallowMount(Preview, {
         props: {
           modelValue: {
             id: 'task-1',
-            request: prompt === undefined ? {} : { prompt },
+            request: prompt === undefined ? {} : ({ prompt } as any),
             response: { success: false, task_id: 'task-1', error: { message: 'failed' } }
           }
         },
@@ -51,6 +51,7 @@ describe('seedream/task/Preview', () => {
       });
 
     expect(mountFailure().find('.content').classes()).toContain('mt-[15px]');
+    expect(mountFailure(null).find('.content').classes()).toContain('mt-[15px]');
     expect(mountFailure('').find('.content').classes()).toContain('mt-[15px]');
     expect(mountFailure('A lighthouse').find('.content').classes()).not.toContain('mt-[15px]');
   });


### PR DESCRIPTION
## 变更说明
- 为 Seedream 旧任务的 `prompt: null` 响应补充间距回归覆盖
- 验证无 prompt、null prompt、空字符串均保留失败内容间距
- 验证有效 prompt 不额外增加顶部间距

## 验证
- `npx vitest run src/components/seedream/task/Preview.test.ts`（2/2）
- ESLint / Prettier
- `npm run verify`
- `npm run build:web`

## 对抗评审（reviewer: codex, 1 round）
- `VERDICT: CLEAN`