### PR TITLE
ci: separate testing vs production concurrency groups for mobile builds

### DIFF
--- a/.github/workflows/build-android.yaml
+++ b/.github/workflows/build-android.yaml
@@ -36,7 +36,10 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Include promote_to_production so a testing build (04:07, promote=false) and a
+  # production release build (09:32, promote=true) — both on --ref main — never
+  # cancel each other. Same-type re-dispatches still coalesce.
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.promote_to_production }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/build-ios.yaml
+++ b/.github/workflows/build-ios.yaml
@@ -26,7 +26,11 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Include auto_submit_review so a testing build (04:07 auto-release-mobile,
+  # submit=false) and a production submit build (09:32 auto-production-mobile,
+  # submit=true) — both dispatched on --ref main — land in DIFFERENT groups and
+  # can never cancel each other. Same-type re-dispatches still coalesce.
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.auto_submit_review }}
   cancel-in-progress: true
 
 env:

--- a/change/@acedatacloud-nexior-6f034f3a-4e05-4867-b85e-077475f36046.json
+++ b/change/@acedatacloud-nexior-6f034f3a-4e05-4867-b85e-077475f36046.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "ci: split build-ios/android concurrency groups by production toggle",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "none"
+}


### PR DESCRIPTION
## Why (follow-up to #1387)

#1387 added `concurrency: { group: '${{ github.workflow }}-${{ github.ref }}', cancel-in-progress: true }` to `build-ios.yaml` and `build-android.yaml` to stop duplicate macOS builds. But **two daily pipelines dispatch both build workflows on `--ref main`**:

| Pipeline | Time (Beijing) | iOS | Android |
|---|---|---|---|
| `auto-release-mobile.yaml` | 04:07 | `auto_submit_review=false` (TestFlight only) | `promote_to_production=false` (Play beta) |
| `auto-production-mobile.yaml` | 09:32 | `auto_submit_review=true` (**submit App Store review**) | `promote_to_production=true` (**promote Play production**) |

Because both dispatch on `ref=main`, they shared **one** concurrency group. Normally the 04:07 build finishes ~5h before 09:32, but if a testing build hangs/queues past 09:32, `cancel-in-progress` would let it **cancel the daily production App Store submission** (or vice-versa) — silently breaking the fully-automatic daily review submission.

## Fix

Append the production-distinguishing input to each group key so testing and production builds land in **distinct** groups:

- `build-ios.yaml`: `...-${{ inputs.auto_submit_review }}`  → `...-false` (04:07) vs `...-true` (09:32)
- `build-android.yaml`: `...-${{ inputs.promote_to_production }}` → same split

Testing vs production builds now **never cancel each other**; same-type re-dispatches still coalesce, so the #1387 cost saving is intact. `desktop.yml` is unchanged (it is not dispatched by these pipelines).

## Verified: daily auto-submit is healthy (unaffected)

Confirmed from live run history that `auto-production-mobile.yaml` runs daily and actually submits:
- 8+ consecutive daily `schedule` runs `success`.
- Today's run: iOS gate `clean (live=63002, target=63015)` → dispatched `build-ios` with `auto_submit_review=true` (App Store review submitted) + `build-android` with `promote_to_production=true` (Play production). Both `success`.

## 🤖 对抗评审

Reviewer: Claude `general-purpose` subagent (Codex timed out on a flaky network, substituted per `.claude/commands/auto-review.md`). **VERDICT: CLEAN.**

- **#1 Separates the pipelines — YES.** iOS `Build iOS-refs/heads/main-false` (04:07) vs `...-true` (09:32); Android analogous. Distinct group strings → no cross-cancel.
- **#3 Boolean rendering cannot re-merge (critical check).** `type: boolean` inputs are coerced by GitHub and render lowercase `true`/`false` regardless of `-f key=…` vs default; the two crons pass opposite hardwired values, so `false` can never hash to `true`. Bug cannot reappear.
- **#2 Tag-push empty-input suffix (`...-refs/tags/ios-v3.x-`) is safe** — tag refs are globally unique, so the trailing `-` only ever collides with a re-push of the same tag (desired coalescing).
- **#4 No needed cancellation lost** — cancellation only ever mattered within same type; same-type coalescing preserved.
- **#5 Leaving `desktop.yml` unchanged is correct** — not dispatched by the mobile pipelines.
- Noted (not a defect): a manual `release-mobile.yaml` production dispatch shares the `...-true` group with the 09:32 cron — that's same-type dedup, which correctly avoids a double App Store submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)