### PR TITLE
refactor: move image result spacing to callers

### DIFF
--- a/change/@acedatacloud-nexior-image-wrapper-spacing.json
+++ b/change/@acedatacloud-nexior-image-wrapper-spacing.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Move generated image result spacing from the shared media primitive to its parent task layouts.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/common/ImageWrapper.spacing.test.ts
+++ b/src/components/common/ImageWrapper.spacing.test.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const readSource = (relativePath: string): string =>
+  readFileSync(fileURLToPath(new URL(relativePath, import.meta.url)), 'utf8');
+
+const TASKS_WITH_SPACED_OPERATIONS = ['flux', 'nanobanana', 'openaiimage', 'qrart', 'seedream'] as const;
+
+describe('ImageWrapper spacing ownership', () => {
+  it('does not own external layout spacing', () => {
+    const source = readSource('./ImageWrapper.vue');
+    const wrapperRule = source.match(/\.image-wrapper\s*\{(?<rule>[\s\S]*?)\n\s*\.image\s*\{/u)?.groups?.rule;
+
+    expect(wrapperRule).toBeDefined();
+    expect(wrapperRule).not.toMatch(/\bmargin(?:-bottom)?\s*:/u);
+  });
+
+  it('keeps the Midjourney image-to-actions boundary caller-owned', () => {
+    const source = readSource('../midjourney/tasks/TaskItem.vue');
+    const imagineResultImage = source.match(
+      /<image-wrapper\s+v-if="modelValue\?\.response\?\.raw_image_url"(?<markup>[\s\S]*?)\/>/u
+    )?.groups?.markup;
+
+    expect(imagineResultImage).toBeDefined();
+    expect(imagineResultImage).toContain('class="mb-4"');
+  });
+
+  it.each(TASKS_WITH_SPACED_OPERATIONS)('%s owns its result-to-actions gap', (family) => {
+    const source = readSource(`../${family}/task/Preview.vue`);
+
+    expect(source).toMatch(/<image-wrapper[\s\S]*?<div :class="\{ operations: true, 'mt-2': true,/u);
+  });
+
+  it('keeps Seedance last-frame spacing on the parent result block', () => {
+    const source = readSource('../seedance/task/Preview.vue');
+
+    expect(source).toMatch(
+      /<div v-if="video\?\.last_frame_url" class="mb-4">\s*<image-wrapper[^>]*video\?\.last_frame_url[^>]*\/>/u
+    );
+  });
+});

--- a/src/components/common/ImageWrapper.vue
+++ b/src/components/common/ImageWrapper.vue
@@ -79,7 +79,6 @@ export default defineComponent({
 .image-wrapper {
   position: relative;
   width: fit-content;
-  margin-bottom: 16px;
   .image {
     max-height: 400px;
     max-width: 300px;

--- a/src/components/midjourney/tasks/TaskItem.vue
+++ b/src/components/midjourney/tasks/TaskItem.vue
@@ -58,6 +58,7 @@
           v-if="modelValue?.response?.raw_image_url"
           :src="modelValue?.response?.image_url"
           :raw-src="modelValue?.response?.raw_image_url"
+          class="mb-4"
         />
         <div v-if="modelValue?.response?.actions" :class="{ operations: true, full }">
           <el-tooltip


### PR DESCRIPTION
## 变更说明
- 移除 `ImageWrapper` 对外部布局间距的隐式所有权
- 在 Midjourney 单图结果 caller 上显式保留 `mb-4`
- 锁定 Flux、Nano Banana、OpenAI Image、QR Art、Seedream、Seedance 和 Midjourney 的 caller-owned spacing contract

## 验证
- `npx vitest run src/components/common/ImageWrapper.spacing.test.ts`（8/8）
- ESLint / Prettier
- `npm run verify`
- `npm run build:web`

## 对抗评审（reviewer: codex, 2 rounds）
- RISK: 共享 margin 移除后其余 caller 未被覆盖 → 已修：fixture 扩展到全部 8 个生产调用边界，并确认各 caller 的 `mt-2`、父级 `mb-4` 或显式 `mb-4`
- 第二轮：`VERDICT: CLEAN`