### PR TITLE
fix(fish): show failed TTS tasks with their error instead of forever-pending

### DIFF
--- a/change/@acedatacloud-nexior-fish-failed-task-ui.json
+++ b/change/@acedatacloud-nexior-fish-failed-task-ui.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Render failed Fish TTS tasks with their error reason instead of showing them as pending forever",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/fish/task/Preview.vue
+++ b/src/components/fish/task/Preview.vue
@@ -103,6 +103,7 @@ import { ElAlert, ElButton } from 'element-plus';
 import { IFishTask } from '@/models';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 import ApiCodeButton from '@/components/common/ApiCodeButton.vue';
+import { humanizeFishError } from '@/utils/fish';
 
 export default defineComponent({
   name: 'FishTaskPreview',
@@ -133,11 +134,20 @@ export default defineComponent({
       return this.modelValue?.response?.audio_url;
     },
     isFailure(): boolean {
-      return this.modelValue?.response?.success === false || !!this.modelValue?.response?.error;
+      const response = this.modelValue?.response;
+      if (!response || response.audio_url) {
+        return false;
+      }
+      // Platform-wrapped failures set success/error; Fish-native failures
+      // (worker sendFailureResult) instead carry status>=400 + message.
+      if (response.success === false || !!response.error) {
+        return true;
+      }
+      const status = Number(response.status);
+      return (!Number.isNaN(status) && status >= 400) || !!response.message;
     },
     failureReason(): string | undefined {
-      const error = this.modelValue?.response?.error;
-      return typeof error === 'string' ? error : error?.message;
+      return humanizeFishError(this.modelValue?.response);
     }
   },
   methods: {

--- a/src/models/fish.ts
+++ b/src/models/fish.ts
@@ -25,6 +25,11 @@ export interface IFishTtsResponse {
   started_at?: number;
   audio_url?: string;
   success?: boolean;
+  // Fish-native failure shape (worker `sendFailureResult`): the record is
+  // persisted as `{status, message, task_id, trace_id}` with NO `success`
+  // or `error` field, so the UI must key failure off `status`/`message` too.
+  status?: number | string;
+  message?: string;
   error?:
     | string
     | {

--- a/src/utils/fish.test.ts
+++ b/src/utils/fish.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { humanizeFishError } from './fish';
+
+describe('humanizeFishError', () => {
+  it('returns undefined when there is no response or message', () => {
+    expect(humanizeFishError(undefined)).toBeUndefined();
+    expect(humanizeFishError({})).toBeUndefined();
+    expect(humanizeFishError({ status: 400 })).toBeUndefined();
+    expect(humanizeFishError({ message: '   ' })).toBeUndefined();
+  });
+
+  it('prefers the platform-wrapped error', () => {
+    expect(humanizeFishError({ error: 'boom' })).toBe('boom');
+    expect(humanizeFishError({ error: { message: 'nested boom' } })).toBe('nested boom');
+  });
+
+  it('flattens a pydantic validation array and de-duplicates twin entries', () => {
+    // Real production shape for the missing/empty `format` failure.
+    const raw = JSON.stringify([
+      { type: 'literal_error', loc: ['parameters', 'format'], msg: "Input should be 'pcm' or 'mp3'", input: '' },
+      { type: 'literal_error', loc: ['format'], msg: "Input should be 'pcm' or 'mp3'", input: '' }
+    ]);
+    expect(humanizeFishError({ status: 400, message: raw })).toBe("format: Input should be 'pcm' or 'mp3'");
+  });
+
+  it('unwraps a doubly-wrapped status/message body', () => {
+    expect(humanizeFishError({ status: 400, message: '{"status":400,"message":"Model abc not found"}' })).toBe(
+      'Model abc not found'
+    );
+  });
+
+  it('recursively flattens a doubly-wrapped pydantic array', () => {
+    const inner = JSON.stringify([{ loc: ['format'], msg: "Input should be 'pcm' or 'mp3'" }]);
+    expect(humanizeFishError({ status: 400, message: JSON.stringify({ status: 400, message: inner }) })).toBe(
+      "format: Input should be 'pcm' or 'mp3'"
+    );
+  });
+
+  it('passes through a plain string message', () => {
+    expect(humanizeFishError({ status: 400, message: 'Text too long' })).toBe('Text too long');
+  });
+
+  it('falls back to the raw string when the array is unparseable', () => {
+    expect(humanizeFishError({ message: '[not json' })).toBe('[not json');
+  });
+});

--- a/src/utils/fish.ts
+++ b/src/utils/fish.ts
@@ -1,0 +1,78 @@
+import { IFishTtsResponse } from '@/models';
+
+/**
+ * Turn a Fish TTS failure `response` into a short, human-readable reason.
+ *
+ * The worker persists failures in Fish-native shape — `{status, message}`
+ * (no `success`/`error` wrapper). The `message` is often raw upstream text:
+ *  - a pydantic validation array: `[{"loc":["format"],"msg":"Input should be
+ *    'pcm' or 'mp3'"}]`
+ *  - a doubly-wrapped body: `{"status":400,"message":"Model X not found"}`
+ *  - a plain string: `Text too long`
+ *
+ * Returns `undefined` when there's nothing usable so the caller can fall back.
+ */
+export function humanizeFishError(response: IFishTtsResponse | undefined): string | undefined {
+  if (!response) {
+    return undefined;
+  }
+
+  // Prefer the platform-wrapped `error` when present.
+  const error = response.error;
+  if (error) {
+    const wrapped = typeof error === 'string' ? error : error.message;
+    if (wrapped) {
+      return wrapped.trim();
+    }
+  }
+
+  const raw = response.message;
+  if (typeof raw !== 'string' || !raw.trim()) {
+    return undefined;
+  }
+  return parseFishMessage(raw.trim());
+}
+
+function parseFishMessage(raw: string): string {
+  // Pydantic validation array → "field: message; field: message".
+  if (raw.startsWith('[')) {
+    try {
+      const items = JSON.parse(raw);
+      if (Array.isArray(items) && items.length) {
+        const parts = items
+          .map((item) => {
+            const msg = typeof item?.msg === 'string' ? item.msg : undefined;
+            if (!msg) {
+              return undefined;
+            }
+            const loc = Array.isArray(item?.loc) ? item.loc.filter((p: unknown) => p !== 'parameters') : [];
+            const field = loc.length ? loc[loc.length - 1] : undefined;
+            return field ? `${field}: ${msg}` : msg;
+          })
+          .filter((p): p is string => !!p);
+        // De-duplicate the twin `parameters.format` / `format` entries.
+        const unique = Array.from(new Set(parts));
+        if (unique.length) {
+          return unique.join('; ');
+        }
+      }
+    } catch {
+      // fall through to the raw string
+    }
+  }
+
+  // Doubly-wrapped `{"status":400,"message":"..."}` → recurse on the inner
+  // message (it may itself be a pydantic array or plain string).
+  if (raw.startsWith('{')) {
+    try {
+      const obj = JSON.parse(raw);
+      if (obj && typeof obj.message === 'string' && obj.message.trim()) {
+        return parseFishMessage(obj.message.trim());
+      }
+    } catch {
+      // fall through
+    }
+  }
+
+  return raw;
+}


### PR DESCRIPTION
## Problem

A Fish Audio TTS task that **fails** (e.g. the missing-\`format\` 400, \`Model … not found\`, \`Text too long\`, moderation, out-of-balance) rendered in the task list as **pending forever** — no error, no result. This is the \"不返回结果\" symptom users see in Studio.

**Why:** Fish TTS is async — \`POST /fish/tts\` returns \`200 {task_id}\` immediately (so the toast always says \"success\"), and the real outcome only lands later in the polled task record. The worker persists a **failed** task's \`response\` in **Fish-native shape**:

\`\`\`json
{ "status": 400, "message": "…", "task_id": "…", "trace_id": "…", "started_at": "…" }
\`\`\`

— with **no \`success\` and no \`error\` field**. But [`Preview.vue`](src/components/fish/task/Preview.vue)'s \`isFailure\` only checked \`response.success === false || !!response.error\`. Both are absent, so the card fell through to the \`v-else\` **pending** branch. (PR #1354 added the failure card but keyed it on the platform \`{success,error}\` wrapper, which the Fish worker never emits.)

Confirmed via CLS: all 21 failed \`/fish/tts\` tasks in the last 7 days had exactly \`{status, message, task_id, trace_id, started_at}\`.

## Fix

1. **`isFailure`** — a task with a \`response\`, no \`audio_url\`, and \`status >= 400\` (or a \`message\`) is now treated as failed, in addition to the existing \`success===false\`/\`error\` shape. Success (\`audio_url\`) and pending (no \`response\`) are unchanged.
2. **`humanizeFishError`** (new util + tests) — turns the raw upstream \`message\` into a readable reason across the three real shapes: pydantic validation array → \`format: Input should be 'pcm' or 'mp3'\`; doubly-wrapped \`{status,message}\` → inner message (recursively flattened); plain string → as-is.
3. **model** — add \`status\`/\`message\` to \`IFishTtsResponse\`.

No new i18n (\`fish.name.failure/failureReason/traceId\` already exist). The failure card shows the reason + task ID + trace ID, matching the Hailuo/Luma/Sora pattern.

> Companion backend fix (already merged): [PlatformService #1596](https://github.com/AceDataCloud/PlatformService/pull/1596) defaults the upstream body \`format\` to \`mp3\`, eliminating the most common of these failures at the source. This PR ensures the *remaining* failure types still surface an error instead of hanging.

## Verification

- \`vitest run src/utils/fish.test.ts\` — 7 passed (covers all production message shapes)
- \`vue-tsc --noEmit\` clean; \`eslint\` clean; \`beachball check\` passes

## 🤖 对抗评审

Reviewer: Claude \`general-purpose\` subagent (Codex \`codex exec\` timed out).

- Core fix verified correct: \`{status:\"400\", message}\` now renders the failure card (\`Number(\"400\")>=400\`), reason flattened, trace ID shown; no i18n/undefined-field gaps.
- False-positives guarded: success early-returns on \`audio_url\`; empty/receipt responses → pending. \`humanizeFishError\` never throws / never returns \`[object Object]\`.
- **RISK (accepted, kept):** \`|| !!response.message\` widens failure detection slightly. Kept deliberately — in this async flow the persisted \`response\` is only ever absent (pending) or terminal; a false-positive error card is far less harmful than the bug being fixed (failures looking pending forever), so biasing toward \"show the error\" is correct.
- **RISK (fixed):** a doubly-wrapped body whose inner \`message\` is itself a pydantic array wasn't flattened → made \`humanizeFishError\` recurse on the unwrapped inner message + added a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)