### PR TITLE
fix(scenarios): align upload actions

### DIFF
--- a/change/@acedatacloud-nexior-scenario-upload-actions.json
+++ b/change/@acedatacloud-nexior-scenario-upload-actions.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(scenarios): align upload actions and preserve field spacing",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/grokvideo/config/ReferenceImagesInput.vue
+++ b/src/components/grokvideo/config/ReferenceImagesInput.vue
@@ -1,43 +1,43 @@
 <template>
-  <div class="field mb-[10px] flex items-center justify-between">
-    <h2 class="title m-0 text-[14px] font-bold">{{ $t('grokvideo.name.referenceImages') }}</h2>
-    <div class="upload-wrapper flex flex-col items-start gap-[8px]">
-      <div class="controls flex items-center">
-        <el-upload
-          ref="uploader"
-          v-model:file-list="fileList"
-          accept=".png,.jpg,.jpeg,.gif,.bmp,.webp"
-          name="file"
-          class="value"
-          :limit="limit"
-          :multiple="true"
-          :show-file-list="false"
-          :action="uploadUrl"
-          :on-exceed="onExceed"
-          :on-error="onError"
-          :on-success="onSuccess"
-          :on-change="onChange"
-          :on-remove="onRemove"
-          :headers="headers"
-        >
-          <el-button size="small" type="primary" round>
-            <upload-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
-            {{ $t('grokvideo.button.upload') }}
-          </el-button>
-        </el-upload>
+  <div>
+    <div class="field mb-[10px] flex min-h-8 w-full items-center justify-between gap-3">
+      <div class="flex min-w-0 items-center">
+        <h2 class="title m-0 text-[14px] font-bold">{{ $t('grokvideo.name.referenceImages') }}</h2>
         <info-icon :content="$t('grokvideo.description.referenceImages')" />
       </div>
+      <el-upload
+        ref="uploader"
+        v-model:file-list="fileList"
+        accept=".png,.jpg,.jpeg,.gif,.bmp,.webp"
+        name="file"
+        class="value shrink-0"
+        :limit="limit"
+        :multiple="true"
+        :show-file-list="false"
+        :action="uploadUrl"
+        :on-exceed="onExceed"
+        :on-error="onError"
+        :on-success="onSuccess"
+        :on-change="onChange"
+        :on-remove="onRemove"
+        :headers="headers"
+      >
+        <el-button size="small" type="primary" round>
+          <upload-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
+          {{ $t('grokvideo.button.upload') }}
+        </el-button>
+      </el-upload>
     </div>
-  </div>
-  <div class="file-list flex flex-wrap gap-[10px]">
-    <image-preview
-      v-for="(file, idx) in fileList"
-      :key="(file as any).uid || (file as any)?.response?.file_url || (file as any).url || idx"
-      :url="(file as any).url || (file as any)?.response?.file_url"
-      :name="(file as any).name"
-      :percentage="(file as any).percentage"
-      @remove="onRemovePreview(idx, file)"
-    />
+    <div class="file-list flex flex-wrap gap-[10px]">
+      <image-preview
+        v-for="(file, idx) in fileList"
+        :key="(file as any).uid || (file as any)?.response?.file_url || (file as any).url || idx"
+        :url="(file as any).url || (file as any)?.response?.file_url"
+        :name="(file as any).name"
+        :percentage="(file as any).percentage"
+        @remove="onRemovePreview(idx, file)"
+      />
+    </div>
   </div>
 </template>
 

--- a/src/components/nanobanana/config/ImageUrlsInput.vue
+++ b/src/components/nanobanana/config/ImageUrlsInput.vue
@@ -1,43 +1,43 @@
 <template>
