### PR TITLE
ci: cut Nexior macOS Actions cost (daily builds + pod cache + cancel-in-progress)

### DIFF
--- a/.github/workflows/auto-release-mobile.yaml
+++ b/.github/workflows/auto-release-mobile.yaml
@@ -1,10 +1,10 @@
 name: Auto Release Mobile (Testing)
 
-# Fires automatically after a merge to main bumps the version. Beachball
-# (publish.yaml) commits the bump and pushes the @acedatacloud/nexior_v* tag
-# using BOT_GITHUB_TOKEN (a PAT), which is what lets this tag push trigger
-# further workflows. We trigger on that tag — not raw `push: main` — so the
-# mobile build uses the final, released version and never races the bump.
+# Runs ONCE PER DAY (not per merge) to keep macOS/iOS Actions minutes down —
+# iOS builds on the 10x-billed macOS runner, so per-merge fan-out was the single
+# largest Actions cost. The daily build uses main's HEAD (the latest released
+# version via beachball). build-ios.yaml's TestFlight dedup preflight auto-skips
+# the macOS job on days with no new version, so a quiet day costs ~nothing.
 #
 # This orchestrator dispatches the existing build-android.yaml / build-ios.yaml
 # with PRODUCTION EXPLICITLY DISABLED:
@@ -18,9 +18,10 @@ name: Auto Release Mobile (Testing)
 # testing, internal = Internal testing), edit ANDROID_TRACK below.
 
 on:
-  push:
-    tags:
-      - '@acedatacloud/nexior_v*'
+  schedule:
+    # 04:07 Beijing time (UTC 20:07). Off the top of the hour to dodge GitHub's
+    # cron congestion. Cadence is intentionally daily, not per-merge.
+    - cron: '7 20 * * *'
   # Allow re-running the auto test-publish by hand for the current ref.
   workflow_dispatch: {}
 

--- a/.github/workflows/build-android.yaml
+++ b/.github/workflows/build-android.yaml
@@ -35,6 +35,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   NODE_VERSION: '22'
   JAVA_VERSION: '21'

--- a/.github/workflows/build-ios.yaml
+++ b/.github/workflows/build-ios.yaml
@@ -25,6 +25,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   NODE_VERSION: '22'
 
@@ -159,6 +163,16 @@ jobs:
 
       - name: Build web assets (iOS surface)
         run: npm run build:ios
+
+      # Restore Pods BEFORE `cap sync` — cap sync runs `pod install` itself, so a
+      # cache restored after it would miss the dominant install. Key on the
+      # committed Podfile.lock; pod install reconciles if cap sync regenerates it.
+      - name: Cache CocoaPods
+        uses: actions/cache@v4
+        with:
+          path: ios/App/Pods
+          key: ${{ runner.os }}-pods-${{ hashFiles('ios/App/Podfile.lock') }}
+          restore-keys: ${{ runner.os }}-pods-
 
       - name: Sync web assets and native plugins to iOS project
         # `cap sync` (not `cap copy`) regenerates the Podfile from the installed

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -5,17 +5,17 @@ name: Desktop
 #
 # Triggers:
 #   - pull_request (desktop paths)        → E2E smoke only
-#   - push tag `@acedatacloud/nexior_v*`  → E2E + build .exe/.dmg (unsigned beta)
-#                                           + ATTACH to that GitHub Release
-#                                           (NO COS publish, NO gate)
+#   - schedule (daily 04:07 Beijing)      → E2E + build .exe/.dmg beta artifacts
+#                                           (30-day retention; NO release attach,
+#                                            NO COS publish). Daily — not per merge —
+#                                            because the macOS leg bills at 10x.
 #   - push tag `desktop-v*`               → E2E + build + PUBLISH to `latest`
 #   - workflow_dispatch (channel/dry_run) → E2E + build + (optional) PUBLISH
 #
