### PR TITLE
fix(chat): stop tool-call rows from spinning forever

### DIFF
--- a/change/@acedatacloud-nexior-tool-status-icon.json
+++ b/change/@acedatacloud-nexior-tool-status-icon.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Settle tool-call status icons so finished/interrupted tool rows stop spinning forever",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/chat/BrowserToolActivity.test.ts
+++ b/src/components/chat/BrowserToolActivity.test.ts
@@ -76,4 +76,31 @@ describe('BrowserToolActivity', () => {
     expect(wrapper.text()).not.toContain('secret');
     expect(wrapper.text()).not.toContain('private');
   });
+
+  it('marks a non-terminal state as interrupted (no spinner) once the turn has ended', () => {
+    const wrapper = mount(BrowserToolActivity, {
+      props: {
+        item: { type: 'tool_use', execution: 'browser', execution_state: 'executing', tool_display_name: 'Read tab' },
+        turnActive: false
+      },
+      global: { mocks: { $t: (key: string) => key } }
+    });
+
+    expect(wrapper.text()).toContain('chat.toolActivity.interrupted');
+    expect(wrapper.text()).not.toContain('chat.browserTool.state.executing');
+    expect(wrapper.find('.is-spinning').exists()).toBe(false);
+  });
+
+  it('keeps a terminal state intact after the turn ends', () => {
+    const wrapper = mount(BrowserToolActivity, {
+      props: {
+        item: { type: 'tool_use', execution: 'browser', execution_state: 'completed', tool_display_name: 'Read tab' },
+        turnActive: false
+      },
+      global: { mocks: { $t: (key: string) => key } }
+    });
+
+    expect(wrapper.text()).toContain('chat.browserTool.state.completed');
+    expect(wrapper.text()).not.toContain('chat.toolActivity.interrupted');
+  });
 });

--- a/src/components/chat/BrowserToolActivity.vue
+++ b/src/components/chat/BrowserToolActivity.vue
@@ -3,7 +3,7 @@
     <div class="activity-icon" aria-hidden="true">
       <component
         :is="icon"
-        :class="{ 'is-spinning': state === 'executing' }"
+        :class="{ 'is-spinning': state === 'executing' && !isStalled }"
         :size="'1em' as any"
         aria-hidden="true"
         focusable="false"
@@ -11,11 +11,13 @@
     </div>
     <div class="activity-copy">
       <div class="activity-title">{{ title }}</div>
-      <div class="activity-status">{{ $t(`chat.browserTool.state.${state}`) }}</div>
+      <div class="activity-status">
+        {{ isStalled ? $t('chat.toolActivity.interrupted') : $t(`chat.browserTool.state.${state}`) }}
+      </div>
       <div v-if="origin" class="activity-origin">{{ origin }}</div>
     </div>
     <div class="activity-actions">
-      <el-button v-if="recoveryAction" text size="small" @click="$emit('recovery', recoveryAction)">
+      <el-button v-if="recoveryAction && !isStalled" text size="small" @click="$emit('recovery', recoveryAction)">
         {{ $t(`chat.browserTool.recovery.${recoveryAction}`) }}
       </el-button>
       <el-button v-if="canStop" text size="small" @click="$emit('stop-session', item.browser_session_id)">
@@ -63,6 +65,11 @@ const RECOVERY_ACTIONS = {
   authorization_required: 'open-consent-card'
 } as const;
 
