### PR TITLE
test: cover Veo task metadata states

### DIFF
--- a/change/@acedatacloud-nexior-3f4d8f97-8c8f-4ac2-9c59-e55c78493a31.json
+++ b/change/@acedatacloud-nexior-3f4d8f97-8c8f-4ac2-9c59-e55c78493a31.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Cover Veo task metadata across pending, successful, and failed generations.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/veo/task/Preview.test.ts
+++ b/src/components/veo/task/Preview.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it, vi } from 'vitest';
 import type { IVeoTask } from '@/models';
 
 vi.mock('@/components/common/VideoPlayer.vue', () => ({
-  default: { name: 'VideoPlayer', template: '<div />' }
+  default: { name: 'VideoPlayer', props: ['src'], template: '<div />' }
 }));
 
 import TaskPreview from './Preview.vue';
@@ -35,7 +35,10 @@ const mountPreview = (modelValue = task) =>
     props: { modelValue },
     global: {
       stubs: {
-        ElAlert: { template: '<div><slot /><slot name="template" /></div>' }
+        ElAlert: {
+          name: 'ElAlert',
+          template: '<div><div class="alert-template"><slot name="template" /></div><slot /></div>'
+        }
       },
       mocks: {
         $t: (key: string) => key,
@@ -45,9 +48,11 @@ const mountPreview = (modelValue = task) =>
   });
 
 describe('veo/task/Preview', () => {
-  it('shows reference images and complete generation metadata', () => {
+  it('shows a successful video with complete metadata and prefers the response trace ID', () => {
     const wrapper = mountPreview();
 
+    expect(wrapper.find('.task-metadata').classes()).toContain('success');
+    expect(wrapper.findComponent({ name: 'VideoPlayer' }).props('src')).toBe('https://cdn.example.com/result.mp4');
     expect(wrapper.findAllComponents({ name: 'ImagePreview' }).map((preview) => preview.props('url'))).toEqual([
       'https://cdn.example.com/start.jpg',
       'https://cdn.example.com/end.jpg'
@@ -59,33 +64,97 @@ describe('veo/task/Preview', () => {
     expect(wrapper.text()).toContain('veo-task');
     expect(wrapper.text()).toContain('42.13s');
     expect(wrapper.text()).toContain('response-trace');
+    expect(wrapper.text()).not.toContain('task-trace');
   });
 
-  it('infers image-to-video for legacy tasks with images but no action', () => {
-    const legacyTask = {
+  it('shows pending metadata before a response and falls back to the task trace ID', () => {
+    const pendingTask: IVeoTask = {
       ...task,
+      response: undefined,
       request: {
         ...task.request,
         action: undefined
       }
     };
+    const wrapper = mountPreview(pendingTask);
 
-    expect((mountPreview(legacyTask).vm as unknown as { actionLabel: string }).actionLabel).toBe('veo.button.action2');
+    expect(wrapper.find('.task-metadata').classes()).toContain('info');
+    expect(wrapper.find('.failure').exists()).toBe(false);
+    expect(wrapper.text()).toContain('veo.status.pending');
+    expect(wrapper.text()).toContain('task-trace');
+    expect(wrapper.text()).toContain('veo.button.action2');
   });
 
-  it('infers ingredients mode for legacy tasks and ignores malformed image lists', () => {
-    const ingredientsTask = {
+  it('shows an explicit failure reason and failure metadata with the task trace fallback', () => {
+    const failedTask: IVeoTask = {
       ...task,
-      request: {
-        ...task.request,
-        action: undefined,
-        model: 'veo31-fast-ingredients'
+      response: {
+        success: false,
+        task_id: 'veo-task',
+        error: {
+          code: 'CONTENT_REJECTED',
+          message: 'The request could not be processed'
+        }
       }
     };
-    expect((mountPreview(ingredientsTask).vm as unknown as { actionLabel: string }).actionLabel).toBe(
-      'veo.button.actionIngredients'
-    );
+    const wrapper = mountPreview(failedTask);
 
+    expect(wrapper.find('.failure .alert-template').text()).toContain('veo.name.failure');
+    expect(wrapper.find('.failure').text()).toContain('veo.name.failureReason');
+    expect(wrapper.find('.failure').text()).toContain('The request could not be processed');
+    expect(wrapper.find('.task-metadata').classes()).toContain('failure');
+    expect(wrapper.findComponent({ name: 'VideoPlayer' }).exists()).toBe(false);
+    expect(wrapper.text()).toContain('task-trace');
+  });
+
+  it('keeps the task ID as the final metadata row when no trace or elapsed time exists', () => {
+    const taskWithoutTrace: IVeoTask = {
+      id: 'pending-without-trace',
+      created_at: 1,
+      request: {
+        model: 'veo31-fast'
+      }
+    };
+    const wrapper = mountPreview(taskWithoutTrace);
+    const metadataRows = wrapper.find('.task-metadata').findAll('p');
+
+    expect(metadataRows.at(-1)?.text()).toContain('pending-without-trace');
+    expect(wrapper.text()).not.toContain('veo.name.traceId');
+  });
+
+  it.each([
+    ['text-to-video', { model: 'veo31-fast' }, 'veo.button.action1'],
+    [
+      'image-to-video',
+      { model: 'veo31-fast', image_urls: ['https://cdn.example.com/start.jpg'] },
+      'veo.button.action2'
+    ],
+    [
+      'ingredients-to-video from its legacy model',
+      {
+        model: 'veo31-fast-ingredients',
+        image_urls: ['https://cdn.example.com/subject.jpg']
+      },
+      'veo.button.actionIngredients'
+    ],
+    [
+      'ingredients-to-video from three references',
+      {
+        model: 'veo31-fast',
+        image_urls: ['subject.jpg', 'style.jpg', 'scene.jpg']
+      },
+      'veo.button.actionIngredients'
+    ]
+  ])('infers %s for legacy tasks without an action', (_name, request, expectedLabel) => {
+    const legacyTask: IVeoTask = {
+      ...task,
+      request
+    };
+
+    expect((mountPreview(legacyTask).vm as unknown as { actionLabel: string }).actionLabel).toBe(expectedLabel);
+  });
+
+  it('ignores malformed legacy image lists', () => {
     const malformedTask = {
       ...task,
       request: {


### PR DESCRIPTION
## 变更说明
- 仅补充 Veo pending、success、failure metadata 状态覆盖
- 验证 response trace 优先、task trace fallback 和无 trace/elapsed 的行顺序
- 验证 legacy action inference 与 malformed image list 兼容
- 不修改 Veo 产品 UI；failure alert 继续与 Sora、Seedance、Kling、Hailuo 等 scenario 使用相同 `#template` 约定

## 验证
- `npx vitest run src/components/veo/task/Preview.test.ts`（9/9）
- ESLint / Prettier
- `npm run verify`
- `npm run build:web`

## 对抗评审（reviewer: Explore subagent, 1 round）
- `VERDICT: CLEAN`
- 明确确认 `Preview.vue` 对最新 `main` 零差异