### PR TITLE
fix: align image task preview gaps

### DIFF
--- a/change/@acedatacloud-nexior-image-task-spacing.json
+++ b/change/@acedatacloud-nexior-image-task-spacing.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Unify inter-item spacing across image generation task previews.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/flux/task/Preview.vue
+++ b/src/components/flux/task/Preview.vue
@@ -174,7 +174,7 @@ $left-width: 70px;
   text-align: left;
   display: flex;
   flex-direction: row;
-  margin-bottom: 16px;
+  margin-bottom: 10px;
   .left {
     width: $left-width;
     .avatar {

--- a/src/components/imageTaskSpacing.test.ts
+++ b/src/components/imageTaskSpacing.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const IMAGE_TASK_PREVIEWS = ['flux', 'seedream', 'nanobanana', 'openaiimage', 'qrart'] as const;
+
+const readPreview = (family: (typeof IMAGE_TASK_PREVIEWS)[number]): string =>
+  readFileSync(fileURLToPath(new URL(`./${family}/task/Preview.vue`, import.meta.url)), 'utf8');
+
+const getTaskGap = (source: string): string | undefined => {
+  const rootDeclarations = source.match(/(?:^|\n)\.preview\s*\{([\s\S]*?)\n\s*\.left\s*\{/)?.[1];
+  return rootDeclarations?.match(/margin-bottom:\s*(\d+px);/)?.[1];
+};
+
+describe('image task preview spacing', () => {
+  it.each(IMAGE_TASK_PREVIEWS)('%s uses the shared inter-item gap', (family) => {
+    expect(getTaskGap(readPreview(family))).toBe('10px');
+  });
+});

--- a/src/components/qrart/task/Preview.vue
+++ b/src/components/qrart/task/Preview.vue
@@ -232,7 +232,7 @@ $left-width: 70px;
   text-align: left;
   display: flex;
   flex-direction: row;
-  margin-bottom: 15px;
+  margin-bottom: 10px;
   .left {
     width: $left-width;
     .avatar {


### PR DESCRIPTION
## 变更说明
- 将 Flux 和 QR Art 图片任务卡片间距统一为 10px
- 与 Seedream、Nano Banana、OpenAI Image 的现有节奏对齐
- 用参数化 fixture 锁定五个图片任务家族

## 验证
- `npx vitest run src/components/imageTaskSpacing.test.ts`（5/5）
- 相关图片任务 fixture
- ESLint / Prettier
- `npm run verify`
- `npm run build:web`

## 对抗评审（reviewer: codex, 2 rounds）
- RISK: QR Art 仍保留旧 15px gap → 已修：改为 10px 并加入参数化 fixture
- 第二轮：`VERDICT: CLEAN`