+// In-flight states — the browser tool is still working. Anything else is a
+// settled outcome. A turn that ends while a tool is still in one of these
+// states left it stalled (no device report), so we stop the spinner.
+const ACTIVE_STATES: IBrowserToolExecutionState[] = ['starting_session', 'attaching_tab', 'ready', 'executing'];
+
 export default defineComponent({
   name: 'BrowserToolActivity',
   components: { ElButton },
@@ -70,12 +77,22 @@ export default defineComponent({
     item: {
       type: Object as PropType<IChatMessageContentItem>,
       required: true
+    },
+    // False once the parent turn has finished/failed. An in-flight browser
+    // state on an ended turn never settled, so we show a stalled/interrupted
+    // icon instead of an eternal spinner.
+    turnActive: {
+      type: Boolean,
+      default: true
     }
   },
   emits: ['stop-session', 'recovery'],
   computed: {
     state(): IBrowserToolExecutionState {
       return isBrowserToolExecutionState(this.item.execution_state) ? this.item.execution_state : 'starting_session';
+    },
+    isStalled(): boolean {
+      return !this.turnActive && ACTIVE_STATES.includes(this.state);
     },
     title(): string {
       return (
@@ -89,16 +106,13 @@ export default defineComponent({
       return origin ? new URL(origin).hostname : undefined;
     },
     icon(): Component {
-      return STATE_ICONS[this.state];
+      return this.isStalled ? WarningIcon : STATE_ICONS[this.state];
     },
     recoveryAction(): (typeof RECOVERY_ACTIONS)[keyof typeof RECOVERY_ACTIONS] | undefined {
       return RECOVERY_ACTIONS[this.state as keyof typeof RECOVERY_ACTIONS];
     },
     canStop(): boolean {
-      return (
-        !!this.item.browser_session_id &&
-        ['starting_session', 'attaching_tab', 'ready', 'executing'].includes(this.state)
-      );
+      return !this.isStalled && !!this.item.browser_session_id && ACTIVE_STATES.includes(this.state);
     }
   }
 });

--- a/src/components/chat/Message.vue
+++ b/src/components/chat/Message.vue
@@ -74,10 +74,12 @@
                   )
                 "
                 :item="item"
+                :turn-active="isTurnActive"
               />
               <browser-tool-activity
                 v-if="item.type === 'tool_use' && item.execution === 'browser'"
                 :item="item"
+                :turn-active="isTurnActive"
                 @stop-session="$emit('stopBrowserSession', $event)"
                 @recovery="$emit('browserRecovery', $event)"
               />
@@ -315,6 +317,12 @@ export default defineComponent({
       // chat session. Optional chaining guards the case where the chat store
       // module isn't registered (anonymous /share/:id route).
       return this.modelGroupOverride || this.$store.state.chat?.modelGroup;
+    },
+    // A turn is "active" only while streaming. A FINISHED/FAILED message that
+    // still carries a `running` tool block never got its result, so tool rows
+    // settle their icon instead of spinning forever (see ToolActivity).
+    isTurnActive(): boolean {
+      return this.message.state === IChatMessageState.PENDING || this.message.state === IChatMessageState.ANSWERING;
     },
     // Plain-text view of `message.content` for the copy button. Assistant
     // messages are now stored as IChatMessageContentItem[] (text + tool_use

--- a/src/components/chat/ToolActivity.test.ts
+++ b/src/components/chat/ToolActivity.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import type { IChatMessageContentItem } from '@/models';
+import ToolActivity from './ToolActivity.vue';
+
+function mountActivity(item: IChatMessageContentItem, turnActive = true) {
+  return mount(ToolActivity, {
+    props: { item, turnActive },
+    global: {
+      // el-icon is auto-imported globally in the app; stub it so a bare mount
+      // renders. We assert on the root state classes + label, not the glyph.
+      stubs: { 'el-icon': true },
+      mocks: { $t: (key: string) => key }
+    }
+  });
+}
+
+const runningItem: IChatMessageContentItem = {
+  type: 'tool_use',
+  tool_name: 'bash',
+  tool_display_name: 'Bash',
+  status: 'running',
+  input: {}
+};
+
+describe('ToolActivity status icon', () => {
+  it('spins only while the tool is running on a live turn', () => {
+    const wrapper = mountActivity(runningItem, true);
+    expect(wrapper.classes()).toContain('is-running');
+    expect(wrapper.classes()).not.toContain('is-error');
+    expect(wrapper.text()).not.toContain('chat.toolActivity.interrupted');
+  });
+
+  it('settles a running block to interrupted (error) once the turn has ended', () => {
+    const wrapper = mountActivity(runningItem, false);
+    // No eternal spinner: the running state is dropped once the turn is over.
+    expect(wrapper.classes()).not.toContain('is-running');
+    // A never-resolved tool is shown as failed, and labeled interrupted.
+    expect(wrapper.classes()).toContain('is-error');
+    expect(wrapper.text()).toContain('chat.toolActivity.interrupted');
+  });
+
+  it('renders an explicit error as error regardless of turn state', () => {
+    const wrapper = mountActivity(
+      { type: 'tool_use', tool_name: 'bash', status: 'done', is_error: true, output: 'boom', input: {} },
+      false
+    );
+    expect(wrapper.classes()).toContain('is-error');
+    expect(wrapper.classes()).not.toContain('is-running');
+    // A real done+error block is not an interruption.
+    expect(wrapper.text()).not.toContain('chat.toolActivity.interrupted');
+  });
+
+  it('leaves an awaiting_input block un-interrupted even after the turn ends', () => {
+    // A deferred desktop client tool sits at 'awaiting_input' (not 'running'),
+    // so it must NOT be marked error/interrupted when turnActive is false.
+    const wrapper = mountActivity({ type: 'tool_use', tool_name: 'bash', status: 'awaiting_input', input: {} }, false);
+    expect(wrapper.classes()).not.toContain('is-running');
+    expect(wrapper.classes()).not.toContain('is-error');
+    expect(wrapper.text()).not.toContain('chat.toolActivity.interrupted');
+  });
+
+  it('renders a completed success without spinner or error', () => {
+    const wrapper = mountActivity(
+      {
+        type: 'tool_use',
+        tool_name: 'bash',
+        status: 'done',
+        is_error: false,
+        output: 'ok',
+        duration_ms: 42,
+        input: {}
+      },
+      false
+    );
+    expect(wrapper.classes()).not.toContain('is-running');
+    expect(wrapper.classes()).not.toContain('is-error');
+    expect(wrapper.text()).toContain('42ms');
+  });
+});

--- a/src/components/chat/ToolActivity.vue
+++ b/src/components/chat/ToolActivity.vue
@@ -1,11 +1,11 @@
 <template>
-  <div :class="['tool-activity', { 'is-error': item.is_error, 'is-running': item.status === 'running' }]">
+  <div :class="['tool-activity', { 'is-error': isError, 'is-running': isRunning }]">
     <div class="tool-header" @click="expanded = !expanded">
       <span class="tool-icon">
-        <el-icon v-if="item.status === 'running'" class="is-loading"
+        <el-icon v-if="isRunning" class="is-loading"
           ><Loading :size="'1em' as any" aria-hidden="true" focusable="false"
         /></el-icon>
-        <el-icon v-else-if="item.is_error" color="var(--el-color-danger)"
+        <el-icon v-else-if="isError" color="var(--el-color-danger)"
           ><CircleCloseFilled :size="'1em' as any" aria-hidden="true" focusable="false"
         /></el-icon>
         <el-icon v-else color="var(--el-color-success)"
@@ -13,7 +13,8 @@
         /></el-icon>
       </span>
       <span class="tool-name">{{ displayName }}</span>
-      <span v-if="item.duration_ms" class="tool-duration">{{ item.duration_ms }}ms</span>
+      <span v-if="isInterrupted" class="tool-interrupted">{{ $t('chat.toolActivity.interrupted') }}</span>
+      <span v-else-if="item.duration_ms" class="tool-duration">{{ item.duration_ms }}ms</span>
       <el-icon class="tool-expand" :class="{ rotated: expanded }"
         ><ArrowRight :size="'1em' as any" aria-hidden="true" focusable="false"
       /></el-icon>
@@ -56,6 +57,14 @@ export default defineComponent({
     item: {
       type: Object as PropType<IChatMessageContentItem>,
       required: true
+    },
+    // False once the parent turn has finished/failed. A `running` block on an
+    // ended turn never received a tool result (error mid-tool, or a legacy
+    // orphan persisted before the backend finalized it), so we settle its icon
+    // instead of spinning forever.
+    turnActive: {
+      type: Boolean,
+      default: true
     }
   },
   data() {
@@ -64,6 +73,20 @@ export default defineComponent({
     };
   },
   computed: {
+    // Spin ONLY while the tool is genuinely in flight on a live turn.
+    isRunning(): boolean {
+      return this.item.status === 'running' && this.turnActive;
+    },
+    // A never-resolved block on an ended turn is shown as failed (honest —
+    // we never observed a success), alongside blocks that errored explicitly.
+    isError(): boolean {
+      return !!this.item.is_error || (this.item.status === 'running' && !this.turnActive);
+    },
+    // Distinguish "the turn ended before this tool reported" from a normal
+    // error, so we can show a short hint instead of a stale duration.
+    isInterrupted(): boolean {
+      return this.item.status === 'running' && !this.turnActive;
+    },
     displayName(): string {
       if (this.item.tool_display_name) return this.item.tool_display_name;
       const name = this.item.tool_name || '';
@@ -134,6 +157,11 @@ export default defineComponent({
 
 .tool-duration {
   color: var(--el-text-color-secondary);
+  font-size: 12px;
+}
+
+.tool-interrupted {
+  color: var(--el-color-danger);
   font-size: 12px;
 }
 

--- a/src/i18n/ar/chat.json
+++ b/src/i18n/ar/chat.json
@@ -1088,9 +1088,25 @@
     "message": "نشاط المتصفح",
     "description": "العنوان الافتراضي لنشاط أداة جهاز المتصفح"
   },
+  "browserTool.state.choose_device": {
+    "message": "يرجى اختيار جهاز المتصفح",
+    "description": "لم يتم اختيار جهاز المتصفح بعد"
+  },
   "browserTool.state.device_offline": {
     "message": "جهاز المتصفح غير متصل",
     "description": "جهاز المتصفح المختار غير متصل بالإنترنت"
+  },
+  "browserTool.state.awaiting_device": {
+    "message": "في انتظار جهاز المتصفح",
+    "description": "انتظار جهاز المتصفح لاستلام المهمة"
+  },
+  "browserTool.state.awaiting_local_approval": {
+    "message": "يرجى الموافقة على جهاز المتصفح",
+    "description": "انتظار الموافقة على العملية من جهاز المتصفح المحلي"
+  },
+  "browserTool.state.takeover_required": {
+    "message": "يرجى الاستحواذ على جهاز المتصفح",
+    "description": "يتطلب من المستخدم الاستحواذ على العملية من جهاز المتصفح المحلي"
   },
   "browserTool.state.executing": {
     "message": "يتم التنفيذ في المتصفح",
@@ -1100,9 +1116,21 @@
     "message": "تم الانتهاء",
     "description": "تم تنفيذ أداة المتصفح بنجاح"
   },
+  "browserTool.state.denied": {
+    "message": "تم الرفض على جهاز المتصفح",
+    "description": "رفض المستخدم العملية على جهاز المتصفح المحلي"
+  },
   "browserTool.state.expired": {
     "message": "انتهت صلاحية الطلب",
     "description": "انتهت صلاحية طلب تنفيذ أداة المتصفح"
+  },
+  "browserTool.state.cancel_too_late": {
+    "message": "لا يمكن الإلغاء",
+    "description": "العملية قد أثرت بالفعل، الطلب للإلغاء متأخر"
+  },
+  "scheduledTasks.run.waiting_for_device": {
+    "message": "انتظار جهاز المتصفح",
+    "description": "المهمة المجدولة تنتظر تشغيل جهاز المتصفح"
   },
   "model.kimiK3": {
     "message": "kimi-k3",
@@ -1119,6 +1147,10 @@
   "model.kimiK26Description": {
     "message": "Reasoning and vision model for compatible K2 workflows",
     "description": "Description of the Kimi K2.6 model"
+  },
+  "toolActivity.interrupted": {
+    "message": "Interrupted",
+    "description": "Shown on a tool row whose turn ended before the tool reported a result"
   },
   "browserTool.state.starting_session": {
     "message": "Starting browser session"

--- a/src/i18n/de/chat.json
+++ b/src/i18n/de/chat.json
@@ -1053,8 +1053,20 @@
     "message": "Browser activity",
     "description": "Fallback title for a BrowserDevice tool activity"
   },
+  "browserTool.state.choose_device": {
+    "message": "Choose a browser device"
+  },
   "browserTool.state.device_offline": {
     "message": "Browser device is offline"
+  },
+  "browserTool.state.awaiting_device": {
+    "message": "Waiting for browser device"
+  },
+  "browserTool.state.awaiting_local_approval": {
+    "message": "Waiting for approval on the browser device"
+  },
+  "browserTool.state.takeover_required": {
+    "message": "Take over on the browser device"
   },
   "browserTool.state.executing": {
     "message": "Executing in browser"
@@ -1062,8 +1074,17 @@
   "browserTool.state.completed": {
     "message": "Completed"
   },
+  "browserTool.state.denied": {
+    "message": "Denied on the browser device"
+  },
   "browserTool.state.expired": {
     "message": "Browser request expired"
+  },
+  "browserTool.state.cancel_too_late": {
+    "message": "Too late to cancel"
+  },
+  "scheduledTasks.run.waiting_for_device": {
+    "message": "Waiting for browser device"
   },
   "model.kimiK3": {
     "message": "kimi-k3",
@@ -1080,6 +1101,10 @@
   "model.kimiK26Description": {
     "message": "Reasoning and vision model for compatible K2 workflows",
     "description": "Description of the Kimi K2.6 model"
+  },
+  "toolActivity.interrupted": {
+    "message": "Interrupted",
+    "description": "Shown on a tool row whose turn ended before the tool reported a result"
   },
   "browserTool.state.starting_session": {
     "message": "Starting browser session"

--- a/src/i18n/el/chat.json
+++ b/src/i18n/el/chat.json
@@ -1053,8 +1053,20 @@
     "message": "Browser activity",
     "description": "Fallback title for a BrowserDevice tool activity"
   },
+  "browserTool.state.choose_device": {
+    "message": "Choose a browser device"
+  },
   "browserTool.state.device_offline": {
     "message": "Browser device is offline"
+  },
+  "browserTool.state.awaiting_device": {
+    "message": "Waiting for browser device"
+  },
+  "browserTool.state.awaiting_local_approval": {
+    "message": "Waiting for approval on the browser device"
+  },
+  "browserTool.state.takeover_required": {
+    "message": "Take over on the browser device"
   },
   "browserTool.state.executing": {
     "message": "Executing in browser"
@@ -1062,8 +1074,17 @@
   "browserTool.state.completed": {
     "message": "Completed"
   },
+  "browserTool.state.denied": {
+    "message": "Denied on the browser device"
+  },
   "browserTool.state.expired": {
     "message": "Browser request expired"
+  },
+  "browserTool.state.cancel_too_late": {
+    "message": "Too late to cancel"
+  },
+  "scheduledTasks.run.waiting_for_device": {
+    "message": "Waiting for browser device"
   },
   "model.kimiK3": {
     "message": "kimi-k3",
@@ -1080,6 +1101,10 @@
   "model.kimiK26Description": {
     "message": "Reasoning and vision model for compatible K2 workflows",
     "description": "Description of the Kimi K2.6 model"
+  },
+  "toolActivity.interrupted": {
+    "message": "Interrupted",
+    "description": "Shown on a tool row whose turn ended before the tool reported a result"
   },
   "browserTool.state.starting_session": {
     "message": "Starting browser session"

--- a/src/i18n/en/chat.json
+++ b/src/i18n/en/chat.json
@@ -649,6 +649,10 @@
   "browserTool.recovery.open-consent-card": {
     "message": "Review authorization"
   },
+  "toolActivity.interrupted": {
+    "message": "Interrupted",
+    "description": "Shown on a tool row whose turn ended before the tool reported a result"
+  },
   "scheduledTasks.navTitle": {
     "message": "Scheduled Tasks"
   },

--- a/src/i18n/es/chat.json
+++ b/src/i18n/es/chat.json
@@ -1053,8 +1053,20 @@
     "message": "Browser activity",
     "description": "Fallback title for a BrowserDevice tool activity"
   },
+  "browserTool.state.choose_device": {
+    "message": "Choose a browser device"
+  },
   "browserTool.state.device_offline": {
     "message": "Browser device is offline"
+  },
+  "browserTool.state.awaiting_device": {
+    "message": "Waiting for browser device"
+  },
+  "browserTool.state.awaiting_local_approval": {
+    "message": "Waiting for approval on the browser device"
+  },
+  "browserTool.state.takeover_required": {
+    "message": "Take over on the browser device"
   },
   "browserTool.state.executing": {
     "message": "Executing in browser"
@@ -1062,8 +1074,17 @@
   "browserTool.state.completed": {
     "message": "Completed"
   },
+  "browserTool.state.denied": {
+    "message": "Denied on the browser device"
+  },
   "browserTool.state.expired": {
     "message": "Browser request expired"
+  },
+  "browserTool.state.cancel_too_late": {
+    "message": "Too late to cancel"
+  },
+  "scheduledTasks.run.waiting_for_device": {
+    "message": "Waiting for browser device"
   },
   "model.kimiK3": {
     "message": "kimi-k3",
@@ -1080,6 +1101,10 @@
   "model.kimiK26Description": {
     "message": "Reasoning and vision model for compatible K2 workflows",
     "description": "Description of the Kimi K2.6 model"
+  },
+  "toolActivity.interrupted": {
+    "message": "Interrupted",
+    "description": "Shown on a tool row whose turn ended before the tool reported a result"
   },
   "browserTool.state.starting_session": {
     "message": "Starting browser session"

--- a/src/i18n/fi/chat.json
+++ b/src/i18n/fi/chat.json
@@ -1053,8 +1053,20 @@
     "message": "Selaimen toiminta",
     "description": "Varakeotsikko BrowserDevice-työkalun toiminnalle"
   },
+  "browserTool.state.choose_device": {
+    "message": "Valitse selainlaite"
+  },
   "browserTool.state.device_offline": {
     "message": "Selainlaite on offline-tilassa"
+  },
+  "browserTool.state.awaiting_device": {
+    "message": "Odotetaan selainlaitetta"
+  },
+  "browserTool.state.awaiting_local_approval": {
+    "message": "Odotetaan hyväksyntää selainlaitteessa"
+  },
+  "browserTool.state.takeover_required": {
+    "message": "Ota haltuun selainlaitteessa"
   },
   "browserTool.state.executing": {
     "message": "Suoritetaan selaimessa"
@@ -1062,8 +1074,17 @@
   "browserTool.state.completed": {
     "message": "Valmis"
   },
+  "browserTool.state.denied": {
+    "message": "Hylätty selainlaitteessa"
+  },
   "browserTool.state.expired": {
     "message": "Selaimen pyyntö vanhentui"
+  },
+  "browserTool.state.cancel_too_late": {
+    "message": "Liian myöhäistä peruuttaa"
+  },
+  "scheduledTasks.run.waiting_for_device": {
+    "message": "Odotetaan selainlaitetta"
   },
   "model.kimiK3": {
     "message": "kimi-k3",
@@ -1080,6 +1101,10 @@
   "model.kimiK26Description": {
     "message": "Reasoning and vision model for compatible K2 workflows",
     "description": "Description of the Kimi K2.6 model"
+  },
+  "toolActivity.interrupted": {
+    "message": "Interrupted",
+    "description": "Shown on a tool row whose turn ended before the tool reported a result"
   },
   "browserTool.state.starting_session": {
     "message": "Starting browser session"

--- a/src/i18n/fr/chat.json
+++ b/src/i18n/fr/chat.json
@@ -1053,8 +1053,20 @@
     "message": "Browser activity",
     "description": "Fallback title for a BrowserDevice tool activity"
   },
+  "browserTool.state.choose_device": {
+    "message": "Choose a browser device"
+  },
   "browserTool.state.device_offline": {
     "message": "Browser device is offline"
+  },
+  "browserTool.state.awaiting_device": {
+    "message": "Waiting for browser device"
+  },
+  "browserTool.state.awaiting_local_approval": {
+    "message": "Waiting for approval on the browser device"
+  },
+  "browserTool.state.takeover_required": {
+    "message": "Take over on the browser device"
   },
   "browserTool.state.executing": {
     "message": "Executing in browser"
@@ -1062,8 +1074,17 @@
   "browserTool.state.completed": {
     "message": "Completed"
   },
+  "browserTool.state.denied": {
+    "message": "Denied on the browser device"
+  },
   "browserTool.state.expired": {
     "message": "Browser request expired"
+  },
+  "browserTool.state.cancel_too_late": {
+    "message": "Too late to cancel"
+  },
+  "scheduledTasks.run.waiting_for_device": {
+    "message": "Waiting for browser device"
   },
   "model.kimiK3": {
     "message": "kimi-k3",
@@ -1080,6 +1101,10 @@
   "model.kimiK26Description": {
     "message": "Reasoning and vision model for compatible K2 workflows",
     "description": "Description of the Kimi K2.6 model"
+  },
+  "toolActivity.interrupted": {
+    "message": "Interrupted",
+    "description": "Shown on a tool row whose turn ended before the tool reported a result"
   },
   "browserTool.state.starting_session": {
     "message": "Starting browser session"

--- a/src/i18n/it/chat.json
+++ b/src/i18n/it/chat.json
@@ -1053,8 +1053,20 @@
     "message": "Browser activity",
     "description": "Fallback title for a BrowserDevice tool activity"
   },
+  "browserTool.state.choose_device": {
+    "message": "Choose a browser device"
+  },
   "browserTool.state.device_offline": {
     "message": "Browser device is offline"
+  },
+  "browserTool.state.awaiting_device": {
+    "message": "Waiting for browser device"
+  },
+  "browserTool.state.awaiting_local_approval": {
+    "message": "Waiting for approval on the browser device"
+  },
+  "browserTool.state.takeover_required": {
+    "message": "Take over on the browser device"
   },
   "browserTool.state.executing": {
     "message": "Executing in browser"
@@ -1062,8 +1074,17 @@
   "browserTool.state.completed": {
     "message": "Completed"
   },
+  "browserTool.state.denied": {
+    "message": "Denied on the browser device"
+  },
   "browserTool.state.expired": {
     "message": "Browser request expired"
+  },
+  "browserTool.state.cancel_too_late": {
+    "message": "Too late to cancel"
+  },
+  "scheduledTasks.run.waiting_for_device": {
+    "message": "Waiting for browser device"
   },
   "model.kimiK3": {
     "message": "kimi-k3",
@@ -1080,6 +1101,10 @@
   "model.kimiK26Description": {
     "message": "Reasoning and vision model for compatible K2 workflows",
     "description": "Description of the Kimi K2.6 model"
+  },
+  "toolActivity.interrupted": {
+    "message": "Interrupted",
+    "description": "Shown on a tool row whose turn ended before the tool reported a result"
   },
   "browserTool.state.starting_session": {
     "message": "Starting browser session"

--- a/src/i18n/ja/chat.json
+++ b/src/i18n/ja/chat.json
@@ -1053,8 +1053,20 @@
     "message": "ブラウザ操作",
     "description": "BrowserDeviceツール操作のフォールバックタイトル"
   },
+  "browserTool.state.choose_device": {
+    "message": "ブラウザデバイスを選択"
+  },
   "browserTool.state.device_offline": {
     "message": "ブラウザデバイスがオフラインです"
+  },
+  "browserTool.state.awaiting_device": {
+    "message": "ブラウザデバイスを待機中"
+  },
+  "browserTool.state.awaiting_local_approval": {
+    "message": "ブラウザデバイスで承認待ち"
+  },
+  "browserTool.state.takeover_required": {
+    "message": "ブラウザデバイスで引き継ぎが必要"
   },
   "browserTool.state.executing": {
     "message": "ブラウザで実行中"
@@ -1062,8 +1074,17 @@
   "browserTool.state.completed": {
     "message": "完了"
   },
+  "browserTool.state.denied": {
+    "message": "ブラウザデバイスで拒否されました"
+  },
   "browserTool.state.expired": {
     "message": "ブラウザリクエストの期限切れ"
+  },
+  "browserTool.state.cancel_too_late": {
+    "message": "キャンセルが間に合いません"
+  },
+  "scheduledTasks.run.waiting_for_device": {
+    "message": "ブラウザデバイスを待機中"
   },
   "model.kimiK3": {
     "message": "kimi-k3",
@@ -1080,6 +1101,10 @@
   "model.kimiK26Description": {
     "message": "Reasoning and vision model for compatible K2 workflows",
     "description": "Description of the Kimi K2.6 model"
+  },
+  "toolActivity.interrupted": {
+    "message": "Interrupted",
+    "description": "Shown on a tool row whose turn ended before the tool reported a result"
   },
   "browserTool.state.starting_session": {
     "message": "Starting browser session"

--- a/src/i18n/ko/chat.json
+++ b/src/i18n/ko/chat.json
@@ -1053,8 +1053,20 @@
     "message": "Browser activity",
     "description": "Fallback title for a BrowserDevice tool activity"
   },
+  "browserTool.state.choose_device": {
+    "message": "Choose a browser device"
+  },
   "browserTool.state.device_offline": {
     "message": "Browser device is offline"
+  },
+  "browserTool.state.awaiting_device": {
+    "message": "Waiting for browser device"
+  },
+  "browserTool.state.awaiting_local_approval": {
+    "message": "Waiting for approval on the browser device"
+  },
+  "browserTool.state.takeover_required": {
+    "message": "Take over on the browser device"
   },
   "browserTool.state.executing": {
     "message": "Executing in browser"
@@ -1062,8 +1074,17 @@
   "browserTool.state.completed": {
     "message": "Completed"
   },
+  "browserTool.state.denied": {
+    "message": "Denied on the browser device"
+  },
   "browserTool.state.expired": {
     "message": "Browser request expired"
+  },
+  "browserTool.state.cancel_too_late": {
+    "message": "Too late to cancel"
+  },
+  "scheduledTasks.run.waiting_for_device": {
+    "message": "Waiting for browser device"
   },
   "model.kimiK3": {
     "message": "kimi-k3",
@@ -1080,6 +1101,10 @@
   "model.kimiK26Description": {
     "message": "Reasoning and vision model for compatible K2 workflows",
     "description": "Description of the Kimi K2.6 model"
+  },
+  "toolActivity.interrupted": {
+    "message": "Interrupted",
+    "description": "Shown on a tool row whose turn ended before the tool reported a result"
   },
   "browserTool.state.starting_session": {
     "message": "Starting browser session"

--- a/src/i18n/pl/chat.json
+++ b/src/i18n/pl/chat.json
@@ -1053,8 +1053,20 @@
     "message": "Browser activity",
     "description": "Fallback title for a BrowserDevice tool activity"
   },
+  "browserTool.state.choose_device": {
+    "message": "Choose a browser device"
+  },
   "browserTool.state.device_offline": {
     "message": "Browser device is offline"
+  },
+  "browserTool.state.awaiting_device": {
+    "message": "Waiting for browser device"
+  },
+  "browserTool.state.awaiting_local_approval": {
+    "message": "Waiting for approval on the browser device"
+  },
+  "browserTool.state.takeover_required": {
+    "message": "Take over on the browser device"
   },
   "browserTool.state.executing": {
     "message": "Executing in browser"
@@ -1062,8 +1074,17 @@
   "browserTool.state.completed": {
     "message": "Completed"
   },
+  "browserTool.state.denied": {
+    "message": "Denied on the browser device"
+  },
   "browserTool.state.expired": {
     "message": "Browser request expired"
+  },
+  "browserTool.state.cancel_too_late": {
+    "message": "Too late to cancel"
+  },
+  "scheduledTasks.run.waiting_for_device": {
+    "message": "Waiting for browser device"
   },
   "model.kimiK3": {
     "message": "kimi-k3",
@@ -1080,6 +1101,10 @@
   "model.kimiK26Description": {
     "message": "Reasoning and vision model for compatible K2 workflows",
     "description": "Description of the Kimi K2.6 model"
+  },
+  "toolActivity.interrupted": {
+    "message": "Interrupted",
+    "description": "Shown on a tool row whose turn ended before the tool reported a result"
   },
   "browserTool.state.starting_session": {
     "message": "Starting browser session"

--- a/src/i18n/pt/chat.json
+++ b/src/i18n/pt/chat.json
@@ -1053,8 +1053,20 @@
     "message": "Browser activity",
     "description": "Fallback title for a BrowserDevice tool activity"
   },
+  "browserTool.state.choose_device": {
+    "message": "Choose a browser device"
+  },
   "browserTool.state.device_offline": {
     "message": "Browser device is offline"
+  },
+  "browserTool.state.awaiting_device": {
+    "message": "Waiting for browser device"
+  },
+  "browserTool.state.awaiting_local_approval": {
+    "message": "Waiting for approval on the browser device"
+  },
+  "browserTool.state.takeover_required": {
+    "message": "Take over on the browser device"
   },
   "browserTool.state.executing": {
     "message": "Executing in browser"
@@ -1062,8 +1074,17 @@
   "browserTool.state.completed": {
     "message": "Completed"
   },
+  "browserTool.state.denied": {
+    "message": "Denied on the browser device"
+  },
   "browserTool.state.expired": {
     "message": "Browser request expired"
+  },
+  "browserTool.state.cancel_too_late": {
+    "message": "Too late to cancel"
+  },
+  "scheduledTasks.run.waiting_for_device": {
+    "message": "Waiting for browser device"
   },
   "model.kimiK3": {
     "message": "kimi-k3",
@@ -1080,6 +1101,10 @@
   "model.kimiK26Description": {
     "message": "Reasoning and vision model for compatible K2 workflows",
     "description": "Description of the Kimi K2.6 model"
+  },
+  "toolActivity.interrupted": {
+    "message": "Interrupted",
+    "description": "Shown on a tool row whose turn ended before the tool reported a result"
   },
   "browserTool.state.starting_session": {
     "message": "Starting browser session"

--- a/src/i18n/ru/chat.json
+++ b/src/i18n/ru/chat.json
@@ -1088,8 +1088,24 @@
     "message": "Активность браузера",
     "description": "Заголовок по умолчанию для активности инструмента BrowserDevice."
   },
+  "browserTool.state.choose_device": {
+    "message": "Выберите браузерное устройство",
+    "description": ""
+  },
   "browserTool.state.device_offline": {
     "message": "Браузерное устройство не в сети",
+    "description": ""
+  },
+  "browserTool.state.awaiting_device": {
+    "message": "Ожидание браузерного устройства",
+    "description": ""
+  },
+  "browserTool.state.awaiting_local_approval": {
+    "message": "Ожидание подтверждения на браузерном устройстве",
+    "description": ""
+  },
+  "browserTool.state.takeover_required": {
+    "message": "Нужно перехватить управление на браузерном устройстве",
     "description": ""
   },
   "browserTool.state.executing": {
@@ -1100,8 +1116,20 @@
     "message": "Завершено",
     "description": ""
   },
+  "browserTool.state.denied": {
+    "message": "Отклонено на браузерном устройстве",
+    "description": ""
+  },
   "browserTool.state.expired": {
     "message": "Срок запроса к браузеру истек",
+    "description": ""
+  },
+  "browserTool.state.cancel_too_late": {
+    "message": "Отменять уже поздно",
+    "description": ""
+  },
+  "scheduledTasks.run.waiting_for_device": {
+    "message": "Ожидание браузерного устройства",
     "description": ""
   },
   "model.kimiK3": {
@@ -1119,6 +1147,10 @@
   "model.kimiK26Description": {
     "message": "Reasoning and vision model for compatible K2 workflows",
     "description": "Description of the Kimi K2.6 model"
+  },
+  "toolActivity.interrupted": {
+    "message": "Interrupted",
+    "description": "Shown on a tool row whose turn ended before the tool reported a result"
   },
   "browserTool.state.starting_session": {
     "message": "Starting browser session"

--- a/src/i18n/sr/chat.json
+++ b/src/i18n/sr/chat.json
@@ -1053,8 +1053,20 @@
     "message": "Активност прегледача",
     "description": "Fallback title for a BrowserDevice tool activity"
   },
+  "browserTool.state.choose_device": {
+    "message": "Изаберите уређај прегледача"
+  },
   "browserTool.state.device_offline": {
     "message": "Уређај прегледача је ван мреже"
+  },
+  "browserTool.state.awaiting_device": {
+    "message": "Чека се уређај прегледача"
+  },
+  "browserTool.state.awaiting_local_approval": {
+    "message": "Чека се одобрење на уређају прегледача"
+  },
+  "browserTool.state.takeover_required": {
+    "message": "Преузмите контролу на уређају прегледача"
   },
   "browserTool.state.executing": {
     "message": "Извршава се у прегледачу"
@@ -1062,8 +1074,17 @@
   "browserTool.state.completed": {
     "message": "Завршено"
   },
+  "browserTool.state.denied": {
+    "message": "Одбијено на уређају прегледача"
+  },
   "browserTool.state.expired": {
     "message": "Захтев прегледача је истекао"
+  },
+  "browserTool.state.cancel_too_late": {
+    "message": "Прекасно за отказивање"
+  },
+  "scheduledTasks.run.waiting_for_device": {
+    "message": "Чека се уређај прегледача"
   },
   "model.kimiK3": {
     "message": "kimi-k3",
@@ -1080,6 +1101,10 @@
   "model.kimiK26Description": {
     "message": "Reasoning and vision model for compatible K2 workflows",
     "description": "Description of the Kimi K2.6 model"
+  },
+  "toolActivity.interrupted": {
+    "message": "Interrupted",
+    "description": "Shown on a tool row whose turn ended before the tool reported a result"
   },
   "browserTool.state.starting_session": {
     "message": "Starting browser session"

--- a/src/i18n/sv/chat.json
+++ b/src/i18n/sv/chat.json
@@ -1053,8 +1053,20 @@
     "message": "Browser activity",
     "description": "Fallback title for a BrowserDevice tool activity"
   },
+  "browserTool.state.choose_device": {
+    "message": "Choose a browser device"
+  },
   "browserTool.state.device_offline": {
     "message": "Browser device is offline"
+  },
+  "browserTool.state.awaiting_device": {
+    "message": "Waiting for browser device"
+  },
+  "browserTool.state.awaiting_local_approval": {
+    "message": "Waiting for approval on the browser device"
+  },
+  "browserTool.state.takeover_required": {
+    "message": "Take over on the browser device"
   },
   "browserTool.state.executing": {
     "message": "Executing in browser"
@@ -1062,8 +1074,17 @@
   "browserTool.state.completed": {
     "message": "Completed"
   },
+  "browserTool.state.denied": {
+    "message": "Denied on the browser device"
+  },
   "browserTool.state.expired": {
     "message": "Browser request expired"
+  },
+  "browserTool.state.cancel_too_late": {
+    "message": "Too late to cancel"
+  },
+  "scheduledTasks.run.waiting_for_device": {
+    "message": "Waiting for browser device"
   },
   "model.kimiK3": {
     "message": "kimi-k3",
@@ -1080,6 +1101,10 @@
   "model.kimiK26Description": {
     "message": "Reasoning and vision model for compatible K2 workflows",
     "description": "Description of the Kimi K2.6 model"
+  },
+  "toolActivity.interrupted": {
+    "message": "Interrupted",
+    "description": "Shown on a tool row whose turn ended before the tool reported a result"
   },
   "browserTool.state.starting_session": {
     "message": "Starting browser session"

--- a/src/i18n/uk/chat.json
+++ b/src/i18n/uk/chat.json
@@ -1053,8 +1053,20 @@
     "message": "Browser activity",
     "description": "Fallback title for a BrowserDevice tool activity"
   },
+  "browserTool.state.choose_device": {
+    "message": "Choose a browser device"
+  },
   "browserTool.state.device_offline": {
     "message": "Browser device is offline"
+  },
+  "browserTool.state.awaiting_device": {
+    "message": "Waiting for browser device"
+  },
+  "browserTool.state.awaiting_local_approval": {
+    "message": "Waiting for approval on the browser device"
+  },
+  "browserTool.state.takeover_required": {
+    "message": "Take over on the browser device"
   },
   "browserTool.state.executing": {
     "message": "Executing in browser"
@@ -1062,8 +1074,17 @@
   "browserTool.state.completed": {
     "message": "Completed"
   },
+  "browserTool.state.denied": {
+    "message": "Denied on the browser device"
+  },
   "browserTool.state.expired": {
     "message": "Browser request expired"
+  },
+  "browserTool.state.cancel_too_late": {
+    "message": "Too late to cancel"
+  },
+  "scheduledTasks.run.waiting_for_device": {
+    "message": "Waiting for browser device"
   },
   "model.kimiK3": {
     "message": "kimi-k3",
@@ -1080,6 +1101,10 @@
   "model.kimiK26Description": {
     "message": "Reasoning and vision model for compatible K2 workflows",
     "description": "Description of the Kimi K2.6 model"
+  },
+  "toolActivity.interrupted": {
+    "message": "Interrupted",
+    "description": "Shown on a tool row whose turn ended before the tool reported a result"
   },
   "browserTool.state.starting_session": {
     "message": "Starting browser session"

--- a/src/i18n/zh-CN/chat.json
+++ b/src/i18n/zh-CN/chat.json
@@ -653,6 +653,10 @@
   "browserTool.recovery.open-consent-card": {
     "message": "查看授权"
   },
+  "toolActivity.interrupted": {
+    "message": "已中断",
+    "description": "工具所在回合在返回结果前结束时，在工具行上显示"
+  },
   "scheduledTasks.navTitle": {
     "message": "定时任务",
     "description": "侧边栏定时任务入口"

--- a/src/i18n/zh-TW/chat.json
+++ b/src/i18n/zh-TW/chat.json
@@ -1053,8 +1053,20 @@
     "message": "瀏覽器活動",
     "description": "BrowserDevice 工具活動的預設標題"
   },
+  "browserTool.state.choose_device": {
+    "message": "請選擇瀏覽器裝置"
+  },
   "browserTool.state.device_offline": {
     "message": "瀏覽器裝置已離線"
+  },
+  "browserTool.state.awaiting_device": {
+    "message": "正在等待瀏覽器裝置"
+  },
+  "browserTool.state.awaiting_local_approval": {
+    "message": "請在瀏覽器裝置上批准"
+  },
+  "browserTool.state.takeover_required": {
+    "message": "請在瀏覽器裝置上接管"
   },
   "browserTool.state.executing": {
     "message": "正在瀏覽器中執行"
@@ -1062,8 +1074,17 @@
   "browserTool.state.completed": {
     "message": "已完成"
   },
+  "browserTool.state.denied": {
+    "message": "已在瀏覽器裝置上拒絕"
+  },
   "browserTool.state.expired": {
     "message": "瀏覽器請求已過期"
+  },
+  "browserTool.state.cancel_too_late": {
+    "message": "已無法取消"
+  },
+  "scheduledTasks.run.waiting_for_device": {
+    "message": "等待瀏覽器裝置"
   },
   "model.kimiK3": {
     "message": "kimi-k3",
@@ -1080,6 +1101,10 @@
   "model.kimiK26Description": {
     "message": "Reasoning and vision model for compatible K2 workflows",
     "description": "Description of the Kimi K2.6 model"
+  },
+  "toolActivity.interrupted": {
+    "message": "Interrupted",
+    "description": "Shown on a tool row whose turn ended before the tool reported a result"
   },
   "browserTool.state.starting_session": {
     "message": "Starting browser session"


### PR DESCRIPTION
## Problem

On `studio.acedata.cloud/chatgpt/conversations` (and every aichat2 scenario), tool-call rows in assistant messages (e.g. "Bash", "Record output") showed a **loading spinner that never resolves** — still spinning under a finished message ("已发送成功"). Reported as "the icons look like they didn't load."

It is not a missing icon. `ToolActivity.vue` spins while `item.status === 'running'`; a block that never received a `tool_result` (an error mid-tool, or a legacy orphan persisted before the backend finalized it) stays `running` forever, so the Element-Plus `Loading` spinner keeps spinning even though the turn is over.

## Fix

- Add a `turnActive` prop (default `true`). `Message.vue` passes `false` for `FINISHED`/`FAILED` messages via `isTurnActive`.
- `ToolActivity.vue`: spin only when `status==='running' && turnActive`; a `running` block on an ended turn settles to an honest **interrupted** (red/error) icon with an "Interrupted" label — we never fake a success we didn't observe. Genuine in-flight tools on a live turn still spin.
- `BrowserToolActivity.vue`: a non-terminal `execution_state` on an ended turn shows a warning icon (no spin) + "Interrupted".
- New i18n key `chat.toolActivity.interrupted` (zh-CN + en authored; backfilled to all 18 locales — coverage guard green).

This is the render-side companion that also back-heals **legacy** orphans already persisted in Mongo. The backend fix that stops minting new orphans at the source is AceDataCloud/PlatformService#1600.

## Tests

- New `ToolActivity.test.ts` + extended `BrowserToolActivity.test.ts`: running+live → spinner; running+ended → settled/interrupted (no spinner); explicit error → error; `awaiting_input` on an ended turn → stays green (no false interrupt); completed → success; browser non-terminal+ended → warning, no spin.
- **18/18 pass.** `vue-tsc --noEmit` clean; ESLint clean; `check_i18n_coverage.py` green.

## 🤖 对抗评审

Reviewer: Claude `general-purpose` subagent (Codex unavailable — hung/timed out; fell back per protocol). One round. **VERDICT: CLEAN.**

Reviewer verified: live-streaming spinner preserved (`ANSWERING` until the `.then()` finalizer sets `FINISHED`); no `awaiting_input` regression (deferred client tools are `awaiting_input`, not `running`, so they fall through to the success branch unchanged — now locked in by a guard test); shared/readonly views correct (static snapshot; settling an orphan is the intended fix); `TERMINAL_STATES` correct and spin-gating sound; i18n namespace/key correct; no reactivity staleness (spinner `v-if` unmounts on settle). Non-blocking note: a user-Stopped (`FAILED`) turn shows a still-`running` tool as interrupted — intentional (honest, no success observed).