-  <div class="field mb-[10px] flex items-center justify-between">
-    <h2 class="title m-0 text-[14px] font-bold">{{ $t('nanobanana.name.imageUrls') }}</h2>
-    <div class="upload-wrapper flex flex-col items-start gap-[8px]">
-      <div class="controls flex items-center">
-        <el-upload
-          ref="uploader"
-          v-model:file-list="fileList"
-          accept=".png,.jpg,.jpeg,.gif,.bmp,.webp"
-          name="file"
-          class="value"
-          :limit="5"
-          :multiple="true"
-          :show-file-list="false"
-          :action="uploadUrl"
-          :on-exceed="onExceed"
-          :on-error="onError"
-          :on-success="onSuccess"
-          :on-change="onChange"
-          :on-remove="onRemove"
-          :headers="headers"
-        >
-          <el-button size="small" type="primary" round>
-            <upload-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
-            {{ $t('nanobanana.button.uploadImageUrls') }}
-          </el-button>
-        </el-upload>
+  <div>
+    <div class="field mb-[10px] flex min-h-8 w-full items-center justify-between gap-3">
+      <div class="flex min-w-0 items-center">
+        <h2 class="title m-0 text-[14px] font-bold">{{ $t('nanobanana.name.imageUrls') }}</h2>
         <info-icon :content="$t('nanobanana.description.imageUrls')" />
       </div>
+      <el-upload
+        ref="uploader"
+        v-model:file-list="fileList"
+        accept=".png,.jpg,.jpeg,.gif,.bmp,.webp"
+        name="file"
+        class="value shrink-0"
+        :limit="5"
+        :multiple="true"
+        :show-file-list="false"
+        :action="uploadUrl"
+        :on-exceed="onExceed"
+        :on-error="onError"
+        :on-success="onSuccess"
+        :on-change="onChange"
+        :on-remove="onRemove"
+        :headers="headers"
+      >
+        <el-button size="small" type="primary" round>
+          <upload-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
+          {{ $t('nanobanana.button.uploadImageUrls') }}
+        </el-button>
+      </el-upload>
     </div>
-  </div>
-  <div class="file-list flex flex-wrap gap-[10px]">
-    <image-preview
-      v-for="(file, idx) in fileList"
-      :key="(file as any).uid || (file as any)?.response?.file_url || (file as any).url || idx"
-      :url="(file as any).url || (file as any)?.response?.file_url"
-      :name="(file as any).name"
-      :percentage="(file as any).percentage"
-      @remove="onRemovePreview(idx, file)"
-    />
+    <div class="file-list flex flex-wrap gap-[10px]">
+      <image-preview
+        v-for="(file, idx) in fileList"
+        :key="(file as any).uid || (file as any)?.response?.file_url || (file as any).url || idx"
+        :url="(file as any).url || (file as any)?.response?.file_url"
+        :name="(file as any).name"
+        :percentage="(file as any).percentage"
+        @remove="onRemovePreview(idx, file)"
+      />
+    </div>
   </div>
 </template>
 

--- a/src/components/omni/config/ReferenceImagesInput.vue
+++ b/src/components/omni/config/ReferenceImagesInput.vue
@@ -1,43 +1,43 @@
 <template>
-  <div class="field mb-[10px] flex items-center justify-between">
-    <h2 class="title m-0 text-[14px] font-bold">{{ $t('omni.name.referenceImages') }}</h2>
-    <div class="upload-wrapper flex flex-col items-start gap-[8px]">
-      <div class="controls flex items-center">
-        <el-upload
-          ref="uploader"
-          v-model:file-list="fileList"
-          accept=".png,.jpg,.jpeg,.gif,.bmp,.webp"
-          name="file"
-          class="value"
-          :limit="limit"
-          :multiple="true"
-          :show-file-list="false"
-          :action="uploadUrl"
-          :on-exceed="onExceed"
-          :on-error="onError"
-          :on-success="onSuccess"
-          :on-change="onChange"
-          :on-remove="onRemove"
-          :headers="headers"
-        >
-          <el-button size="small" type="primary" round>
-            <upload-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
-            {{ $t('omni.button.upload') }}
-          </el-button>
-        </el-upload>
+  <div>
+    <div class="field mb-[10px] flex min-h-8 w-full items-center justify-between gap-3">
+      <div class="flex min-w-0 items-center">
+        <h2 class="title m-0 text-[14px] font-bold">{{ $t('omni.name.referenceImages') }}</h2>
         <info-icon :content="$t('omni.description.referenceImages')" />
       </div>
