### PR TITLE
fix(poivelle): delegate standard billing credentials

### DIFF
--- a/change/@acedatacloud-nexior-poivelle-standard-billing.json
+++ b/change/@acedatacloud-nexior-poivelle-standard-billing.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Route Poivelle provider runs through standard user Credentials, API cost rules, and usage recording.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/poivelle/StudioWorkspace.vue
+++ b/src/components/poivelle/StudioWorkspace.vue
@@ -441,11 +441,7 @@ const confirmRun = async () => {
   await submittingTask(async () => {
     const run = await store.dispatch('poivelle/confirmDryRun');
     dryRunDialogVisible.value = false;
-    if (run?.state === 'reservation_pending') {
-      ElMessage.warning(t('poivelle.run.reservationPending'));
-    } else {
-      ElMessage.success(t('poivelle.run.queued'));
-    }
+    if (run) ElMessage.success(t('poivelle.run.queued'));
   });
 };
 const openProposal = (proposalId: string) => {

--- a/src/i18n/ar/poivelle.json
+++ b/src/i18n/ar/poivelle.json
@@ -264,7 +264,7 @@
     "description": "Dry run approval class"
   },
   "run.confirmBody": {
-    "message": "The compiler will execute only the selected dependency closure against this immutable revision. Provider-backed work remains reservation-gated.",
+    "message": "The compiler executes this immutable dependency closure with a short-lived API credential. Each provider call uses its existing cost rules and usage record.",
     "description": "Run confirmation explanation"
   },
   "run.confirm": {
@@ -283,10 +283,6 @@
     "message": "Plan selected",
     "description": "Plan a skill action for the selected graph node"
   },
-  "run.reservationPending": {
-    "message": "Run created; Gateway budget reservation is required before provider execution.",
-    "description": "Reservation-pending run notice"
-  },
   "review.reject": {
     "message": "Reject",
     "description": "Reject agent proposal command"
@@ -304,7 +300,7 @@
     "description": "Cancel execution run command"
   },
   "run.cancelConfirm": {
-    "message": "Cancel this execution run and release its reservation?",
+    "message": "Cancel this execution run?",
     "description": "Cancel run confirmation"
   },
   "project.workflow": {

--- a/src/i18n/de/poivelle.json
+++ b/src/i18n/de/poivelle.json
@@ -264,7 +264,7 @@
     "description": "Dry run approval class"
   },
   "run.confirmBody": {
-    "message": "The compiler will execute only the selected dependency closure against this immutable revision. Provider-backed work remains reservation-gated.",
+    "message": "The compiler executes this immutable dependency closure with a short-lived API credential. Each provider call uses its existing cost rules and usage record.",
     "description": "Run confirmation explanation"
   },
   "run.confirm": {
@@ -283,10 +283,6 @@
     "message": "Plan selected",
     "description": "Plan a skill action for the selected graph node"
   },
-  "run.reservationPending": {
-    "message": "Run created; Gateway budget reservation is required before provider execution.",
-    "description": "Reservation-pending run notice"
-  },
   "review.reject": {
     "message": "Reject",
     "description": "Reject agent proposal command"
@@ -304,7 +300,7 @@
     "description": "Cancel execution run command"
   },
   "run.cancelConfirm": {
-    "message": "Cancel this execution run and release its reservation?",
+    "message": "Cancel this execution run?",
     "description": "Cancel run confirmation"
   },
   "project.workflow": {

--- a/src/i18n/el/poivelle.json
+++ b/src/i18n/el/poivelle.json
@@ -264,7 +264,7 @@
     "description": "Dry run approval class"
   },
   "run.confirmBody": {
-    "message": "The compiler will execute only the selected dependency closure against this immutable revision. Provider-backed work remains reservation-gated.",
+    "message": "The compiler executes this immutable dependency closure with a short-lived API credential. Each provider call uses its existing cost rules and usage record.",
     "description": "Run confirmation explanation"
   },
   "run.confirm": {
@@ -283,10 +283,6 @@
     "message": "Plan selected",
     "description": "Plan a skill action for the selected graph node"
   },
-  "run.reservationPending": {
-    "message": "Run created; Gateway budget reservation is required before provider execution.",
-    "description": "Reservation-pending run notice"
-  },
   "review.reject": {
     "message": "Reject",
     "description": "Reject agent proposal command"
@@ -304,7 +300,7 @@
     "description": "Cancel execution run command"
   },
   "run.cancelConfirm": {
-    "message": "Cancel this execution run and release its reservation?",
+    "message": "Cancel this execution run?",
     "description": "Cancel run confirmation"
   },
   "project.workflow": {

--- a/src/i18n/en/poivelle.json
+++ b/src/i18n/en/poivelle.json
@@ -119,13 +119,12 @@
   "run.maximum": { "message": "Maximum cost", "description": "Dry run maximum cost" },
   "run.approval": { "message": "Approval class", "description": "Dry run approval class" },
   "run.confirmBody": {
-    "message": "The compiler will execute only the selected dependency closure against this immutable revision. Provider-backed work remains reservation-gated.",
+    "message": "The compiler executes this immutable dependency closure with a short-lived API credential. Each provider call uses its existing cost rules and usage record.",
     "description": "Run confirmation explanation"
   },
   "run.confirm": { "message": "Confirm run", "description": "Confirm run command" },
   "run.queued": { "message": "Production run queued", "description": "Run queue success toast" },
-  "run.reservationPending": { "message": "Run created; Gateway budget reservation is required before provider execution.", "description": "Reservation-pending run notice" },
   "run.cancel": { "message": "Cancel", "description": "Cancel execution run command" },
-  "run.cancelConfirm": { "message": "Cancel this execution run and release its reservation?", "description": "Cancel run confirmation" },
+  "run.cancelConfirm": { "message": "Cancel this execution run?", "description": "Cancel run confirmation" },
   "error.generic": { "message": "Poivelle could not complete the request.", "description": "Generic Poivelle request error" }
 }

