### PR TITLE
fix(fish): render voice model visibility & train-mode controls at normal size

### DIFF
--- a/change/@acedatacloud-nexior-fish-control-size.json
+++ b/change/@acedatacloud-nexior-fish-control-size.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(fish): render voice model visibility & train-mode controls at normal size",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/fish/ModelConfigPanel.vue
+++ b/src/components/fish/ModelConfigPanel.vue
@@ -101,7 +101,7 @@
       <!-- Visibility -->
       <div class="field-block mb-4">
         <h2 class="title font-bold">{{ $t('fish.name.visibility') }}</h2>
-        <el-radio-group v-model="form.visibility" size="small">
+        <el-radio-group v-model="form.visibility">
           <el-radio-button label="private" value="private">{{ $t('fish.value.private') }}</el-radio-button>
           <el-radio-button label="unlist" value="unlist">{{ $t('fish.value.unlist') }}</el-radio-button>
           <el-radio-button label="public" value="public">{{ $t('fish.value.public') }}</el-radio-button>
@@ -111,7 +111,7 @@
       <!-- Train mode -->
       <div class="field-block mb-4">
         <h2 class="title font-bold">{{ $t('fish.name.trainMode') }}</h2>
-        <el-radio-group v-model="form.trainMode" size="small">
+        <el-radio-group v-model="form.trainMode">
           <el-radio-button label="fast" value="fast">{{ $t('fish.value.trainModeFast') }}</el-radio-button>
           <el-radio-button label="precise" value="precise">{{ $t('fish.value.trainModePrecise') }}</el-radio-button>
         </el-radio-group>


### PR DESCRIPTION
## What

In the Fish voice-clone create panel (`studio.acedata.cloud/fish/model` → 声音克隆), the **可见性 (visibility)** and **训练模式 (train mode)** segmented controls were rendered with `size="small"`, making them noticeably smaller than the rest of the form. This drops `size="small"` from both `el-radio-group`s so they render at Element Plus's default (normal) size, matching the surrounding inputs, switches, and buttons.

## Change

`src/components/fish/ModelConfigPanel.vue` — remove `size="small"` from the visibility and train-mode `<el-radio-group>` elements. Two-line template change, no logic/behavior change.

## 🤖 对抗评审

Reviewer: Codex timed out (2m) → fell back to a Claude `general-purpose` subagent (per protocol).

**VERDICT: CLEAN** — no RISKs.

Reviewer verified:
- No `el-form`/`el-form-item` wrapper and no `size` on `<el-config-provider>` in `App.vue`, so the controls resolve to the genuine default (normal) size — exactly the requested behavior; no surprise inheritance.
- Component `<style>` block has no hardcoded heights/paddings or `:deep(.el-radio*)` rules that assumed the small size; nothing clips or overflows (scroll region is `overflow-y-auto`).
- Sibling controls (`el-input`, upload/record buttons, `el-switch`, create button) are all normal size — this change makes the radios *more* consistent, not less.
- `size` is an optional prop; removal is lint/type-safe.