### PR TITLE
fix: label Luma waiting states

### DIFF
--- a/change/@acedatacloud-nexior-luma-pending-state.json
+++ b/change/@acedatacloud-nexior-luma-pending-state.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Label queued and processing Luma tasks with waiting semantics instead of failure copy.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/luma/task/Preview.test.ts
+++ b/src/components/luma/task/Preview.test.ts
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+import { shallowMount } from '@vue/test-utils';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/components/common/VideoPlayer.vue', () => ({
+  default: { name: 'VideoPlayer', template: '<div />' }
+}));
+
+import Preview from './Preview.vue';
+
+describe('luma/task/Preview', () => {
+  it.each([
+    ['without a response', undefined, 'luma.status.pending'],
+    ['with a pending response', 'pending', 'luma.status.processing'],
+    ['with a processing response', 'processing', 'luma.status.processing']
+  ])('labels tasks %s with waiting semantics', (_name, state, expectedStatus) => {
+    const wrapper = shallowMount(Preview, {
+      props: {
+        modelValue: {
+          id: 'task-1',
+          request: { prompt: 'A lighthouse' },
+          response: state ? ({ state } as any) : undefined
+        }
+      },
+      global: {
+        stubs: {
+          ElAlert: { template: '<div><div class="alert-template"><slot name="template" /></div><slot /></div>' }
+        },
+        mocks: {
+          $t: (key: string) => key,
+          $dayjs: { format: () => '2026-07-19' },
+          $store: { state: { luma: { config: {} } } }
+        }
+      }
+    });
+
+    expect(wrapper.find('.alert-template').text()).toContain(expectedStatus);
+    expect(wrapper.find('.alert-template').text()).not.toContain('luma.name.failure');
+    expect(wrapper.findComponent({ name: 'TimeIcon' }).exists()).toBe(true);
+    expect(wrapper.findComponent({ name: 'WarningIcon' }).exists()).toBe(false);
+  });
+});

--- a/src/components/luma/task/Preview.vue
+++ b/src/components/luma/task/Preview.vue
@@ -100,8 +100,8 @@
       >
         <el-alert :closable="false" class="info">
           <template #template>
-            <warning-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
-            {{ $t('luma.name.failure') }}
+            <time-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
+            {{ $t(modelValue?.response ? 'luma.status.processing' : 'luma.status.pending') }}
           </template>
           <p class="text-[var(--el-text-color-regular)] text-xs mb-0">
             <magic-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />


### PR DESCRIPTION
## 变更说明
- Luma 尚无响应时显示 Pending，已有 pending/processing 响应时显示 Processing
- waiting 分支使用时间图标，不再误用 warning 图标与失败文案
- 保持与现有 video scenario 一致的 alert slot 结构

## 验证
- `npx vitest run src/components/luma/task/Preview.test.ts`（3/3）
- ESLint / Prettier
- `npm run verify`
- `npm run build:web`

## 对抗评审（reviewer: codex, 3 rounds）
- RISK: 分支落后导致 Kimi/版本元数据回退 → 已修：rebase 最新 `origin/main` 3.329.44
- RISK: 建议改成 Veo 特有 `#title` → 未采纳：`#template` 是 Luma 及相邻 video scenario 的既有约定，本 PR 不制造新特例
- RISK: 二审误报 Sora prompt 条件 → 不属于 Luma 净 diff；Sora 在独立 PR 修复
- 第三轮：`VERDICT: CLEAN`