### PR TITLE
feat(fish): search public voice library in TTS voice picker

### DIFF
--- a/change/@acedatacloud-nexior-fish-public-voice-search.json
+++ b/change/@acedatacloud-nexior-fish-public-voice-search.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fish TTS voice picker: search Fish's public voice library (self=false) with grouped results and inline audio preview, not just the user's own cloned voices",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/fish/config/VoiceOption.vue
+++ b/src/components/fish/config/VoiceOption.vue
@@ -4,21 +4,33 @@
       v-if="option.audio"
       type="button"
       class="preview"
-      :class="{ playing }"
+      :class="{ playing, loading }"
       :aria-label="playing ? 'stop preview' : 'play preview'"
       @mousedown.prevent
       @click.stop.prevent="$emit('preview', option)"
     >
-      <svg v-if="playing" viewBox="0 0 24 24" width="12" height="12" aria-hidden="true">
+      <svg v-if="loading" class="spin" viewBox="0 0 24 24" width="13" height="13" aria-hidden="true">
+        <circle
+          cx="12"
+          cy="12"
+          r="9"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="3"
+          stroke-linecap="round"
+          stroke-dasharray="42 60"
+        />
+      </svg>
+      <svg v-else-if="playing" viewBox="0 0 24 24" width="13" height="13" aria-hidden="true">
         <rect x="6" y="5" width="4" height="14" rx="1" fill="currentColor" />
         <rect x="14" y="5" width="4" height="14" rx="1" fill="currentColor" />
       </svg>
-      <svg v-else viewBox="0 0 24 24" width="12" height="12" aria-hidden="true">
+      <svg v-else viewBox="0 0 24 24" width="13" height="13" aria-hidden="true">
         <path d="M8 5v14l11-7z" fill="currentColor" />
       </svg>
     </button>
     <span v-else class="preview placeholder" aria-hidden="true">
-      <svg viewBox="0 0 24 24" width="12" height="12">
+      <svg viewBox="0 0 24 24" width="13" height="13">
         <path
           d="M12 14a3 3 0 0 0 3-3V6a3 3 0 0 0-6 0v5a3 3 0 0 0 3 3zm5-3a5 5 0 0 1-10 0H5a7 7 0 0 0 6 6.92V21h2v-3.08A7 7 0 0 0 19 11z"
           fill="currentColor"
