### PR TITLE
fix: label Sora waiting states

### DIFF
--- a/change/@acedatacloud-nexior-sora-pending-state.json
+++ b/change/@acedatacloud-nexior-sora-pending-state.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Label queued and processing Sora tasks with waiting semantics instead of failure copy.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/sora/task/Preview.test.ts
+++ b/src/components/sora/task/Preview.test.ts
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+import { shallowMount } from '@vue/test-utils';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/components/common/VideoPlayer.vue', () => ({
+  default: { name: 'VideoPlayer', template: '<div />' }
+}));
+
+import Preview from './Preview.vue';
+
+describe('sora/task/Preview', () => {
+  it.each([
+    ['without a response', undefined, 'sora.status.pending'],
+    ['with a pending response', 'pending', 'sora.status.processing'],
+    ['with a processing response', 'processing', 'sora.status.processing']
+  ])('labels tasks %s with waiting semantics', (_name, state, expectedStatus) => {
+    const wrapper = shallowMount(Preview, {
+      props: {
+        modelValue: {
+          id: 'task-1',
+          request: { prompt: 'A lighthouse', model: 'sora-2' },
+          response: state ? ({ data: [{ state }] } as any) : undefined
+        }
+      },
+      global: {
+        stubs: {
+          ElAlert: { template: '<div><div class="alert-template"><slot name="template" /></div><slot /></div>' }
+        },
+        mocks: {
+          $t: (key: string) => key,
+          $dayjs: { format: () => '2026-07-19' }
+        }
+      }
+    });
+
+    expect(wrapper.find('.alert-template').text()).toContain(expectedStatus);
+    expect(wrapper.find('.alert-template').text()).not.toContain('sora.name.failure');
+    expect(wrapper.find('.prompt').text()).toContain(expectedStatus);
+    expect(wrapper.findComponent({ name: 'TimeIcon' }).exists()).toBe(true);
+    expect(wrapper.findComponent({ name: 'WarningIcon' }).exists()).toBe(false);
+  });
+});

--- a/src/components/sora/task/Preview.vue
+++ b/src/components/sora/task/Preview.vue
@@ -14,7 +14,7 @@
         <p v-if="modelValue?.request?.prompt" class="prompt mt-2">
           {{ modelValue?.request?.prompt }}
           <span v-if="!modelValue?.response"> - ({{ $t('sora.status.pending') }}) </span>
-          <span v-if="Array.isArray(modelValue?.response?.data) && modelValue?.response?.data[0]?.state === 'pending'">
+          <span v-if="modelValue?.response && modelValue?.response?.success === undefined">
             - ({{ $t('sora.status.processing') }})
           </span>
         </p>
@@ -94,8 +94,8 @@
       <div v-if="modelValue?.response?.success === undefined" :class="{ content: true }">
         <el-alert :closable="false" class="info">
           <template #template>
-            <warning-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
-            {{ $t('sora.name.failure') }}
+            <time-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
+            {{ $t(modelValue?.response ? 'sora.status.processing' : 'sora.status.pending') }}
           </template>
           <p class="text-[var(--el-text-color-regular)] text-xs mb-2">
             <magic-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />


### PR DESCRIPTION
## 变更说明
- Sora 尚无响应时显示 Pending，已有未完成响应时显示 Processing
- waiting 分支使用时间图标，不再误用 warning 图标与失败文案
- prompt 状态后缀与 alert 使用同一 unfinished-response 条件

## 验证
- `npx vitest run src/components/sora/task/Preview.test.ts`（3/3）
- ESLint / Prettier
- `npm run verify`
- `npm run build:web`

## 对抗评审（reviewer: codex, 2 rounds）
- RISK: processing response 的 prompt 后缀只识别 pending → 已修：改用与 alert 一致的 `response && success === undefined`
- RISK: 分支落后导致 Kimi/版本元数据回退 → 已修：rebase 最新 `origin/main` 3.329.44
- 第二轮：`VERDICT: CLEAN`