+      <el-upload
+        ref="uploader"
+        v-model:file-list="fileList"
+        accept=".png,.jpg,.jpeg,.gif,.bmp,.webp"
+        name="file"
+        class="value shrink-0"
+        :limit="limit"
+        :multiple="true"
+        :show-file-list="false"
+        :action="uploadUrl"
+        :on-exceed="onExceed"
+        :on-error="onError"
+        :on-success="onSuccess"
+        :on-change="onChange"
+        :on-remove="onRemove"
+        :headers="headers"
+      >
+        <el-button size="small" type="primary" round>
+          <upload-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
+          {{ $t('omni.button.upload') }}
+        </el-button>
+      </el-upload>
     </div>
-  </div>
-  <div class="file-list flex flex-wrap gap-[10px]">
-    <image-preview
-      v-for="(file, idx) in fileList"
-      :key="(file as any).uid || (file as any)?.response?.file_url || (file as any).url || idx"
-      :url="(file as any).url || (file as any)?.response?.file_url"
-      :name="(file as any).name"
-      :percentage="(file as any).percentage"
-      @remove="onRemovePreview(idx, file)"
-    />
+    <div class="file-list flex flex-wrap gap-[10px]">
+      <image-preview
+        v-for="(file, idx) in fileList"
+        :key="(file as any).uid || (file as any)?.response?.file_url || (file as any).url || idx"
+        :url="(file as any).url || (file as any)?.response?.file_url"
+        :name="(file as any).name"
+        :percentage="(file as any).percentage"
+        @remove="onRemovePreview(idx, file)"
+      />
+    </div>
   </div>
 </template>
 

--- a/src/components/omni/config/VideoInput.vue
+++ b/src/components/omni/config/VideoInput.vue
@@ -1,34 +1,34 @@
 <template>
-  <div class="field flex items-center justify-between">
-    <h2 class="title font-bold text-[14px] mb-[10px]">{{ $t('omni.name.referenceVideo') }}</h2>
-    <div class="upload-wrapper flex flex-col items-start gap-[8px]">
-      <div class="controls flex items-center">
-        <el-upload
-          v-model:file-list="fileList"
-          accept=".mp4,.mov"
-          name="file"
-          class="value"
-          :show-file-list="false"
-          :limit="1"
-          :multiple="false"
-          :action="uploadUrl"
-          :before-upload="beforeUpload"
-          :on-exceed="onExceed"
-          :on-error="onError"
-          :on-success="onSuccess"
-          :headers="headers"
-        >
-          <el-button size="small" type="primary" round>
-            <upload-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
-            {{ $t('omni.button.uploadVideo') }}
-          </el-button>
-        </el-upload>
-        <info-icon :content="$t('omni.description.referenceVideo')" class="ml-2" />
+  <div>
+    <div class="field flex min-h-8 w-full items-center justify-between gap-3">
+      <div class="flex min-w-0 items-center">
+        <h2 class="title m-0 text-[14px] font-bold">{{ $t('omni.name.referenceVideo') }}</h2>
+        <info-icon :content="$t('omni.description.referenceVideo')" />
       </div>
+      <el-upload
+        v-model:file-list="fileList"
+        accept=".mp4,.mov"
+        name="file"
+        class="value shrink-0"
+        :show-file-list="false"
+        :limit="1"
+        :multiple="false"
+        :action="uploadUrl"
+        :before-upload="beforeUpload"
+        :on-exceed="onExceed"
+        :on-error="onError"
+        :on-success="onSuccess"
+        :headers="headers"
+      >
+        <el-button size="small" type="primary" round>
+          <upload-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
+          {{ $t('omni.button.uploadVideo') }}
+        </el-button>
+      </el-upload>
     </div>