--- a/src/i18n/es/poivelle.json
+++ b/src/i18n/es/poivelle.json
@@ -264,7 +264,7 @@
     "description": "Dry run approval class"
   },
   "run.confirmBody": {
-    "message": "The compiler will execute only the selected dependency closure against this immutable revision. Provider-backed work remains reservation-gated.",
+    "message": "The compiler executes this immutable dependency closure with a short-lived API credential. Each provider call uses its existing cost rules and usage record.",
     "description": "Run confirmation explanation"
   },
   "run.confirm": {
@@ -283,10 +283,6 @@
     "message": "Plan selected",
     "description": "Plan a skill action for the selected graph node"
   },
-  "run.reservationPending": {
-    "message": "Run created; Gateway budget reservation is required before provider execution.",
-    "description": "Reservation-pending run notice"
-  },
   "review.reject": {
     "message": "Reject",
     "description": "Reject agent proposal command"
@@ -304,7 +300,7 @@
     "description": "Cancel execution run command"
   },
   "run.cancelConfirm": {
-    "message": "Cancel this execution run and release its reservation?",
+    "message": "Cancel this execution run?",
     "description": "Cancel run confirmation"
   },
   "project.workflow": {

--- a/src/i18n/fi/poivelle.json
+++ b/src/i18n/fi/poivelle.json
@@ -264,7 +264,7 @@
     "description": "Dry run approval class"
   },
   "run.confirmBody": {
-    "message": "The compiler will execute only the selected dependency closure against this immutable revision. Provider-backed work remains reservation-gated.",
+    "message": "The compiler executes this immutable dependency closure with a short-lived API credential. Each provider call uses its existing cost rules and usage record.",
     "description": "Run confirmation explanation"
   },
   "run.confirm": {
@@ -283,10 +283,6 @@
     "message": "Plan selected",
     "description": "Plan a skill action for the selected graph node"
   },
-  "run.reservationPending": {
-    "message": "Run created; Gateway budget reservation is required before provider execution.",
-    "description": "Reservation-pending run notice"
-  },
   "review.reject": {
     "message": "Reject",
     "description": "Reject agent proposal command"
@@ -304,7 +300,7 @@
     "description": "Cancel execution run command"
   },
   "run.cancelConfirm": {
-    "message": "Cancel this execution run and release its reservation?",
+    "message": "Cancel this execution run?",
     "description": "Cancel run confirmation"
   },
   "project.workflow": {

--- a/src/i18n/fr/poivelle.json
+++ b/src/i18n/fr/poivelle.json
@@ -264,7 +264,7 @@
     "description": "Dry run approval class"
   },
   "run.confirmBody": {
-    "message": "The compiler will execute only the selected dependency closure against this immutable revision. Provider-backed work remains reservation-gated.",
+    "message": "The compiler executes this immutable dependency closure with a short-lived API credential. Each provider call uses its existing cost rules and usage record.",
     "description": "Run confirmation explanation"
   },
   "run.confirm": {
@@ -283,10 +283,6 @@
     "message": "Plan selected",
     "description": "Plan a skill action for the selected graph node"
   },
-  "run.reservationPending": {
-    "message": "Run created; Gateway budget reservation is required before provider execution.",
-    "description": "Reservation-pending run notice"
-  },
   "review.reject": {
     "message": "Reject",
     "description": "Reject agent proposal command"
@@ -304,7 +300,7 @@
     "description": "Cancel execution run command"
   },
   "run.cancelConfirm": {
-    "message": "Cancel this execution run and release its reservation?",
+    "message": "Cancel this execution run?",
     "description": "Cancel run confirmation"
   },
   "project.workflow": {

--- a/src/i18n/it/poivelle.json
+++ b/src/i18n/it/poivelle.json
@@ -264,7 +264,7 @@
     "description": "Dry run approval class"
   },
   "run.confirmBody": {
-    "message": "The compiler will execute only the selected dependency closure against this immutable revision. Provider-backed work remains reservation-gated.",
+    "message": "The compiler executes this immutable dependency closure with a short-lived API credential. Each provider call uses its existing cost rules and usage record.",
     "description": "Run confirmation explanation"
   },
   "run.confirm": {
@@ -283,10 +283,6 @@
     "message": "Plan selected",
     "description": "Plan a skill action for the selected graph node"
   },
