### PR TITLE
fix(chat): stop tool-call rows spinning forever (reactivity, not state)

### DIFF
--- a/change/@acedatacloud-nexior-tool-status-reactivity.json
+++ b/change/@acedatacloud-nexior-tool-status-reactivity.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix chat tool-call rows spinning forever: clone rebuilt content parts so a settled tool block gets a fresh ref and Vue re-renders its icon",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/pages/chat/Conversation.toolReactivity.test.ts
+++ b/src/pages/chat/Conversation.toolReactivity.test.ts
@@ -1,0 +1,155 @@
+// @vitest-environment jsdom
+import { shallowMount } from '@vue/test-utils';
+import { nextTick } from 'vue';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { Status } from '@/models';
+import type { IChatConversationResponse, IChatMessageContentItem } from '@/models';
+import Conversation from './Conversation.vue';
+
+// Capture the SSE `stream` callback so the test can drive tool events by hand.
+let capturedStream: ((r: IChatConversationResponse) => void) | undefined;
+
+vi.mock('@/operators', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    chatOperator: {
+      chatConversation: vi.fn((_body: unknown, options: { stream?: (r: IChatConversationResponse) => void }) => {
+        capturedStream = options.stream;
+        // Never-resolving promise: we only exercise the streaming callback, not
+        // the finalizer, so the turn stays mid-stream for the assertions.
+        return new Promise(() => undefined);
+      })
+    }
+  };
+});
+
+const mountComponent = () =>
+  shallowMount(Conversation, {
+    global: {
+      stubs: {
+        Layout: { template: '<main><slot name="chat" /></main>' },
+        ElSkeleton: { template: '<div><slot name="template" /></div>' },
+        ElSkeletonItem: { template: '<span />' }
+      },
+      mocks: {
+        $t: (key: string) => key,
+        $route: { matched: [{ path: '/chatgpt' }], params: { id: 'c1' }, path: '/chatgpt/conversations/c1', query: {} },
+        $router: { push: vi.fn(), replace: vi.fn() },
+        $store: {
+          commit: vi.fn(),
+          dispatch: vi.fn(() => Promise.resolve(undefined)),
+          getters: { authenticated: true },
+          state: {
+            chat: {
+              application: undefined,
+              applications: undefined,
+              conversations: [],
+              credential: { token: 't' },
+              memoryEnabled: true,
+              model: undefined,
+              modelGroup: undefined,
+              service: undefined,
+              status: { getApplications: Status.None }
+            }
+          }
+        }
+      }
+    }
+  });
+
+const findToolBlock = (messages: { content: unknown }[], toolId: string): IChatMessageContentItem | undefined => {
+  for (const m of messages) {
+    if (!Array.isArray(m.content)) continue;
+    const hit = (m.content as IChatMessageContentItem[]).find((p) => p.type === 'tool_use' && p.tool_id === toolId);
+    if (hit) return hit;
+  }
+  return undefined;
+};
+
+afterEach(() => {
+  capturedStream = undefined;
+  vi.clearAllMocks();
+});
+
+describe('chat/Conversation tool-block reactivity', () => {
+  it('gives a settled tool block a NEW object reference so the child re-renders (no manual expand)', async () => {
+    const wrapper = mountComponent();
+    const vm = wrapper.vm as unknown as {
+      messages: { role: string; content: unknown }[];
+      canceler: AbortController;
+      _streamAssistantTurn: (body: unknown, token: string, id?: string) => void;
+    };
+
+    // A pending assistant slot, as the real submit path pushes before streaming.
+    vm.canceler = new AbortController();
+    vm.messages.push({ role: 'assistant', content: '' });
+    vm._streamAssistantTurn({ id: 'c1', model: 'gpt', stateful: true }, 't', 'c1');
+    await nextTick();
+    expect(capturedStream).toBeTypeOf('function');
+
+    // Tool announced → running.
+    capturedStream!({
+      type: 'tool_use_start',
+      tool_id: 'tool-1',
+      tool_name: 'code_execute'
+    } as IChatConversationResponse);
+    await nextTick();
+    const running = findToolBlock(vm.messages, 'tool-1');
+    expect(running?.status).toBe('running');
+
+    // Tool finishes → the block is mutated in place inside the stream handler.
+    // The fix must surface this as a fresh reference on the rendered content.
+    capturedStream!({
+      type: 'tool_result',
+      tool_id: 'tool-1',
+      output: 'ok',
+      is_error: false,
+      duration_ms: 42
+    } as IChatConversationResponse);
+    await nextTick();
+    const settled = findToolBlock(vm.messages, 'tool-1');
+
+    expect(settled?.status).toBe('done');
+    expect(settled?.is_error).toBe(false);
+    // The crux: a different object identity from the running snapshot, which is
+    // what forces Vue to update the child <tool-activity> and drop the spinner.
+    expect(settled).not.toBe(running);
+  });
+
+  it('surfaces a failed tool as a settled error block (new ref, is_error true)', async () => {
+    const wrapper = mountComponent();
+    const vm = wrapper.vm as unknown as {
+      messages: { role: string; content: unknown }[];
+      canceler: AbortController;
+      _streamAssistantTurn: (body: unknown, token: string, id?: string) => void;
+    };
+    vm.canceler = new AbortController();
+    vm.messages.push({ role: 'assistant', content: '' });
+    vm._streamAssistantTurn({ id: 'c1', model: 'gpt', stateful: true }, 't', 'c1');
+    await nextTick();
+
+    capturedStream!({
+      type: 'tool_use_start',
+      tool_id: 'tool-2',
+      tool_name: 'web_search'
+    } as IChatConversationResponse);
+    await nextTick();
+    const running = findToolBlock(vm.messages, 'tool-2');
+
+    capturedStream!({
+      type: 'tool_result',
+      tool_id: 'tool-2',
+      output: 'boom',
+      is_error: true,
+      duration_ms: 7
+    } as IChatConversationResponse);
+    await nextTick();
+    const settled = findToolBlock(vm.messages, 'tool-2');
+
+    expect(settled?.status).toBe('done');
+    expect(settled?.is_error).toBe(true);
+    expect(settled).not.toBe(running);
+  });
+});

