### PR TITLE
fix(nanobanana): show pending task metadata

### DIFF
--- a/change/@acedatacloud-nexior-nanobanana-waiting-metadata.json
+++ b/change/@acedatacloud-nexior-nanobanana-waiting-metadata.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Show Nano Banana task metadata while generated images are still pending.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/nanobanana/task/Preview.test.ts
+++ b/src/components/nanobanana/task/Preview.test.ts
@@ -32,6 +32,16 @@ const mountPreview = (response: INanobananaTask['response']) =>
   });
 
 describe('nanobanana/task/Preview', () => {
+  it('shows task metadata before the first response arrives', () => {
+    const wrapper = mountPreview(undefined);
+
+    expect(wrapper.text()).toContain('nanobanana.status.pending');
+    expect(wrapper.text()).toContain('nanobanana.name.model');
+    expect(wrapper.text()).toContain('nanobanana.name.taskId');
+    expect(wrapper.text()).toContain('task-1');
+    expect(wrapper.findComponent({ name: 'TimeIcon' }).exists()).toBe(true);
+  });
+
   it('labels an unfinished response as pending rather than failed', () => {
     const wrapper = mountPreview({ task_id: 'task-1' } as INanobananaTask['response']);
 

--- a/src/components/nanobanana/task/Preview.vue
+++ b/src/components/nanobanana/task/Preview.vue
@@ -141,7 +141,7 @@
           </p>
         </el-alert>
       </div>
-      <div v-else-if="modelValue?.response" :class="{ content: true }">
+      <div v-else :class="{ content: true }">
         <el-alert :closable="false" class="info">
           <template #template>
             <time-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />


### PR DESCRIPTION
## Summary
- show Nano Banana model, resolution, aspect ratio, task action, and task ID while a generation is still pending
- preserve existing success and failure rendering once a response arrives
- add regression coverage for the pre-response waiting state

## Scenario audit
- checked the task previews for Flux, Seedream, OpenAI Image, Midjourney, Veo, Wan, Kling, Luma, Pika, Hailuo, Grok Video, Seedance, and Suno
- no other preview hid its task ID through the same no-response condition

## Validation
- `vitest run src/components/nanobanana/task/Preview.test.ts` (4 passed)
- `eslint src/components/nanobanana/task/Preview.vue src/components/nanobanana/task/Preview.test.ts`
- `prettier --check` for the changed Vue, test, and Beachball files
- `npm run verify`
- `git diff --check origin/main...HEAD`

## Adversarial review
- reviewer: claude-subagent, 1 round
- verdict: `CLEAN`