### PR TITLE
fix: label Pika waiting states

### DIFF
--- a/change/@acedatacloud-nexior-pika-waiting-state.json
+++ b/change/@acedatacloud-nexior-pika-waiting-state.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Show accurate pending and processing semantics for Pika tasks.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/pika/task/Preview.test.ts
+++ b/src/components/pika/task/Preview.test.ts
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+import { shallowMount } from '@vue/test-utils';
+import { describe, expect, it, vi } from 'vitest';
+import type { IPikaTask } from '@/models';
+
+vi.mock('../VideoPlayer.vue', () => ({
+  default: { name: 'VideoPlayer', template: '<div />' }
+}));
+vi.mock('@/components/common/ApiCodeButton.vue', () => ({
+  default: { name: 'ApiCodeButton', template: '<button />' }
+}));
+
+import TaskPreview from './Preview.vue';
+
+const baseTask = {
+  id: 'pika-task',
+  created_at: 1,
+  request: { prompt: 'A paper boat crossing the ocean' }
+} as IPikaTask;
+
+const mountPreview = (modelValue: IPikaTask) =>
+  shallowMount(TaskPreview, {
+    props: { modelValue },
+    global: {
+      stubs: {
+        ElAlert: { template: '<div><slot /><slot name="template" /></div>' }
+      },
+      mocks: {
+        $t: (key: string) => key,
+        $dayjs: { format: () => '' },
+        $store: { state: { pika: {} } }
+      }
+    }
+  });
+
+describe('pika/task/Preview waiting states', () => {
+  it.each([
+    {
+      name: 'pending without a response',
+      task: baseTask,
+      status: 'pika.status.pending'
+    },
+    {
+      name: 'pending unfinished response',
+      task: {
+        ...baseTask,
+        response: { success: true, data: [{ state: 'pending' }] }
+      } as IPikaTask,
+      status: 'pika.status.processing'
+    },
+    {
+      name: 'processing unfinished response',
+      task: {
+        ...baseTask,
+        response: { success: true, data: [{ state: 'processing' }] }
+      } as IPikaTask,
+      status: 'pika.status.processing'
+    },
+    {
+      name: 'unfinished response before video data arrives',
+      task: {
+        ...baseTask,
+        response: { task_id: 'pika-task' }
+      } as IPikaTask,
+      status: 'pika.status.processing'
+    }
+  ])('shows TimeIcon and matching copy for $name', ({ task, status }) => {
+    const wrapper = mountPreview(task);
+
+    expect(wrapper.findComponent({ name: 'TimeIcon' }).exists()).toBe(true);
+    expect(wrapper.findComponent({ name: 'WarningIcon' }).exists()).toBe(false);
+    expect(wrapper.text().match(new RegExp(status, 'g'))).toHaveLength(2);
+    expect(wrapper.text()).not.toContain('pika.name.failure');
+    expect(wrapper.find('.success').exists()).toBe(false);
+  });
+
+  it('preserves explicit failure semantics', () => {
+    const wrapper = mountPreview({
+      ...baseTask,
+      response: {
+        success: false,
+        data: [{ state: 'pending' }],
+        error: { message: 'generation failed' },
+        trace_id: 'trace-1'
+      }
+    } as IPikaTask);
+
+    expect(wrapper.findComponent({ name: 'WarningIcon' }).exists()).toBe(true);
+    expect(wrapper.findComponent({ name: 'TimeIcon' }).exists()).toBe(false);
+    expect(wrapper.text()).toContain('pika.name.failure');
+    expect(wrapper.text()).not.toContain('pika.status.pending');
+    expect(wrapper.text()).not.toContain('pika.status.processing');
+  });
+
+  it.each([
+    { success: true, data: [{ state: 'failed' }] },
+    { error: { message: 'Provider rejected the task' }, data: [] }
+  ])('keeps terminal legacy responses on failure semantics', (response) => {
+    const wrapper = mountPreview({ ...baseTask, response } as IPikaTask);
+
+    expect(wrapper.text()).toContain('pika.name.failure');
+    expect(wrapper.text()).not.toContain('pika.status.processing');
+    expect(wrapper.findComponent({ name: 'WarningIcon' }).exists()).toBe(true);
+  });
+});

--- a/src/components/pika/task/Preview.vue
+++ b/src/components/pika/task/Preview.vue
@@ -14,13 +14,11 @@
         <p v-if="modelValue?.request?.prompt" class="prompt mt-2">
           {{ modelValue?.request?.prompt }}
           <span v-if="!modelValue?.response"> - ({{ $t('pika.status.pending') }}) </span>
-          <span v-if="video?.state === 'processing' || video?.state === 'pending'">
-            - ({{ $t('pika.status.processing') }})
-          </span>
+          <span v-if="modelValue?.response && isWaiting(video)"> - ({{ $t('pika.status.processing') }}) </span>
         </p>
       </div>
       <!-- Display success message -->
-      <div v-if="modelValue?.response?.success === true" :class="{ content: true, failed: true }">
+      <div v-if="modelValue?.response?.success === true && video?.video_url" :class="{ content: true, failed: true }">
         <div class="image-wrapper">
           <VideoPlayer :model-value="video" />
         </div>
@@ -57,7 +55,7 @@
         </el-alert>
       </div>
       <!-- Display error message -->
-      <div v-if="modelValue?.response?.success === false" :class="{ content: true }">
+      <div v-if="isFailure(video)" :class="{ content: true }">
         <el-alert :closable="false" class="failure">
           <template #template>
             <warning-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
@@ -87,15 +85,12 @@
           </p>
         </el-alert>
       </div>
-      <!-- Display error message -->
-      <div
-        v-if="!modelValue?.response || video?.state === 'processing' || video?.state === 'pending'"
-        :class="{ content: true }"
-      >
+      <!-- Display waiting message -->
+      <div v-if="isWaiting(video)" :class="{ content: true }">
         <el-alert :closable="false" class="info">
           <template #template>
-            <warning-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
-            {{ $t('pika.name.failure') }}
+            <time-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
+            {{ $t(!modelValue?.response ? 'pika.status.pending' : 'pika.status.processing') }}
           </template>
           <p class="description">
             <magic-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
@@ -162,10 +157,25 @@ export default defineComponent({
           result.push(audio);
         });
       }
+      if (result.length === 0) {
+        result.push({} as IPikaVideo);
+      }
       return result;
     }
   },
   methods: {
+    isFailure(video: IPikaVideo): boolean {
+      const response = this.modelValue?.response;
+      return (
+        response?.success === false || !!response?.error || video?.state === 'failed' || video?.state === 'cancelled'
+      );
+    },
+    isWaiting(video: IPikaVideo): boolean {
+      const response = this.modelValue?.response;
+      if (!response) return true;
+      if (this.isFailure(video) || video?.video_url) return false;
+      return !video?.state || ['queued', 'pending', 'processing', 'running'].includes(video.state);
+    },
     // onExtend(event: MouseEvent, response: IPikaGenerateResponse) {
     //   event.stopPropagation();
     //   // extend url here


### PR DESCRIPTION
## 变更说明
- Pika 无 response 显示 Pending，未完成 response 显示 Processing
- 空 data 中间态仍渲染任务卡，不再静默消失
- failed/cancelled/error 优先失败，可播放媒体进入成功态

## 验证
- `npx vitest run src/components/pika/task/Preview.test.ts`（7/7）
- ESLint / Prettier / Beachball
- `npm run build:web`

## 对抗评审
- 多轮审查补齐空 data、显式 failure 携带 pending data、failed/cancelled state 等边界
- 最终：`VERDICT: CLEAN`