### PR TITLE
fix: label Kling waiting states

### DIFF
--- a/change/@acedatacloud-nexior-kling-waiting-state.json
+++ b/change/@acedatacloud-nexior-kling-waiting-state.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Show pending and processing states for unfinished Kling video tasks.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/kling/task/Preview.test.ts
+++ b/src/components/kling/task/Preview.test.ts
@@ -6,6 +6,9 @@ import type { IKlingTask } from '@/models';
 vi.mock('@/components/common/VideoPlayer.vue', () => ({
   default: { name: 'VideoPlayer', template: '<div />' }
 }));
+vi.mock('@/components/common/ApiCodeButton.vue', () => ({
+  default: { name: 'ApiCodeButton', template: '<div />' }
+}));
 
 import TaskPreview from './Preview.vue';
 
@@ -34,6 +37,9 @@ const mountPreview = (modelValue = task) =>
   shallowMount(TaskPreview, {
     props: { modelValue },
     global: {
+      stubs: {
+        ElAlert: { template: '<div><slot /><slot name="template" /></div>' }
+      },
       mocks: {
         $t: (key: string) => key,
         $dayjs: { format: () => '' },
@@ -43,6 +49,84 @@ const mountPreview = (modelValue = task) =>
   });
 
 describe('kling/task/Preview', () => {
+  it('shows pending copy and a time icon before a response exists', () => {
+    const wrapper = mountPreview({
+      ...task,
+      response: undefined
+    });
+
+    expect(wrapper.find('.prompt').text()).toContain('kling.status.pending');
+    expect(wrapper.text()).toContain('kling.status.pending');
+    expect(wrapper.text()).not.toContain('kling.name.failure');
+    expect(wrapper.findComponent({ name: 'TimeIcon' }).exists()).toBe(true);
+    expect(wrapper.findComponent({ name: 'WarningIcon' }).exists()).toBe(false);
+  });
+
+  it.each(['pending', 'processing', undefined])(
+    'shows processing copy for an unfinished response with state %s',
+    (state) => {
+      const wrapper = mountPreview({
+        ...task,
+        response: {
+          task_id: 'kling-task',
+          state
+        } as IKlingTask['response']
+      });
+
+      expect(wrapper.find('.prompt').text()).toContain('kling.status.processing');
+      expect(wrapper.text()).toContain('kling.status.processing');
+      expect(wrapper.text()).not.toContain('kling.status.pending');
+      expect(wrapper.text()).not.toContain('kling.name.failure');
+      expect(wrapper.findComponent({ name: 'TimeIcon' }).exists()).toBe(true);
+      expect(wrapper.findComponent({ name: 'WarningIcon' }).exists()).toBe(false);
+    }
+  );
+
+  it('preserves explicit failure copy and warning icon', () => {
+    const wrapper = mountPreview({
+      ...task,
+      response: {
+        success: false,
+        task_id: 'kling-task',
+        error: { message: 'Generation failed' }
+      }
+    });
+
+    expect(wrapper.text()).toContain('kling.name.failure');
+    expect(wrapper.text()).not.toContain('kling.status.pending');
+    expect(wrapper.text()).not.toContain('kling.status.processing');
+    expect(wrapper.findComponent({ name: 'WarningIcon' }).exists()).toBe(true);
+  });
+
+  it.each([
+    { state: 'failed', error: { message: 'Generation failed' } },
+    { error: { message: 'Provider rejected the task' } }
+  ])('keeps legacy terminal responses on failure semantics', (response) => {
+    const wrapper = mountPreview({
+      ...task,
+      response: { task_id: 'kling-task', ...response } as IKlingTask['response']
+    });
+
+    expect(wrapper.text()).toContain('kling.name.failure');
+    expect(wrapper.text()).not.toContain('kling.status.processing');
+    expect(wrapper.findComponent({ name: 'WarningIcon' }).exists()).toBe(true);
+  });
+
+  it('gives failure semantics priority over a contradictory success flag', () => {
+    const wrapper = mountPreview({
+      ...task,
+      response: {
+        success: true,
+        task_id: 'kling-task',
+        video_url: 'https://cdn.example.com/result.mp4',
+        error: { message: 'Provider marked the task failed' }
+      }
+    });
+
+    expect(wrapper.text()).toContain('kling.name.failure');
+    expect(wrapper.find('.success').exists()).toBe(false);
+  });
+
   it('shows every previewable request input before the prompt', () => {
     const wrapper = mountPreview();
 

--- a/src/components/kling/task/Preview.vue
+++ b/src/components/kling/task/Preview.vue
@@ -38,20 +38,11 @@
         <p v-if="modelValue?.request?.prompt" class="prompt mt-2">
           {{ modelValue?.request?.prompt }}
           <span v-if="!modelValue?.response"> - ({{ $t('kling.status.pending') }}) </span>
-          <span
-            v-if="
-              modelValue?.response?.state === 'submitted' ||
-              modelValue?.response?.state === 'processing' ||
-              modelValue?.response?.state === 'pending' ||
-              modelValue?.response?.state === 'completed'
-            "
-          >
-            - ({{ $t('kling.status.processing') }})
-          </span>
+          <span v-else-if="isWaiting"> - ({{ $t('kling.status.processing') }}) </span>
         </p>
       </div>
       <!-- Display success message -->
-      <div v-if="modelValue?.response?.success === true" :class="{ content: true, failed: true }">
+      <div v-if="modelValue?.response?.success === true && !isFailure" :class="{ content: true, failed: true }">
         <div v-if="modelValue?.response.video_url" class="mb-4">
           <video-player :src="modelValue?.response.video_url" />
         </div>
@@ -88,7 +79,7 @@
         </el-alert>
       </div>
       <!-- Display error message -->
-      <div v-if="modelValue?.response?.success === false" :class="{ content: true }">
+      <div v-if="isFailure" :class="{ content: true }">
         <el-alert :closable="false" class="failure">
           <template #template>
             <warning-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
@@ -119,11 +110,11 @@
         </el-alert>
       </div>
       <!-- Display error message -->
-      <div v-if="modelValue?.response?.success === undefined" :class="{ content: true }">
+      <div v-if="isWaiting" :class="{ content: true }">
         <el-alert :closable="false" class="info">
           <template #template>
-            <warning-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
-            {{ $t('kling.name.failure') }}
+            <time-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
+            {{ $t(modelValue?.response ? 'kling.status.processing' : 'kling.status.pending') }}
           </template>
           <p class="text-[var(--el-text-color-regular)] text-xs mb-2">
             <magic-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
@@ -183,6 +174,19 @@ export default defineComponent({
     return {};
   },
   computed: {
+    isFailure(): boolean {
+      const response = this.modelValue?.response;
+      return (
+        response?.success === false ||
+        !!response?.error ||
+        response?.state === 'failed' ||
+        response?.state === 'cancelled'
+      );
+    },
+    isWaiting(): boolean {
+      const response = this.modelValue?.response;
+      return !response || (!this.isFailure && response.success !== true && !response.video_url);
+    },
     application() {
       return this.$store.state.kling?.application;
     },


### PR DESCRIPTION
## 变更说明
- Kling 未返回 response 时显示 Pending，已有未完成 response 时显示 Processing
- failure/error/failed/cancelled 优先进入失败态，成功媒体不与 waiting/failure 重叠
- prompt 后缀与 alert 使用同一状态判定

## 验证
- `npx vitest run src/components/kling/task/Preview.test.ts`（11/11）
- ESLint / Prettier / Beachball
- `npm run build:web`

## 对抗评审
- 多轮审查补齐 error-only、failed/cancelled、success+error 和媒体终态边界
- 最终：`VERDICT: CLEAN`