-# Nexior releases on (almost) every merge via beachball, so the version tag
-# fires per release — that one build both produces downloadable artifacts AND
-# attaches the installers to the Release page. (Replaces the old per-main-push
-# build, which double-built on every release.) Publishing to the live update
-# feed is a separate, admin-gated job on desktop-v*.
+# The macOS/Windows build used to fire on every beachball release tag
+# (@acedatacloud/nexior_v*), i.e. almost every merge — the single biggest
+# desktop Actions cost. It's now a once-daily beta build; the live auto-update
+# feed (COS) is still an admin-gated `desktop-v*` release, untouched.
 #
 # Required repo secrets:
 #   TENCENT_CLOUD_SECRET_ID / TENCENT_CLOUD_SECRET_KEY        COS upload
@@ -43,14 +43,13 @@ on:
       - 'scripts/gen-windows-icon.py'
       - 'scripts/publish_desktop_release.py'
       - '.github/workflows/desktop.yml'
+  schedule:
+    # 04:07 Beijing time (UTC 20:07), off the top of the hour to dodge cron
+    # congestion. Daily beta build of the desktop installers.
+    - cron: '7 20 * * *'
   push:
     tags:
       - 'desktop-v*'
-      # The beachball release tag (pushed by publish.yaml on every version bump).
-      # On this tag we build the unsigned beta installers and ATTACH them to the
-      # matching GitHub Release — we do NOT publish to the COS feed (resolve sets
-      # publish=false for it), so the auto-update channel is untouched.
-      - '@acedatacloud/nexior_v*'
   workflow_dispatch:
     inputs:
       channel:
@@ -69,6 +68,10 @@ on:
 
 permissions:
   contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   NODE_VERSION: '22'
@@ -248,28 +251,28 @@ jobs:
           retention-days: 30
           if-no-files-found: error
 
-      # On a beachball release tag, attach this OS's installer to the matching
-      # GitHub Release. github-release.yaml creates that release concurrently;
-      # the desktop build is far slower, so it's normally ready — but we still
-      # WAIT for it and SKIP (never create a bare release) if it never appears,
-      # mirroring the Android guard. Each matrix leg attaches ONLY its own
-      # installer with fail_on_unmatched_files: true, so a missing .exe/.dmg
-      # fails loudly. No COS publish happens for this tag (feed untouched).
-      - name: Wait for GitHub Release
+      # Attach this OS's installer to the GitHub Release for the version
+      # currently on main (@acedatacloud/nexior_v<package.json version>, created
+      # by github-release.yaml on the beachball tag). We gate on the release
+      # ALREADY EXISTING (mirroring build-android.yaml) rather than on a tag ref,
+      # so the daily scheduled build still attaches to the day's release. A
+      # manual desktop-v* / workflow_dispatch run never creates a bare release.
+      - name: Resolve release tag from package.json
         id: rel
-        if: startsWith(github.ref, 'refs/tags/@acedatacloud/nexior_v')
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN || github.token }}
         run: |
-          for i in $(seq 1 18); do
-            if gh release view "$GITHUB_REF_NAME" -R "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-              echo "exists=true" >> "$GITHUB_OUTPUT"; exit 0
-            fi
-            echo "release $GITHUB_REF_NAME not ready (attempt $i) — waiting 10s"; sleep 10
-          done
-          echo "::warning::release $GITHUB_REF_NAME not found after wait — skipping installer attach."
-          echo "exists=false" >> "$GITHUB_OUTPUT"
+          VERSION=$(node -p "require('./package.json').version")
+          REL_TAG="@acedatacloud/nexior_v${VERSION}"
+          echo "tag=$REL_TAG" >> "$GITHUB_OUTPUT"
+          if gh release view "$REL_TAG" -R "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::release $REL_TAG not found — skipping installer attach (artifacts still uploaded)."
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Attach installer to GitHub Release
         if: steps.rel.outputs.exists == 'true'
@@ -277,7 +280,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN || github.token }}
         with:
-          tag_name: ${{ github.ref_name }}
+          tag_name: ${{ steps.rel.outputs.tag }}
           files: ${{ runner.os == 'Windows' && 'release/*.exe' || 'release/*.dmg' }}
           fail_on_unmatched_files: true
 

--- a/change/@acedatacloud-nexior-db584d60-7543-435e-85ce-38b6aeb7b5a8.json
+++ b/change/@acedatacloud-nexior-db584d60-7543-435e-85ce-38b6aeb7b5a8.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "ci: retime Nexior macOS builds to daily + pod cache + cancel-in-progress",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "none"
+}