-  </div>
-  <div v-if="videoUrl" class="file-list flex flex-wrap gap-[10px]">
-    <file-preview :url="videoUrl" :name="videoName" :percentage="100" @remove="onRemove" />
+    <div v-if="videoUrl" class="file-list flex flex-wrap gap-[10px]">
+      <file-preview :url="videoUrl" :name="videoName" :percentage="100" @remove="onRemove" />
+    </div>
   </div>
 </template>
 

--- a/src/components/openaiimage/config/ImageUrlsInput.vue
+++ b/src/components/openaiimage/config/ImageUrlsInput.vue
@@ -1,42 +1,42 @@
 <template>
-  <div class="field flex items-center justify-between">
-    <h2 class="title font-bold text-[14px] mb-[10px]">{{ $t('openaiimage.name.imageUrls') }}</h2>
-    <div class="upload-wrapper flex flex-col items-start gap-[8px]">
-      <div class="controls flex items-center">
-        <el-upload
-          v-model:file-list="fileList"
-          accept=".png,.jpg,.jpeg,.gif,.bmp,.webp"
-          name="file"
-          class="value"
-          :limit="5"
-          :multiple="true"
-          :show-file-list="false"
-          :action="uploadUrl"
-          :on-exceed="onExceed"
-          :on-error="onError"
-          :on-success="onSuccess"
-          :on-change="onChange"
-          :on-remove="onRemove"
-          :headers="headers"
-        >
-          <el-button size="small" type="primary" round>
-            <upload-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
-            {{ $t('openaiimage.button.uploadImageUrls') }}
-          </el-button>
-        </el-upload>
-        <info-icon :content="$t('openaiimage.description.imageUrls')" class="ml-2" />
+  <div>
+    <div class="field flex min-h-8 w-full items-center justify-between gap-3">
+      <div class="flex min-w-0 items-center">
+        <h2 class="title m-0 text-[14px] font-bold">{{ $t('openaiimage.name.imageUrls') }}</h2>
+        <info-icon :content="$t('openaiimage.description.imageUrls')" />
       </div>
+      <el-upload
+        v-model:file-list="fileList"
+        accept=".png,.jpg,.jpeg,.gif,.bmp,.webp"
+        name="file"
+        class="value shrink-0"
+        :limit="5"
+        :multiple="true"
+        :show-file-list="false"
+        :action="uploadUrl"
+        :on-exceed="onExceed"
+        :on-error="onError"
+        :on-success="onSuccess"
+        :on-change="onChange"
+        :on-remove="onRemove"
+        :headers="headers"
+      >
+        <el-button size="small" type="primary" round>
+          <upload-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
+          {{ $t('openaiimage.button.uploadImageUrls') }}
+        </el-button>
+      </el-upload>
     </div>
-  </div>
-  <div class="file-list flex flex-wrap gap-[10px]">
-    <image-preview
-      v-for="(file, idx) in fileList"
-      :key="(file as any).uid || (file as any)?.response?.file_url || (file as any).url || idx"
-      :url="(file as any).url || (file as any)?.response?.file_url"
-      :name="(file as any).name"
-      :percentage="(file as any).percentage"
-      @remove="onRemovePreview(idx, file)"
-    />
+    <div class="file-list flex flex-wrap gap-[10px]">
+      <image-preview
+        v-for="(file, idx) in fileList"
+        :key="(file as any).uid || (file as any)?.response?.file_url || (file as any).url || idx"
+        :url="(file as any).url || (file as any)?.response?.file_url"
+        :name="(file as any).name"
+        :percentage="(file as any).percentage"
+        @remove="onRemovePreview(idx, file)"
+      />
+    </div>
   </div>
 </template>
 

--- a/src/components/pika/config/ImageUrlInput.vue
+++ b/src/components/pika/config/ImageUrlInput.vue
@@ -1,39 +1,42 @@
 <template>