-  "run.reservationPending": {
-    "message": "Run created; Gateway budget reservation is required before provider execution.",
-    "description": "Reservation-pending run notice"
-  },
   "review.reject": {
     "message": "Reject",
     "description": "Reject agent proposal command"
@@ -304,7 +300,7 @@
     "description": "Cancel execution run command"
   },
   "run.cancelConfirm": {
-    "message": "Cancel this execution run and release its reservation?",
+    "message": "Cancel this execution run?",
     "description": "Cancel run confirmation"
   },
   "project.workflow": {

--- a/src/i18n/ja/poivelle.json
+++ b/src/i18n/ja/poivelle.json
@@ -264,7 +264,7 @@
     "description": "Dry run approval class"
   },
   "run.confirmBody": {
-    "message": "The compiler will execute only the selected dependency closure against this immutable revision. Provider-backed work remains reservation-gated.",
+    "message": "The compiler executes this immutable dependency closure with a short-lived API credential. Each provider call uses its existing cost rules and usage record.",
     "description": "Run confirmation explanation"
   },
   "run.confirm": {
@@ -283,10 +283,6 @@
     "message": "Plan selected",
     "description": "Plan a skill action for the selected graph node"
   },
-  "run.reservationPending": {
-    "message": "Run created; Gateway budget reservation is required before provider execution.",
-    "description": "Reservation-pending run notice"
-  },
   "review.reject": {
     "message": "Reject",
     "description": "Reject agent proposal command"
@@ -304,7 +300,7 @@
     "description": "Cancel execution run command"
   },
   "run.cancelConfirm": {
-    "message": "Cancel this execution run and release its reservation?",
+    "message": "Cancel this execution run?",
     "description": "Cancel run confirmation"
   },
   "project.workflow": {

--- a/src/i18n/ko/poivelle.json
+++ b/src/i18n/ko/poivelle.json
@@ -264,7 +264,7 @@
     "description": "Dry run approval class"
   },
   "run.confirmBody": {
-    "message": "The compiler will execute only the selected dependency closure against this immutable revision. Provider-backed work remains reservation-gated.",
+    "message": "The compiler executes this immutable dependency closure with a short-lived API credential. Each provider call uses its existing cost rules and usage record.",
     "description": "Run confirmation explanation"
   },
   "run.confirm": {
@@ -283,10 +283,6 @@
     "message": "Plan selected",
     "description": "Plan a skill action for the selected graph node"
   },
-  "run.reservationPending": {
-    "message": "Run created; Gateway budget reservation is required before provider execution.",
-    "description": "Reservation-pending run notice"
-  },
   "review.reject": {
     "message": "Reject",
     "description": "Reject agent proposal command"
@@ -304,7 +300,7 @@
     "description": "Cancel execution run command"
   },
   "run.cancelConfirm": {
-    "message": "Cancel this execution run and release its reservation?",
+    "message": "Cancel this execution run?",
     "description": "Cancel run confirmation"
   },
   "project.workflow": {

--- a/src/i18n/pl/poivelle.json
+++ b/src/i18n/pl/poivelle.json
@@ -264,7 +264,7 @@
     "description": "Dry run approval class"
   },
   "run.confirmBody": {
-    "message": "The compiler will execute only the selected dependency closure against this immutable revision. Provider-backed work remains reservation-gated.",
+    "message": "The compiler executes this immutable dependency closure with a short-lived API credential. Each provider call uses its existing cost rules and usage record.",
     "description": "Run confirmation explanation"
   },
   "run.confirm": {
@@ -283,10 +283,6 @@
     "message": "Plan selected",
     "description": "Plan a skill action for the selected graph node"
   },
-  "run.reservationPending": {
-    "message": "Run created; Gateway budget reservation is required before provider execution.",
-    "description": "Reservation-pending run notice"
-  },
   "review.reject": {
     "message": "Reject",
     "description": "Reject agent proposal command"
@@ -304,7 +300,7 @@
     "description": "Cancel execution run command"
   },
   "run.cancelConfirm": {
-    "message": "Cancel this execution run and release its reservation?",
+    "message": "Cancel this execution run?",
     "description": "Cancel run confirmation"
   },
   "project.workflow": {

--- a/src/i18n/pt/poivelle.json
+++ b/src/i18n/pt/poivelle.json
@@ -264,7 +264,7 @@
     "description": "Dry run approval class"
   },
   "run.confirmBody": {
-    "message": "The compiler will execute only the selected dependency closure against this immutable revision. Provider-backed work remains reservation-gated.",
+    "message": "The compiler executes this immutable dependency closure with a short-lived API credential. Each provider call uses its existing cost rules and usage record.",
     "description": "Run confirmation explanation"
   },
   "run.confirm": {
@@ -283,10 +283,6 @@
     "message": "Plan selected",
     "description": "Plan a skill action for the selected graph node"
   },
