### PR TITLE
fix: label Nano Banana waiting states

### DIFF
--- a/change/@acedatacloud-nexior-nanobanana-waiting-state.json
+++ b/change/@acedatacloud-nexior-nanobanana-waiting-state.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Label unfinished Nano Banana responses with pending semantics instead of failure copy.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/nanobanana/task/Preview.test.ts
+++ b/src/components/nanobanana/task/Preview.test.ts
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+import { shallowMount } from '@vue/test-utils';
+import { describe, expect, it, vi } from 'vitest';
+import type { INanobananaTask } from '@/models';
+
+vi.mock('@/components/common/ApiCodeButton.vue', () => ({
+  default: { name: 'ApiCodeButton', template: '<div />' }
+}));
+
+import Preview from './Preview.vue';
+
+const mountPreview = (response: INanobananaTask['response']) =>
+  shallowMount(Preview, {
+    props: {
+      modelValue: {
+        id: 'task-1',
+        created_at: 1,
+        request: { prompt: 'A lighthouse', model: 'nano-banana-pro' },
+        response
+      }
+    },
+    global: {
+      stubs: {
+        ElAlert: { template: '<div><slot name="template" /><slot /></div>' }
+      },
+      mocks: {
+        $t: (key: string) => key,
+        $dayjs: { format: () => '2026-07-19' },
+        $store: { state: { nanobanana: { config: {} } }, commit: () => undefined }
+      }
+    }
+  });
+
+describe('nanobanana/task/Preview', () => {
+  it('labels an unfinished response as pending rather than failed', () => {
+    const wrapper = mountPreview({ task_id: 'task-1' } as INanobananaTask['response']);
+
+    expect(wrapper.text()).toContain('nanobanana.status.pending');
+    expect(wrapper.text()).not.toContain('nanobanana.name.failure');
+    expect(wrapper.findComponent({ name: 'TimeIcon' }).exists()).toBe(true);
+    expect(wrapper.findComponent({ name: 'WarningIcon' }).exists()).toBe(false);
+  });
+
+  it('keeps explicit failures on failure semantics', () => {
+    const wrapper = mountPreview({
+      success: false,
+      task_id: 'task-1',
+      error: { message: 'generation failed' }
+    });
+
+    expect(wrapper.text()).toContain('nanobanana.name.failure');
+    expect(wrapper.findComponent({ name: 'WarningIcon' }).exists()).toBe(true);
+  });
+
+  it('keeps error-only legacy responses on failure semantics', () => {
+    const wrapper = mountPreview({
+      task_id: 'task-1',
+      error: { message: 'Provider rejected the task' }
+    } as INanobananaTask['response']);
+
+    expect(wrapper.text()).toContain('nanobanana.name.failure');
+    expect(wrapper.text()).not.toContain('nanobanana.status.pending');
+    expect(wrapper.findComponent({ name: 'WarningIcon' }).exists()).toBe(true);
+  });
+});

--- a/src/components/nanobanana/task/Preview.vue
+++ b/src/components/nanobanana/task/Preview.vue
@@ -86,7 +86,10 @@
           </p>
         </el-alert>
       </div>
-      <div v-else-if="modelValue?.response?.success === false" :class="{ content: true }">
+      <div
+        v-else-if="modelValue?.response?.success === false || modelValue?.response?.error"
+        :class="{ content: true }"
+      >
         <el-alert :closable="false" class="failure">
           <template #template>
             <warning-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
@@ -141,8 +144,8 @@
       <div v-else-if="modelValue?.response" :class="{ content: true }">
         <el-alert :closable="false" class="info">
           <template #template>
-            <warning-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
-            {{ $t('nanobanana.name.failure') }}
+            <time-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
+            {{ $t('nanobanana.status.pending') }}
           </template>
           <p v-if="modelValue?.request?.model" class="text-[var(--el-text-color-regular)] text-xs mb-2">
             <application-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />


### PR DESCRIPTION
## 变更说明
- Nano Banana 未完成 response 使用 Pending 与时间图标，不再显示失败文案
- error-only legacy response 仍优先进入失败态
- 成功结果渲染逻辑保持不变

## 验证
- `npx vitest run src/components/nanobanana/task/Preview.test.ts`（3/3）
- ESLint / Prettier / Beachball
- `npm run build:web`

## 对抗评审
- 审查补齐 error-only legacy response 边界
- 最终：`VERDICT: CLEAN`