-  <div class="field">
-    <div class="label">
-      <h2 class="title font-bold">{{ $t('pika.name.imageUrl') }}</h2>
-      <info-icon :content="$t('pika.description.imageUrl')" class="info" />
-    </div>
-    <div class="upload-control">
+  <div>
+    <div class="field">
+      <div class="label">
+        <h2 class="title font-bold">{{ $t('pika.name.imageUrl') }}</h2>
+        <info-icon :content="$t('pika.description.imageUrl')" class="info" />
+      </div>
       <el-upload
         ref="uploader"
         v-model:file-list="fileList"
         accept=".png,.jpg,.jpeg,.gif,.bmp,.webp"
         name="file"
-        class="value upload-wrapper"
+        class="value shrink-0"
         :limit="3"
         :multiple="true"
-        list-type="picture"
+        :show-file-list="false"
         :action="uploadUrl"
         :on-exceed="onExceed"
         :on-error="onError"
+        :on-change="onChange"
         :on-remove="onRemove"
         :on-success="onSuccess"
         :headers="headers"
       >
-        <template #file="{ file }">
-          <image-preview
-            :url="file.url || (file.response as any)?.file_url"
-            :name="file.name"
-            :percentage="file.percentage"
-            @remove="onRemovePreview(file)"
-          />
-        </template>
         <el-button size="small" type="primary" round>
           <upload-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
           {{ $t('pika.button.uploadImageUrl') }}
         </el-button>
       </el-upload>
+    </div>
+    <div v-if="fileList.length" class="file-list mt-2 flex flex-wrap gap-[10px]">
+      <image-preview
+        v-for="(file, index) in fileList"
+        :key="file.uid || file.url || index"
+        :url="file.url || (file.response as any)?.file_url"
+        :name="file.name"
+        :percentage="file.percentage"
+        @remove="onRemovePreview(file)"
+      />
     </div>
   </div>
 </template>
