### PR TITLE
fix(veo): remove large empty band above config tabs

### DIFF
--- a/change/@acedatacloud-nexior-veo-config-top-whitespace.json
+++ b/change/@acedatacloud-nexior-veo-config-top-whitespace.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix large empty band above the Veo config tabs by aligning ActionSelector with the shared 48px scenario-tabs pattern.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/assets/scenarioTabs.test.ts
+++ b/src/assets/scenarioTabs.test.ts
@@ -45,10 +45,10 @@ describe('scenario tab style contract', () => {
   });
 
   it('preserves Kling and Veo readability and overflow rules locally', () => {
-    expect(components.kling).toMatch(/:deep\(\.el-tabs__item\)[\s\S]*?height: 48px;[\s\S]*?white-space: normal;/);
-    expect(components.kling).toContain('-webkit-line-clamp: 2;');
-    expect(components.veo).toMatch(/:deep\(\.el-tabs__nav-scroll\)[\s\S]*?overflow: visible;[\s\S]*?height: 64px;/);
-    expect(components.veo).toMatch(/:deep\(\.el-tabs__nav-prev\),[\s\S]*?display: none;/);
-    expect(components.veo).toMatch(/:deep\(\.el-tabs__item\)[\s\S]*?min-width: 0;[\s\S]*?overflow-wrap: anywhere;/);
+    for (const name of ['kling', 'veo'] as const) {
+      expect(components[name]).toMatch(/:deep\(\.el-tabs__item\)[\s\S]*?height: 48px;[\s\S]*?white-space: normal;/);
+      expect(components[name]).toContain('-webkit-line-clamp: 2;');
+      expect(components[name]).toMatch(/\.text\s*{[\s\S]*?overflow-wrap: anywhere;/);
+    }
   });
 });

--- a/src/components/veo/config/ActionSelector.vue
+++ b/src/components/veo/config/ActionSelector.vue
@@ -5,7 +5,13 @@
     stretch
     @update:model-value="onUpdate"
   >
-    <el-tab-pane v-for="item in options" :key="item.value" :name="item.value" :label="item.label" />
+    <el-tab-pane v-for="item in options" :key="item.value" :name="item.value">
+      <template #label>
+        <span class="tab-label">
+          <span class="text">{{ item.label }}</span>
+        </span>
+      </template>
+    </el-tab-pane>
   </el-tabs>
 </template>
 
@@ -62,54 +68,37 @@ export default defineComponent({
 </script>
 
 <style lang="scss" scoped>
+// Mirror the shared Kling tab pattern so all scenario tab bars stay uniform:
+// fixed 48px header (tight top/bottom) with a 2-line clamp for long locales
+// (ru/ar) instead of a taller fixed height that leaves dead space above CJK.
+// No horizontal padding here — unlike Kling's standalone header, this tab bar
+// sits inside ConfigPanel's p-5 column and must align with the fields below.
 .action-tabs {
-  :deep(.el-tabs__header) {
-    height: 64px;
-  }
-
-  :deep(.el-tabs__nav-scroll) {
-    overflow: visible;
-    height: 64px;
-  }
-
-  :deep(.el-tabs__nav) {
-    width: 100%;
-    height: 64px;
-    transform: none !important;
-  }
-
-  :deep(.el-tabs__nav-wrap) {
-    height: 64px;
-  }
-
-  :deep(.el-tabs__nav-prev),
-  :deep(.el-tabs__nav-next) {
-    display: none;
-  }
-
-  :deep(.el-tabs__active-bar) {
-    display: none;
-  }
-
   :deep(.el-tabs__item) {
-    flex: 1;
-    min-width: 0;
-    height: 64px;
-    padding: 0 6px;
-    border-bottom: 2px solid transparent;
-    font-size: 12px;
+    height: 48px;
     line-height: 16px;
-    letter-spacing: 0;
-    text-align: center;
+    font-size: 13px;
+    padding: 0 6px;
     white-space: normal;
-    overflow-wrap: anywhere;
-    word-break: break-word;
+  }
+
+  .tab-label {
+    display: inline-flex;
     align-items: center;
     justify-content: center;
-  }
+    width: 100%;
+    min-width: 0;
 
-  :deep(.el-tabs__item.is-active) {
-    border-bottom-color: var(--el-color-primary);
+    .text {
+      display: -webkit-box;
+      flex: 1;
+      min-width: 0;
+      overflow: hidden;
+      text-align: center;
+      overflow-wrap: anywhere;
+      -webkit-box-orient: vertical;
+      -webkit-line-clamp: 2;
+    }
   }
 }
 </style>


### PR DESCRIPTION
## Problem

The Veo config panel (studio.acedata.cloud/veo) showed a tall empty band **above** the 文生视频 / 图生视频 / 多图融合视频 tabs.

**Root cause:** PR #1321 hard-coded `height: 64px` on the el-tabs `__header` / `__nav` / `__nav-wrap` / `__nav-scroll` / `__item`. Single-line CJK labels get vertically centered in that 64px band, leaving ~24px of dead space above them (on top of ConfigPanel's `p-5` padding) — the visible whitespace strip.

The 64px was also a one-off: every other scenario tab bar (Kling, fish, …) uses the shared `scenario-tabs` system, so Veo was the odd one out.

## Fix

Align `ActionSelector` with the shared **Kling `scenario-tabs`** pattern:
- Fixed **48px** tab item with `line-height: 16px` + `-webkit-line-clamp: 2` for long locales (ru/ar), replacing the bespoke 64px block.
- Use the `#label` slot (`.tab-label > .text`) like Kling, instead of a bare `:label`.
- **No horizontal padding** — unlike Kling's standalone header, this tab bar lives *inside* ConfigPanel's `p-5` form column, so it must keep the fields' left edge alignment.

Updated `scenarioTabs.test.ts` so `kling` **and** `veo` assert the same `height: 48px` + `line-clamp: 2` + `.text { overflow-wrap: anywhere }` contract.

## Verification

Measured against real Element Plus CSS at Veo's actual 320px sidebar width:
- Top gap above tabs: ~44px → **20px** (just the intended `p-5` padding; dead band gone).
- Tab item height: 64px → **48px**; single-line CJK now 1 line, no dead space.
- Tab bar left edge (20px) **aligns** with the field labels below.
- Long ru/es/pt/el/uk labels clamp to 2 lines + ellipsis (same graceful behavior Kling already ships).

`npm run lint` + all touched unit tests pass (`scenarioTabs.test.ts`, `ActionSelector.test.ts`).

## 🤖 对抗评审

Independent reviewer (Claude `general-purpose` subagent — Codex was network-unreachable) ran two rounds with **real-browser measurement** against Element Plus's actual stylesheet. It caught two real defects in earlier iterations, both fixed before this PR:

- **RISK (fixed):** A first `min-height` patch was powerless against EP's default `.el-tabs__item { height: 40px }` + `.el-tabs__nav-wrap { overflow: hidden }` → long ru/ar labels would clip mid-glyph. Resolved by adopting Kling's fixed-height + 2-line-clamp pattern.
- **RISK (fixed):** Copying Kling's header chrome (`padding: 0 8px`, `flex: none`, `background-color`) inset the tab bar + divider 8px vs the fields below (ragged left edge), because Veo's tabs sit inside the padded form column, not as a standalone header. Resolved by dropping that chrome.

Final verdict after fixes: **CLEAN** — top-whitespace goal met, no clipping, edges aligned, tests green.