### PR TITLE
fix: label Wan waiting states

### DIFF
--- a/change/@acedatacloud-nexior-wan-waiting-state.json
+++ b/change/@acedatacloud-nexior-wan-waiting-state.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Label queued and processing Wan tasks with waiting semantics instead of failure copy.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/wan/task/Preview.test.ts
+++ b/src/components/wan/task/Preview.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+import { shallowMount } from '@vue/test-utils';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/components/common/VideoPlayer.vue', () => ({
+  default: { name: 'VideoPlayer', template: '<div />' }
+}));
+vi.mock('@/components/common/ApiCodeButton.vue', () => ({
+  default: { name: 'ApiCodeButton', template: '<div />' }
+}));
+
+import Preview from './Preview.vue';
+
+const mountPreview = (response?: { state?: string; success?: boolean; error?: { message?: string } }) =>
+  shallowMount(Preview, {
+    props: {
+      modelValue: {
+        id: 'wan-task-0187',
+        created_at: 1_721_234_567,
+        request: {
+          prompt: 'A paper kite gliding above terraced rice fields at sunrise',
+          model: 'wan2.6-i2v'
+        },
+        response: response as any
+      }
+    },
+    global: {
+      stubs: {
+        ElAlert: { template: '<div><div class="alert-template"><slot name="template" /></div><slot /></div>' }
+      },
+      mocks: {
+        $t: (key: string) => key,
+        $dayjs: { format: () => '2026-07-19' },
+        $store: { state: { wan: { config: {} } } }
+      }
+    }
+  });
+
+describe('wan/task/Preview', () => {
+  it.each([
+    ['without a response', undefined, 'wan.status.pending'],
+    ['with an unfinished pending response', { state: 'pending' }, 'wan.status.processing'],
+    ['with an unfinished processing response', { state: 'processing' }, 'wan.status.processing'],
+    ['with an unfinished running response', { state: 'running' }, 'wan.status.processing'],
+    ['with a queued response', { state: 'queued' }, 'wan.status.processing']
+  ])('labels tasks %s with waiting semantics', (_name, response, expectedStatus) => {
+    const wrapper = mountPreview(response);
+
+    expect(wrapper.find('.alert-template').text()).toContain(expectedStatus);
+    expect(wrapper.find('.prompt').text()).toContain(`- (${expectedStatus})`);
+    expect(wrapper.find('.alert-template').text()).not.toContain('wan.name.failure');
+    expect(wrapper.findComponent({ name: 'TimeIcon' }).exists()).toBe(true);
+    expect(wrapper.findComponent({ name: 'WarningIcon' }).exists()).toBe(false);
+  });
+
+  it('preserves explicit failure semantics', () => {
+    const wrapper = mountPreview({ success: false, error: { message: 'Input video could not be decoded' } });
+
+    expect(wrapper.find('.alert-template').text()).toContain('wan.name.failure');
+    expect(wrapper.findComponent({ name: 'WarningIcon' }).exists()).toBe(true);
+  });
+
+  it.each([{ state: 'failed', error: { message: 'Generation failed' } }, { state: 'cancelled' }])(
+    'keeps terminal response %s on failure semantics',
+    (response) => {
+      const wrapper = mountPreview(response);
+
+      expect(wrapper.find('.alert-template').text()).toContain('wan.name.failure');
+      expect(wrapper.text()).not.toContain('wan.status.processing');
+      expect(wrapper.findComponent({ name: 'WarningIcon' }).exists()).toBe(true);
+    }
+  );
+
+  it('renders a successful response without a state as complete', () => {
+    const wrapper = mountPreview({ success: true });
+
+    expect(wrapper.find('.success').exists()).toBe(true);
+    expect(wrapper.text()).not.toContain('wan.status.processing');
+  });
+
+  it('keeps a success-flagged processing response on waiting semantics', () => {
+    const wrapper = mountPreview({ success: true, state: 'processing' });
+
+    expect(wrapper.text()).toContain('wan.status.processing');
+    expect(wrapper.find('.success').exists()).toBe(false);
+  });
+
+  it('gives failure semantics priority over a contradictory success flag', () => {
+    const wrapper = mountPreview({ success: true, error: { message: 'Provider marked the task failed' } });
+
+    expect(wrapper.text()).toContain('wan.name.failure');
+    expect(wrapper.find('.success').exists()).toBe(false);
+  });
+});