-  "run.reservationPending": {
-    "message": "Run created; Gateway budget reservation is required before provider execution.",
-    "description": "Reservation-pending run notice"
-  },
   "review.reject": {
     "message": "Reject",
     "description": "Reject agent proposal command"
@@ -304,7 +300,7 @@
     "description": "Cancel execution run command"
   },
   "run.cancelConfirm": {
-    "message": "Cancel this execution run and release its reservation?",
+    "message": "Cancel this execution run?",
     "description": "Cancel run confirmation"
   },
   "project.workflow": {

--- a/src/i18n/ru/poivelle.json
+++ b/src/i18n/ru/poivelle.json
@@ -264,7 +264,7 @@
     "description": "Dry run approval class"
   },
   "run.confirmBody": {
-    "message": "The compiler will execute only the selected dependency closure against this immutable revision. Provider-backed work remains reservation-gated.",
+    "message": "The compiler executes this immutable dependency closure with a short-lived API credential. Each provider call uses its existing cost rules and usage record.",
     "description": "Run confirmation explanation"
   },
   "run.confirm": {
@@ -283,10 +283,6 @@
     "message": "Plan selected",
     "description": "Plan a skill action for the selected graph node"
   },
-  "run.reservationPending": {
-    "message": "Run created; Gateway budget reservation is required before provider execution.",
-    "description": "Reservation-pending run notice"
-  },
   "review.reject": {
     "message": "Reject",
     "description": "Reject agent proposal command"
@@ -304,7 +300,7 @@
     "description": "Cancel execution run command"
   },
   "run.cancelConfirm": {
-    "message": "Cancel this execution run and release its reservation?",
+    "message": "Cancel this execution run?",
     "description": "Cancel run confirmation"
   },
   "project.workflow": {

--- a/src/i18n/sr/poivelle.json
+++ b/src/i18n/sr/poivelle.json
@@ -264,7 +264,7 @@
     "description": "Dry run approval class"
   },
   "run.confirmBody": {
-    "message": "The compiler will execute only the selected dependency closure against this immutable revision. Provider-backed work remains reservation-gated.",
+    "message": "The compiler executes this immutable dependency closure with a short-lived API credential. Each provider call uses its existing cost rules and usage record.",
     "description": "Run confirmation explanation"
   },
   "run.confirm": {
@@ -283,10 +283,6 @@
     "message": "Plan selected",
     "description": "Plan a skill action for the selected graph node"
   },
-  "run.reservationPending": {
-    "message": "Run created; Gateway budget reservation is required before provider execution.",
-    "description": "Reservation-pending run notice"
-  },
   "review.reject": {
     "message": "Reject",
     "description": "Reject agent proposal command"
@@ -304,7 +300,7 @@
     "description": "Cancel execution run command"
   },
   "run.cancelConfirm": {
-    "message": "Cancel this execution run and release its reservation?",
+    "message": "Cancel this execution run?",
     "description": "Cancel run confirmation"
   },
   "project.workflow": {

--- a/src/i18n/sv/poivelle.json
+++ b/src/i18n/sv/poivelle.json
@@ -264,7 +264,7 @@
     "description": "Dry run approval class"
   },
   "run.confirmBody": {
-    "message": "The compiler will execute only the selected dependency closure against this immutable revision. Provider-backed work remains reservation-gated.",
+    "message": "The compiler executes this immutable dependency closure with a short-lived API credential. Each provider call uses its existing cost rules and usage record.",
     "description": "Run confirmation explanation"
   },
   "run.confirm": {
@@ -283,10 +283,6 @@
     "message": "Plan selected",
     "description": "Plan a skill action for the selected graph node"
   },
-  "run.reservationPending": {
-    "message": "Run created; Gateway budget reservation is required before provider execution.",
-    "description": "Reservation-pending run notice"
-  },
   "review.reject": {
     "message": "Reject",
     "description": "Reject agent proposal command"
@@ -304,7 +300,7 @@
     "description": "Cancel execution run command"
   },
   "run.cancelConfirm": {
-    "message": "Cancel this execution run and release its reservation?",
+    "message": "Cancel this execution run?",
     "description": "Cancel run confirmation"
   },
   "project.workflow": {

--- a/src/i18n/uk/poivelle.json
+++ b/src/i18n/uk/poivelle.json
@@ -264,7 +264,7 @@
     "description": "Dry run approval class"
   },
   "run.confirmBody": {
-    "message": "The compiler will execute only the selected dependency closure against this immutable revision. Provider-backed work remains reservation-gated.",
+    "message": "The compiler executes this immutable dependency closure with a short-lived API credential. Each provider call uses its existing cost rules and usage record.",
     "description": "Run confirmation explanation"
   },
   "run.confirm": {
@@ -283,10 +283,6 @@
     "message": "Plan selected",
     "description": "Plan a skill action for the selected graph node"
   },
