### PR TITLE
style(poivelle): align studio with Nexior

### DIFF
--- a/change/@acedatacloud-nexior-poivelle-visual-alignment.json
+++ b/change/@acedatacloud-nexior-poivelle-visual-alignment.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Align the Poivelle studio with Nexior design tokens, responsive surfaces, and keyboard focus states.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/poivelle/AgentDock.vue
+++ b/src/components/poivelle/AgentDock.vue
@@ -50,8 +50,8 @@ const pendingProposals = computed(() => props.proposals.filter((proposal) => pro
   display: grid;
   grid-template-columns: 190px minmax(0, 1fr) auto;
   align-items: center;
-  min-height: 58px;
-  padding: 8px 12px;
+  min-height: 64px;
+  padding: 10px 14px;
   border-top: 1px solid var(--poivelle-line-strong);
   background: var(--poivelle-paper);
 }
@@ -80,8 +80,7 @@ const pendingProposals = computed(() => props.proposals.filter((proposal) => pro
 
 .agent-identity span {
   color: var(--poivelle-muted);
-  font-family: 'Courier New', monospace;
-  font-size: 8px;
+  font-size: 9px;
 }
 
 .proposal-strip {
@@ -97,6 +96,7 @@ const pendingProposals = computed(() => props.proposals.filter((proposal) => pro
   gap: 7px;
   padding: 0 9px;
   border: 1px solid var(--poivelle-line);
+  border-radius: var(--poivelle-radius-small);
   color: var(--poivelle-ink);
   background: var(--poivelle-canvas);
   font: inherit;
@@ -125,7 +125,7 @@ const pendingProposals = computed(() => props.proposals.filter((proposal) => pro
   width: 7px;
   height: 7px;
   border-radius: 50%;
-  background: #9d9d92;
+  background: var(--el-text-color-placeholder);
 }
 
 .risk-high,
@@ -134,20 +134,32 @@ const pendingProposals = computed(() => props.proposals.filter((proposal) => pro
 }
 
 .risk-medium {
-  background: #bd8b2f;
+  background: var(--el-color-warning);
 }
 
 .agent-button {
   height: 34px;
   gap: 7px;
   padding: 0 12px;
-  border: 1px solid var(--poivelle-ink);
-  color: var(--poivelle-ink);
-  background: var(--poivelle-mint);
+  border: 1px solid var(--app-brand-hex);
+  border-radius: var(--poivelle-radius-small);
+  color: var(--app-brand-hex-dark-2);
+  background: var(--poivelle-hover);
   font: inherit;
   font-size: 10px;
   font-weight: 700;
   cursor: pointer;
+}
+
+.agent-button:not(:disabled):hover {
+  color: #fff;
+  background: var(--app-brand-hex);
+}
+
+.proposal-strip button:focus-visible,
+.agent-button:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--app-brand-hex) 38%, transparent);
+  outline-offset: 2px;
 }
 
 .agent-button:disabled {
@@ -158,12 +170,25 @@ const pendingProposals = computed(() => props.proposals.filter((proposal) => pro
 @media (max-width: 767px) {
   .agent-dock {
     grid-template-columns: minmax(0, 1fr) auto;
-    min-height: 52px;
-    padding: 7px 9px;
+    min-height: 50px;
+    padding: 6px 10px calc(6px + var(--app-safe-area-bottom));
+    background: color-mix(in srgb, var(--poivelle-paper) 92%, transparent);
+    backdrop-filter: blur(12px);
   }
 
   .agent-identity {
     display: none;
+  }
+
+  .proposal-strip p {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .agent-button {
+    height: 32px;
+    padding: 0 10px;
   }
 }
 </style>

--- a/src/components/poivelle/GraphCanvas.vue
+++ b/src/components/poivelle/GraphCanvas.vue
@@ -101,9 +101,9 @@ const summary = (node: IPoivelleGraphNode) => {
 }
 
 .connections line {
-  stroke: var(--poivelle-line-strong);
-  stroke-width: 1.5;
-  stroke-dasharray: 4 4;
+  stroke: color-mix(in srgb, var(--app-brand-hex) 32%, var(--poivelle-line-strong));
+  stroke-width: 1.25;
+  stroke-dasharray: 5 5;
 }
 
 .graph-node {
@@ -112,8 +112,9 @@ const summary = (node: IPoivelleGraphNode) => {
   grid-template-rows: auto auto 1fr;
   gap: 7px;
   padding: 12px 13px;
-  border: 1px solid var(--poivelle-line-strong);
-  box-shadow: 2px 2px 0 rgba(23, 33, 29, 0.08);
+  border: 1px solid var(--poivelle-line);
+  border-radius: var(--poivelle-radius);
+  box-shadow: var(--poivelle-shadow);
   color: var(--poivelle-ink);
   background: var(--poivelle-paper);
   text-align: left;
@@ -122,26 +123,35 @@ const summary = (node: IPoivelleGraphNode) => {
 
 .graph-node:hover,
 .graph-node.selected {
-  border-color: var(--poivelle-red);
+  border-color: color-mix(in srgb, var(--app-brand-hex) 58%, transparent);
 }
 
 .graph-node.selected {
-  box-shadow: 3px 3px 0 color-mix(in srgb, var(--poivelle-red) 24%, transparent);
+  box-shadow:
+    0 0 0 3px rgba(var(--app-brand-rgb), 0.12),
+    var(--app-shadow-md);
+}
+
+.graph-node:focus-visible,
+.empty-canvas button:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--app-brand-hex) 38%, transparent);
+  outline-offset: 2px;
 }
 
 .node-type {
-  color: var(--poivelle-red);
-  font-family: 'Courier New', monospace;
+  width: fit-content;
+  padding: 2px 6px;
+  border-radius: var(--adc-radius-full);
+  color: var(--app-brand-hex-dark-2);
+  background: var(--poivelle-hover);
   font-size: 9px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  font-weight: 650;
 }
 
 .graph-node strong {
   overflow: hidden;
-  font-family: Georgia, 'Times New Roman', serif;
-  font-size: 16px;
+  font-size: 14px;
+  font-weight: 650;
   line-height: 1.2;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -163,24 +173,23 @@ const summary = (node: IPoivelleGraphNode) => {
   gap: 4px;
   color: var(--poivelle-muted);
   font-size: 9px;
-  text-transform: uppercase;
 }
 
 .type-character,
 .type-location,
 .type-prop {
-  border-top: 3px solid #2f7c6a;
+  border-left: 3px solid var(--el-color-success);
 }
 
 .type-shot,
 .type-storyboard,
 .type-scene {
-  border-top: 3px solid var(--poivelle-red);
+  border-left: 3px solid var(--app-brand-hex);
 }
 
 .type-audio,
 .type-subtitle {
-  border-top: 3px solid #bd8b2f;
+  border-left: 3px solid var(--el-color-warning);
 }
 
 .empty-canvas {
@@ -198,8 +207,8 @@ const summary = (node: IPoivelleGraphNode) => {
 .empty-canvas h2 {
   margin: 12px 0 6px;
   color: var(--poivelle-ink);
-  font-family: Georgia, 'Times New Roman', serif;
-  font-size: 24px;
+  font-size: 22px;
+  font-weight: 650;
 }
 
 .empty-canvas p {
@@ -214,9 +223,10 @@ const summary = (node: IPoivelleGraphNode) => {
   gap: 7px;
   height: 34px;
   padding: 0 13px;
-  border: 1px solid var(--poivelle-ink);
-  color: var(--poivelle-paper);
-  background: var(--poivelle-ink);
+  border: 1px solid var(--app-brand-hex);
+  border-radius: var(--poivelle-radius-small);
+  color: #fff;
+  background: var(--app-brand-hex);
   font: inherit;
   font-size: 11px;
   cursor: pointer;

--- a/src/components/poivelle/InspectorPanel.vue
+++ b/src/components/poivelle/InspectorPanel.vue
@@ -86,10 +86,10 @@ const savePrompt = () => {
 .inspector-panel {
   display: flex;
   flex-direction: column;
-  width: 272px;
-  min-width: 272px;
+  width: 284px;
+  min-width: 284px;
   min-height: 0;
-  padding: 14px;
+  padding: 16px;
   border-left: 1px solid var(--poivelle-line);
   background: var(--poivelle-paper);
   overflow-y: auto;
@@ -114,18 +114,15 @@ const savePrompt = () => {
 .field > span,
 .node-meta > span {
   color: var(--poivelle-muted);
-  font-family: 'Courier New', monospace;
-  font-size: 9px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  font-size: 10px;
+  font-weight: 650;
 }
 
 .inspector-heading strong {
   overflow: hidden;
   margin-top: 4px;
-  font-family: Georgia, 'Times New Roman', serif;
   font-size: 15px;
+  font-weight: 650;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -141,9 +138,9 @@ const savePrompt = () => {
   width: 100%;
   box-sizing: border-box;
   border: 1px solid var(--poivelle-line-strong);
-  border-radius: 0;
+  border-radius: var(--poivelle-radius-small);
   color: var(--poivelle-ink);
-  background: var(--poivelle-canvas);
+  background: var(--poivelle-paper);
   font: inherit;
   font-size: 11px;
   outline: none;
@@ -163,11 +160,14 @@ const savePrompt = () => {
 
 .field input:focus,
 .field textarea:focus {
-  border-color: var(--poivelle-red);
+  border-color: var(--app-brand-hex);
+  box-shadow: 0 0 0 3px rgba(var(--app-brand-rgb), 0.18);
 }
 
 .field input:disabled {
   color: var(--poivelle-muted);
+  background: var(--poivelle-canvas);
+  cursor: not-allowed;
 }
 
 .node-meta {
@@ -194,12 +194,22 @@ const savePrompt = () => {
   height: 34px;
   gap: 7px;
   margin-top: 14px;
-  border: 1px solid #bd5b50;
-  color: #a63329;
+  border: 1px solid color-mix(in srgb, var(--el-color-danger) 45%, transparent);
+  border-radius: var(--poivelle-radius-small);
+  color: var(--el-color-danger);
   background: transparent;
   font: inherit;
   font-size: 10px;
   cursor: pointer;
+}
+
+.danger-button:hover {
+  background: color-mix(in srgb, var(--el-color-danger) 8%, transparent);
+}
+
+.danger-button:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--el-color-danger) 45%, transparent);
+  outline-offset: 2px;
 }
 
 .empty-inspector {

--- a/src/components/poivelle/ProductionRail.vue
+++ b/src/components/poivelle/ProductionRail.vue
@@ -105,16 +105,16 @@ const assetIcon = (kind: string): Component => {
 .production-rail {
   display: flex;
   flex-direction: column;
-  width: 236px;
-  min-width: 236px;
+  width: 248px;
+  min-width: 248px;
   min-height: 0;
   border-right: 1px solid var(--poivelle-line);
-  background: var(--poivelle-paper);
+  background: var(--app-sidebar-bg);
   overflow-y: auto;
 }
 
 .rail-section {
-  padding: 12px 10px;
+  padding: 14px 12px;
   border-bottom: 1px solid var(--poivelle-line);
 }
 
@@ -137,11 +137,8 @@ const assetIcon = (kind: string): Component => {
   height: 28px;
   padding: 0 5px;
   color: var(--poivelle-muted);
-  font-family: 'Courier New', monospace;
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  font-size: 11px;
+  font-weight: 650;
 }
 
 .section-heading button {
@@ -150,6 +147,7 @@ const assetIcon = (kind: string): Component => {
   height: 26px;
   padding: 0;
   border: 0;
+  border-radius: var(--poivelle-radius-small);
   color: inherit;
   background: transparent;
   cursor: pointer;
@@ -159,7 +157,7 @@ const assetIcon = (kind: string): Component => {
 .asset-list,
 .revision-list {
   display: grid;
-  gap: 3px;
+  gap: 5px;
 }
 
 .project-row,
@@ -174,16 +172,19 @@ const assetIcon = (kind: string): Component => {
 }
 
 .project-row {
-  height: 34px;
+  height: 38px;
   gap: 8px;
-  padding: 0 7px;
+  padding: 0 9px;
+  border-radius: var(--poivelle-radius-small);
   font: inherit;
   font-size: 12px;
 }
 
 .project-row.active {
-  background: var(--poivelle-mint);
+  color: var(--app-brand-hex-dark-2);
+  background: var(--poivelle-hover);
   font-weight: 700;
+  box-shadow: inset 3px 0 0 var(--app-brand-hex);
 }
 
 .project-row span {
@@ -197,7 +198,6 @@ const assetIcon = (kind: string): Component => {
 .project-row small,
 .revision-row small {
   color: var(--poivelle-muted);
-  font-family: 'Courier New', monospace;
   font-size: 9px;
 }
 
@@ -211,29 +211,43 @@ const assetIcon = (kind: string): Component => {
 .asset-filters button {
   padding: 3px 7px;
   border: 1px solid var(--poivelle-line);
+  border-radius: var(--adc-radius-full);
   color: var(--poivelle-muted);
   background: transparent;
   font: inherit;
   font-size: 9px;
-  text-transform: uppercase;
   cursor: pointer;
 }
 
 .asset-filters button.active {
-  border-color: var(--poivelle-ink);
-  color: var(--poivelle-paper);
-  background: var(--poivelle-ink);
+  border-color: var(--app-brand-hex);
+  color: var(--app-brand-hex-dark-2);
+  background: var(--poivelle-hover);
 }
 
 .asset-row {
   min-height: 42px;
   gap: 9px;
   padding: 6px 7px;
+  border-radius: var(--poivelle-radius-small);
 }
 
 .asset-row:hover,
 .project-row:hover {
   background: var(--poivelle-hover);
+}
+
+.section-heading button:hover {
+  color: var(--app-brand-hex);
+  background: var(--poivelle-hover);
+}
+
+.section-heading button:focus-visible,
+.project-row:focus-visible,
+.asset-filters button:focus-visible,
+.asset-row:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--app-brand-hex) 38%, transparent);
+  outline-offset: 2px;
 }
 
 .asset-row > span {
@@ -252,7 +266,6 @@ const assetIcon = (kind: string): Component => {
 .asset-row small {
   color: var(--poivelle-muted);
   font-size: 9px;
-  text-transform: uppercase;
 }
 
 .revision-row {

--- a/src/components/poivelle/ProjectionTabs.vue
+++ b/src/components/poivelle/ProjectionTabs.vue
@@ -38,9 +38,10 @@ const items = [
 <style scoped>
 .projection-tabs {
   display: flex;
-  align-items: stretch;
-  height: 40px;
-  min-height: 40px;
+  align-items: center;
+  height: 48px;
+  min-height: 48px;
+  padding: 6px 10px;
   border-bottom: 1px solid var(--poivelle-line);
   background: var(--poivelle-paper);
   overflow-x: auto;
@@ -50,22 +51,34 @@ const items = [
   display: flex;
   align-items: center;
   justify-content: center;
-  min-width: 100px;
+  min-width: 104px;
+  height: 36px;
   gap: 7px;
   padding: 0 12px;
   border: 0;
-  border-right: 1px solid var(--poivelle-line);
+  border-radius: var(--poivelle-radius-small);
   color: var(--poivelle-muted);
   background: transparent;
   font: inherit;
-  font-size: 10px;
+  font-size: 11px;
   cursor: pointer;
 }
 
 .projection-tabs button.active {
-  color: var(--poivelle-ink);
-  background: var(--poivelle-mint);
+  color: var(--app-brand-hex-dark-2);
+  background: var(--poivelle-hover);
   font-weight: 700;
+  box-shadow: inset 0 -2px 0 var(--app-brand-hex);
+}
+
+.projection-tabs button:hover {
+  color: var(--app-brand-hex);
+  background: var(--poivelle-hover);
+}
+
+.projection-tabs button:focus-visible {
+  outline: 2px solid var(--app-brand-hex);
+  outline-offset: 2px;
 }
 
 .spacer {
@@ -74,9 +87,7 @@ const items = [
 }
 
 .projection-tabs .add-node {
-  border-left: 1px solid var(--poivelle-line);
-  border-right: 0;
-  color: var(--poivelle-ink);
+  color: var(--app-brand-hex);
 }
 
 @media (max-width: 767px) {

--- a/src/components/poivelle/ReviewView.vue
+++ b/src/components/poivelle/ReviewView.vue
@@ -98,23 +98,22 @@ const cancellable = (run: IPoivelleRun) => !['release_pending', 'succeeded', 'fa
   justify-content: space-between;
   padding: 18px;
   border: 1px solid var(--poivelle-line-strong);
+  border-radius: var(--poivelle-radius);
   background: var(--poivelle-paper);
+  box-shadow: var(--app-shadow-xs);
 }
 
 .eyebrow,
 .review-columns h3 {
-  color: var(--poivelle-red);
-  font-family: 'Courier New', monospace;
-  font-size: 9px;
-  font-weight: 700;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
+  color: var(--app-brand-hex);
+  font-size: 10px;
+  font-weight: 650;
 }
 
 .review-summary h2 {
   margin: 5px 0 0;
-  font-family: Georgia, 'Times New Roman', serif;
-  font-size: 24px;
+  font-size: 22px;
+  font-weight: 650;
 }
 
 .summary-metrics {
@@ -125,12 +124,10 @@ const cancellable = (run: IPoivelleRun) => !['release_pending', 'succeeded', 'fa
   display: grid;
   color: var(--poivelle-muted);
   font-size: 9px;
-  text-transform: uppercase;
 }
 
 .summary-metrics strong {
   color: var(--poivelle-ink);
-  font-family: Georgia, 'Times New Roman', serif;
   font-size: 20px;
 }
 
@@ -153,6 +150,7 @@ const cancellable = (run: IPoivelleRun) => !['release_pending', 'succeeded', 'fa
   margin-bottom: 8px;
   padding: 12px;
   border: 1px solid var(--poivelle-line);
+  border-radius: var(--poivelle-radius);
   background: var(--poivelle-paper);
 }
 
@@ -186,8 +184,9 @@ const cancellable = (run: IPoivelleRun) => !['release_pending', 'succeeded', 'fa
 
 .item-actions button,
 .cancel-run {
-  border: 1px solid #bd5b50;
-  color: #a63329;
+  border: 1px solid color-mix(in srgb, var(--el-color-danger) 45%, transparent);
+  border-radius: var(--poivelle-radius-small);
+  color: var(--el-color-danger);
   background: transparent;
   font: inherit;
   font-size: 9px;
@@ -204,13 +203,13 @@ const cancellable = (run: IPoivelleRun) => !['release_pending', 'succeeded', 'fa
   color: var(--poivelle-muted);
   background: var(--poivelle-hover);
   font-size: 8px;
-  text-transform: uppercase;
+  border-radius: var(--adc-radius-full);
 }
 
 .risk-high,
 .risk-critical {
-  color: #a63329;
-  background: #f6d8d3;
+  color: var(--el-color-danger);
+  background: color-mix(in srgb, var(--el-color-danger) 10%, transparent);
 }
 
 .run-item {
@@ -222,7 +221,7 @@ const cancellable = (run: IPoivelleRun) => !['release_pending', 'succeeded', 'fa
   width: 8px;
   height: 8px;
   border-radius: 50%;
-  background: #9d9d92;
+  background: var(--el-text-color-placeholder);
 }
 
 .state-running,
@@ -246,6 +245,12 @@ const cancellable = (run: IPoivelleRun) => !['release_pending', 'succeeded', 'fa
   padding: 0 8px;
 }
 
+.item-actions button:focus-visible,
+.cancel-run:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--el-color-danger) 45%, transparent);
+  outline-offset: 2px;
+}
+
 .run-item strong {
   font-size: 11px;
   text-transform: capitalize;
@@ -254,7 +259,6 @@ const cancellable = (run: IPoivelleRun) => !['release_pending', 'succeeded', 'fa
 .run-item small {
   overflow: hidden;
   color: var(--poivelle-muted);
-  font-family: 'Courier New', monospace;
   font-size: 8px;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/src/components/poivelle/StoryboardMediaLane.vue
+++ b/src/components/poivelle/StoryboardMediaLane.vue
@@ -105,19 +105,22 @@ header {
   margin-bottom: 7px;
 }
 header span {
-  font:
-    9px 'Courier New',
-    monospace;
-  text-transform: uppercase;
+  font-size: 10px;
+  font-weight: 650;
 }
 header button,
 .candidate button {
   padding: 0;
   border: 0;
-  color: var(--poivelle-red);
+  color: var(--app-brand-hex);
   background: transparent;
   font: 9px inherit;
   cursor: pointer;
+}
+header button:focus-visible,
+.candidate button:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--app-brand-hex) 38%, transparent);
+  outline-offset: 2px;
 }
 .candidate-strip {
   display: flex;
@@ -128,11 +131,12 @@ header button,
   flex: 0 0 132px;
   overflow: hidden;
   border: 1px solid var(--poivelle-line-strong);
+  border-radius: var(--poivelle-radius);
   background: var(--poivelle-canvas);
 }
 .candidate.selected {
-  border-color: var(--poivelle-green);
-  box-shadow: inset 0 -3px 0 var(--poivelle-green);
+  border-color: var(--app-brand-hex);
+  box-shadow: 0 0 0 2px rgba(var(--app-brand-rgb), 0.12);
 }
 .candidate img,
 .candidate video {
@@ -140,7 +144,7 @@ header button,
   width: 100%;
   aspect-ratio: 16 / 9;
   object-fit: cover;
-  background: #111;
+  background: var(--poivelle-media-stage);
 }
 .candidate > div {
   display: grid;
@@ -150,16 +154,14 @@ header button,
 }
 .candidate span {
   color: var(--poivelle-muted);
-  font:
-    8px 'Courier New',
-    monospace;
+  font-size: 8px;
 }
 .candidate strong {
   grid-column: 1 / -1;
   font-size: 9px;
 }
 .candidate em {
-  color: var(--poivelle-green);
+  color: var(--app-brand-hex);
   font-size: 8px;
   font-style: normal;
   font-weight: 700;
@@ -169,6 +171,7 @@ header button,
   min-height: 82px;
   place-items: center;
   border: 1px dashed var(--poivelle-line);
+  border-radius: var(--poivelle-radius-small);
   color: var(--poivelle-muted);
   font-size: 9px;
 }
@@ -179,6 +182,7 @@ header button,
 .unavailable-takes span {
   padding: 7px;
   border: 1px solid var(--poivelle-line);
+  border-radius: var(--poivelle-radius-small);
   color: var(--poivelle-muted);
   background: var(--poivelle-canvas);
   font-size: 9px;

--- a/src/components/poivelle/StoryboardView.vue
+++ b/src/components/poivelle/StoryboardView.vue
@@ -100,16 +100,17 @@
     </template>
 
     <template v-else>
-      <article
+      <button
         v-for="(node, index) in legacyNodes"
         :key="node.id"
+        type="button"
         :class="['legacy-card', { selected: node.id === selectedNodeId }]"
         @click="$emit('select-node', node.id)"
       >
         <span>{{ String(index + 1).padStart(2, '0') }}</span>
         <Clapperboard :size="26" stroke-width="1.25" aria-hidden="true" />
         <strong>{{ node.title }}</strong>
-      </article>
+      </button>
       <div v-if="!legacyNodes.length" class="empty-view">
         <Clapperboard :size="30" stroke-width="1.4" />
         <h2>{{ $t('poivelle.storyboard.emptyTitle') }}</h2>
@@ -156,7 +157,7 @@ const legacyNodes = computed(() =>
 <style scoped>
 .storyboard-view {
   height: 100%;
-  padding: 18px;
+  padding: 20px;
   overflow: auto;
   background: var(--poivelle-canvas);
 }
@@ -165,22 +166,24 @@ const legacyNodes = computed(() =>
   align-items: end;
   justify-content: space-between;
   gap: 20px;
-  padding-bottom: 16px;
-  border-bottom: 2px solid var(--poivelle-ink);
+  margin-bottom: 12px;
+  padding: 18px 20px;
+  border: 1px solid var(--poivelle-line);
+  border-radius: var(--poivelle-radius);
+  background: var(--poivelle-paper);
+  box-shadow: var(--app-shadow-xs);
 }
 .storyboard-heading span,
 .shot-number,
 dt,
 .prompt-columns span {
   color: var(--poivelle-muted);
-  font-family: 'Courier New', monospace;
   font-size: 9px;
-  text-transform: uppercase;
 }
 .storyboard-heading h2 {
   margin: 4px 0 0;
-  font-family: Georgia, serif;
-  font-size: 24px;
+  font-size: 22px;
+  font-weight: 650;
 }
 .storyboard-heading dl {
   display: flex;
@@ -197,7 +200,7 @@ dt,
   font-weight: 700;
 }
 .story-section {
-  border-bottom: 1px solid var(--poivelle-line-strong);
+  margin-top: 14px;
 }
 .section-label {
   display: flex;
@@ -206,23 +209,29 @@ dt,
   min-height: 42px;
 }
 .section-label span {
-  color: var(--poivelle-red);
-  font-family: 'Courier New', monospace;
+  color: var(--app-brand-hex);
   font-size: 10px;
 }
 .section-label h3 {
   margin: 0;
   font-size: 12px;
-  text-transform: uppercase;
+  font-weight: 650;
 }
 .shot-row {
   display: grid;
   grid-template-columns: 210px minmax(280px, 0.9fr) minmax(430px, 1.25fr);
-  border-top: 1px solid var(--poivelle-line);
+  margin-bottom: 8px;
+  overflow: hidden;
+  border: 1px solid var(--poivelle-line);
+  border-radius: var(--poivelle-radius);
   background: var(--poivelle-paper);
+  box-shadow: var(--app-shadow-xs);
 }
 .shot-row.selected {
-  box-shadow: inset 3px 0 0 var(--poivelle-red);
+  border-color: color-mix(in srgb, var(--app-brand-hex) 45%, var(--poivelle-line));
+  box-shadow:
+    inset 3px 0 0 var(--app-brand-hex),
+    var(--app-shadow-sm);
 }
 .shot-brief {
   display: grid;
@@ -237,13 +246,18 @@ dt,
   cursor: pointer;
 }
 .shot-brief strong {
-  font-family: Georgia, serif;
-  font-size: 15px;
+  font-size: 14px;
+  font-weight: 650;
   line-height: 1.35;
 }
 .shot-brief > span:last-child {
   color: var(--poivelle-muted);
   font-size: 10px;
+}
+.shot-brief:focus-visible,
+.legacy-card:focus-visible {
+  outline: 2px solid var(--app-brand-hex);
+  outline-offset: 2px;
 }
 .shot-production {
   min-width: 0;
@@ -272,7 +286,8 @@ dt,
 .prompt-columns div {
   min-width: 0;
   padding: 8px;
-  background: var(--poivelle-canvas);
+  border-radius: var(--poivelle-radius-small);
+  background: var(--app-bg-section);
 }
 .prompt-columns p {
   margin: 4px 0 0;
@@ -294,17 +309,16 @@ dt,
   justify-items: center;
   gap: 8px;
   border: 1px solid var(--poivelle-line-strong);
+  border-radius: var(--poivelle-radius);
   background: var(--poivelle-paper);
   cursor: pointer;
 }
 .legacy-card.selected {
-  border-color: var(--poivelle-red);
+  border-color: var(--app-brand-hex);
 }
 .legacy-card span {
-  color: var(--poivelle-red);
-  font:
-    10px 'Courier New',
-    monospace;
+  color: var(--app-brand-hex);
+  font-size: 10px;
 }
 .empty-view {
   display: grid;
@@ -317,9 +331,8 @@ dt,
 .empty-view h2 {
   margin: 12px 0 5px;
   color: var(--poivelle-ink);
-  font:
-    22px Georgia,
-    serif;
+  font-size: 22px;
+  font-weight: 650;
 }
 .empty-view p {
   margin: 0;
@@ -355,7 +368,7 @@ dt,
   .shot-row {
     display: block;
     margin-bottom: 12px;
-    border: 1px solid var(--poivelle-line-strong);
+    border: 1px solid var(--poivelle-line);
   }
   .shot-brief {
     border-right: 0;

--- a/src/components/poivelle/StudioHeader.vue
+++ b/src/components/poivelle/StudioHeader.vue
@@ -1,7 +1,7 @@
 <template>
   <header class="studio-header">
     <div class="identity">
-      <span class="wordmark">POIVELLE</span>
+      <span class="wordmark"><Clapperboard :size="15" aria-hidden="true" /> POIVELLE</span>
       <button class="project-button" type="button" @click="$emit('open-projects')">
         <span>{{ projectTitle || $t('poivelle.project.noProject') }}</span>
         <ChevronDown :size="14" aria-hidden="true" />
@@ -31,7 +31,7 @@
 </template>
 
 <script setup lang="ts">
-import { ChevronDown, GitCommitHorizontal, Play } from '@lucide/vue';
+import { ChevronDown, Clapperboard, GitCommitHorizontal, Play } from '@lucide/vue';
 
 defineProps<{
   projectTitle?: string;
@@ -52,10 +52,12 @@ defineEmits<{
   display: flex;
   align-items: center;
   justify-content: space-between;
-  min-height: 58px;
-  padding: 8px 14px 8px 18px;
+  min-height: 60px;
+  padding: 10px 16px;
   border-bottom: 1px solid var(--poivelle-line);
   background: var(--poivelle-paper);
+  box-shadow: var(--app-shadow-xs);
+  z-index: 2;
 }
 
 .identity,
@@ -77,17 +79,20 @@ defineEmits<{
 }
 
 .wordmark {
-  color: var(--poivelle-red);
-  font-family: 'Courier New', monospace;
-  font-size: 11px;
-  font-weight: 700;
-  letter-spacing: 0.16em;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--app-brand-hex);
+  font-size: 12px;
+  font-weight: 750;
+  letter-spacing: 0.08em;
 }
 
 .project-button,
 .icon-button,
 .primary-button {
   border: 1px solid var(--poivelle-line-strong);
+  border-radius: var(--poivelle-radius-small);
   color: var(--poivelle-ink);
   background: transparent;
   cursor: pointer;
@@ -96,12 +101,13 @@ defineEmits<{
 .project-button {
   min-width: 0;
   max-width: 280px;
-  height: 34px;
+  height: 36px;
   gap: 7px;
   padding: 0 10px;
   font: inherit;
   font-size: 13px;
   font-weight: 650;
+  background: var(--poivelle-canvas);
 }
 
 .project-button span {
@@ -113,8 +119,7 @@ defineEmits<{
 .version,
 .sync-state {
   color: var(--poivelle-muted);
-  font-family: 'Courier New', monospace;
-  font-size: 10px;
+  font-size: 11px;
 }
 
 .sync-state {
@@ -126,24 +131,26 @@ defineEmits<{
   width: 7px;
   height: 7px;
   border-radius: 50%;
-  background: var(--poivelle-green);
+  background: var(--el-color-success);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--el-color-success) 14%, transparent);
 }
 
 .icon-button {
   display: grid;
   place-items: center;
   width: 34px;
-  height: 34px;
+  height: 36px;
   padding: 0;
 }
 
 .primary-button {
-  height: 34px;
+  height: 36px;
   gap: 7px;
   padding: 0 13px;
-  border-color: var(--poivelle-ink);
-  color: var(--poivelle-paper);
-  background: var(--poivelle-ink);
+  border-color: var(--app-brand-hex);
+  color: #fff;
+  background: var(--app-brand-hex);
+  box-shadow: var(--app-shadow-sm);
   font: inherit;
   font-size: 12px;
   font-weight: 700;
@@ -152,6 +159,25 @@ defineEmits<{
 .primary-button:disabled {
   cursor: not-allowed;
   opacity: 0.42;
+}
+
+.project-button:hover,
+.icon-button:hover {
+  border-color: var(--app-brand-hex);
+  color: var(--app-brand-hex);
+  background: var(--poivelle-hover);
+}
+
+.primary-button:not(:disabled):hover {
+  background: var(--app-brand-hex-dark-2);
+  box-shadow: var(--app-glow-primary);
+}
+
+.project-button:focus-visible,
+.icon-button:focus-visible,
+.primary-button:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--app-brand-hex) 38%, transparent);
+  outline-offset: 2px;
 }
 
 @media (max-width: 767px) {

--- a/src/components/poivelle/StudioWorkspace.vue
+++ b/src/components/poivelle/StudioWorkspace.vue
@@ -470,17 +470,24 @@ onMounted(bootstrap);
 
 <style scoped>
 .poivelle-studio {
-  --poivelle-ink: #17211d;
-  --poivelle-muted: #68726d;
-  --poivelle-red: #d04435;
-  --poivelle-green: #2b8b67;
-  --poivelle-mint: #b8e0cc;
-  --poivelle-paper: #f8faf6;
-  --poivelle-canvas: #edf1eb;
-  --poivelle-hover: #e5ebe4;
-  --poivelle-line: rgba(23, 33, 29, 0.13);
-  --poivelle-line-strong: rgba(23, 33, 29, 0.28);
-  --poivelle-grid: rgba(23, 33, 29, 0.045);
+  --poivelle-ink: var(--el-text-color-primary);
+  --poivelle-muted: var(--el-text-color-secondary);
+  --poivelle-red: var(--app-brand-hex);
+  --poivelle-green: var(--el-color-success);
+  --poivelle-mint: var(--app-badge-bg);
+  --poivelle-paper: var(--app-bg-surface);
+  --poivelle-canvas: var(--app-bg-section);
+  --poivelle-hover: rgba(var(--app-brand-rgb), 0.08);
+  --poivelle-line: var(--app-border-subtle);
+  --poivelle-line-strong: var(--el-border-color);
+  --poivelle-grid: rgba(var(--app-brand-rgb), 0.055);
+  --poivelle-radius: var(--adc-radius-card);
+  --poivelle-radius-small: var(--adc-radius-control);
+  --poivelle-shadow: var(--app-shadow-sm);
+  --poivelle-media-stage: #050706;
+  --poivelle-media-overlay: rgb(5 7 6 / 78%);
+  --poivelle-on-media: var(--el-color-white);
+  --poivelle-on-media-danger: var(--el-color-danger-light-3);
   display: flex;
   flex-direction: column;
   height: 100%;
@@ -488,7 +495,7 @@ onMounted(bootstrap);
   overflow: hidden;
   color: var(--poivelle-ink);
   background: var(--poivelle-canvas);
-  font-family: 'Avenir Next', Avenir, sans-serif;
+  font-family: var(--adc-font-family-sans);
 }
 
 .studio-body {
@@ -515,10 +522,10 @@ onMounted(bootstrap);
   min-height: 36px;
   gap: 8px;
   padding: 0 12px;
-  border-bottom: 1px solid #d8998f;
-  color: #8f2c23;
-  background: #f8ddd8;
-  font-size: 11px;
+  border-bottom: 1px solid color-mix(in srgb, var(--el-color-danger) 28%, transparent);
+  color: var(--el-color-danger);
+  background: color-mix(in srgb, var(--el-color-danger) 9%, var(--poivelle-paper));
+  font-size: 12px;
 }
 .error-banner span {
   flex: 1;
@@ -542,9 +549,7 @@ onMounted(bootstrap);
 }
 .loading-state {
   gap: 10px;
-  font-family: 'Courier New', monospace;
-  font-size: 10px;
-  text-transform: uppercase;
+  font-size: 12px;
 }
 .is-spinning {
   animation: spin 0.9s linear infinite;
@@ -552,31 +557,26 @@ onMounted(bootstrap);
 .onboarding {
   padding: 28px;
   text-align: center;
-  background-color: var(--poivelle-canvas);
-  background-image:
-    linear-gradient(var(--poivelle-grid) 1px, transparent 1px),
-    linear-gradient(90deg, var(--poivelle-grid) 1px, transparent 1px);
-  background-size: 24px 24px;
+  background: var(--poivelle-canvas);
 }
 .onboarding-number {
-  margin-bottom: 24px;
-  color: var(--poivelle-red);
-  font-family: 'Courier New', monospace;
-  font-size: 10px;
+  margin-bottom: 20px;
+  color: var(--app-brand-hex);
+  font-size: 11px;
+  font-weight: 650;
 }
 .onboarding h1 {
   max-width: 620px;
   margin: 15px 0 8px;
-  font-family: Georgia, 'Times New Roman', serif;
-  font-size: 38px;
-  font-weight: 500;
+  font-size: 30px;
+  font-weight: 650;
   letter-spacing: 0;
 }
 .onboarding > p {
   max-width: 520px;
   margin: 0 0 22px;
   color: var(--poivelle-muted);
-  font-size: 13px;
+  font-size: 14px;
   line-height: 1.6;
 }
 .onboarding > button {
@@ -585,9 +585,11 @@ onMounted(bootstrap);
   height: 38px;
   gap: 8px;
   padding: 0 15px;
-  border: 1px solid var(--poivelle-ink);
-  color: var(--poivelle-paper);
-  background: var(--poivelle-ink);
+  border: 1px solid var(--app-brand-hex);
+  border-radius: var(--poivelle-radius-small);
+  color: #fff;
+  background: var(--app-brand-hex);
+  box-shadow: var(--app-shadow-sm);
   font: inherit;
   font-size: 11px;
   font-weight: 700;
@@ -598,6 +600,8 @@ onMounted(bootstrap);
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   border: 1px solid var(--poivelle-line-strong);
+  border-radius: var(--poivelle-radius);
+  overflow: hidden;
 }
 .dry-run-summary div {
   display: grid;
@@ -610,8 +614,7 @@ onMounted(bootstrap);
 }
 .dry-run-summary span {
   color: var(--poivelle-muted);
-  font-size: 9px;
-  text-transform: uppercase;
+  font-size: 10px;
 }
 .dry-run-summary strong {
   font-size: 13px;
@@ -627,18 +630,6 @@ onMounted(bootstrap);
   to {
     transform: rotate(360deg);
   }
-}
-
-:global(html.dark) .poivelle-studio {
-  --poivelle-ink: #eef2ed;
-  --poivelle-muted: #9fa9a3;
-  --poivelle-paper: #141a17;
-  --poivelle-canvas: #0d1210;
-  --poivelle-hover: #202923;
-  --poivelle-line: rgba(238, 242, 237, 0.1);
-  --poivelle-line-strong: rgba(238, 242, 237, 0.24);
-  --poivelle-grid: rgba(238, 242, 237, 0.04);
-  --poivelle-mint: #356c59;
 }
 
 @media (max-width: 767px) {

--- a/src/components/poivelle/TimelineView.vue
+++ b/src/components/poivelle/TimelineView.vue
@@ -71,8 +71,9 @@
             type="button"
             class="timeline-clip"
             :style="clipStyle(clip)"
+            :title="clip.artifact_id"
           >
-            {{ clip.artifact_id }}
+            {{ clipLabel(clip) }}
           </button>
         </div>
       </div>
@@ -142,6 +143,7 @@ const frameLabel = computed(() => {
   return width && height ? `${width} × ${height}` : '—';
 });
 const clipsFor = (trackId: string) => props.timeline?.clips.filter((clip) => clip.track_id === trackId) ?? [];
+const clipLabel = (clip: IPoivelleTimelineClip) => clip.artifact_id.slice(-6);
 const clipStyle = (clip: IPoivelleTimelineClip) => ({
   left: `${clip.timeline_start_ms / 100}px`,
   width: `${Math.max(48, (clip.source_out_ms - clip.source_in_ms) / 100)}px`
@@ -151,7 +153,7 @@ const clipStyle = (clip: IPoivelleTimelineClip) => ({
 <style scoped>
 .timeline-view {
   height: 100%;
-  padding: 18px;
+  padding: 22px;
   overflow: auto;
   background: var(--poivelle-canvas);
 }
@@ -159,8 +161,11 @@ const clipStyle = (clip: IPoivelleTimelineClip) => ({
 .master-output {
   width: min(100%, 960px);
   margin: 0 auto 24px;
-  padding-bottom: 22px;
-  border-bottom: 1px solid var(--poivelle-line-strong);
+  overflow: hidden;
+  border: 1px solid var(--poivelle-line);
+  border-radius: var(--poivelle-radius);
+  background: var(--poivelle-paper);
+  box-shadow: var(--app-shadow-md);
 }
 
 .master-heading {
@@ -168,22 +173,22 @@ const clipStyle = (clip: IPoivelleTimelineClip) => ({
   align-items: end;
   justify-content: space-between;
   gap: 16px;
-  margin-bottom: 12px;
+  margin-bottom: 0;
+  padding: 18px 20px;
+  background: var(--app-gradient-subtle);
 }
 
 .master-kicker {
-  color: var(--poivelle-muted);
-  font-family: 'Courier New', monospace;
-  font-size: 9px;
-  text-transform: uppercase;
+  color: var(--app-brand-hex);
+  font-size: 10px;
+  font-weight: 650;
 }
 
 .master-heading h2 {
   margin: 3px 0 0;
   color: var(--poivelle-ink);
-  font-family: Georgia, 'Times New Roman', serif;
   font-size: 20px;
-  font-weight: 500;
+  font-weight: 650;
 }
 
 .master-download {
@@ -193,24 +198,35 @@ const clipStyle = (clip: IPoivelleTimelineClip) => ({
   min-height: 34px;
   padding: 0 12px;
   border: 1px solid var(--poivelle-line-strong);
-  color: var(--poivelle-ink);
+  border-radius: var(--poivelle-radius-small);
+  color: var(--app-brand-hex-dark-2);
   background: var(--poivelle-paper);
   font-size: 10px;
   text-decoration: none;
+}
+
+.master-download:hover {
+  border-color: var(--app-brand-hex);
+  background: var(--poivelle-hover);
+}
+
+.master-download:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--app-brand-hex) 38%, transparent);
+  outline-offset: 2px;
 }
 
 .master-media {
   position: relative;
   width: 100%;
   aspect-ratio: 16 / 9;
-  background: #050706;
+  background: var(--poivelle-media-stage);
 }
 
 .master-player {
   display: block;
   width: 100%;
   height: 100%;
-  background: #050706;
+  background: var(--poivelle-media-stage);
   object-fit: contain;
 }
 
@@ -221,15 +237,15 @@ const clipStyle = (clip: IPoivelleTimelineClip) => ({
   place-content: center;
   justify-items: center;
   gap: 8px;
-  color: #d8ddd8;
-  background: rgb(5 7 6 / 78%);
+  color: var(--poivelle-on-media);
+  background: var(--poivelle-media-overlay);
   font-size: 10px;
   pointer-events: none;
   z-index: 1;
 }
 
 .master-status.is-error {
-  color: #f0c4b7;
+  color: var(--poivelle-on-media-danger);
 }
 
 .is-spinning {
@@ -246,13 +262,13 @@ const clipStyle = (clip: IPoivelleTimelineClip) => ({
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
   margin: 0;
-  border: 1px solid var(--poivelle-line);
+  border: 0;
   border-top: 0;
 }
 
 .master-metadata div {
   min-width: 0;
-  padding: 9px 11px;
+  padding: 11px 13px;
   border-right: 1px solid var(--poivelle-line);
 }
 
@@ -262,20 +278,23 @@ const clipStyle = (clip: IPoivelleTimelineClip) => ({
 
 .master-metadata dt {
   color: var(--poivelle-muted);
-  font-size: 8px;
-  text-transform: uppercase;
+  font-size: 9px;
 }
 
 .master-metadata dd {
   margin: 3px 0 0;
   overflow: hidden;
   color: var(--poivelle-ink);
-  font-family: 'Courier New', monospace;
-  font-size: 10px;
+  font-size: 11px;
+  font-weight: 600;
   text-overflow: ellipsis;
 }
 
 @media (max-width: 720px) {
+  .timeline-view {
+    padding: 16px 18px 28px;
+  }
+
   .master-heading {
     align-items: stretch;
     flex-direction: column;
@@ -283,6 +302,10 @@ const clipStyle = (clip: IPoivelleTimelineClip) => ({
 
   .master-download {
     align-self: flex-start;
+  }
+
+  .master-output {
+    box-shadow: var(--app-shadow-sm);
   }
 
   .master-metadata {
@@ -304,9 +327,10 @@ const clipStyle = (clip: IPoivelleTimelineClip) => ({
   width: 1200px;
   height: 28px;
   padding-left: 120px;
-  border-bottom: 1px solid var(--poivelle-line-strong);
+  border: 1px solid var(--poivelle-line);
+  border-bottom: 0;
+  border-radius: var(--poivelle-radius) var(--poivelle-radius) 0 0;
   color: var(--poivelle-muted);
-  font-family: 'Courier New', monospace;
   font-size: 9px;
 }
 
@@ -315,7 +339,14 @@ const clipStyle = (clip: IPoivelleTimelineClip) => ({
   grid-template-columns: 120px 1fr;
   width: 1320px;
   min-height: 58px;
-  border-bottom: 1px solid var(--poivelle-line);
+  border: 1px solid var(--poivelle-line);
+  border-top: 0;
+  background: var(--poivelle-paper);
+}
+
+.track-row:last-child {
+  border-radius: 0 0 var(--poivelle-radius) var(--poivelle-radius);
+  overflow: hidden;
 }
 
 .track-label {
@@ -324,9 +355,8 @@ const clipStyle = (clip: IPoivelleTimelineClip) => ({
   padding: 0 10px;
   border-right: 1px solid var(--poivelle-line-strong);
   color: var(--poivelle-muted);
-  background: var(--poivelle-paper);
+  background: var(--app-sidebar-bg);
   font-size: 10px;
-  text-transform: uppercase;
 }
 
 .track-lane {
@@ -340,13 +370,19 @@ const clipStyle = (clip: IPoivelleTimelineClip) => ({
   height: 38px;
   padding: 0 8px;
   overflow: hidden;
-  border: 1px solid #6aa48d;
+  border: 1px solid color-mix(in srgb, var(--app-brand-hex) 42%, transparent);
+  border-radius: var(--poivelle-radius-small);
   color: var(--poivelle-ink);
-  background: var(--poivelle-mint);
+  background: var(--poivelle-hover);
   font: inherit;
   font-size: 9px;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.timeline-clip:focus-visible {
+  outline: 0;
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--app-brand-hex) 55%, transparent);
 }
 
 .empty-timeline {
@@ -361,8 +397,8 @@ const clipStyle = (clip: IPoivelleTimelineClip) => ({
 .empty-timeline h2 {
   margin: 12px 0 5px;
   color: var(--poivelle-ink);
-  font-family: Georgia, 'Times New Roman', serif;
   font-size: 22px;
+  font-weight: 650;
 }
 
 .empty-timeline p {


### PR DESCRIPTION
## Summary

- replace Poivelle's standalone paper/editorial palette with Nexior's shared runtime brand, surface, typography, radius, shadow, safe-area, and dark-mode tokens
- align the studio header, project/asset rail, projection tabs, inspector, agent dock, graph canvas, Storyboard, Timeline, Review, and media candidates with existing Nexior interaction states
- preserve professional information density while adding clear teal selection, responsive card hierarchy, keyboard focus indicators, semantic media-stage colors, and mobile-safe controls
- keep every API, Vuex, graph, run, Artifact, Timeline, and media behavior unchanged

## Visual direction

The merged Poivelle UI had its own red/cream/mint, Georgia/Courier design system and square native controls, which made it feel embedded from another product. This change uses the same Inter/system typography, Ace Data Cloud teal, light/dark surfaces, elevations, radii, and button behavior as Nexior.

## Validation

- `npm test -- --run` → **81 test files / 595 tests passed**
- `npx vue-tsc --noEmit` → passed
- `npm run lint:check` → passed
- `python3 scripts/check_i18n_coverage.py` → 17 locales × 45 namespaces passed
- `npm run verify` → Beachball passed
- `npm run build:web` → built in **4.27s**
- `git diff --check origin/main...HEAD` → passed

Production-backed Playwright used the real PulseCam Project and exercised:

| Scenario | Projection | API requests | Runtime errors | Page overflow |
| --- | --- | ---: | ---: | ---: |
| Desktop light, 1440×900 | Storyboard | 13 × HTTP 200 | 0 | 0 |
| Desktop dark, 1440×900 | Canvas | 13 × HTTP 200 | 0 | 0 |
| Mobile light, 390×844 | Timeline | 13 × HTTP 200 | 0 | 0 |
| Mobile dark, 390×844 | Review | 13 × HTTP 200 | 0 | 0 |

Measured results:
- Poivelle font: Nexior `Inter` stack in all four scenarios
- Active tab: runtime teal brand, 12px radius
- cards: 16px radius with shared light/dark shadows
- mobile document width: exactly 390px, no page-level horizontal overflow
- preview: `http://127.0.0.1:4320/poivelle?features=poivelle&lang=en`

Validation-machine screenshots and machine-readable metrics:
- `artifacts/poivelle-visual-alignment/desktop-light.png`
- `artifacts/poivelle-visual-alignment/desktop-dark.png`
- `artifacts/poivelle-visual-alignment/mobile-light.png`
- `artifacts/poivelle-visual-alignment/mobile-dark.png`
- `artifacts/poivelle-visual-alignment/result.json`

## 🤖 对抗评审 (reviewer: Codex attempted + Explore, 3 rounds)

- RISK: hardcoded media blacks/overlay text could drift in dark mode → fixed with semantic Poivelle media tokens derived from Element/Nexior text tokens
- RISK: disabled Inspector input lost dark-mode contrast → fixed with shared sidebar surface and disabled text tokens
- RISK: interactive controls lacked visible keyboard focus → fixed across header, rail, tabs, graph, Storyboard, Timeline, Review, inspector, and agent controls
- RISK: negative/internal focus offsets were too subtle → fixed with full-brand external rings; Timeline clips use a visible non-clipped focus shadow
- RISK: legacy Storyboard fallback cards were not keyboard-focusable → changed to native `button type="button"`
- RISK: mobile dock could overlap/clip content → validated with safe-area padding and real 390×844 Timeline/Review screenshots; page overflow remains 0
- Codex was invoked read-only but its separate usage quota remains exhausted; Explore final exact-diff review returned `VERDICT: CLEAN`

## Notes

- Media previews intentionally retain a dark theater stage in both themes; all surrounding chrome and overlay text follow Nexior tokens.
- No new product copy or locale keys were introduced.