@@ -50,6 +53,7 @@ export const DEFAULT_CONTENT = '';
 interface IData {
   fileList: UploadFiles;
   uploadUrl: string;
+  suppressWatch: boolean;
 }
 
 export default defineComponent({
@@ -65,7 +69,8 @@ export default defineComponent({
   data(): IData {
     return {
       fileList: [],
-      uploadUrl: getBaseUrlPlatform() + '/api/v1/files/'
+      uploadUrl: getBaseUrlPlatform() + '/api/v1/files/',
+      suppressWatch: false
     };
   },
   computed: {
@@ -83,10 +88,33 @@ export default defineComponent({
       return this.$store.state.pika?.config?.image_url;
     }
   },
-  mounted() {
-    this.onSetStartImageUrl();
+  watch: {
+    value: {
+      immediate: true,
+      handler(value?: string[]) {
+        if (this.suppressWatch) return;
+        const uploading = this.fileList.filter((file) => !(file.response as any)?.file_url);
+        const restored = (value || []).map((url) => {
+          const existing = this.fileList.find((file) => (file.response as any)?.file_url === url || file.url === url);
+          return (
+            existing ||
+            ({
+              name: url.split('/').pop() || url,
+              url,
+              status: 'success',
+              percentage: 100,
+              response: { file_url: url }
+            } as UploadFile)
+          );
+        });
+        this.fileList = [...restored, ...uploading.filter((file) => !restored.includes(file))];
+      }
+    }
   },
   methods: {
+    onChange(file: UploadFile) {
+      if (!file.url && file.raw) file.url = URL.createObjectURL(file.raw);
+    },
     onExceed() {
       ElMessage.warning(this.$t('pika.message.uploadStartImageExceed'));
     },
@@ -97,9 +125,13 @@ export default defineComponent({
       this.onSetStartImageUrl();
     },
     onSetStartImageUrl() {
+      this.suppressWatch = true;
       this.$store.commit('pika/setConfig', {
         ...this.$store.state.pika?.config,
         image_url: this.urls
+      });
+      this.$nextTick(() => {
+        this.suppressWatch = false;
       });
     },
     onSuccess() {
@@ -108,6 +140,7 @@ export default defineComponent({
     onRemovePreview(file: UploadFiles[number]) {
       const index = this.fileList.indexOf(file);
       if (index >= 0) this.fileList.splice(index, 1);
+      if (file.url?.startsWith('blob:')) URL.revokeObjectURL(file.url);
       this.onSetStartImageUrl();
     }
   }
@@ -116,10 +149,12 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 .field {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) 160px;
-  gap: 8px;
-  align-items: start;
+  display: flex;
+  min-height: 32px;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
 
   .label {
     display: flex;
@@ -138,17 +173,8 @@ export default defineComponent({
     font-size: 14px;
   }
 
-  .upload-control {
-    width: 160px;
-    min-width: 0;
-  }
-
-  .upload-wrapper {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    width: 100%;
-    gap: 8px;
+  .value {
+    flex: none;
   }
 }
 </style>

--- a/src/components/scenarioUploadLayout.test.ts
+++ b/src/components/scenarioUploadLayout.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const readSource = (relativePath: string): string =>
+  readFileSync(fileURLToPath(new URL(relativePath, import.meta.url)), 'utf8');
+
+const RIGHT_ALIGNED_UPLOAD_FIELDS = [
+  './grokvideo/config/ReferenceImagesInput.vue',
+  './nanobanana/config/ImageUrlsInput.vue',
+  './omni/config/ReferenceImagesInput.vue',
+  './omni/config/VideoInput.vue',
+  './openaiimage/config/ImageUrlsInput.vue'
+] as const;
+
+describe('scenario upload layout', () => {
+  it.each(RIGHT_ALIGNED_UPLOAD_FIELDS)('%s keeps help with the label and the action on the right', (path) => {
+    const source = readSource(path);
+    const uploadStart = source.indexOf('<el-upload');
+
+    expect(source).toContain('class="field');
+    expect(source).toContain('w-full');
+    expect(source).toContain('justify-between');
+    expect(source).toContain('class="value shrink-0"');
+    expect(source.slice(0, uploadStart)).toContain('<info-icon');
+  });
+
+  it('keeps Pika previews below its full-width upload header', () => {
+    const source = readSource('./pika/config/ImageUrlInput.vue');
+
+    expect(source).toContain(':show-file-list="false"');
+    expect(source).toContain(':on-change="onChange"');
+    expect(source).toContain('class="value shrink-0"');
+    expect(source).toContain('<div v-if="fileList.length" class="file-list mt-2 flex flex-wrap gap-[10px]">');
+    expect(source).toContain('<image-preview');
+    expect(source).toContain('URL.revokeObjectURL(file.url)');
+    expect(source).not.toContain('grid-template-columns');
+    expect(source).not.toContain('list-type="picture"');
+  });
+});


### PR DESCRIPTION
## Summary

- Keep scenario upload actions pinned to the far right while labels and help icons stay together on the left.
- Restore ConfigPanel spacing by giving affected upload components a single inheritable root.
- Move Pika previews below the header and preserve upload/restored-image preview lifecycle.

## Validation

- `npm run test:run -- src/components/scenarioUploadLayout.test.ts` (6 passed)
- Focused ESLint and Prettier checks on all changed files
- `npm run build:web`
- `npx beachball check --branch origin/main --no-fetch`
- Playwright at a 279px config width: Omni, Nano Banana, and Pika upload actions measured `rightGap=0`; help icons stayed before actions; `mb-4` inherited on component roots

## 🤖 对抗评审 (reviewer: claude-subagent, 2 rounds)

- RISK: Pika explicit preview lost local blob lifecycle → 已修 (create/revoke blob URLs and preserve uploading entries)
- RISK: Pika restored store images were not reflected in explicit previews → 已修 (URL-based store-to-file-list synchronization with watcher suppression)
- RISK: Omni video local preview omission → 未采纳，理由: remote-only preview is pre-existing intentional behavior and this change does not alter it
- RISK: `el-upload` remove callbacks are dead → 未采纳，理由: every custom preview removal explicitly updates the file list and store; callback remains for Element Plus removal paths
- RISK: Maestro a11y/narrow-header findings → 未采纳，理由: Maestro is outside this diff and no Maestro file was modified
- NIT: static source assertions can be weak → 已补强 (Pika lifecycle assertions plus real browser geometry validation)