### PR TITLE
fix(midjourney): enforce V8.1 capabilities

### DIFF
--- a/change/@acedatacloud-nexior-midjourney-v81-capabilities.json
+++ b/change/@acedatacloud-nexior-midjourney-v81-capabilities.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Hide unsupported Quality and Turbo controls when Midjourney V8.1 is selected.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/midjourney/ConfigPanel.vue
+++ b/src/components/midjourney/ConfigPanel.vue
@@ -8,7 +8,7 @@
             <prompt-input class="mb-4" />
             <reference-image class="mb-4" />
             <ratio-selector class="mb-4" />
-            <quality-selector class="mb-4" />
+            <quality-selector v-if="config?.version !== '8.1'" class="mb-4" />
             <version-selector v-if="!isNiji" class="mb-4" />
             <hd-selector v-if="isV8 && !isNiji" class="mb-4" />
             <elements-selector class="mb-2" />

--- a/src/components/midjourney/config/ModeSelector2.vue
+++ b/src/components/midjourney/config/ModeSelector2.vue
@@ -2,7 +2,7 @@
   <el-dropdown trigger="click" @command="onCommand">
     <el-button round>
       <component
-        :is="activeOption.icon"
+        :is="activeOption?.icon"
         v-if="activeOption?.icon"
         :style="{
           color: activeOption?.color
