### PR TITLE
fix: align Midjourney task state spacing

### DIFF
--- a/change/@acedatacloud-nexior-midjourney-state-rhythm.json
+++ b/change/@acedatacloud-nexior-midjourney-state-rhythm.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Align Midjourney task state metadata to a consistent top-spacing rhythm.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/midjourney/tasks/TaskItem.test.ts
+++ b/src/components/midjourney/tasks/TaskItem.test.ts
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+import { shallowMount } from '@vue/test-utils';
+import { describe, expect, it, vi } from 'vitest';
+import type { IMidjourneyTask } from '@/models';
+
+vi.mock('@/components/common/VideoPlayer.vue', () => ({
+  default: { name: 'VideoPlayer', template: '<div />' }
+}));
+
+import TaskItem from './TaskItem.vue';
+
+type TaskType = IMidjourneyTask['type'];
+type TaskState = 'pending' | 'success' | 'failure';
+
+const buildTask = (type: TaskType, state: TaskState): IMidjourneyTask => {
+  const response =
+    state === 'pending'
+      ? undefined
+      : type === 'describe'
+        ? state === 'success'
+          ? { descriptions: ['A quiet landscape'] }
+          : { error: { message: 'Describe failed' } }
+        : {
+            success: state === 'success',
+            error: state === 'failure' ? { message: 'Generation failed' } : undefined
+          };
+
+  return {
+    id: `${type}-${state}`,
+    type,
+    created_at: 1,
+    request: type === 'describe' ? { image_url: 'https://cdn.example.com/input.jpg' } : { prompt: 'Create a scene' },
+    response
+  } as IMidjourneyTask;
+};
+
+const mountTask = (modelValue: IMidjourneyTask) =>
+  shallowMount(TaskItem, {
+    props: { modelValue },
+    global: {
+      stubs: {
+        CapabilityPresentation: true
+      },
+      mocks: {
+        $t: (key: string) => key,
+        $dayjs: { format: () => '' },
+        $store: {
+          state: {
+            midjourney: {
+              application: undefined,
+              config: {},
+              service: undefined
+            }
+          }
+        }
+      }
+    }
+  });
+
+const cases = (['imagine', 'videos', 'describe'] as const).flatMap((type) =>
+  (['pending', 'success', 'failure'] as const).map((state) => ({ type, state }))
+);
+
+describe('midjourney/tasks/TaskItem state spacing', () => {
+  it.each(cases)('keeps $type $state state metadata separated from preceding content', ({ type, state }) => {
+    const wrapper = mountTask(buildTask(type, state));
+    const alert = wrapper.find('el-alert-stub');
+
+    expect(wrapper.findAll('el-alert-stub')).toHaveLength(1);
+    expect(alert.classes()).toContain('mt-2');
+    expect(alert.classes()).toContain(state === 'pending' ? 'info' : state);
+  });
+});

--- a/src/components/midjourney/tasks/TaskItem.vue
+++ b/src/components/midjourney/tasks/TaskItem.vue
@@ -27,7 +27,7 @@
       </div>
       <!-- response error -->
       <div v-if="modelValue?.response?.success === false" :class="{ content: true, full: full, failed: true }">
-        <el-alert :closable="false" class="failure">
+        <el-alert :closable="false" class="mt-2 failure">
           <p class="text-[var(--el-text-color-regular)] text-xs mb-2">
             <magic-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
             {{ $t('midjourney.field.taskId') }}:
@@ -171,7 +171,7 @@
       </div>
       <!-- response error -->
       <div v-if="modelValue?.response?.success === false" :class="{ content: true, full: full, failed: true }">
-        <el-alert :closable="false" class="failure">
+        <el-alert :closable="false" class="mt-2 failure">
           <p v-if="modelValue?.request?.action" class="text-[var(--el-text-color-regular)] text-xs mb-2">
             <lightning-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
             {{ $t('midjourney.field.action') }}:
@@ -289,7 +289,7 @@
       </div>
       <!-- response pending -->
       <div v-if="!modelValue?.response">
-        <el-alert :closable="false" class="info">
+        <el-alert :closable="false" class="mt-2 info">
           <p v-if="modelValue?.request?.action" class="text-[var(--el-text-color-regular)] text-xs mb-2">
             <lightning-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
             {{ $t('midjourney.field.action') }}:
@@ -343,7 +343,7 @@
         v-if="modelValue?.response && !modelValue?.response?.descriptions"
         :class="{ content: true, full: full, failed: true }"
       >
-        <el-alert :closable="false" class="failure">
+        <el-alert :closable="false" class="mt-2 failure">
           <p class="text-[var(--el-text-color-regular)] text-xs mb-2">
             <magic-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
             {{ $t('midjourney.field.taskId') }}:
@@ -393,7 +393,7 @@
         <div :class="{ operations: true, 'mt-2': true, 'mb-2': true, full }">
           <api-code-button path="/midjourney/describe" :body="modelValue?.request" />
         </div>
-        <el-alert :closable="false" class="success">
+        <el-alert :closable="false" class="mt-2 success">
           <p class="text-[var(--el-text-color-regular)] text-xs mb-2">
             <magic-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
             {{ $t('midjourney.field.taskId') }}:
@@ -414,7 +414,7 @@
       </div>
       <!-- response pending -->
       <div v-if="!modelValue?.response">
-        <el-alert :closable="false" class="info">
+        <el-alert :closable="false" class="mt-2 info">
           <p class="text-[var(--el-text-color-regular)] text-xs mb-0">
             <magic-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
             {{ $t('midjourney.field.taskId') }}:


### PR DESCRIPTION
## 变更说明
- 为 Midjourney imagine、videos、describe 的缺失状态 alert 补齐统一 `mt-2`
- 对齐 pending、success、failure 三种 metadata 节奏
- 参数化覆盖 3 类任务 × 3 种状态

## 验证
- `npx vitest run src/components/midjourney/tasks/TaskItem.test.ts`（9/9）
- ESLint / Prettier
- `npm run verify`
- `npm run build:web`

## 对抗评审（reviewer: codex, 1 round）
- `VERDICT: CLEAN`