### PR TITLE
fix(fish): default voice models to private and drop the visibility picker

### DIFF
--- a/change/@acedatacloud-nexior-fish-hide-visibility.json
+++ b/change/@acedatacloud-nexior-fish-hide-visibility.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(fish): create voice models as private by default and remove the visibility picker",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/fish/ModelConfigPanel.vue
+++ b/src/components/fish/ModelConfigPanel.vue
@@ -98,16 +98,6 @@
         />
       </div>
 
-      <!-- Visibility -->
-      <div class="field-block mb-4">
-        <h2 class="title font-bold">{{ $t('fish.name.visibility') }}</h2>
-        <el-radio-group v-model="form.visibility">
-          <el-radio-button label="private" value="private">{{ $t('fish.value.private') }}</el-radio-button>
-          <el-radio-button label="unlist" value="unlist">{{ $t('fish.value.unlist') }}</el-radio-button>
-          <el-radio-button label="public" value="public">{{ $t('fish.value.public') }}</el-radio-button>
-        </el-radio-group>
-      </div>
-
       <!-- Train mode -->
       <div class="field-block mb-4">
         <h2 class="title font-bold">{{ $t('fish.name.trainMode') }}</h2>
@@ -209,7 +199,7 @@ const defaultForm = (): IForm => ({
   description: '',
   texts: '',
   voicesUrl: '',
-  visibility: 'unlist',
+  visibility: 'private',
   trainMode: 'fast',
   enhanceAudio: true,
   generateSample: false


### PR DESCRIPTION
## What

Follow-up to #1376. The **可见性 (visibility)** segmented control in the Fish voice-clone create panel (`studio.acedata.cloud/fish/model` → 声音克隆) added little value, so this removes it from the UI and always creates voices as **private (仅自己可见)** by default.

## Change

`src/components/fish/ModelConfigPanel.vue`
- Remove the visibility `<el-radio-group>` field block from the template.
- Change the form default from `visibility: 'unlist'` → `visibility: 'private'`.

The create payload still sends `visibility` (now always `'private'`); the train-mode control is unchanged. `ElRadioGroup`/`ElRadioButton` imports are retained (still used by train mode). The `fish.name.visibility` i18n key is still used by `model/Card.vue` to display a saved voice's visibility, so no locale keys were touched.

## 🤖 对抗评审

Reviewer: Codex was unavailable this round (usage/timeout) → Claude `general-purpose` subagent (per protocol).

**VERDICT: CLEAN** — no RISKs.

Reviewer verified against the actual code:
- `onCreate` still submits `visibility: this.form.visibility`; with the picker gone `form.visibility` is never mutated, so the payload always carries `'private'`.
- No dead imports — `ElRadioGroup`/`ElRadioButton` still used by the train-mode block.
- Types consistent — `'private'` is a valid member of `Visibility` / `IFishCreatePayload.visibility` / `IForm.visibility`; no orphaned members.
- `model/Card.vue` reads `modelValue?.visibility` from backend data (not the picker) — unaffected.
- i18n guard (`scripts/check_i18n_coverage.py`) only flags MISSING keys, never unused ones; the diff touches no locale files, so leftover `fish.value.*` keys are harmless.