-  "run.reservationPending": {
-    "message": "Run created; Gateway budget reservation is required before provider execution.",
-    "description": "Reservation-pending run notice"
-  },
   "review.reject": {
     "message": "Reject",
     "description": "Reject agent proposal command"
@@ -304,7 +300,7 @@
     "description": "Cancel execution run command"
   },
   "run.cancelConfirm": {
-    "message": "Cancel this execution run and release its reservation?",
+    "message": "Cancel this execution run?",
     "description": "Cancel run confirmation"
   },
   "project.workflow": {

--- a/src/i18n/zh-CN/poivelle.json
+++ b/src/i18n/zh-CN/poivelle.json
@@ -112,11 +112,10 @@
   "run.targets": { "message": "依赖闭包", "description": "Dry run 目标数量" },
   "run.maximum": { "message": "最高成本", "description": "Dry run 最高成本" },
   "run.approval": { "message": "审批级别", "description": "Dry run 审批级别" },
-  "run.confirmBody": { "message": "编译器只会针对这个不可变修订执行选中的依赖闭包。调用外部供应商的工作仍必须先完成额度预留。", "description": "运行确认说明" },
+  "run.confirmBody": { "message": "编译器将使用短期 API Credential 执行这个不可变依赖闭包；每次供应商调用均沿用现有成本规则与用量记录。", "description": "运行确认说明" },
   "run.confirm": { "message": "确认运行", "description": "确认运行命令" },
   "run.queued": { "message": "制作运行已进入队列", "description": "运行入队成功提示" },
-  "run.reservationPending": { "message": "运行已创建；调用外部供应商前仍需由 Gateway 完成额度预留。", "description": "等待额度预留的运行提示" },
   "run.cancel": { "message": "取消", "description": "取消执行运行操作" },
-  "run.cancelConfirm": { "message": "取消此执行运行并释放其额度预留吗？", "description": "取消运行确认" },
+  "run.cancelConfirm": { "message": "确定取消此执行运行吗？", "description": "取消运行确认" },
   "error.generic": { "message": "Poivelle 未能完成该请求。", "description": "Poivelle 通用错误" }
 }

--- a/src/i18n/zh-TW/poivelle.json
+++ b/src/i18n/zh-TW/poivelle.json
@@ -264,7 +264,7 @@
     "description": "Dry run approval class"
   },
   "run.confirmBody": {
-    "message": "The compiler will execute only the selected dependency closure against this immutable revision. Provider-backed work remains reservation-gated.",
+    "message": "The compiler executes this immutable dependency closure with a short-lived API credential. Each provider call uses its existing cost rules and usage record.",
     "description": "Run confirmation explanation"
   },
   "run.confirm": {
@@ -283,10 +283,6 @@
     "message": "Plan selected",
     "description": "Plan a skill action for the selected graph node"
   },