### PR DESCRIPTION
## Why

Actions bill audit found ~90% of GitHub Actions spend comes from **Nexior's macOS builds firing on every merge**. GitHub bills macOS at **10×** Linux and Windows at **2×**. The chain: every merge → beachball pushes `@acedatacloud/nexior_v*` → (a) `auto-release-mobile` fans out to **iOS build (macos-15, 10×)** + Android, and (b) `desktop.yml` builds **macOS + Windows** directly. At ~9 macOS builds/day this dominated everything.

Measured over 14 days: iOS ≈ 1,040 macOS wall-min (**≈10,400 billed min**), Desktop ≈ similar. Everything Linux is comparatively free.

## What changed

1. **Retime iOS + Desktop from per-merge → daily schedule** (`cron: '7 20 * * *'` = **04:07 Beijing / 20:07 UTC**, off the hour to dodge cron congestion).
   - `auto-release-mobile.yaml`: trigger `push: tag nexior_v*` → `schedule`. Scheduled runs execute on `main` HEAD, so `gh workflow run --ref main` dispatches iOS+Android against the latest released version. iOS's existing **TestFlight-dedup preflight** auto-skips the macOS job on days with no new version → a quiet day costs ~nothing.
   - `desktop.yml`: dropped the `@acedatacloud/nexior_v*` tag trigger, added the same daily `schedule`. `desktop-v*` (COS publish, admin-gated) + `pull_request` + `workflow_dispatch` unchanged.

2. **`concurrency: cancel-in-progress`** on `build-ios` / `build-android` / `desktop`, grouped by `${{ github.workflow }}-${{ github.ref }}`. A re-push on the same ref no longer pays for two macOS builds. Distinct release tags have distinct refs, so a `desktop-v*` COS publish can't be cancelled by an unrelated run.

3. **Cache CocoaPods** (`ios/App/Pods` keyed on `Podfile.lock`), restored **before** `npx cap sync ios` — `cap sync` runs `pod install` itself, so caching after it would miss the dominant install. At 10× billing every minute saved is worth 10 Linux min.

Desktop installer attach re-gated on **release-existence** (mirroring `build-android`, driven by `package.json` version) instead of the removed tag ref, so the daily build still attaches `.dmg`/`.exe` to the day's GitHub Release — keeping `github-release.yaml`'s promised downloads intact.

## Tradeoff (accepted)

If multiple releases land in one day, installers/TestFlight come only from that day's single build. That's the intended **per-merge → daily** cost swap. Manual `workflow_dispatch` on any of the build workflows remains as an escape hatch for an immediate build.

## 🤖 对抗评审

Reviewer: Claude `general-purpose` subagent (Codex hit a network/usage failure mid-run and was substituted, per `.claude/commands/auto-review.md`). Round 1 surfaced 3 findings; 2 were fixed, 1 accepted.

- **RISK (HIGH) — daily desktop build produced no deliverable + broke Release downloads.** Old attach was gated `if: startsWith(github.ref, 'refs/tags/@acedatacloud/nexior_v')`, which is false on a `schedule` run (`github.ref = refs/heads/main`) → build burned macOS+Windows minutes with `.dmg`/`.exe` only as throwaway artifacts, while `github-release.yaml` still promised installers in the Release. **Fixed:** re-gated on release-existence via `package.json` version (mirrors `build-android`), so the daily build attaches to the day's release.
- **RISK (MEDIUM) — pod cache placed after `cap sync`.** `cap sync` runs `pod install` itself, so a cache restored after it saved almost nothing. **Fixed:** moved the cache step **before** `cap sync`.
- **RISK (LOW) — same-day intermediate releases only get the latest day's installers.** **Accepted & documented** — this is the deliberate per-merge→daily cost tradeoff.
- **Confirmed safe (round 1):** schedule always runs on default branch (`--ref main` valid); concurrency-by-ref cannot cancel a gated `desktop-v*` COS publish or a needed PR run; `cron '7 20 * * *'` = 04:07 Beijing is correct; no double-builds (tag self-triggers live on distinct refs).
- Concurrent matrix-leg attach (both legs upsert to the same release): pre-existing behavior, disjoint files (`*.exe` vs `*.dmg`), `action-gh-release` is idempotent — not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)