--- a/src/pages/chat/Conversation.vue
+++ b/src/pages/chat/Conversation.vue
@@ -1415,8 +1415,13 @@ export default defineComponent({
               currentText = (response.answer || '').slice(answerOffset);
             }
 
-            // Build display content: parts + trailing text
-            const displayParts: IChatMessageContentItem[] = [...contentParts];
+            // Build display content: parts + trailing text. Clone each part
+            // (not just the array) so an in-place mutation of a persisted block
+            // — e.g. a tool_use flipping status 'running'→'done' on tool_result
+            // — yields a NEW object reference. Otherwise the child's `:item`
+            // prop ref is unchanged and Vue skips its update, leaving the tool
+            // row's spinner frozen until an unrelated re-render (expanding it).
+            const displayParts: IChatMessageContentItem[] = contentParts.map((part) => ({ ...part }));
             if (currentText) {
               displayParts.push({ type: 'text', text: currentText });
             }


### PR DESCRIPTION
## 问题

`studio.acedata.cloud` 聊天里 tool-call 行的图标一直转圈,永不停;**点一下展开该行,图标立刻变成对号**。这个「一展开就好」的现象是决定性线索。

## 根因:前端响应式更新丢失(不是数据卡在 running)

如果数据真卡在 `status: 'running'`,点展开(只切换本地 `expanded`)不可能让图标变对号。它一展开就变对号,说明**内存里的 `status` 早已是 `done`,只是折叠态的 DOM 没有响应式更新**。

`_streamAssistantTurn` 的 SSE 流处理里,每个 `tool_use` block 是一个**裸对象**,存进本地 `contentParts` 数组 + `toolMap`。`tool_result` 到达时**原地 mutate**(`toolItem.status = 'done'` 等)。随后用 `[...contentParts]` 重建渲染内容——这是**数组浅拷贝,元素仍是同一批对象引用**。于是 `<tool-activity :item="item">` 拿到的 prop 引用没变,Vue 判定 props 未变 → **跳过子组件更新** → 图标冻结在首帧的转圈。点展开切换了 reactive 的 `expanded` → 强制该子组件重渲染 → 重新读 `item.status`(此刻裸对象已是 `done`)→ 秒变对号。

文字流为什么正常?因为文字块每个事件都 `push` **新对象**,引用变了会更新;唯独已提交的 tool block 是原地 mutate,所以只有它卡。**所有** tool 折叠图标都中招。

## 修复(一行)

```diff
- const displayParts: IChatMessageContentItem[] = [...contentParts];
+ const displayParts: IChatMessageContentItem[] = contentParts.map((part) => ({ ...part }));
```

重建时**克隆每个元素**,让被 mutate 的 block 产生**新引用** → 子组件 `:item` prop 变化 → Vue 正常重渲染 → `tool_result` 一到就如实显示终态图标:**成功绿色对号、失败红色叉**。覆盖所有 tool 行(普通 + browser),它们都走同一条 `displayParts` 重建路径。不碰后端。

## 测试

新增 `Conversation.toolReactivity.test.ts`:驱动 `tool_use_start`→`tool_result` 事件序列,断言结算后的 block 是**新对象引用**(`expect(settled).not.toBe(running)`)——这正是触发子组件更新的关键。**已验证:回退修复→测试失败,恢复修复→测试通过**,确保不是假绿。成功/失败两条路径各一个用例。

`npx vue-tsc --noEmit` 无错误;`src/components/chat` + `src/pages/chat` 全部 10 文件 93 测试通过;eslint 干净。

> 注:本 PR 取代先前误诊的 #1391-系列两个 PR(PlatformService#1600 后端 finalize 孤儿 block + Nexior#1392 前端 `turnActive`)。那两个建立在「数据真卡在 running」的错误假设上——`turnActive` 会把**成功**的 tool 谎报成红色「已中断」,治标不治本。均已关闭并附更正说明。

## 🤖 对抗评审

- **Reviewer:** codex 两次超时(已知 stdin/usage 问题),回退到 Claude `general-purpose` subagent。
- **Loop:** 一轮收敛,`VERDICT: CLEAN`。
- **审查覆盖 + 结论:**
  1. **修的是症状不是测试** — `ToolActivity.vue` / `BrowserToolActivity.vue` 只读**顶层字段**(`status`/`is_error`/`output`/`duration_ms`/`execution_state`/`origin` 等),浅拷贝 `{...part}` 复制了这些顶层字段,新引用 → 子组件更新。确认。
  2. **无引用依赖被破坏** — 克隆后 `toolMap`/`contentParts` 仍持有原对象,但所有下游查找(resume、ask/consent 卡片匹配、`findPendingConsentBlock`、browser `Object.assign`、`pendingClientTools`)都按 `tool_id` 匹配,**从不按对象引用**;克隆保留 `tool_id`,无失配。
  3. **无丢更新** — resume/consent 处理器只在本轮 `.then()` 结算后 mutate `this.messages` 上的 block;下一轮用全新 `contentParts`/`toolMap` 且写入**不同 targetIndex**,不会覆盖上一条消息的 block。
  4. **持久化完整** — 浅拷贝复制了 `tool_result` 设置的所有顶层字段,`setConversation` 序列化无缺失;无消费者深度 watch 嵌套字段。
  5. **测试非脆弱** — 尽管 mounted 的异步 restore 会短暂清空 messages,stream 回调无条件重写 `messages[targetIndex]`,5/5 稳定通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