--- a/src/components/wan/task/Preview.vue
+++ b/src/components/wan/task/Preview.vue
@@ -14,19 +14,14 @@
         <p v-if="modelValue?.request?.prompt" class="prompt mt-2">
           {{ modelValue?.request?.prompt }}
           <span v-if="!modelValue?.response"> - ({{ $t('wan.status.pending') }}) </span>
-          <span
-            v-if="
-              modelValue?.response?.state === 'processing' ||
-              modelValue?.response?.state === 'pending' ||
-              modelValue?.response?.state === 'running'
-            "
-          >
-            - ({{ $t('wan.status.processing') }})
-          </span>
+          <span v-if="modelValue?.response && isWaiting"> - ({{ $t('wan.status.processing') }}) </span>
         </p>
       </div>
       <!-- Display success message -->
-      <div v-if="modelValue?.response?.success === true" :class="{ content: true, failed: true }">
+      <div
+        v-if="modelValue?.response?.success === true && !isFailure && !isWaiting"
+        :class="{ content: true, failed: true }"
+      >
         <div v-if="modelValue?.response?.video_url" class="mb-4">
           <video-player :src="modelValue?.response?.video_url" />
         </div>
@@ -58,7 +53,7 @@
         </el-alert>
       </div>
       <!-- Display error message -->
-      <div v-if="modelValue?.response?.success === false" :class="{ content: true }">
+      <div v-if="isFailure" :class="{ content: true }">
         <el-alert :closable="false" class="failure">
           <template #template>
             <warning-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
@@ -89,11 +84,11 @@
         </el-alert>
       </div>
       <!-- Display error message -->
-      <div v-if="modelValue?.response?.success === undefined" :class="{ content: true }">
+      <div v-if="isWaiting" :class="{ content: true }">
         <el-alert :closable="false" class="info">
           <template #template>
-            <warning-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
-            {{ $t('wan.name.failure') }}
+            <time-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
+            {{ $t(modelValue?.response ? 'wan.status.processing' : 'wan.status.pending') }}
           </template>
           <p class="text-[var(--el-text-color-regular)] text-xs mb-0">
             <magic-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
@@ -138,6 +133,22 @@ export default defineComponent({
     }
   },
   computed: {
+    isFailure(): boolean {
+      const response = this.modelValue?.response;
+      return (
+        response?.success === false ||
+        !!response?.error ||
+        response?.state === 'failed' ||
+        response?.state === 'cancelled'
+      );
+    },
+    isWaiting(): boolean {
+      const response = this.modelValue?.response;
+      if (!response) return true;
+      if (this.isFailure) return false;
+      if (['queued', 'pending', 'processing', 'running'].includes(response.state || '')) return true;
+      return response.success !== true && !response.state;
+    },
     application() {
       return this.$store.state.wan?.application;
     },


### PR DESCRIPTION
## 变更说明
- Wan queued/pending/processing/running 显示 Processing，无 response 显示 Pending
- error、failed、cancelled 优先进入失败态
- `success: true` 仅在非 waiting/failure 时进入成功态

## 验证
- `npx vitest run src/components/wan/task/Preview.test.ts`（11/11）
- ESLint / Prettier / Beachball
- `npm run build:web`

## 对抗评审
- 多轮审查补齐 queued、error-only、success 无 state、success+processing 等互斥边界
- 最终：`VERDICT: CLEAN`