-  "run.reservationPending": {
-    "message": "Run created; Gateway budget reservation is required before provider execution.",
-    "description": "Reservation-pending run notice"
-  },
   "review.reject": {
     "message": "Reject",
     "description": "Reject agent proposal command"
@@ -304,7 +300,7 @@
     "description": "Cancel execution run command"
   },
   "run.cancelConfirm": {
-    "message": "Cancel this execution run and release its reservation?",
+    "message": "Cancel this execution run?",
     "description": "Cancel run confirmation"
   },
   "project.workflow": {

--- a/src/models/credential.ts
+++ b/src/models/credential.ts
@@ -21,6 +21,7 @@ export interface ICredential {
   created_at?: string;
   updated_at?: string;
   user_id?: string;
+  metadata?: Record<string, unknown>;
 }
 
 export interface ICredentialListResponse {

--- a/src/models/poivelle.ts
+++ b/src/models/poivelle.ts
@@ -274,6 +274,7 @@ export interface IPoivelleActionDryRun {
   revision_id: string;
   dependency_closure: string[];
   max_cost_microcredits: number;
+  requires_credential: boolean;
   required_approval: 'auto' | 'batch' | 'always';
   confirmation_nonce: string;
   expires_at: string;
@@ -314,17 +315,8 @@ export interface IPoivelleRun {
   id: string;
   project_id: string;
   revision_id: string;
-  state:
-    | 'reservation_pending'
-    | 'pending'
-    | 'running'
-    | 'paused'
-    | 'paused_for_recovery'
-    | 'settling'
-    | 'release_pending'
-    | 'succeeded'
-    | 'failed'
-    | 'cancelled';
+  funding_mode?: 'user_credential' | 'user_reserved' | 'managed';
+  state: 'pending' | 'running' | 'paused' | 'paused_for_recovery' | 'succeeded' | 'failed' | 'cancelled';
   created_at: string;
   finished_at?: string;
 }

--- a/src/operators/poivelle.ts
+++ b/src/operators/poivelle.ts
@@ -264,7 +264,13 @@ class PoivelleOperator {
 
   confirmAction(
     projectId: string,
-    payload: { dry_run_id: string; revision_id: string; confirmation_nonce: string; idempotency_key: string },
+    payload: {
+      dry_run_id: string;
+      revision_id: string;
+      confirmation_nonce: string;
+      idempotency_key: string;
+      execution_credential?: string;
+    },
     options: IPoivelleRequestOptions
   ): Promise<AxiosResponse<{ run: IPoivelleRun; steps: unknown[] }>> {
     return axios.post(`/poivelle/projects/${encode(projectId)}/actions/confirm`, payload, this.config(options));

--- a/src/store/poivelle/actions.test.ts
+++ b/src/store/poivelle/actions.test.ts
@@ -11,11 +11,19 @@ import {
   retryStep,
   selectTake
 } from './actions';
-import { poivelleOperator } from '@/operators';
+import { applicationOperator, credentialOperator, poivelleOperator } from '@/operators';
 import { setCurrentProject } from './mutations';
 import stateFactory from './state';
 
 vi.mock('@/operators', () => ({
+  applicationOperator: {
+    getAll: vi.fn()
+  },
+  credentialOperator: {
+    getAll: vi.fn(),
+    create: vi.fn(),
+    delete: vi.fn()
+  },
   poivelleOperator: {
     getWorkspaces: vi.fn(),
     applyGraphCommand: vi.fn(),
@@ -46,13 +54,16 @@ vi.mock('@/operators', () => ({
 
 const context = (access?: string) => ({
   state: stateFactory(),
-  rootState: { token: { access } },
+  rootState: { token: { access }, user: { id: 'user' }, applications: [] },
   commit: vi.fn(),
   dispatch: vi.fn()
 });
 
 describe('Poivelle Vuex actions', () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(credentialOperator.getAll).mockResolvedValue({ data: { count: 0, items: [] } } as any);
+  });
 
   it('fails bootstrap without sending an unauthenticated request', async () => {
     const ctx = context();
@@ -172,17 +183,27 @@ describe('Poivelle Vuex actions', () => {
     expect(state.selectedNodeId).toBeUndefined();
   });
 
-  it('returns a reservation-pending run to the confirmation UI', async () => {
+  it('delegates a capped temporary Global credential to a provider run', async () => {
     const run = {
       id: 'run',
       project_id: 'project',
       revision_id: 'revision',
-      state: 'reservation_pending',
+      state: 'pending',
+      funding_mode: 'user_credential',
       created_at: 'now'
     } as const;
     vi.mocked(poivelleOperator.confirmAction).mockResolvedValue({ data: { run, steps: [] } } as any);
+    vi.mocked(applicationOperator.getAll).mockResolvedValue({
+      data: {
+        items: [{ id: 'global-app', scope: 'Global', role: 'owner' }]
+      }
+    } as any);
+    vi.mocked(credentialOperator.create).mockResolvedValue({
+      data: { id: 'temporary-credential', token: 'temporary-global-credential-00000001' }
+    } as any);
     const ctx = context('token');
     ctx.state.currentProjectId = 'project';
+    ctx.state.projects = [{ id: 'project', managed_execution: false } as any];
     ctx.state.dryRun = {
       id: 'dryrun',
       project_id: 'project',
@@ -190,14 +211,80 @@ describe('Poivelle Vuex actions', () => {
       target_ids: ['node'],
       revision_id: 'revision',
       dependency_closure: ['node'],
-      max_cost_microcredits: 0,
+      max_cost_microcredits: 2_500_000,
+      requires_credential: true,
       required_approval: 'batch',
       confirmation_nonce: 'nonce',
       expires_at: 'later'
     };
 
     await expect(confirmDryRun(ctx as any)).resolves.toEqual(run);
+    expect(credentialOperator.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        application_id: 'global-app',
+        limited_amount: 2.5,
+        metadata: {
+          purpose: 'poivelle_execution',
+          project_id: 'project',
+          dry_run_id: 'dryrun'
+        }
+      })
+    );
+    expect(poivelleOperator.confirmAction).toHaveBeenCalledWith(
+      'project',
+      expect.objectContaining({
+        idempotency_key: 'confirm-dryrun',
+        execution_credential: 'temporary-global-credential-00000001'
+      }),
+      { token: 'token' }
+    );
     expect(ctx.commit).toHaveBeenCalledWith('setRuns', [run]);
+  });
+
+  it('reuses the temporary credential for an idempotent confirmation retry', async () => {
+    const run = { id: 'run', project_id: 'project', revision_id: 'revision', state: 'pending', created_at: 'now' };
+    vi.mocked(applicationOperator.getAll).mockResolvedValue({
+      data: { items: [{ id: 'global-app', scope: 'Global', role: 'owner' }] }
+    } as any);
+    vi.mocked(credentialOperator.getAll).mockResolvedValue({
+      data: {
+        count: 1,
+        items: [
+          {
+            id: 'existing-credential',
+            token: 'existing-temporary-credential-000001',
+            expired_at: new Date(Date.now() + 60_000).toISOString(),
+            metadata: { purpose: 'poivelle_execution', dry_run_id: 'dryrun' }
+          }
+        ]
+      }
+    } as any);
+    vi.mocked(poivelleOperator.confirmAction).mockResolvedValue({ data: { run, steps: [] } } as any);
+    const ctx = context('token');
+    ctx.state.currentProjectId = 'project';
+    ctx.state.projects = [{ id: 'project' } as any];
+    ctx.state.dryRun = {
+      id: 'dryrun',
+      project_id: 'project',
+      action_type: 'generate',
+      target_ids: ['node'],
+      revision_id: 'revision',
+      dependency_closure: ['node'],
+      max_cost_microcredits: 1_000_000,
+      requires_credential: true,
+      required_approval: 'batch',
+      confirmation_nonce: 'nonce',
+      expires_at: 'later'
+    };
+
+    await confirmDryRun(ctx as any);
+
+    expect(credentialOperator.create).not.toHaveBeenCalled();
+    expect(poivelleOperator.confirmAction).toHaveBeenCalledWith(
+      'project',
+      expect.objectContaining({ execution_credential: 'existing-temporary-credential-000001' }),
+      { token: 'token' }
+    );
   });
 
   it('replaces the rejected proposal with the server result', async () => {
@@ -217,7 +304,7 @@ describe('Poivelle Vuex actions', () => {
 
   it('replaces a cancelling run with the server lifecycle state', async () => {
     const run = { id: 'run', state: 'running' } as const;
-    const cancelling = { ...run, state: 'release_pending' as const };
+    const cancelling = { ...run, state: 'cancelled' as const };
     vi.mocked(poivelleOperator.cancelRun).mockResolvedValue({ data: cancelling } as any);
     const ctx = context('token');
     ctx.state.currentProjectId = 'project';

--- a/src/store/poivelle/actions.ts
+++ b/src/store/poivelle/actions.ts
@@ -1,6 +1,9 @@
 import type { ActionContext } from 'vuex';
 import {
   Status,
+  IApplicationScope,
+  IApplicationType,
+  type ICredential,
   type IPoivelleCommercialTVCBlueprintRequest,
   type IPoivelleGraphCommandRequest,
   type IPoivelleActionDryRun,
@@ -9,7 +12,7 @@ import {
   type IPoivelleTimeline,
   type PoivelleProjection
 } from '@/models';
-import { poivelleOperator } from '@/operators';
+import { applicationOperator, credentialOperator, poivelleOperator } from '@/operators';
 import type { IRootState } from '../common/models';
 import type { IPoivelleState } from './models';
 
@@ -24,7 +27,7 @@ const message = (error: unknown): string => {
   if (error && typeof error === 'object' && 'response' in error) {
     const detail = (error as any).response?.data?.detail;
     if (typeof detail === 'string') return detail;
-    if (detail?.message) return detail.message;
+    if (typeof detail?.message === 'string') return detail.message;
   }
   return error instanceof Error ? error.message : 'Poivelle request failed';
 };
@@ -32,6 +35,65 @@ const uid = (): string =>
   typeof crypto !== 'undefined' && crypto.randomUUID
     ? crypto.randomUUID()
     : `${Date.now().toString(16)}${Math.random().toString(16).slice(2)}`;
+
+const createExecutionCredential = async (
+  rootState: IRootState,
+  dryRun: IPoivelleActionDryRun
+): Promise<ICredential | undefined> => {
+  if (!dryRun.requires_credential) return undefined;
+  const userId = rootState.user?.id;
+  if (!userId) throw new Error('Poivelle provider execution requires an authenticated user');
+  let applications = rootState.applications ?? [];
+  let globalApplication = applications
+    .filter((application) => application.scope === IApplicationScope.GLOBAL && application.role === 'owner')
+    .sort((left, right) => (right.remaining_amount ?? 0) - (left.remaining_amount ?? 0))[0];
+  if (!globalApplication) {
+    const response = await applicationOperator.getAll({
+      limit: 100,
+      offset: 0,
+      user_id: 'me',
+      ordering: '-created_at',
+      type: IApplicationType.USAGE,
+      scope: IApplicationScope.GLOBAL,
+      affiliation: 'owner'
+    });
+    applications = response.data.items;
+    globalApplication = [...applications].sort(
+      (left, right) => (right.remaining_amount ?? 0) - (left.remaining_amount ?? 0)
+    )[0];
+  }
+  if (!globalApplication?.id) throw new Error('A Global usage application is required for provider execution');
+  const usable = (credential: ICredential): boolean =>
+    credential.metadata?.purpose === 'poivelle_execution' &&
+    credential.metadata?.dry_run_id === dryRun.id &&
+    !!credential.token &&
+    (!credential.expired_at || Date.parse(credential.expired_at) > Date.now());
+  let credential = globalApplication.credentials?.find(usable);
+  if (!credential) {
+    const response = await credentialOperator.getAll({
+      application_id: globalApplication.id,
+      limit: 100,
+      ordering: '-created_at'
+    });
+    credential = response.data.items.find(usable);
+  }
+  if (credential) return credential;
+  const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+  const limitedAmount = dryRun.max_cost_microcredits > 0 ? dryRun.max_cost_microcredits / 1_000_000 : undefined;
+  const { data: createdCredential } = await credentialOperator.create({
+    application_id: globalApplication.id,
+    host: typeof window === 'undefined' ? 'https://studio.acedata.cloud' : window.location.origin,
+    expired_at: expiresAt,
+    limited_amount: limitedAmount,
+    metadata: {
+      purpose: 'poivelle_execution',
+      project_id: dryRun.project_id,
+      dry_run_id: dryRun.id
+    }
+  });
+  if (!createdCredential.token) throw new Error('The temporary execution credential has no token');
+  return createdCredential;
+};
 
 const loadMembership = async (
   { commit, rootState }: Pick<Context, 'commit' | 'rootState'>,
@@ -300,16 +362,29 @@ export const dryRun = async (
 
 export const confirmDryRun = async ({ state, commit, rootState }: Context): Promise<IPoivelleRun | undefined> => {
   if (!state.currentProjectId || !state.dryRun) return;
-  const { data } = await poivelleOperator.confirmAction(
-    state.currentProjectId,
-    {
-      dry_run_id: state.dryRun.id,
-      revision_id: state.dryRun.revision_id,
-      confirmation_nonce: state.dryRun.confirmation_nonce,
-      idempotency_key: `confirm-${uid()}`
-    },
-    { token: token(rootState) }
-  );
+  const project = state.projects.find((item) => item.id === state.currentProjectId);
+  const credential = project?.managed_execution ? undefined : await createExecutionCredential(rootState, state.dryRun);
+  let data;
+  try {
+    const response = await poivelleOperator.confirmAction(
+      state.currentProjectId,
+      {
+        dry_run_id: state.dryRun.id,
+        revision_id: state.dryRun.revision_id,
+        confirmation_nonce: state.dryRun.confirmation_nonce,
+        idempotency_key: `confirm-${state.dryRun.id}`,
+        execution_credential: credential?.token
+      },
+      { token: token(rootState) }
+    );
+    data = response.data;
+  } catch (error: any) {
+    const status = error?.response?.status;
+    if (credential?.id && [400, 401, 403, 404, 422].includes(status)) {
+      await credentialOperator.delete(credential.id).catch(() => undefined);
+    }
+    throw new Error(message(error));
+  }
   commit('setRuns', [data.run, ...state.runs.filter((run) => run.id !== data.run.id)]);
   commit('setDryRun');
   return data.run;


### PR DESCRIPTION
## Summary

Makes Poivelle follow Nexior's existing Application/Credential billing pattern instead of waiting for a separate reservation ledger.

For external provider closures, Nexior creates or reuses a 24-hour temporary Credential on the caller's owner Global Usage Application, caps it to the dry-run authorization maximum, and sends it once during run confirmation. The worker then calls the existing public APIs, so Kong `/auth`, provider cost JSON, Gateway `/record`, Application balance, Credential usage, and ApiUsage remain authoritative.

## Behavior

- Fetches only caller-owned Global Usage Applications.
- Chooses the owner Global Application with the highest available balance when more than one exists.
- Creates a temporary Credential only when `dryRun.requires_credential` is true.
- Reuses an unexpired Credential bound by metadata to the same dry-run on network/idempotent retries.
- Sets `limited_amount = max_cost_microcredits / 1_000_000` as authorization cap; the backend rejects external closures without a positive cap.
- Sets 24-hour expiration and metadata `{purpose, project_id, dry_run_id}`.
- Never writes the Credential token to Vuex or persisted state.
- Uses deterministic `confirm-${dry_run_id}` idempotency.
- Wraps Axios failures in a safe Error so request config/body cannot leak the token to logs or telemetry.
- Deletes credentials on deterministic 4xx confirmation rejection; ambiguous network/5xx outcomes retain them for retry and automatic expiry.
- Removes reservation activation copy and states from the active UI contract.

## Dependency

Requires https://github.com/AceDataCloud/PlatformService/pull/1585

## Validation

- Poivelle frontend suite: `24 passed`
- ESLint: passed
- `vue-tsc -b`: passed
- i18n coverage: `17 locales x 45 namespaces`
- Prettier: passed
- Production web build: passed
- Beachball: passed
- `git diff --check`: passed

## Rollout / rollback

Merge after PlatformService #1585. This uses existing PlatformBackend Credential APIs and existing Gateway billing behavior; no new endpoint or database schema is introduced. Rollback restores the prior UI. Temporary credentials are time-limited even if confirmation outcome is ambiguous.

## 🤖 对抗评审 (reviewer: independent Explore, 3 rounds)

- RISK: token leaks via Axios error config -> fixed by safe Error normalization.
- RISK: duplicate credentials on retry -> fixed by metadata-bound unexpired credential lookup and deterministic confirmation idempotency.
- RISK: wrong Global app -> fixed by owner-only query and highest-balance selection.
- RISK: zero-cost external credential becomes unlimited -> backend dependency now rejects external closures without positive cap.
- RISK: success credential is orphaned -> rebutted; async worker needs it for provider polling, and it expires after 24h while encrypted Poivelle copy is purged terminally.
- RISK: delete on network/5xx -> rebutted; outcome may already be committed, so only deterministic 4xx deletes immediately.
- RISK: token persisted in Vuex -> verified false; credential remains function-local only.