@@ -45,6 +57,10 @@ export default defineComponent({
     playing: {
       type: Boolean,
       default: false
+    },
+    loading: {
+      type: Boolean,
+      default: false
     }
   },
   emits: ['preview']
@@ -56,13 +72,14 @@ export default defineComponent({
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 2px 0;
-  max-width: 100%;
+  width: 100%;
+  min-width: 0;
 
   .preview {
     flex: none;
-    width: 26px;
-    height: 26px;
+    width: 28px;
+    height: 28px;
+    padding: 0;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -74,7 +91,8 @@ export default defineComponent({
     transition: background 0.15s ease;
 
     &:hover,
-    &.playing {
+    &.playing,
+    &.loading {
       background: var(--el-color-primary-light-7);
     }
     &.placeholder {
@@ -82,28 +100,41 @@ export default defineComponent({
       color: var(--el-text-color-secondary);
       cursor: default;
     }
+    .spin {
+      animation: fish-voice-spin 0.8s linear infinite;
+    }
   }
 
   .meta {
     display: flex;
     flex-direction: column;
     min-width: 0;
-    line-height: 1.3;
+    line-height: 1.35;
+    padding: 2px 0;
 
     .label {
       font-size: 13px;
+      font-weight: 500;
       color: var(--el-text-color-primary);
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
     }
     .description {
+      margin-top: 1px;
       font-size: 11px;
       color: var(--el-text-color-secondary);
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
       overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
     }
+  }
+}
+
+@keyframes fish-voice-spin {
+  to {
+    transform: rotate(360deg);
   }
 }
 </style>

--- a/src/components/fish/config/VoiceOption.vue
+++ b/src/components/fish/config/VoiceOption.vue
@@ -1,0 +1,109 @@
+<template>
+  <div class="voice-option">
+    <button
+      v-if="option.audio"
+      type="button"
+      class="preview"
+      :class="{ playing }"
+      :aria-label="playing ? 'stop preview' : 'play preview'"
+      @mousedown.prevent
+      @click.stop.prevent="$emit('preview', option)"
+    >
+      <svg v-if="playing" viewBox="0 0 24 24" width="12" height="12" aria-hidden="true">
+        <rect x="6" y="5" width="4" height="14" rx="1" fill="currentColor" />
+        <rect x="14" y="5" width="4" height="14" rx="1" fill="currentColor" />
+      </svg>
+      <svg v-else viewBox="0 0 24 24" width="12" height="12" aria-hidden="true">
+        <path d="M8 5v14l11-7z" fill="currentColor" />
+      </svg>
+    </button>
+    <span v-else class="preview placeholder" aria-hidden="true">
+      <svg viewBox="0 0 24 24" width="12" height="12">
+        <path
+          d="M12 14a3 3 0 0 0 3-3V6a3 3 0 0 0-6 0v5a3 3 0 0 0 3 3zm5-3a5 5 0 0 1-10 0H5a7 7 0 0 0 6 6.92V21h2v-3.08A7 7 0 0 0 19 11z"
+          fill="currentColor"
+        />
+      </svg>
+    </span>
+    <div class="meta">
+      <span class="label">{{ option.label }}</span>
+      <span v-if="option.description" class="description">{{ option.description }}</span>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+  name: 'FishVoiceOption',
+  props: {
+    option: {
+      type: Object as () => { value: string; label: string; description?: string; audio?: string },
+      required: true
+    },
+    playing: {
+      type: Boolean,
+      default: false
+    }
+  },
+  emits: ['preview']
+});
+</script>
+
+<style lang="scss" scoped>
+.voice-option {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 2px 0;
+  max-width: 100%;
+
+  .preview {
+    flex: none;
+    width: 26px;
+    height: 26px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: none;
+    border-radius: 50%;
+    cursor: pointer;
+    background: var(--el-color-primary-light-9);
+    color: var(--el-color-primary);
+    transition: background 0.15s ease;
+
+    &:hover,
+    &.playing {
+      background: var(--el-color-primary-light-7);
+    }
+    &.placeholder {
+      background: var(--el-fill-color-light);
+      color: var(--el-text-color-secondary);
+      cursor: default;
+    }
+  }
+
+  .meta {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    line-height: 1.3;
+
+    .label {
+      font-size: 13px;
+      color: var(--el-text-color-primary);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .description {
+      font-size: 11px;
+      color: var(--el-text-color-secondary);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+  }
+}
+</style>

--- a/src/components/fish/config/VoicePicker.vue
+++ b/src/components/fish/config/VoicePicker.vue
@@ -4,12 +4,14 @@
     <el-select
       v-model="value"
       class="value"
+      popper-class="fish-voice-popper"
       :placeholder="$t('fish.placeholder.voice')"
       clearable
       filterable
       remote
       :remote-method="onSearch"
-      :loading="loading"
+      :loading="remoteLoading"
+      :loading-text="$t('fish.message.searching')"
       :no-data-text="noDataText"
       @focus="onFocus"
     >
@@ -24,13 +26,23 @@
 
       <el-option-group v-if="filteredMyOptions.length" :label="$t('fish.title.myVoices')">
         <el-option v-for="item in filteredMyOptions" :key="item.value" :label="item.label" :value="item.value">
-          <voice-option :option="item" :playing="playingId === item.value" @preview="togglePreview" />
+          <voice-option
+            :option="item"
+            :playing="playingId === item.value"
+            :loading="loadingId === item.value"
+            @preview="togglePreview"
+          />
         </el-option>
       </el-option-group>
 
       <el-option-group v-if="publicOptions.length" :label="$t('fish.group.publicVoices')">
         <el-option v-for="item in publicOptions" :key="item.value" :label="item.label" :value="item.value">
-          <voice-option :option="item" :playing="playingId === item.value" @preview="togglePreview" />
+          <voice-option
+            :option="item"
+            :playing="playingId === item.value"
+            :loading="loadingId === item.value"
+            @preview="togglePreview"
+          />
         </el-option>
       </el-option-group>
     </el-select>
@@ -40,7 +52,7 @@
 <script lang="ts">
 import { defineComponent } from 'vue';
 import { ElSelect, ElOption, ElOptionGroup } from 'element-plus';
-import { IFishVoiceModel, Status } from '@/models';
+import { IFishVoiceModel } from '@/models';
 import { fishOperator } from '@/operators';
 import VoiceOption from './VoiceOption.vue';
 
@@ -79,6 +91,7 @@ export default defineComponent({
       remoteLoading: false,
       query: '',
       playingId: null as string | null,
+      loadingId: null as string | null,
       // Remember labels for every voice we have ever rendered so a selected
       // public voice keeps its name after the result set changes.
       labelCache: {} as Record<string, string>,
@@ -88,9 +101,6 @@ export default defineComponent({
     };
   },
   computed: {
-    loading(): boolean {
-      return this.remoteLoading || this.$store.state.fish?.status?.getApplications === Status.Request;
-    },
     myVoices(): IFishVoiceModel[] {
       return this.$store.state.fish?.voices ?? [];
     },
@@ -203,7 +213,8 @@ export default defineComponent({
     },
     togglePreview(option: IVoiceOption) {
       if (!option.audio) return;
-      if (this.playingId === option.value) {
+      // Second click on the currently playing/loading clip → stop.
+      if (this.playingId === option.value || this.loadingId === option.value) {
         this.stopPreview();
         return;
       }
@@ -211,13 +222,21 @@ export default defineComponent({
       const audio = new Audio(option.audio);
       // Scope handlers to THIS instance: a stale callback from a previously
       // stopped clip must not tear down the clip the user just started.
+      const onPlaying = () => {
+        if (this.previewAudio !== audio) return;
+        this.loadingId = null;
+        this.playingId = option.value;
+      };
       const onEnd = () => {
         if (this.previewAudio === audio) this.stopPreview();
       };
+      audio.addEventListener('playing', onPlaying);
       audio.addEventListener('ended', onEnd);
       audio.addEventListener('error', onEnd);
       this.previewAudio = audio;
-      this.playingId = option.value;
+      // Show a spinner on the button until the (often slow) R2 clip buffers.
+      this.loadingId = option.value;
+      this.playingId = null;
       audio.play().catch(() => {
         if (this.previewAudio === audio) this.stopPreview();
       });
@@ -229,6 +248,7 @@ export default defineComponent({
         this.previewAudio = null;
       }
       this.playingId = null;
+      this.loadingId = null;
     }
   }
 });
@@ -247,6 +267,23 @@ export default defineComponent({
   }
   .value {
     flex: 1;
+  }
+}
+</style>
+
+<!-- The dropdown popper is teleported to <body>, so it must be styled
+     un-scoped. Cap its width (fish descriptions are long) and let each row
+     grow to fit a two-line description instead of the default 34px. -->
+<style lang="scss">
+.fish-voice-popper {
+  max-width: 420px;
+
+  .el-select-dropdown__item {
+    height: auto;
+    min-height: 34px;
+    line-height: 1.35;
+    padding-top: 6px;
+    padding-bottom: 6px;
   }
 }
 </style>

--- a/src/components/fish/config/VoicePicker.vue
+++ b/src/components/fish/config/VoicePicker.vue
@@ -7,47 +7,119 @@
       :placeholder="$t('fish.placeholder.voice')"
       clearable
       filterable
+      remote
+      :remote-method="onSearch"
       :loading="loading"
-      :no-data-text="$t('fish.message.noVoices')"
+      :no-data-text="noDataText"
+      @focus="onFocus"
     >
-      <el-option v-for="item in displayOptions" :key="item.value" :label="item.label" :value="item.value" />
+      <!-- Keep the currently-selected voice renderable even when it is not in
+           the freshly-fetched result set (e.g. a public voice picked earlier). -->
+      <el-option
+        v-if="fallbackOption"
+        :key="fallbackOption.value"
+        :label="fallbackOption.label"
+        :value="fallbackOption.value"
+      />
+
+      <el-option-group v-if="filteredMyOptions.length" :label="$t('fish.title.myVoices')">
+        <el-option v-for="item in filteredMyOptions" :key="item.value" :label="item.label" :value="item.value">
+          <voice-option :option="item" :playing="playingId === item.value" @preview="togglePreview" />
+        </el-option>
+      </el-option-group>
+
+      <el-option-group v-if="publicOptions.length" :label="$t('fish.group.publicVoices')">
+        <el-option v-for="item in publicOptions" :key="item.value" :label="item.label" :value="item.value">
+          <voice-option :option="item" :playing="playingId === item.value" @preview="togglePreview" />
+        </el-option>
+      </el-option-group>
     </el-select>
   </div>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElSelect, ElOption } from 'element-plus';
+import { ElSelect, ElOption, ElOptionGroup } from 'element-plus';
 import { IFishVoiceModel, Status } from '@/models';
+import { fishOperator } from '@/operators';
+import VoiceOption from './VoiceOption.vue';
+
+interface IVoiceOption {
+  value: string;
+  label: string;
+  description?: string;
+  audio?: string;
+}
+
+// Resolve fish-audio's canonical reference id, surfaced under `id`, `_id`
+// (Mongo) or `reference_id` depending on which shape the proxy forwards.
+const resolveId = (m: IFishVoiceModel & { _id?: string }): string => (m.id || m._id || m.reference_id || '').toString();
+
+const toOption = (m: IFishVoiceModel): IVoiceOption => {
+  const id = resolveId(m as IFishVoiceModel & { _id?: string });
+  return {
+    value: id,
+    label: m.title || id,
+    description: m.description,
+    audio: m.samples?.[0]?.audio
+  };
+};
 
 export default defineComponent({
   name: 'FishVoicePicker',
   components: {
     ElSelect,
-    ElOption
+    ElOption,
+    ElOptionGroup,
+    VoiceOption
+  },
+  data() {
+    return {
+      publicVoices: [] as IFishVoiceModel[],
+      remoteLoading: false,
+      query: '',
+      playingId: null as string | null,
+      // Remember labels for every voice we have ever rendered so a selected
+      // public voice keeps its name after the result set changes.
+      labelCache: {} as Record<string, string>,
+      previewAudio: null as HTMLAudioElement | null,
+      searchTimer: null as ReturnType<typeof setTimeout> | null,
+      searchSeq: 0
+    };
   },
   computed: {
     loading(): boolean {
-      return this.$store.state.fish?.status?.getApplications === Status.Request;
+      return this.remoteLoading || this.$store.state.fish?.status?.getApplications === Status.Request;
     },
-    options(): IFishVoiceModel[] {
+    myVoices(): IFishVoiceModel[] {
       return this.$store.state.fish?.voices ?? [];
     },
-    displayOptions(): { value: string; label: string }[] {
-      // Fish-audio's `/fish/model` response surfaces the canonical reference id
-      // under one of three keys depending on which shape the platform proxy
-      // forwards: `id`, `_id` (Mongo), or `reference_id`. Resolve them in that
-      // order so each voice always has a non-empty `:value` — otherwise the
-      // <el-option> renders with `value=""` and el-select treats it as the
-      // "clear" sentinel, which surfaces as the dropdown showing
-      // 'No voice models yet' even when voices state has items.
-      return this.options
-        .map((item) => {
-          const m = item as IFishVoiceModel & { _id?: string };
-          const id = (m.id || m._id || m.reference_id || '').toString();
-          return { value: id, label: m.title || id };
-        })
-        .filter((o) => !!o.value);
+    myOptions(): IVoiceOption[] {
+      return this.myVoices.map(toOption).filter((o) => !!o.value);
+    },
+    // Remote mode delegates filtering to `remote-method`, so own voices would
+    // otherwise stay unfiltered while the user types. Filter them locally by
+    // label/description to keep the two groups in sync.
+    filteredMyOptions(): IVoiceOption[] {
+      const q = this.query.toLowerCase();
+      if (!q) return this.myOptions;
+      return this.myOptions.filter(
+        (o) => o.label.toLowerCase().includes(q) || (o.description || '').toLowerCase().includes(q)
+      );
+    },
+    publicOptions(): IVoiceOption[] {
+      const mine = new Set(this.myOptions.map((o) => o.value));
+      return this.publicVoices.map(toOption).filter((o) => !!o.value && !mine.has(o.value));
+    },
+    fallbackOption(): IVoiceOption | null {
+      const id = this.value;
+      if (!id) return null;
+      const inList = this.myOptions.some((o) => o.value === id) || this.publicOptions.some((o) => o.value === id);
+      if (inList) return null;
+      return { value: id, label: this.labelCache[id] || id };
+    },
+    noDataText(): string {
+      return this.remoteLoading ? this.$t('fish.message.searching') : this.$t('fish.message.searchVoiceHint');
     },
     credential() {
       return this.$store.state.fish?.credential;
@@ -65,21 +137,98 @@ export default defineComponent({
     }
   },
   watch: {
+    myOptions: {
+      immediate: true,
+      handler(opts: IVoiceOption[]) {
+        this.cacheLabels(opts);
+      }
+    },
+    publicOptions(opts: IVoiceOption[]) {
+      this.cacheLabels(opts);
+    },
     credential: {
       immediate: true,
       handler(val) {
-        // Refetch when credential becomes available AND we either don't have a
-        // voices snapshot yet OR the snapshot is empty. The latter handles the
-        // case where the user created their first voice on /fish/model: by the
-        // time they hop back to /fish/tts the cached `voices` may have been an
-        // empty array, which used to lock the picker into "No voice models
-        // yet" indefinitely.
+        // Refetch the user's own voices when the credential arrives and we have
+        // no snapshot yet — covers the picker mounting before the fish
+        // credential is resolved, or the user just creating their first voice.
         if (!val?.token) return;
         const voices = this.$store.state.fish?.voices;
         if (voices === undefined || voices.length === 0) {
           this.$store.dispatch('fish/getVoices');
         }
       }
+    }
+  },
+  beforeUnmount() {
+    this.stopPreview();
+    if (this.searchTimer) clearTimeout(this.searchTimer);
+  },
+  methods: {
+    cacheLabels(opts: IVoiceOption[]) {
+      for (const o of opts) this.labelCache[o.value] = o.label;
+    },
+    onFocus() {
+      // Preload popular public voices so the dropdown is never empty before the
+      // user types.
+      if (!this.publicVoices.length && !this.remoteLoading) this.fetchPublic('');
+    },
+    onSearch(query: string) {
+      this.query = (query || '').trim();
+      // Invalidate any in-flight request immediately so a slower earlier
+      // response (e.g. the focus preload) can't repopulate under a newer query.
+      this.searchSeq++;
+      if (this.searchTimer) clearTimeout(this.searchTimer);
+      this.searchTimer = setTimeout(() => this.fetchPublic(this.query), 350);
+    },
+    async fetchPublic(title: string) {
+      const token = this.credential?.token;
+      if (!token) return;
+      const seq = ++this.searchSeq;
+      this.remoteLoading = true;
+      try {
+        const { data } = await fishOperator.listModels(
+          { self: false, page_size: 30, page_number: 1, ...(title ? { title } : {}) },
+          { token }
+        );
+        // Drop stale responses so a slow earlier query can't overwrite a newer one.
+        if (seq !== this.searchSeq) return;
+        this.publicVoices = data?.items ?? [];
+      } catch (error) {
+        if (seq === this.searchSeq) this.publicVoices = [];
+        console.error('fish.searchPublicVoices failed', error);
+      } finally {
+        if (seq === this.searchSeq) this.remoteLoading = false;
+      }
+    },
+    togglePreview(option: IVoiceOption) {
+      if (!option.audio) return;
+      if (this.playingId === option.value) {
+        this.stopPreview();
+        return;
+      }
+      this.stopPreview();
+      const audio = new Audio(option.audio);
+      // Scope handlers to THIS instance: a stale callback from a previously
+      // stopped clip must not tear down the clip the user just started.
+      const onEnd = () => {
+        if (this.previewAudio === audio) this.stopPreview();
+      };
+      audio.addEventListener('ended', onEnd);
+      audio.addEventListener('error', onEnd);
+      this.previewAudio = audio;
+      this.playingId = option.value;
+      audio.play().catch(() => {
+        if (this.previewAudio === audio) this.stopPreview();
+      });
+    },
+    stopPreview() {
+      if (this.previewAudio) {
+        this.previewAudio.pause();
+        this.previewAudio.src = '';
+        this.previewAudio = null;
+      }
+      this.playingId = null;
     }
   }
 });

--- a/src/components/fish/config/VoicePicker.vue
+++ b/src/components/fish/config/VoicePicker.vue
@@ -8,12 +8,11 @@
       :placeholder="$t('fish.placeholder.voice')"
       clearable
       filterable
-      remote
-      :remote-method="onSearch"
+      :filter-method="onFilter"
       :loading="remoteLoading"
       :loading-text="$t('fish.message.searching')"
       :no-data-text="noDataText"
-      @focus="onFocus"
+      @visible-change="onVisibleChange"
     >
       <!-- Keep the currently-selected voice renderable even when it is not in
            the freshly-fetched result set (e.g. a public voice picked earlier). -->
@@ -35,8 +34,8 @@
         </el-option>
       </el-option-group>
 
-      <el-option-group v-if="publicOptions.length" :label="$t('fish.group.publicVoices')">
-        <el-option v-for="item in publicOptions" :key="item.value" :label="item.label" :value="item.value">
+      <el-option-group v-if="filteredPublicOptions.length" :label="$t('fish.group.publicVoices')">
+        <el-option v-for="item in filteredPublicOptions" :key="item.value" :label="item.label" :value="item.value">
           <voice-option
             :option="item"
             :playing="playingId === item.value"
@@ -87,8 +86,14 @@ export default defineComponent({
   },
   data() {
     return {
-      publicVoices: [] as IFishVoiceModel[],
-      remoteLoading: false,
+      // Stable set of popular public voices loaded once with an empty query;
+      // never overwritten by searches, so clearing the query restores it.
+      popularVoices: [] as IFishVoiceModel[],
+      // Transient server results for the current non-empty query.
+      searchVoices: [] as IFishVoiceModel[],
+      popularLoading: false,
+      searchLoading: false,
+      preloaded: false,
       query: '',
       playingId: null as string | null,
       loadingId: null as string | null,
@@ -101,25 +106,38 @@ export default defineComponent({
     };
   },
   computed: {
+    remoteLoading(): boolean {
+      return this.popularLoading || this.searchLoading;
+    },
     myVoices(): IFishVoiceModel[] {
       return this.$store.state.fish?.voices ?? [];
     },
     myOptions(): IVoiceOption[] {
       return this.myVoices.map(toOption).filter((o) => !!o.value);
     },
-    // Remote mode delegates filtering to `remote-method`, so own voices would
-    // otherwise stay unfiltered while the user types. Filter them locally by
-    // label/description to keep the two groups in sync.
-    filteredMyOptions(): IVoiceOption[] {
-      const q = this.query.toLowerCase();
-      if (!q) return this.myOptions;
-      return this.myOptions.filter(
-        (o) => o.label.toLowerCase().includes(q) || (o.description || '').toLowerCase().includes(q)
-      );
+    // While a query is active show the server's search results; otherwise show
+    // the stable popular set. Server results are already title-filtered, so we
+    // render them as-is; the popular set is narrowed locally for instant feel.
+    publicPool(): { voices: IFishVoiceModel[]; isSearch: boolean } {
+      if (this.query && (this.searchVoices.length || this.searchLoading)) {
+        return { voices: this.searchVoices, isSearch: true };
+      }
+      return { voices: this.popularVoices, isSearch: false };
     },
     publicOptions(): IVoiceOption[] {
       const mine = new Set(this.myOptions.map((o) => o.value));
-      return this.publicVoices.map(toOption).filter((o) => !!o.value && !mine.has(o.value));
+      return this.publicPool.voices.map(toOption).filter((o) => !!o.value && !mine.has(o.value));
+    },
+    // Local, instant filtering (no `remote` mode) so the dropdown is populated
+    // the moment it opens and narrows as the user types — a debounced server
+    // search still runs in the background to reach beyond the loaded page.
+    filteredMyOptions(): IVoiceOption[] {
+      return this.applyQuery(this.myOptions);
+    },
+    filteredPublicOptions(): IVoiceOption[] {
+      // Don't re-narrow server search results — the API already matched the
+      // query and a stricter local substring test could hide valid hits.
+      return this.publicPool.isSearch ? this.publicOptions : this.applyQuery(this.publicOptions);
     },
     fallbackOption(): IVoiceOption | null {
       const id = this.value;
@@ -129,7 +147,9 @@ export default defineComponent({
       return { value: id, label: this.labelCache[id] || id };
     },
     noDataText(): string {
-      return this.remoteLoading ? this.$t('fish.message.searching') : this.$t('fish.message.searchVoiceHint');
+      if (this.remoteLoading) return this.$t('fish.message.searching');
+      if (!this.credential?.token) return this.$t('fish.message.noVoices');
+      return this.$t('fish.message.searchVoiceHint');
     },
     credential() {
       return this.$store.state.fish?.credential;
@@ -159,14 +179,17 @@ export default defineComponent({
     credential: {
       immediate: true,
       handler(val) {
+        if (!val?.token) return;
         // Refetch the user's own voices when the credential arrives and we have
         // no snapshot yet — covers the picker mounting before the fish
         // credential is resolved, or the user just creating their first voice.
-        if (!val?.token) return;
         const voices = this.$store.state.fish?.voices;
         if (voices === undefined || voices.length === 0) {
           this.$store.dispatch('fish/getVoices');
         }
+        // Eager-load popular public voices so the dropdown already has content
+        // the first time it opens — no focus-then-wait dead feeling.
+        if (!this.preloaded) this.fetchPopular();
       }
     }
   },
@@ -178,37 +201,61 @@ export default defineComponent({
     cacheLabels(opts: IVoiceOption[]) {
       for (const o of opts) this.labelCache[o.value] = o.label;
     },
-    onFocus() {
-      // Preload popular public voices so the dropdown is never empty before the
-      // user types.
-      if (!this.publicVoices.length && !this.remoteLoading) this.fetchPublic('');
+    applyQuery(opts: IVoiceOption[]): IVoiceOption[] {
+      const q = this.query.toLowerCase();
+      if (!q) return opts;
+      return opts.filter((o) => o.label.toLowerCase().includes(q) || (o.description || '').toLowerCase().includes(q));
     },
-    onSearch(query: string) {
+    onVisibleChange(open: boolean) {
+      if (open && !this.preloaded && !this.popularLoading) this.fetchPopular();
+    },
+    onFilter(query: string) {
       this.query = (query || '').trim();
-      // Invalidate any in-flight request immediately so a slower earlier
-      // response (e.g. the focus preload) can't repopulate under a newer query.
-      this.searchSeq++;
+      // Local filtering already narrowed the popular set instantly; also pull
+      // matching voices from the server (debounced) to reach beyond page 1.
       if (this.searchTimer) clearTimeout(this.searchTimer);
-      this.searchTimer = setTimeout(() => this.fetchPublic(this.query), 350);
+      if (!this.query) {
+        // Cleared the box → drop stale search results so the popular set shows.
+        this.searchSeq++;
+        this.searchVoices = [];
+        this.searchLoading = false;
+        return;
+      }
+      this.searchTimer = setTimeout(() => this.fetchSearch(this.query), 350);
     },
-    async fetchPublic(title: string) {
+    // Load the stable popular set once. Its own in-flight flag never collides
+    // with search seq, so a concurrent search can't stop `preloaded` latching.
+    async fetchPopular() {
+      const token = this.credential?.token;
+      if (!token || this.popularLoading) return;
+      this.popularLoading = true;
+      try {
+        const { data } = await fishOperator.listModels({ self: false, page_size: 30, page_number: 1 }, { token });
+        this.popularVoices = data?.items ?? [];
+        this.preloaded = true;
+      } catch (error) {
+        console.error('fish.loadPopularVoices failed', error);
+      } finally {
+        this.popularLoading = false;
+      }
+    },
+    async fetchSearch(title: string) {
       const token = this.credential?.token;
       if (!token) return;
       const seq = ++this.searchSeq;
-      this.remoteLoading = true;
+      this.searchLoading = true;
       try {
         const { data } = await fishOperator.listModels(
-          { self: false, page_size: 30, page_number: 1, ...(title ? { title } : {}) },
+          { self: false, page_size: 30, page_number: 1, title },
           { token }
         );
-        // Drop stale responses so a slow earlier query can't overwrite a newer one.
         if (seq !== this.searchSeq) return;
-        this.publicVoices = data?.items ?? [];
+        this.searchVoices = data?.items ?? [];
       } catch (error) {
-        if (seq === this.searchSeq) this.publicVoices = [];
+        if (seq === this.searchSeq) this.searchVoices = [];
         console.error('fish.searchPublicVoices failed', error);
       } finally {
-        if (seq === this.searchSeq) this.remoteLoading = false;
+        if (seq === this.searchSeq) this.searchLoading = false;
       }
     },
     togglePreview(option: IVoiceOption) {

--- a/src/i18n/ar/fish.json
+++ b/src/i18n/ar/fish.json
@@ -91,6 +91,18 @@
     "message": "لا توجد نماذج صوتية",
     "description": "تنبيه عند فراغ محدد الصوت في Fish"
   },
+  "group.publicVoices": {
+    "message": "Public voice library",
+    "description": "Fish voice picker public voices group header"
+  },
+  "message.searching": {
+    "message": "Searching…",
+    "description": "Fish voice picker remote search loading hint"
+  },
+  "message.searchVoiceHint": {
+    "message": "Type a keyword to search public voices",
+    "description": "Fish voice picker remote search empty-state hint"
+  },
   "name.voiceTitle": {
     "message": "الاسم",
     "description": "علامة حقل اسم نموذج الصوت في Fish"

--- a/src/i18n/de/fish.json
+++ b/src/i18n/de/fish.json
@@ -91,6 +91,18 @@
     "message": "Keine Sprachmodelle verfügbar",
     "description": "Fish Sprachwähler ist leer Hinweis"
   },
+  "group.publicVoices": {
+    "message": "Public voice library",
+    "description": "Fish voice picker public voices group header"
+  },
+  "message.searching": {
+    "message": "Searching…",
+    "description": "Fish voice picker remote search loading hint"
+  },
+  "message.searchVoiceHint": {
+    "message": "Type a keyword to search public voices",
+    "description": "Fish voice picker remote search empty-state hint"
+  },
   "name.voiceTitle": {
     "message": "Name",
     "description": "Fish Geräuschmodell Name Feldbezeichnung"

--- a/src/i18n/el/fish.json
+++ b/src/i18n/el/fish.json
@@ -91,6 +91,18 @@
     "message": "Δεν υπάρχουν διαθέσιμα μοντέλα ήχου",
     "description": "Μήνυμα όταν ο επιλογέας ήχου του Fish είναι κενός"
   },
+  "group.publicVoices": {
+    "message": "Public voice library",
+    "description": "Fish voice picker public voices group header"
+  },
+  "message.searching": {
+    "message": "Searching…",
+    "description": "Fish voice picker remote search loading hint"
+  },
+  "message.searchVoiceHint": {
+    "message": "Type a keyword to search public voices",
+    "description": "Fish voice picker remote search empty-state hint"
+  },
   "name.voiceTitle": {
     "message": "Όνομα",
     "description": "Ετικέτα πεδίου ονόματος στο μοντέλο ήχου Fish"

--- a/src/i18n/en/fish.json
+++ b/src/i18n/en/fish.json
@@ -103,6 +103,18 @@
     "message": "No voice models yet",
     "description": "Fish voice picker empty state"
   },
+  "group.publicVoices": {
+    "message": "Public voice library",
+    "description": "Fish voice picker public voices group header"
+  },
+  "message.searching": {
+    "message": "Searching…",
+    "description": "Fish voice picker remote search loading hint"
+  },
+  "message.searchVoiceHint": {
+    "message": "Type a keyword to search public voices",
+    "description": "Fish voice picker remote search empty-state hint"
+  },
   "name.voiceTitle": {
     "message": "Name",
     "description": "Fish voice model title label"

--- a/src/i18n/es/fish.json
+++ b/src/i18n/es/fish.json
@@ -91,6 +91,18 @@
     "message": "No hay modelos de voz disponibles",
     "description": "Mensaje de advertencia cuando el selector de voz de Fish está vacío"
   },
+  "group.publicVoices": {
+    "message": "Public voice library",
+    "description": "Fish voice picker public voices group header"
+  },
+  "message.searching": {
+    "message": "Searching…",
+    "description": "Fish voice picker remote search loading hint"
+  },
+  "message.searchVoiceHint": {
+    "message": "Type a keyword to search public voices",
+    "description": "Fish voice picker remote search empty-state hint"
+  },
   "name.voiceTitle": {
     "message": "Nombre",
     "description": "Etiqueta del campo de nombre del modelo de sonido en Fish"

--- a/src/i18n/fi/fish.json
+++ b/src/i18n/fi/fish.json
@@ -91,6 +91,18 @@
     "message": "Äänimalleja ei ole saatavilla",
     "description": "Ilmoitus, kun Fish-äänenvalitsin on tyhjä"
   },
+  "group.publicVoices": {
+    "message": "Public voice library",
+    "description": "Fish voice picker public voices group header"
+  },
+  "message.searching": {
+    "message": "Searching…",
+    "description": "Fish voice picker remote search loading hint"
+  },
+  "message.searchVoiceHint": {
+    "message": "Type a keyword to search public voices",
+    "description": "Fish voice picker remote search empty-state hint"
+  },
   "name.voiceTitle": {
     "message": "Nimi",
     "description": "Fish äänen mallin nimi kenttäotsikko"

--- a/src/i18n/fr/fish.json
+++ b/src/i18n/fr/fish.json
@@ -91,6 +91,18 @@
     "message": "Aucun modèle vocal disponible",
     "description": "Message indiquant que le sélecteur de voix de Fish est vide"
   },
+  "group.publicVoices": {
+    "message": "Public voice library",
+    "description": "Fish voice picker public voices group header"
+  },
+  "message.searching": {
+    "message": "Searching…",
+    "description": "Fish voice picker remote search loading hint"
+  },
+  "message.searchVoiceHint": {
+    "message": "Type a keyword to search public voices",
+    "description": "Fish voice picker remote search empty-state hint"
+  },
   "name.voiceTitle": {
     "message": "Nom",
     "description": "Étiquette du champ de nom pour le modèle de son Fish"

--- a/src/i18n/it/fish.json
+++ b/src/i18n/it/fish.json
@@ -91,6 +91,18 @@
     "message": "Nessun modello vocale disponibile",
     "description": "Messaggio di avviso quando il selettore vocale Fish è vuoto"
   },
+  "group.publicVoices": {
+    "message": "Public voice library",
+    "description": "Fish voice picker public voices group header"
+  },
+  "message.searching": {
+    "message": "Searching…",
+    "description": "Fish voice picker remote search loading hint"
+  },
+  "message.searchVoiceHint": {
+    "message": "Type a keyword to search public voices",
+    "description": "Fish voice picker remote search empty-state hint"
+  },
   "name.voiceTitle": {
     "message": "Nome",
     "description": "Etichetta del campo per il nome del modello vocale in Fish"

--- a/src/i18n/ja/fish.json
+++ b/src/i18n/ja/fish.json
@@ -91,6 +91,18 @@
     "message": "音声モデルはありません",
     "description": "Fish 音声セレクターが空であることを示すメッセージ"
   },
+  "group.publicVoices": {
+    "message": "Public voice library",
+    "description": "Fish voice picker public voices group header"
+  },
+  "message.searching": {
+    "message": "Searching…",
+    "description": "Fish voice picker remote search loading hint"
+  },
+  "message.searchVoiceHint": {
+    "message": "Type a keyword to search public voices",
+    "description": "Fish voice picker remote search empty-state hint"
+  },
   "name.voiceTitle": {
     "message": "名前",
     "description": "Fish 音声モデル名称フィールドラベル"

--- a/src/i18n/ko/fish.json
+++ b/src/i18n/ko/fish.json
@@ -91,6 +91,18 @@
     "message": "음성 모델이 없습니다",
     "description": "Fish 음성 선택기가 비어있음을 알리는 메시지"
   },
+  "group.publicVoices": {
+    "message": "Public voice library",
+    "description": "Fish voice picker public voices group header"
+  },
+  "message.searching": {
+    "message": "Searching…",
+    "description": "Fish voice picker remote search loading hint"
+  },
+  "message.searchVoiceHint": {
+    "message": "Type a keyword to search public voices",
+    "description": "Fish voice picker remote search empty-state hint"
+  },
   "name.voiceTitle": {
     "message": "이름",
     "description": "Fish 소리 모델 이름 필드 레이블"

--- a/src/i18n/pl/fish.json
+++ b/src/i18n/pl/fish.json
@@ -91,6 +91,18 @@
     "message": "Brak modeli głosów",
     "description": "Komunikat, gdy wybór głosów Fish jest pusty"
   },
+  "group.publicVoices": {
+    "message": "Public voice library",
+    "description": "Fish voice picker public voices group header"
+  },
+  "message.searching": {
+    "message": "Searching…",
+    "description": "Fish voice picker remote search loading hint"
+  },
+  "message.searchVoiceHint": {
+    "message": "Type a keyword to search public voices",
+    "description": "Fish voice picker remote search empty-state hint"
+  },
   "name.voiceTitle": {
     "message": "Nazwa",
     "description": "Etykieta pola nazwy modelu dźwięku w Fish"

--- a/src/i18n/pt/fish.json
+++ b/src/i18n/pt/fish.json
@@ -91,6 +91,18 @@
     "message": "Nenhum modelo de voz disponível",
     "description": "Mensagem de aviso quando o seletor de voz do Fish está vazio"
   },
+  "group.publicVoices": {
+    "message": "Public voice library",
+    "description": "Fish voice picker public voices group header"
+  },
+  "message.searching": {
+    "message": "Searching…",
+    "description": "Fish voice picker remote search loading hint"
+  },
+  "message.searchVoiceHint": {
+    "message": "Type a keyword to search public voices",
+    "description": "Fish voice picker remote search empty-state hint"
+  },
   "name.voiceTitle": {
     "message": "Nome",
     "description": "Etiqueta do campo de nome do modelo de voz no Fish"

--- a/src/i18n/ru/fish.json
+++ b/src/i18n/ru/fish.json
@@ -91,6 +91,18 @@
     "message": "Нет доступных голосовых моделей",
     "description": "Подсказка, когда выбор голосов Fish пуст"
   },
+  "group.publicVoices": {
+    "message": "Public voice library",
+    "description": "Fish voice picker public voices group header"
+  },
+  "message.searching": {
+    "message": "Searching…",
+    "description": "Fish voice picker remote search loading hint"
+  },
+  "message.searchVoiceHint": {
+    "message": "Type a keyword to search public voices",
+    "description": "Fish voice picker remote search empty-state hint"
+  },
   "name.voiceTitle": {
     "message": "Название",
     "description": "Метка поля названия для модели звука Fish"

--- a/src/i18n/sr/fish.json
+++ b/src/i18n/sr/fish.json
@@ -91,6 +91,18 @@
     "message": "Nema dostupnih zvučnih modela",
     "description": "Poruka kada je selektor zvukova Fish prazan"
   },
+  "group.publicVoices": {
+    "message": "Public voice library",
+    "description": "Fish voice picker public voices group header"
+  },
+  "message.searching": {
+    "message": "Searching…",
+    "description": "Fish voice picker remote search loading hint"
+  },
+  "message.searchVoiceHint": {
+    "message": "Type a keyword to search public voices",
+    "description": "Fish voice picker remote search empty-state hint"
+  },
   "name.voiceTitle": {
     "message": "Име",
     "description": "Fish ознака за поље имена модела звука"

--- a/src/i18n/sv/fish.json
+++ b/src/i18n/sv/fish.json
@@ -91,6 +91,18 @@
     "message": "Inga ljudmodeller tillgängliga",
     "description": "Fish ljudväljare är tomt meddelande"
   },
+  "group.publicVoices": {
+    "message": "Public voice library",
+    "description": "Fish voice picker public voices group header"
+  },
+  "message.searching": {
+    "message": "Searching…",
+    "description": "Fish voice picker remote search loading hint"
+  },
+  "message.searchVoiceHint": {
+    "message": "Type a keyword to search public voices",
+    "description": "Fish voice picker remote search empty-state hint"
+  },
   "name.voiceTitle": {
     "message": "Namn",
     "description": "Fish röstmodell namn fältetikett"

--- a/src/i18n/uk/fish.json
+++ b/src/i18n/uk/fish.json
@@ -91,6 +91,18 @@
     "message": "Немає доступних голосових моделей",
     "description": "Підказка, що вибір голосів Fish порожній"
   },
+  "group.publicVoices": {
+    "message": "Public voice library",
+    "description": "Fish voice picker public voices group header"
+  },
+  "message.searching": {
+    "message": "Searching…",
+    "description": "Fish voice picker remote search loading hint"
+  },
+  "message.searchVoiceHint": {
+    "message": "Type a keyword to search public voices",
+    "description": "Fish voice picker remote search empty-state hint"
+  },
   "name.voiceTitle": {
     "message": "Назва",
     "description": "Мітка поля назви моделі звуку Fish"

--- a/src/i18n/zh-CN/fish.json
+++ b/src/i18n/zh-CN/fish.json
@@ -103,6 +103,18 @@
     "message": "暂无声音模型",
     "description": "Fish 声音选择器为空提示"
   },
+  "group.publicVoices": {
+    "message": "公共音色库",
+    "description": "Fish 声音选择器公共音色分组标题"
+  },
+  "message.searching": {
+    "message": "搜索中…",
+    "description": "Fish 声音选择器远程搜索加载提示"
+  },
+  "message.searchVoiceHint": {
+    "message": "输入关键词搜索公共音色",
+    "description": "Fish 声音选择器远程搜索空状态提示"
+  },
   "name.voiceTitle": {
     "message": "名称",
     "description": "Fish 声音模型名称字段标签"

--- a/src/i18n/zh-TW/fish.json
+++ b/src/i18n/zh-TW/fish.json
@@ -91,6 +91,18 @@
     "message": "暫無聲音模型",
     "description": "Fish 聲音選擇器為空提示"
   },
+  "group.publicVoices": {
+    "message": "Public voice library",
+    "description": "Fish voice picker public voices group header"
+  },
+  "message.searching": {
+    "message": "Searching…",
+    "description": "Fish voice picker remote search loading hint"
+  },
+  "message.searchVoiceHint": {
+    "message": "Type a keyword to search public voices",
+    "description": "Fish voice picker remote search empty-state hint"
+  },
   "name.voiceTitle": {
     "message": "名稱",
     "description": "Fish 聲音模型名稱欄位標籤"


### PR DESCRIPTION
## Problem

On `studio.acedata.cloud/fish/tts` the **Voice** picker only listed the user's *own* cloned voices — it calls `GET /fish/model?self=true`. A user who has never cloned a voice sees **“No voice models yet”** and can only fall back to the model's default voice, even though Fish exposes a public library of **2.4M+** voices (`self=false`).

## Change

`VoicePicker.vue` now uses `el-select` in **remote** mode to search Fish's public voice library (`GET /fish/model?self=false&title=<query>`) alongside the user's own voices:

- **Two grouped sections** — “My voices” (from `state.fish.voices`) and “Public voice library” (remote search results), deduped by reference id.
- **Debounced remote search** (350 ms) with a stale-response guard so a slow earlier request can't overwrite a newer one.
- **Inline audio preview** per option (new `VoiceOption.vue`) using each voice's default sample; play/pause via inline SVG (Nexior doesn't register FA solid icons globally). Preview click uses `@click.stop` so it never selects the option.
- **Selected-label persistence** via a `labelCache` + `fallbackOption` so a public voice keeps its name after the result set changes.
- Existing “use my own voice” flow is unchanged; own voices still auto-fetch when the credential arrives.

i18n: 3 new keys (`group.publicVoices`, `message.searching`, `message.searchVoiceHint`) authored in zh-CN + en and backfilled across all 17 locales (coverage guard green).

## Verification

- `vue-tsc --noEmit` clean; `eslint` clean on changed files.
- `check_i18n_coverage.py` → `i18n validation OK: 17 locale(s) × 45 namespace(s)`.
- `src/utils/fish.test.ts` passes (the `Preview.test.ts` failure is a pre-existing stale `@acedatacloud/core` icons export in the local symlinked node_modules, unrelated to this change; CI uses a clean install).
- Confirmed live: `self=false` returns 2,453,432 voices; `title=trump` returns 916 with playable `samples[].audio`.

## 🤖 对抗评审

Reviewer: **Codex** (`codex exec --sandbox read-only`, cross-model). Converged in 2 rounds.

**Round 1 — 3 RISKs, all fixed:**
1. *Audio callback cross-talk* — clicking preview B while A is starting: A's async `error`/`ended`/`play().catch` handler called `stopPreview()` and killed B. → Handlers now guarded by `this.previewAudio === audio` so a stale clip can't tear down the current one.
2. *Stale focus-fetch race* — focus preload (`fetchPublic('')`) wasn't invalidated until the debounce fired, so empty results could flash under a typed query. → `onSearch` now bumps `searchSeq` and sets `this.query` synchronously before debouncing.
3. *Own voices unfiltered under remote mode* — Element Plus delegates filtering to `remote-method`, so “My voices” stayed full while typing. → Added `filteredMyOptions` computed that filters own voices locally by label/description.

**Round 2 — `VERDICT: CLEAN`.**