### PR TITLE
fix: label Hailuo waiting states

### DIFF
--- a/change/@acedatacloud-nexior-hailuo-waiting-state.json
+++ b/change/@acedatacloud-nexior-hailuo-waiting-state.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Show pending and processing states for unfinished Hailuo video tasks.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/hailuo/task/Preview.test.ts
+++ b/src/components/hailuo/task/Preview.test.ts
@@ -1,0 +1,136 @@
+// @vitest-environment jsdom
+import { shallowMount } from '@vue/test-utils';
+import { describe, expect, it, vi } from 'vitest';
+import type { IHailuoTask } from '@/models';
+
+vi.mock('@/components/common/VideoPlayer.vue', () => ({
+  default: { name: 'VideoPlayer', template: '<div />' }
+}));
+
+import TaskPreview from './Preview.vue';
+
+const task: IHailuoTask = {
+  id: 'hailuo-task',
+  created_at: 1,
+  request: {
+    prompt: 'A paper boat crossing a moonlit lake',
+    model: 'MiniMax-Hailuo-02'
+  }
+};
+
+const mountPreview = (modelValue: IHailuoTask) =>
+  shallowMount(TaskPreview, {
+    props: { modelValue },
+    global: {
+      stubs: {
+        ElAlert: { template: '<div><div class="alert-template"><slot name="template" /></div><slot /></div>' }
+      },
+      mocks: {
+        $t: (key: string) => key,
+        $dayjs: { format: () => '2026-07-19' },
+        $store: { state: { hailuo: {} } }
+      }
+    }
+  });
+
+describe('hailuo/task/Preview', () => {
+  it('shows pending copy and a time icon before a response exists', () => {
+    const wrapper = mountPreview(task);
+
+    expect(wrapper.find('.alert-template').text()).toContain('hailuo.status.pending');
+    expect(wrapper.find('.prompt').text()).toContain('hailuo.status.pending');
+    expect(wrapper.text()).not.toContain('hailuo.name.failure');
+    expect(wrapper.findComponent({ name: 'TimeIcon' }).exists()).toBe(true);
+    expect(wrapper.findComponent({ name: 'WarningIcon' }).exists()).toBe(false);
+  });
+
+  it.each(['pending', 'processing', 'running'])('shows processing copy for a video in the %s state', (state) => {
+    const wrapper = mountPreview({
+      ...task,
+      response: {
+        data: [{ state }]
+      } as IHailuoTask['response']
+    });
+
+    expect(wrapper.find('.alert-template').text()).toContain('hailuo.status.processing');
+    expect(wrapper.find('.prompt').text()).toContain('hailuo.status.processing');
+    expect(wrapper.text()).not.toContain('hailuo.status.pending');
+    expect(wrapper.text()).not.toContain('hailuo.name.failure');
+    expect(wrapper.findComponent({ name: 'TimeIcon' }).exists()).toBe(true);
+    expect(wrapper.findComponent({ name: 'WarningIcon' }).exists()).toBe(false);
+    expect(wrapper.find('.success').exists()).toBe(false);
+  });
+
+  it('does not render success metadata while a successful response is still processing', () => {
+    const wrapper = mountPreview({
+      ...task,
+      response: { success: true, data: [{ state: 'processing' }] } as IHailuoTask['response']
+    });
+
+    expect(wrapper.find('.alert-template').text()).toContain('hailuo.status.processing');
+    expect(wrapper.find('.success').exists()).toBe(false);
+  });
+
+  it('preserves explicit failure copy and warning icon', () => {
+    const wrapper = mountPreview({
+      ...task,
+      response: {
+        success: false,
+        error: { message: 'Generation failed' }
+      } as IHailuoTask['response']
+    });
+
+    expect(wrapper.find('.alert-template').text()).toContain('hailuo.name.failure');
+    expect(wrapper.text()).not.toContain('hailuo.status.pending');
+    expect(wrapper.text()).not.toContain('hailuo.status.processing');
+    expect(wrapper.findComponent({ name: 'WarningIcon' }).exists()).toBe(true);
+  });
+
+  it('gives failure semantics priority over stale processing data', () => {
+    const wrapper = mountPreview({
+      ...task,
+      response: {
+        success: false,
+        error: { message: 'Generation failed' },
+        data: [{ state: 'processing' }]
+      } as IHailuoTask['response']
+    });
+
+    expect(wrapper.text()).toContain('hailuo.name.failure');
+    expect(wrapper.text()).not.toContain('hailuo.status.processing');
+  });
+
+  it('gives error semantics priority over a contradictory success flag', () => {
+    const wrapper = mountPreview({
+      ...task,
+      response: {
+        success: true,
+        error: { message: 'Provider marked the task failed' }
+      } as IHailuoTask['response']
+    });
+
+    expect(wrapper.text()).toContain('hailuo.name.failure');
+    expect(wrapper.find('.success').exists()).toBe(false);
+  });
+
+  it('shows queued responses as processing', () => {
+    const wrapper = mountPreview({
+      ...task,
+      response: { success: true, data: [{ state: 'queued' }] } as IHailuoTask['response']
+    });
+
+    expect(wrapper.text()).toContain('hailuo.status.processing');
+    expect(wrapper.find('.success').exists()).toBe(false);
+  });
+
+  it.each(['failed', 'cancelled'])('keeps a %s provider state on failure semantics', (state) => {
+    const wrapper = mountPreview({
+      ...task,
+      response: { success: true, data: [{ state }] } as IHailuoTask['response']
+    });
+
+    expect(wrapper.text()).toContain('hailuo.name.failure');
+    expect(wrapper.text()).not.toContain('hailuo.status.processing');
+    expect(wrapper.find('.success').exists()).toBe(false);
+  });
+});