@@ -61,7 +61,7 @@ export default defineComponent({
   },
   data() {
     return {
-      options: [
+      allOptions: [
         {
           label: this.$t('midjourney.button.fast'),
           value: 'fast',
@@ -84,6 +84,18 @@ export default defineComponent({
     };
   },
   computed: {
+    version(): string {
+      return this.$store.state.midjourney.config.version || '';
+    },
+    type(): string {
+      return this.$store.state.midjourney.config.type || 'imagine';
+    },
+    isV81Imagine(): boolean {
+      return this.type === 'imagine' && this.version === '8.1';
+    },
+    options() {
+      return this.isV81Imagine ? this.allOptions.filter((option) => option.value !== 'turbo') : this.allOptions;
+    },
     activeOption() {
       return this.options.find((option) => option.value === this.value);
     },
@@ -96,6 +108,16 @@ export default defineComponent({
           ...this.$store.state.midjourney.config,
           mode: val
         });
+      }
+    }
+  },
+  watch: {
+    isV81Imagine: {
+      immediate: true,
+      handler(val: boolean) {
+        if (val && this.value === 'turbo') {
+          this.value = DEFAULT_MODE;
+        }
       }
     }
   },

--- a/src/components/midjourney/config/QualitySelector.vue
+++ b/src/components/midjourney/config/QualitySelector.vue
@@ -25,7 +25,7 @@ export default defineComponent({
       return this.$store.state.midjourney.config.version || '';
     },
     isV8(): boolean {
-      return this.version === '8' || this.version === '8.1';
+      return this.version === '8';
     },
     options() {
       if (this.isV8) {

--- a/src/components/midjourney/config/VersionSelector.vue
+++ b/src/components/midjourney/config/VersionSelector.vue
@@ -86,10 +86,23 @@ export default defineComponent({
         return this.$store.state.midjourney.config.version;
       },
       set(val: string) {
+        const config = this.$store.state.midjourney.config;
         this.$store.commit('midjourney/setConfig', {
-          ...this.$store.state.midjourney.config,
-          version: val
+          ...config,
+          version: val,
+          ...(val === '8.1' ? { quality: undefined, mode: config.mode === 'turbo' ? 'fast' : config.mode } : {})
         });
+      }
+    }
+  },
+  watch: {
+    value: {
+      immediate: true,
+      handler(val: string) {
+        const config = this.$store.state.midjourney.config;
+        if (val === '8.1' && (config.quality || config.mode === 'turbo')) {
+          this.value = val;
+        }
       }
     }
   },

--- a/src/components/midjourney/v81Capabilities.test.ts
+++ b/src/components/midjourney/v81Capabilities.test.ts
@@ -1,0 +1,39 @@
+// @vitest-environment node
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const source = (relativePath: string) => readFileSync(fileURLToPath(new URL(relativePath, import.meta.url)), 'utf8');
+
+describe('Midjourney V8.1 capability controls', () => {
+  const panel = source('./ConfigPanel.vue');
+  const versionSelector = source('./config/VersionSelector.vue');
+  const modeSelector = source('./config/ModeSelector2.vue');
+  const qualitySelector = source('./config/QualitySelector.vue');
+  const page = source('../../pages/midjourney/Index.vue');
+
+  it('hides the unsupported Quality control', () => {
+    expect(panel).toContain('<quality-selector v-if="config?.version !== \'8.1\'"');
+  });
+
+  it('normalizes persisted Quality and Turbo values when V8.1 is selected', () => {
+    expect(versionSelector).toContain("val === '8.1' ? { quality: undefined");
+    expect(versionSelector).toContain("config.mode === 'turbo' ? 'fast' : config.mode");
+    expect(versionSelector).toContain("val === '8.1' && (config.quality || config.mode === 'turbo')");
+  });
+
+  it('removes Turbo from V8.1 mode options and resets stale selections', () => {
+    expect(modeSelector).toContain("this.type === 'imagine' && this.version === '8.1'");
+    expect(modeSelector).toContain("filter((option) => option.value !== 'turbo')");
+    expect(modeSelector).toContain("if (val && this.value === 'turbo')");
+    expect(modeSelector).toContain('this.value = DEFAULT_MODE');
+  });
+
+  it('keeps video Turbo available and omits Quality from V8.1 requests', () => {
+    expect(modeSelector).toContain("return this.$store.state.midjourney.config.type || 'imagine'");
+    expect(qualitySelector).toContain("return this.version === '8'");
+    expect(page).toContain("this.config?.version !== '8.1' &&");
+    expect(page.match(/\.\.\.\(!isV81 \? \{ quality:/g)).toHaveLength(2);
+    expect(page).toContain('mode: isV81 ? MIDJOURNEY_DEFAULT_MODE : this.config?.mode || MIDJOURNEY_DEFAULT_MODE');
+  });
+});

--- a/src/pages/midjourney/Index.vue
+++ b/src/pages/midjourney/Index.vue
@@ -102,6 +102,7 @@ export default defineComponent({
         content += ` --chaos ${this.config.chaos}`;
       }
       if (
+        this.config?.version !== '8.1' &&
         this.config?.quality &&
         !content.includes(`--quality `) &&
         !content.includes(`--q `) &&
@@ -322,14 +323,15 @@ export default defineComponent({
         });
     },
     async onCustom(payload: { image_id: string; action: MidjourneyImagineAction }) {
+      const isV81 = this.config?.version === '8.1';
       const request = {
         image_id: payload.image_id,
         action: payload.action,
-        mode: this.config?.mode || MIDJOURNEY_DEFAULT_MODE,
+        mode: isV81 ? MIDJOURNEY_DEFAULT_MODE : this.config?.mode || MIDJOURNEY_DEFAULT_MODE,
         async: true,
         version: this.config?.version,
         hd: this.config?.hd || false,
-        quality: this.config?.quality || MIDJOURNEY_DEFAULT_QUALITY
+        ...(!isV81 ? { quality: this.config?.quality || MIDJOURNEY_DEFAULT_QUALITY } : {})
       };
       this.onStartImagineTask(request);
     },
@@ -358,6 +360,7 @@ export default defineComponent({
         };
         await this.onStartVideosTask(request);
       } else if (this.config?.type === 'imagine') {
+        const isV81 = this.config?.version === '8.1';
         const isV8 = this.config?.version === '8' || this.config?.version === '8.1';
         const hasSref = !!(this.finalPrompt && this.finalPrompt.includes('--sref'));
         const hasMoodboard = !!(isV8 && this.config?.references && this.config.references.length > 0);
@@ -369,7 +372,7 @@ export default defineComponent({
           async: true,
           version: this.config?.version,
           hd: this.config?.hd || false,
-          quality: this.config?.quality || MIDJOURNEY_DEFAULT_QUALITY,
+          ...(!isV81 ? { quality: this.config?.quality || MIDJOURNEY_DEFAULT_QUALITY } : {}),
           style_reference: hasSref,
           moodboard: hasMoodboard
         };


### PR DESCRIPTION
## Summary

- hide Quality when V8.1 is selected and keep Q4 available for V8.0 Alpha
- remove Turbo only for V8.1 image generation while preserving video Turbo
- normalize stale persisted Quality/Turbo selections
- omit Quality from V8.1 generate/custom payloads and prevent prompt flag leakage
- force V8.1 historical image actions to Fast when a video-tab Turbo selection is active

## Public evidence

- https://docs.midjourney.com/hc/en-us/articles/32176522101773-Quality
- https://docs.midjourney.com/hc/en-us/articles/32016412137741-GPU-Speed-Fast-Relax-Turbo

## Validation

- full Vitest suite
- focused capability tests: 4 passed
- full `vue-tsc -b`
- focused ESLint / Prettier
- production web build
- beachball change file included and validated in a normal command checkout

## 🤖 对抗评审

- fixed stale payload fallback, active-option undefined state, video-tab contamination, custom-action cross-tab leakage, and watcher termination concerns
- final verdict: CLEAN

## Related

Backend billing/OpenAPI correction: pending

## Coordinated PRs
- Backend: https://github.com/AceDataCloud/PlatformBackend/pull/1081
- Frontend: https://github.com/AceDataCloud/PlatformFrontend/pull/844
- Nexior: https://github.com/AceDataCloud/Nexior/pull/1377
- Worker: https://github.com/AceDataCloud/PlatformService/pull/1587
- MCPs: https://github.com/AceDataCloud/MCPs/pull/441