### PR TITLE
refactor: consolidate scenario tab styles

### DIFF
--- a/change/@acedatacloud-nexior-6d1a58cc-2f68-47c5-b46d-39ba831c04be.json
+++ b/change/@acedatacloud-nexior-6d1a58cc-2f68-47c5-b46d-39ba831c04be.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Consolidate shared scenario tab baseline styles while preserving specialized overflow behavior.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/assets/scenarioTabs.test.ts
+++ b/src/assets/scenarioTabs.test.ts
@@ -1,0 +1,54 @@
+// @vitest-environment node
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = (relativePath: string) => readFileSync(resolve(__dirname, '../..', relativePath), 'utf8');
+
+const components = {
+  fish: source('src/components/fish/TabSwitcher.vue'),
+  kling: source('src/components/kling/TabSwitcher.vue'),
+  midjourney: source('src/components/midjourney/ConfigPanel.vue'),
+  producer: source('src/components/producer/ConfigPanel.vue'),
+  suno: source('src/components/suno/ConfigPanel.vue'),
+  veo: source('src/components/veo/config/ActionSelector.vue')
+};
+
+describe('scenario tab style contract', () => {
+  it('keeps shared baseline rules in the global utility', () => {
+    const styles = source('src/assets/scss/_common.scss');
+
+    expect(styles).toMatch(/\.scenario-tabs\s*{[\s\S]*?> \.el-tabs__header\s*{\s*margin: 0;/);
+    expect(styles).toMatch(
+      /&\.scenario-tabs--scrollable\s*{[\s\S]*?display: flex;[\s\S]*?flex-direction: column;[\s\S]*?height: 100%;/
+    );
+    expect(styles).toMatch(/> \.el-tabs__content\s*{\s*flex: 1;\s*min-height: 0;\s*overflow-y: auto;\s*}/);
+    expect(styles).toMatch(
+      /&\.scenario-tabs--divided > \.el-tabs__header > \.el-tabs__nav-wrap::after\s*{\s*height: 1px;/
+    );
+  });
+
+  it('opts only compatible top-level tabs into each shared rule', () => {
+    Object.values(components).forEach((component) => expect(component).toContain('scenario-tabs'));
+
+    for (const name of ['suno', 'producer', 'midjourney'] as const) {
+      expect(components[name]).toContain('scenario-tabs--scrollable');
+    }
+    for (const name of ['fish', 'kling', 'producer', 'veo'] as const) {
+      expect(components[name]).toContain('scenario-tabs--divided');
+    }
+
+    expect(source('src/components/suno/config/UploadAudio.vue')).not.toContain('scenario-tabs');
+    expect(source('src/components/suno/voice/VoiceManager.vue')).not.toContain('scenario-tabs');
+    expect(source('src/components/midjourney/config/ElementsSelector.vue')).not.toContain('scenario-tabs');
+    expect(source('src/components/webextrator/ResultPanel.vue')).not.toContain('scenario-tabs');
+  });
+
+  it('preserves Kling and Veo readability and overflow rules locally', () => {
+    expect(components.kling).toMatch(/:deep\(\.el-tabs__item\)[\s\S]*?height: 48px;[\s\S]*?white-space: normal;/);
+    expect(components.kling).toContain('-webkit-line-clamp: 2;');
+    expect(components.veo).toMatch(/:deep\(\.el-tabs__nav-scroll\)[\s\S]*?overflow: visible;[\s\S]*?height: 64px;/);
+    expect(components.veo).toMatch(/:deep\(\.el-tabs__nav-prev\),[\s\S]*?display: none;/);
+    expect(components.veo).toMatch(/:deep\(\.el-tabs__item\)[\s\S]*?min-width: 0;[\s\S]*?overflow-wrap: anywhere;/);
+  });
+});

--- a/src/assets/scss/_common.scss
+++ b/src/assets/scss/_common.scss
@@ -419,6 +419,33 @@ html.dark .el-dialog {
   }
 }
 
+.scenario-tabs {
+  > .el-tabs__header {
+    margin: 0;
+  }
+
+  &.scenario-tabs--scrollable {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+
+    > .el-tabs__header {
+      flex: none;
+      padding: 0 8px;
+    }
+
+    > .el-tabs__content {
+      flex: 1;
+      min-height: 0;
+      overflow-y: auto;
+    }
+  }
+
+  &.scenario-tabs--divided > .el-tabs__header > .el-tabs__nav-wrap::after {
+    height: 1px;
+  }
+}
+
 .el-select {
   .el-select__wrapper {
     width: 100%;

--- a/src/components/fish/TabSwitcher.vue
+++ b/src/components/fish/TabSwitcher.vue
@@ -1,5 +1,10 @@
 <template>
-  <el-tabs :model-value="active" class="fish-tabs" stretch @update:model-value="onUpdate">
+  <el-tabs
+    :model-value="active"
+    class="fish-tabs scenario-tabs scenario-tabs--divided"
+    stretch
+    @update:model-value="onUpdate"
+  >
     <el-tab-pane :label="$t('fish.tab.tts')" :name="ROUTE_FISH_TTS_INDEX" />
     <el-tab-pane :label="$t('fish.tab.model')" :name="ROUTE_FISH_MODEL_INDEX" />
   </el-tabs>
@@ -44,14 +49,6 @@ export default defineComponent({
   flex: none;
   padding: 0 8px;
   background-color: var(--app-sidebar-bg);
-
-  :deep(.el-tabs__header) {
-    margin: 0;
-  }
-
-  :deep(.el-tabs__nav-wrap::after) {
-    height: 1px;
-  }
 
   :deep(.el-tabs__item) {
     height: 38px;

--- a/src/components/kling/TabSwitcher.vue
+++ b/src/components/kling/TabSwitcher.vue
@@ -1,5 +1,10 @@
 <template>
-  <el-tabs :model-value="modelValue" class="kling-tabs" stretch @update:model-value="onUpdate">
+  <el-tabs
+    :model-value="modelValue"
+    class="kling-tabs scenario-tabs scenario-tabs--divided"
+    stretch
+    @update:model-value="onUpdate"
+  >
     <el-tab-pane v-for="tab in tabs" :key="tab.value" :name="tab.value" :disabled="tab.disabled">
       <template #label>
         <span class="tab-label" :title="tab.disabled ? tab.disabledReason : undefined">
@@ -69,14 +74,6 @@ export default defineComponent({
   flex: none;
   padding: 0 8px;
   background-color: var(--app-sidebar-bg);
-
-  :deep(.el-tabs__header) {
-    margin: 0;
-  }
-
-  :deep(.el-tabs__nav-wrap::after) {
-    height: 1px;
-  }
 
   :deep(.el-tabs__item) {
     height: 48px;

--- a/src/components/midjourney/ConfigPanel.vue
+++ b/src/components/midjourney/ConfigPanel.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="flex flex-col h-full">
     <div class="flex-1 min-h-0 overflow-hidden">
-      <el-tabs v-model="type" class="demo-tabs" stretch>
+      <el-tabs v-model="type" class="demo-tabs scenario-tabs scenario-tabs--scrollable" stretch>
         <el-tab-pane :label="$t('midjourney.tab.images')" name="imagine">
           <div class="p-5">
             <model-selector class="mb-2" />
@@ -148,23 +148,3 @@ export default defineComponent({
   }
 });
 </script>
-
-<style lang="scss" scoped>
-.demo-tabs {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-
-  :deep(.el-tabs__header) {
-    flex: none;
-    margin: 0;
-    padding: 0 8px;
-  }
-
-  :deep(.el-tabs__content) {
-    flex: 1;
-    min-height: 0;
-    overflow-y: auto;
-  }
-}
-</style>

--- a/src/components/producer/ConfigPanel.vue
+++ b/src/components/producer/ConfigPanel.vue
@@ -1,7 +1,11 @@
 <template>
   <div class="flex flex-col h-full">
     <div class="flex-1 min-h-0 overflow-hidden">
-      <el-tabs v-model="mode" class="producer-mode-tabs" stretch>
+      <el-tabs
+        v-model="mode"
+        class="producer-mode-tabs scenario-tabs scenario-tabs--scrollable scenario-tabs--divided"
+        stretch
+      >
         <el-tab-pane :label="$t('producer.mode.simple')" name="simple">
           <div class="p-5">
             <type-selector class="mb-4" />
@@ -139,25 +143,6 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 .producer-mode-tabs {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-
-  :deep(.el-tabs__header) {
-    flex: none;
-    margin: 0;
-    padding: 0 8px;
-  }
-
-  :deep(.el-tabs__content) {
-    flex: 1;
-    min-height: 0;
-    overflow-y: auto;
-  }
-
-  :deep(.el-tabs__nav-wrap::after) {
-    height: 1px;
-  }
   :deep(.el-tabs__item) {
     font-size: 14px;
     font-weight: 500;

--- a/src/components/suno/ConfigPanel.vue
+++ b/src/components/suno/ConfigPanel.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="flex flex-col h-full">
     <div class="flex-1 min-h-0 overflow-hidden">
-      <el-tabs v-model="mode" class="suno-mode-tabs" stretch>
+      <el-tabs v-model="mode" class="suno-mode-tabs scenario-tabs scenario-tabs--scrollable" stretch>
         <el-tab-pane :label="$t('suno.mode.simple')" name="simple">
           <div class="p-5">
             <type-selector class="mb-4" />
@@ -173,24 +173,6 @@ export default defineComponent({
 </script>
 
 <style lang="scss" scoped>
-.suno-mode-tabs {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-
-  :deep(.el-tabs__header) {
-    flex: none;
-    margin: 0;
-    padding: 0 8px;
-  }
-
-  :deep(.el-tabs__content) {
-    flex: 1;
-    min-height: 0;
-    overflow-y: auto;
-  }
-}
-
 .panel {
   height: 100%;
   padding: 20px;

--- a/src/components/veo/config/ActionSelector.vue
+++ b/src/components/veo/config/ActionSelector.vue
@@ -1,5 +1,10 @@
 <template>
-  <el-tabs :model-value="value" class="action-tabs" stretch @update:model-value="onUpdate">
+  <el-tabs
+    :model-value="value"
+    class="action-tabs scenario-tabs scenario-tabs--divided"
+    stretch
+    @update:model-value="onUpdate"
+  >
     <el-tab-pane v-for="item in options" :key="item.value" :name="item.value" :label="item.label" />
   </el-tabs>
 </template>
@@ -59,12 +64,7 @@ export default defineComponent({
 <style lang="scss" scoped>
 .action-tabs {
   :deep(.el-tabs__header) {
-    margin: 0;
     height: 64px;
-  }
-
-  :deep(.el-tabs__nav-wrap::after) {
-    height: 1px;
   }
 
   :deep(.el-tabs__nav-scroll) {


### PR DESCRIPTION
## 变更说明
- 提取 opt-in 的 `scenario-tabs` 基线样式与 scrollable/divided modifiers
- 迁移 Fish、Kling、Midjourney、Producer、Suno、Veo 顶层 scenario tabs
- 保留 Kling 多行可读性和 Veo overflow 等局部特例，不影响嵌套工具 tabs

## 验证
- `npx vitest run src/assets/scenarioTabs.test.ts`（3/3）
- ESLint / Prettier
- `npm run verify`
- `npm run build:web`

## 对抗评审（reviewer: codex, 1 round）
- `VERDICT: CLEAN`