--- a/src/components/hailuo/task/Preview.vue
+++ b/src/components/hailuo/task/Preview.vue
@@ -14,13 +14,14 @@
         <p v-if="modelValue?.request?.prompt" class="prompt mt-2">
           {{ modelValue?.request?.prompt }}
           <span v-if="!modelValue?.response"> - ({{ $t('hailuo.status.pending') }}) </span>
-          <span v-if="video?.state === 'processing' || video?.state === 'pending' || video?.state === 'running'">
-            - ({{ $t('hailuo.status.processing') }})
-          </span>
+          <span v-if="modelValue?.response && isWaiting"> - ({{ $t('hailuo.status.processing') }}) </span>
         </p>
       </div>
       <!-- Display success message -->
-      <div v-if="modelValue?.response?.success === true" :class="{ content: true, failed: true }">
+      <div
+        v-if="modelValue?.response?.success === true && !isFailure && !isWaiting"
+        :class="{ content: true, failed: true }"
+      >
         <div v-if="video?.video_url" class="mb-4">
           <video-player :src="video?.video_url" />
         </div>
@@ -63,7 +64,7 @@
         </el-alert>
       </div>
       <!-- Display error message -->
-      <div v-if="modelValue?.response?.success === false" :class="{ content: true }">
+      <div v-if="isFailure" :class="{ content: true }">
         <el-alert :closable="false" class="failure">
           <template #template>
             <warning-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
@@ -93,12 +94,12 @@
           </p>
         </el-alert>
       </div>
-      <!-- Display error message -->
-      <div v-if="modelValue?.response?.success === undefined" :class="{ content: true }">
+      <!-- Display waiting message -->
+      <div v-if="isWaiting" :class="{ content: true }">
         <el-alert :closable="false" class="info">
           <template #template>
-            <warning-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
-            {{ $t('hailuo.name.failure') }}
+            <time-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
+            {{ $t(modelValue?.response ? 'hailuo.status.processing' : 'hailuo.status.pending') }}
           </template>
           <p class="text-[var(--el-text-color-regular)] text-xs mb-0">
             <magic-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
@@ -143,6 +144,22 @@ export default defineComponent({
     }
   },
   computed: {
+    isFailure(): boolean {
+      const response = this.modelValue?.response;
+      return (
+        response?.success === false ||
+        !!response?.error ||
+        this.video?.state === 'failed' ||
+        this.video?.state === 'cancelled'
+      );
+    },
+    isWaiting(): boolean {
+      const response = this.modelValue?.response;
+      return (
+        !response ||
+        (!this.isFailure && ['queued', 'pending', 'processing', 'running'].includes(this.video?.state || ''))
+      );
+    },
     application() {
       return this.$store.state.hailuo?.application;
     },


### PR DESCRIPTION
## 变更说明
- Hailuo queued/pending/processing/running 显示 Processing，无 response 显示 Pending
- error、failed、cancelled 优先进入失败态
- success、waiting、failure 三类面板及 prompt 后缀互斥

## 验证
- `npx vitest run src/components/hailuo/task/Preview.test.ts`（11/11）
- ESLint / Prettier / Beachball
- `npm run build:web`

## 对抗评审
- 多轮审查补齐 error-only、queued、failure+processing data、success+failed/cancelled 等边界
- 最终：`VERDICT: CLEAN`