### PR TITLE
feat(tasks): per-card delete button on GPT-image + Nano Banana history

### DIFF
--- a/change/@acedatacloud-nexior-tasks-delete-ui.json
+++ b/change/@acedatacloud-nexior-tasks-delete-ui.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(tasks): per-card delete button on GPT-image + Nano Banana history — hover-reveal trash control hard-deletes a task server-side across all devices",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/digitalhuman/task/Preview.vue
+++ b/src/components/digitalhuman/task/Preview.vue
@@ -9,6 +9,17 @@
         <span class="datetime">
           {{ $dayjs.format('' + new Date(parseFloat((modelValue?.created_at || '').toString()) * 1000)) }}
         </span>
+        <el-tooltip effect="dark" :content="$t('common.button.delete')" placement="top">
+          <button
+            v-if="modelValue?.id"
+            type="button"
+            class="btn-delete"
+            :aria-label="$t('common.button.delete')"
+            @click.stop="onDelete"
+          >
+            <delete-icon :size="'1em' as any" aria-hidden="true" focusable="false" />
+          </button>
+        </el-tooltip>
       </div>
       <div class="info">
         <p v-if="modelValue?.request?.text" class="prompt mt-2">
@@ -90,6 +101,7 @@
 <script lang="ts">
 import {
   ControlsIcon,
+  DeleteIcon,
   ImageIcon,
   InfoIcon,
   TimeIcon,
@@ -98,7 +110,7 @@ import {
   WarningIcon
 } from '@acedatacloud/core/icons/components';
 import { defineComponent } from 'vue';
-import { ElAlert, ElButton, ElProgress } from 'element-plus';
+import { ElAlert, ElButton, ElProgress, ElMessageBox, ElMessage, ElTooltip } from 'element-plus';
 import { IDigitalHumanTask } from '@/models';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 import VideoPlayer from '@/components/common/VideoPlayer.vue';
@@ -107,6 +119,8 @@ import ApiCodeButton from '@/components/common/ApiCodeButton.vue';
 export default defineComponent({
   name: 'TaskPreview',
   components: {
+    DeleteIcon,
+    ElTooltip,
     ControlsIcon,
     ImageIcon,
     InfoIcon,
@@ -175,6 +189,26 @@ export default defineComponent({
     }
   },
   methods: {
+    async onDelete() {
+      const id = this.modelValue?.id;
+      if (!id) return;
+      try {
+        await ElMessageBox.confirm(this.$t('common.message.deleteTaskConfirm'), this.$t('common.button.delete'), {
+          type: 'warning',
+          confirmButtonText: this.$t('common.button.delete'),
+          cancelButtonText: this.$t('common.button.cancel'),
+          confirmButtonClass: 'el-button--danger'
+        });
+      } catch {
+        return; // user cancelled
+      }
+      try {
+        await this.$store.dispatch('digitalhuman/deleteTask', { id });
+        ElMessage.success(this.$t('common.message.deleteTaskSuccess'));
+      } catch {
+        ElMessage.error(this.$t('common.message.deleteTaskFailed'));
+      }
+    },
     onDownload(event: MouseEvent, url: string) {
       event?.stopPropagation();
       window.open(url, '_blank');
@@ -209,6 +243,8 @@ $left-width: 70px;
     padding: 10px 10px 0 10px;
 
     .bot {
+      display: flex;
+      align-items: center;
       font-size: 16px;
       font-weight: bold;
       color: var(--el-color-primary);
@@ -217,9 +253,32 @@ $left-width: 70px;
       white-space: nowrap;
       .datetime {
         font-size: 12px;
+        overflow: hidden;
+        text-overflow: ellipsis;
         font-weight: normal;
         color: var(--el-text-color-secondary);
         margin-left: 10px;
+      }
+      .btn-delete {
+        margin-left: auto;
+        padding: 4px 6px;
+        border: none;
+        background: transparent;
+        cursor: pointer;
+        line-height: 1;
+        color: var(--el-text-color-secondary);
+        // Hover-reveal on pointer devices; keep it out of the way until wanted.
+        opacity: 0;
+        transition:
+          opacity 0.15s ease,
+          color 0.15s ease;
+        &:hover {
+          color: var(--el-color-danger);
+        }
+        // Touch devices have no hover — always show the control.
+        @media (hover: none) {
+          opacity: 1;
+        }
       }
     }
 
@@ -254,6 +313,11 @@ $left-width: 70px;
         }
       }
     }
+  }
+
+  // Reveal the trash icon when hovering anywhere on the card.
+  &:hover .main .bot .btn-delete {
+    opacity: 1;
   }
 }
 </style>

--- a/src/components/fish/task/Preview.vue
+++ b/src/components/fish/task/Preview.vue
@@ -9,6 +9,17 @@
         <span class="datetime">
           {{ $dayjs.format('' + new Date(parseFloat((modelValue?.created_at || '').toString()) * 1000)) }}
         </span>
+        <el-tooltip effect="dark" :content="$t('common.button.delete')" placement="top">
+          <button
+            v-if="modelValue?.id"
+            type="button"
+            class="btn-delete"
+            :aria-label="$t('common.button.delete')"
+            @click.stop="onDelete"
+          >
+            <delete-icon :size="'1em' as any" aria-hidden="true" focusable="false" />
+          </button>
+        </el-tooltip>
       </div>
       <div class="info">
         <p v-if="prompt" class="prompt mt-2">
@@ -92,6 +103,7 @@
 import {
   ChannelIcon,
   CpuIcon,
+  DeleteIcon,
   InfoIcon,
   MagicIcon,
   MicrophoneIcon,
@@ -99,7 +111,7 @@ import {
   WarningIcon
 } from '@acedatacloud/core/icons/components';
 import { defineComponent } from 'vue';
-import { ElAlert, ElButton } from 'element-plus';
+import { ElAlert, ElButton, ElMessageBox, ElMessage, ElTooltip } from 'element-plus';
 import { IFishTask } from '@/models';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 import ApiCodeButton from '@/components/common/ApiCodeButton.vue';
@@ -108,6 +120,8 @@ import { humanizeFishError } from '@/utils/fish';
 export default defineComponent({
   name: 'FishTaskPreview',
   components: {
+    DeleteIcon,
+    ElTooltip,
     ChannelIcon,
     CpuIcon,
     InfoIcon,
@@ -151,6 +165,26 @@ export default defineComponent({
     }
   },
   methods: {
+    async onDelete() {
+      const id = this.modelValue?.id;
+      if (!id) return;
+      try {
+        await ElMessageBox.confirm(this.$t('common.message.deleteTaskConfirm'), this.$t('common.button.delete'), {
+          type: 'warning',
+          confirmButtonText: this.$t('common.button.delete'),
+          cancelButtonText: this.$t('common.button.cancel'),
+          confirmButtonClass: 'el-button--danger'
+        });
+      } catch {
+        return; // user cancelled
+      }
+      try {
+        await this.$store.dispatch('fish/deleteTask', { id });
+        ElMessage.success(this.$t('common.message.deleteTaskSuccess'));
+      } catch {
+        ElMessage.error(this.$t('common.message.deleteTaskFailed'));
+      }
+    },
     onDownload(url: string) {
       window.open(url, '_blank');
     }
@@ -186,15 +220,40 @@ $left-width: 70px;
     padding: 10px 10px 0 10px;
 
     .bot {
+      display: flex;
+      align-items: center;
       font-size: 16px;
       font-weight: bold;
       color: var(--el-color-primary);
       margin-bottom: 0;
       .datetime {
         font-size: 12px;
+        overflow: hidden;
+        text-overflow: ellipsis;
         font-weight: normal;
         color: var(--el-text-color-secondary);
         margin-left: 10px;
+      }
+      .btn-delete {
+        margin-left: auto;
+        padding: 4px 6px;
+        border: none;
+        background: transparent;
+        cursor: pointer;
+        line-height: 1;
+        color: var(--el-text-color-secondary);
+        // Hover-reveal on pointer devices; keep it out of the way until wanted.
+        opacity: 0;
+        transition:
+          opacity 0.15s ease,
+          color 0.15s ease;
+        &:hover {
+          color: var(--el-color-danger);
+        }
+        // Touch devices have no hover — always show the control.
+        @media (hover: none) {
+          opacity: 1;
+        }
       }
     }
 
@@ -219,6 +278,11 @@ $left-width: 70px;
         margin-bottom: 0;
       }
     }
+  }
+
+  // Reveal the trash icon when hovering anywhere on the card.
+  &:hover .main .bot .btn-delete {
+    opacity: 1;
   }
 }
 </style>

--- a/src/components/flux/task/Preview.vue
+++ b/src/components/flux/task/Preview.vue
@@ -9,6 +9,17 @@
         <span class="datetime">
           {{ $dayjs.format('' + new Date(parseFloat((modelValue?.created_at || '').toString()) * 1000)) }}
         </span>
+        <el-tooltip effect="dark" :content="$t('common.button.delete')" placement="top">
+          <button
+            v-if="modelValue?.id"
+            type="button"
+            class="btn-delete"
+            :aria-label="$t('common.button.delete')"
+            @click.stop="onDelete"
+          >
+            <delete-icon :size="'1em' as any" aria-hidden="true" focusable="false" />
+          </button>
+        </el-tooltip>
       </div>
       <div class="info">
         <p v-if="modelValue?.request?.prompt" class="prompt mt-2">
@@ -98,9 +109,16 @@
 </template>
 
 <script lang="ts">
-import { ChannelIcon, InfoIcon, MagicIcon, TimeIcon, WarningIcon } from '@acedatacloud/core/icons/components';
+import {
+  ChannelIcon,
+  DeleteIcon,
+  InfoIcon,
+  MagicIcon,
+  TimeIcon,
+  WarningIcon
+} from '@acedatacloud/core/icons/components';
 import { defineComponent } from 'vue';
-import { ElAlert } from 'element-plus';
+import { ElAlert, ElMessageBox, ElMessage, ElTooltip } from 'element-plus';
 import { IFluxTask, IFluxImage } from '@/models';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 import ImageWrapper from '@/components/common/ImageWrapper.vue';
@@ -109,6 +127,8 @@ import ApiCodeButton from '@/components/common/ApiCodeButton.vue';
 export default defineComponent({
   name: 'TaskPreview',
   components: {
+    DeleteIcon,
+    ElTooltip,
     ChannelIcon,
     InfoIcon,
     MagicIcon,
@@ -153,6 +173,26 @@ export default defineComponent({
     }
   },
   methods: {
+    async onDelete() {
+      const id = this.modelValue?.id;
+      if (!id) return;
+      try {
+        await ElMessageBox.confirm(this.$t('common.message.deleteTaskConfirm'), this.$t('common.button.delete'), {
+          type: 'warning',
+          confirmButtonText: this.$t('common.button.delete'),
+          cancelButtonText: this.$t('common.button.cancel'),
+          confirmButtonClass: 'el-button--danger'
+        });
+      } catch {
+        return; // user cancelled
+      }
+      try {
+        await this.$store.dispatch('flux/deleteTask', { id });
+        ElMessage.success(this.$t('common.message.deleteTaskSuccess'));
+      } catch {
+        ElMessage.error(this.$t('common.message.deleteTaskFailed'));
+      }
+    },
     onDownload(event: MouseEvent, image_url: string) {
       event?.stopPropagation();
       console.log('on download');
@@ -192,6 +232,8 @@ $left-width: 70px;
     padding: 10px 10px 0 10px;
 
     .bot {
+      display: flex;
+      align-items: center;
       font-size: 16px;
       font-weight: bold;
       color: var(--el-color-primary);
@@ -202,9 +244,32 @@ $left-width: 70px;
       white-space: nowrap;
       .datetime {
         font-size: 12px;
+        overflow: hidden;
+        text-overflow: ellipsis;
         font-weight: normal;
         color: var(--el-text-color-secondary);
         margin-left: 10px;
+      }
+      .btn-delete {
+        margin-left: auto;
+        padding: 4px 6px;
+        border: none;
+        background: transparent;
+        cursor: pointer;
+        line-height: 1;
+        color: var(--el-text-color-secondary);
+        // Hover-reveal on pointer devices; keep it out of the way until wanted.
+        opacity: 0;
+        transition:
+          opacity 0.15s ease,
+          color 0.15s ease;
+        &:hover {
+          color: var(--el-color-danger);
+        }
+        // Touch devices have no hover — always show the control.
+        @media (hover: none) {
+          opacity: 1;
+        }
       }
     }
 
@@ -243,6 +308,11 @@ $left-width: 70px;
         }
       }
     }
+  }
+
+  // Reveal the trash icon when hovering anywhere on the card.
+  &:hover .main .bot .btn-delete {
+    opacity: 1;
   }
 }
 </style>

--- a/src/components/grokvideo/task/Preview.vue
+++ b/src/components/grokvideo/task/Preview.vue
@@ -9,6 +9,17 @@
         <span class="datetime">
           {{ $dayjs.format('' + new Date(parseFloat((modelValue?.created_at || '').toString()) * 1000)) }}
         </span>
+        <el-tooltip effect="dark" :content="$t('common.button.delete')" placement="top">
+          <button
+            v-if="modelValue?.id"
+            type="button"
+            class="btn-delete"
+            :aria-label="$t('common.button.delete')"
+            @click.stop="onDelete"
+          >
+            <delete-icon :size="'1em' as any" aria-hidden="true" focusable="false" />
+          </button>
+        </el-tooltip>
       </div>
       <div class="info">
         <div v-if="inputImage" class="flex justify-start items-center gap-2 mt-2 w-full overflow-x-auto">
@@ -139,6 +150,7 @@
 import {
   ApplicationIcon,
   ChannelIcon,
+  DeleteIcon,
   FullscreenIcon,
   InfoIcon,
   MagicIcon,
@@ -146,7 +158,7 @@ import {
   WarningIcon
 } from '@acedatacloud/core/icons/components';
 import { defineComponent } from 'vue';
-import { ElAlert, ElButton, ElTooltip } from 'element-plus';
+import { ElAlert, ElButton, ElTooltip, ElMessageBox, ElMessage } from 'element-plus';
 import { IGrokVideoTask, IGrokVideoVideo } from '@/models';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 import VideoPlayer from '@/components/common/VideoPlayer.vue';
@@ -156,6 +168,7 @@ import ApiCodeButton from '@/components/common/ApiCodeButton.vue';
 export default defineComponent({
   name: 'GrokVideoTaskPreview',
   components: {
+    DeleteIcon,
     ApplicationIcon,
     ChannelIcon,
     FullscreenIcon,
@@ -220,6 +233,26 @@ export default defineComponent({
     this.stopTimer();
   },
   methods: {
+    async onDelete() {
+      const id = this.modelValue?.id;
+      if (!id) return;
+      try {
+        await ElMessageBox.confirm(this.$t('common.message.deleteTaskConfirm'), this.$t('common.button.delete'), {
+          type: 'warning',
+          confirmButtonText: this.$t('common.button.delete'),
+          cancelButtonText: this.$t('common.button.cancel'),
+          confirmButtonClass: 'el-button--danger'
+        });
+      } catch {
+        return; // user cancelled
+      }
+      try {
+        await this.$store.dispatch('grokvideo/deleteTask', { id });
+        ElMessage.success(this.$t('common.message.deleteTaskSuccess'));
+      } catch {
+        ElMessage.error(this.$t('common.message.deleteTaskFailed'));
+      }
+    },
     stopTimer() {
       if (this.timer) {
         window.clearInterval(this.timer);
@@ -260,6 +293,8 @@ $left-width: 70px;
     padding: 10px 10px 0 10px;
 
     .bot {
+      display: flex;
+      align-items: center;
       font-size: 16px;
       font-weight: bold;
       color: var(--el-color-primary);
@@ -270,9 +305,32 @@ $left-width: 70px;
       white-space: nowrap;
       .datetime {
         font-size: 12px;
+        overflow: hidden;
+        text-overflow: ellipsis;
         font-weight: normal;
         color: var(--el-text-color-secondary);
         margin-left: 10px;
+      }
+      .btn-delete {
+        margin-left: auto;
+        padding: 4px 6px;
+        border: none;
+        background: transparent;
+        cursor: pointer;
+        line-height: 1;
+        color: var(--el-text-color-secondary);
+        // Hover-reveal on pointer devices; keep it out of the way until wanted.
+        opacity: 0;
+        transition:
+          opacity 0.15s ease,
+          color 0.15s ease;
+        &:hover {
+          color: var(--el-color-danger);
+        }
+        // Touch devices have no hover — always show the control.
+        @media (hover: none) {
+          opacity: 1;
+        }
       }
     }
 
@@ -309,6 +367,11 @@ $left-width: 70px;
         }
       }
     }
+  }
+
+  // Reveal the trash icon when hovering anywhere on the card.
+  &:hover .main .bot .btn-delete {
+    opacity: 1;
   }
 }
 </style>

--- a/src/components/hailuo/task/Preview.vue
+++ b/src/components/hailuo/task/Preview.vue
@@ -9,6 +9,17 @@
         <span class="datetime">
           {{ $dayjs.format('' + new Date(parseFloat((modelValue?.created_at || '').toString()) * 1000)) }}
         </span>
+        <el-tooltip effect="dark" :content="$t('common.button.delete')" placement="top">
+          <button
+            v-if="modelValue?.id"
+            type="button"
+            class="btn-delete"
+            :aria-label="$t('common.button.delete')"
+            @click.stop="onDelete"
+          >
+            <delete-icon :size="'1em' as any" aria-hidden="true" focusable="false" />
+          </button>
+        </el-tooltip>
       </div>
       <div class="info">
         <p v-if="modelValue?.request?.prompt" class="prompt mt-2">
@@ -114,9 +125,16 @@
 </template>
 
 <script lang="ts">
-import { ChannelIcon, InfoIcon, MagicIcon, TimeIcon, WarningIcon } from '@acedatacloud/core/icons/components';
+import {
+  ChannelIcon,
+  DeleteIcon,
+  InfoIcon,
+  MagicIcon,
+  TimeIcon,
+  WarningIcon
+} from '@acedatacloud/core/icons/components';
 import { defineComponent } from 'vue';
-import { ElAlert, ElButton, ElTooltip } from 'element-plus';
+import { ElAlert, ElButton, ElTooltip, ElMessageBox, ElMessage } from 'element-plus';
 import { IHailuoTask, IHailuoVideo } from '@/models';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 import VideoPlayer from '@/components/common/VideoPlayer.vue';
@@ -125,6 +143,7 @@ import ApiCodeButton from '@/components/common/ApiCodeButton.vue';
 export default defineComponent({
   name: 'TaskPreview',
   components: {
+    DeleteIcon,
     ChannelIcon,
     InfoIcon,
     MagicIcon,
@@ -171,6 +190,26 @@ export default defineComponent({
     }
   },
   methods: {
+    async onDelete() {
+      const id = this.modelValue?.id;
+      if (!id) return;
+      try {
+        await ElMessageBox.confirm(this.$t('common.message.deleteTaskConfirm'), this.$t('common.button.delete'), {
+          type: 'warning',
+          confirmButtonText: this.$t('common.button.delete'),
+          cancelButtonText: this.$t('common.button.cancel'),
+          confirmButtonClass: 'el-button--danger'
+        });
+      } catch {
+        return; // user cancelled
+      }
+      try {
+        await this.$store.dispatch('hailuo/deleteTask', { id });
+        ElMessage.success(this.$t('common.message.deleteTaskSuccess'));
+      } catch {
+        ElMessage.error(this.$t('common.message.deleteTaskFailed'));
+      }
+    },
     onDownload(videoUrl: string) {
       console.debug('on download hailuo video', videoUrl);
       window.open(videoUrl, '_blank');
@@ -206,6 +245,8 @@ $left-width: 70px;
     padding: 10px 10px 0 10px;
 
     .bot {
+      display: flex;
+      align-items: center;
       font-size: 16px;
       font-weight: bold;
       color: var(--el-color-primary);
@@ -216,9 +257,32 @@ $left-width: 70px;
       white-space: nowrap;
       .datetime {
         font-size: 12px;
+        overflow: hidden;
+        text-overflow: ellipsis;
         font-weight: normal;
         color: var(--el-text-color-secondary);
         margin-left: 10px;
+      }
+      .btn-delete {
+        margin-left: auto;
+        padding: 4px 6px;
+        border: none;
+        background: transparent;
+        cursor: pointer;
+        line-height: 1;
+        color: var(--el-text-color-secondary);
+        // Hover-reveal on pointer devices; keep it out of the way until wanted.
+        opacity: 0;
+        transition:
+          opacity 0.15s ease,
+          color 0.15s ease;
+        &:hover {
+          color: var(--el-color-danger);
+        }
+        // Touch devices have no hover — always show the control.
+        @media (hover: none) {
+          opacity: 1;
+        }
       }
     }
 
@@ -257,6 +321,11 @@ $left-width: 70px;
         }
       }
     }
+  }
+
+  // Reveal the trash icon when hovering anywhere on the card.
+  &:hover .main .bot .btn-delete {
+    opacity: 1;
   }
 }
 </style>

--- a/src/components/kling/task/Preview.test.ts
+++ b/src/components/kling/task/Preview.test.ts
@@ -10,6 +10,16 @@ vi.mock('@/components/common/ApiCodeButton.vue', () => ({
   default: { name: 'ApiCodeButton', template: '<div />' }
 }));
 
+const confirm = vi.fn();
+vi.mock('element-plus', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('element-plus')>();
+  return {
+    ...actual,
+    ElMessageBox: { confirm: (...args: unknown[]) => confirm(...args) },
+    ElMessage: { success: vi.fn(), error: vi.fn() }
+  };
+});
+
 import TaskPreview from './Preview.vue';
 
 const task: IKlingTask = {
@@ -161,4 +171,59 @@ describe('kling/task/Preview', () => {
       expect(() => mountPreview(malformedTask)).not.toThrow();
     }
   );
+
+  it('renders a hover-reveal delete button whenever the task has an id', () => {
+    const wrapper = shallowMount(TaskPreview, {
+      props: { modelValue: { ...task, response: undefined } },
+      global: {
+        stubs: {
+          ElAlert: { template: '<div><slot /><slot name="template" /></div>' },
+          ElTooltip: { template: '<div><slot /></div>' }
+        },
+        mocks: { $t: (key: string) => key, $dayjs: { format: () => '' }, $store: { state: { kling: {} } } }
+      }
+    });
+    expect(wrapper.find('.btn-delete').exists()).toBe(true);
+  });
+
+  it('dispatches kling/deleteTask after the user confirms', async () => {
+    confirm.mockResolvedValueOnce(undefined);
+    const dispatch = vi.fn().mockResolvedValue(undefined);
+    const wrapper = shallowMount(TaskPreview, {
+      props: { modelValue: task },
+      global: {
+        stubs: {
+          ElAlert: { template: '<div><slot /><slot name="template" /></div>' },
+          ElTooltip: { template: '<div><slot /></div>' }
+        },
+        mocks: { $t: (key: string) => key, $dayjs: { format: () => '' }, $store: { state: { kling: {} }, dispatch } }
+      }
+    });
+
+    await wrapper.find('.btn-delete').trigger('click');
+    await Promise.resolve();
+
+    expect(confirm).toHaveBeenCalled();
+    expect(dispatch).toHaveBeenCalledWith('kling/deleteTask', { id: 'kling-task' });
+  });
+
+  it('does not dispatch when the user cancels the confirm dialog', async () => {
+    confirm.mockRejectedValueOnce(new Error('cancel'));
+    const dispatch = vi.fn();
+    const wrapper = shallowMount(TaskPreview, {
+      props: { modelValue: task },
+      global: {
+        stubs: {
+          ElAlert: { template: '<div><slot /><slot name="template" /></div>' },
+          ElTooltip: { template: '<div><slot /></div>' }
+        },
+        mocks: { $t: (key: string) => key, $dayjs: { format: () => '' }, $store: { state: { kling: {} }, dispatch } }
+      }
+    });
+
+    await wrapper.find('.btn-delete').trigger('click');
+    await Promise.resolve();
+
+    expect(dispatch).not.toHaveBeenCalled();
+  });
 });

--- a/src/components/kling/task/Preview.vue
+++ b/src/components/kling/task/Preview.vue
@@ -9,6 +9,17 @@
         <span class="datetime">
           {{ $dayjs.format('' + new Date(parseFloat((modelValue?.created_at || '').toString()) * 1000)) }}
         </span>
+        <el-tooltip effect="dark" :content="$t('common.button.delete')" placement="top">
+          <button
+            v-if="modelValue?.id"
+            type="button"
+            class="btn-delete"
+            :aria-label="$t('common.button.delete')"
+            @click.stop="onDelete"
+          >
+            <delete-icon :size="'1em' as any" aria-hidden="true" focusable="false" />
+          </button>
+        </el-tooltip>
       </div>
       <div class="info">
         <div
@@ -135,9 +146,16 @@
 </template>
 
 <script lang="ts">
-import { ChannelIcon, InfoIcon, MagicIcon, TimeIcon, WarningIcon } from '@acedatacloud/core/icons/components';
+import {
+  ChannelIcon,
+  DeleteIcon,
+  InfoIcon,
+  MagicIcon,
+  TimeIcon,
+  WarningIcon
+} from '@acedatacloud/core/icons/components';
 import { defineComponent } from 'vue';
-import { ElAlert, ElButton, ElTooltip } from 'element-plus';
+import { ElAlert, ElButton, ElTooltip, ElMessageBox, ElMessage } from 'element-plus';
 import { IKlingTask } from '@/models';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 import VideoPlayer from '@/components/common/VideoPlayer.vue';
@@ -149,6 +167,7 @@ import ApiCodeButton from '@/components/common/ApiCodeButton.vue';
 export default defineComponent({
   name: 'TaskPreview',
   components: {
+    DeleteIcon,
     ChannelIcon,
     InfoIcon,
     MagicIcon,
@@ -229,6 +248,26 @@ export default defineComponent({
     }
   },
   methods: {
+    async onDelete() {
+      const id = this.modelValue?.id;
+      if (!id) return;
+      try {
+        await ElMessageBox.confirm(this.$t('common.message.deleteTaskConfirm'), this.$t('common.button.delete'), {
+          type: 'warning',
+          confirmButtonText: this.$t('common.button.delete'),
+          cancelButtonText: this.$t('common.button.cancel'),
+          confirmButtonClass: 'el-button--danger'
+        });
+      } catch {
+        return; // user cancelled
+      }
+      try {
+        await this.$store.dispatch('kling/deleteTask', { id });
+        ElMessage.success(this.$t('common.message.deleteTaskSuccess'));
+      } catch {
+        ElMessage.error(this.$t('common.message.deleteTaskFailed'));
+      }
+    },
     onDownload(event: MouseEvent, video_url: string) {
       event?.stopPropagation();
       console.log('on download');
@@ -268,6 +307,8 @@ $left-width: 70px;
     padding: 10px 10px 0 10px;
 
     .bot {
+      display: flex;
+      align-items: center;
       font-size: 16px;
       font-weight: bold;
       color: var(--el-color-primary);
@@ -278,9 +319,32 @@ $left-width: 70px;
       white-space: nowrap;
       .datetime {
         font-size: 12px;
+        overflow: hidden;
+        text-overflow: ellipsis;
         font-weight: normal;
         color: var(--el-text-color-secondary);
         margin-left: 10px;
+      }
+      .btn-delete {
+        margin-left: auto;
+        padding: 4px 6px;
+        border: none;
+        background: transparent;
+        cursor: pointer;
+        line-height: 1;
+        color: var(--el-text-color-secondary);
+        // Hover-reveal on pointer devices; keep it out of the way until wanted.
+        opacity: 0;
+        transition:
+          opacity 0.15s ease,
+          color 0.15s ease;
+        &:hover {
+          color: var(--el-color-danger);
+        }
+        // Touch devices have no hover — always show the control.
+        @media (hover: none) {
+          opacity: 1;
+        }
       }
     }
 
@@ -341,6 +405,11 @@ $left-width: 70px;
         margin-bottom: 10px;
       }
     }
+  }
+
+  // Reveal the trash icon when hovering anywhere on the card.
+  &:hover .main .bot .btn-delete {
+    opacity: 1;
   }
 }
 </style>

--- a/src/components/luma/task/Preview.vue
+++ b/src/components/luma/task/Preview.vue
@@ -9,6 +9,17 @@
         <span class="datetime">
           {{ $dayjs.format('' + new Date(parseFloat((modelValue?.created_at || '').toString()) * 1000)) }}
         </span>
+        <el-tooltip effect="dark" :content="$t('common.button.delete')" placement="top">
+          <button
+            v-if="modelValue?.id"
+            type="button"
+            class="btn-delete"
+            :aria-label="$t('common.button.delete')"
+            @click.stop="onDelete"
+          >
+            <delete-icon :size="'1em' as any" aria-hidden="true" focusable="false" />
+          </button>
+        </el-tooltip>
       </div>
       <div class="info">
         <p v-if="modelValue?.request?.prompt" class="prompt mt-2">
@@ -116,9 +127,16 @@
 </template>
 
 <script lang="ts">
-import { ChannelIcon, InfoIcon, MagicIcon, TimeIcon, WarningIcon } from '@acedatacloud/core/icons/components';
+import {
+  ChannelIcon,
+  DeleteIcon,
+  InfoIcon,
+  MagicIcon,
+  TimeIcon,
+  WarningIcon
+} from '@acedatacloud/core/icons/components';
 import { defineComponent } from 'vue';
-import { ElAlert, ElButton, ElTooltip } from 'element-plus';
+import { ElAlert, ElButton, ElTooltip, ElMessageBox, ElMessage } from 'element-plus';
 import { ILumaTask, ILumaGenerateResponse } from '@/models';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 import VideoPlayer from '@/components/common/VideoPlayer.vue';
@@ -127,6 +145,7 @@ import ApiCodeButton from '@/components/common/ApiCodeButton.vue';
 export default defineComponent({
   name: 'TaskPreview',
   components: {
+    DeleteIcon,
     ChannelIcon,
     InfoIcon,
     MagicIcon,
@@ -158,6 +177,26 @@ export default defineComponent({
     }
   },
   methods: {
+    async onDelete() {
+      const id = this.modelValue?.id;
+      if (!id) return;
+      try {
+        await ElMessageBox.confirm(this.$t('common.message.deleteTaskConfirm'), this.$t('common.button.delete'), {
+          type: 'warning',
+          confirmButtonText: this.$t('common.button.delete'),
+          cancelButtonText: this.$t('common.button.cancel'),
+          confirmButtonClass: 'el-button--danger'
+        });
+      } catch {
+        return; // user cancelled
+      }
+      try {
+        await this.$store.dispatch('luma/deleteTask', { id });
+        ElMessage.success(this.$t('common.message.deleteTaskSuccess'));
+      } catch {
+        ElMessage.error(this.$t('common.message.deleteTaskFailed'));
+      }
+    },
     onExtend(_event: MouseEvent, response: ILumaGenerateResponse) {
       // extend url here
       console.debug('set config', response);
@@ -207,6 +246,8 @@ $left-width: 70px;
     padding: 10px 10px 0 10px;
 
     .bot {
+      display: flex;
+      align-items: center;
       font-size: 16px;
       font-weight: bold;
       color: var(--el-color-primary);
@@ -217,9 +258,32 @@ $left-width: 70px;
       white-space: nowrap;
       .datetime {
         font-size: 12px;
+        overflow: hidden;
+        text-overflow: ellipsis;
         font-weight: normal;
         color: var(--el-text-color-secondary);
         margin-left: 10px;
+      }
+      .btn-delete {
+        margin-left: auto;
+        padding: 4px 6px;
+        border: none;
+        background: transparent;
+        cursor: pointer;
+        line-height: 1;
+        color: var(--el-text-color-secondary);
+        // Hover-reveal on pointer devices; keep it out of the way until wanted.
+        opacity: 0;
+        transition:
+          opacity 0.15s ease,
+          color 0.15s ease;
+        &:hover {
+          color: var(--el-color-danger);
+        }
+        // Touch devices have no hover — always show the control.
+        @media (hover: none) {
+          opacity: 1;
+        }
       }
     }
 
@@ -258,6 +322,11 @@ $left-width: 70px;
         }
       }
     }
+  }
+
+  // Reveal the trash icon when hovering anywhere on the card.
+  &:hover .main .bot .btn-delete {
+    opacity: 1;
   }
 }
 </style>

--- a/src/components/maestro/task/Preview.vue
+++ b/src/components/maestro/task/Preview.vue
@@ -9,6 +9,17 @@
         <span class="datetime">
           {{ $dayjs.format('' + new Date(parseFloat((modelValue?.created_at || '').toString()) * 1000)) }}
         </span>
+        <el-tooltip effect="dark" :content="$t('common.button.delete')" placement="top">
+          <button
+            v-if="modelValue?.id"
+            type="button"
+            class="btn-delete"
+            :aria-label="$t('common.button.delete')"
+            @click.stop="onDelete"
+          >
+            <delete-icon :size="'1em' as any" aria-hidden="true" focusable="false" />
+          </button>
+        </el-tooltip>
       </div>
       <div class="info">
         <div v-if="files.length" class="flex justify-start items-center gap-2 mt-2 w-full overflow-x-auto">
@@ -175,6 +186,7 @@
 <script lang="ts">
 import {
   ChannelIcon,
+  DeleteIcon,
   DownloadIcon,
   FullscreenIcon,
   InfoIcon,
@@ -188,7 +200,7 @@ import {
   WarningIcon
 } from '@acedatacloud/core/icons/components';
 import { defineComponent, markRaw, type Component } from 'vue';
-import { ElAlert, ElButton, ElMessage } from 'element-plus';
+import { ElAlert, ElButton, ElMessage, ElMessageBox, ElTooltip } from 'element-plus';
 import { IMaestroTask, IMaestroVariant } from '@/models';
 import { MAESTRO_ACTION_REMIX } from '@/constants';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
@@ -216,6 +228,8 @@ interface IMaestroInputFile {
 export default defineComponent({
   name: 'TaskPreview',
   components: {
+    DeleteIcon,
+    ElTooltip,
     ChannelIcon,
     DownloadIcon,
     InfoIcon,
@@ -388,6 +402,26 @@ export default defineComponent({
     this.resetReferenceLoad();
   },
   methods: {
+    async onDelete() {
+      const id = this.modelValue?.id;
+      if (!id) return;
+      try {
+        await ElMessageBox.confirm(this.$t('common.message.deleteTaskConfirm'), this.$t('common.button.delete'), {
+          type: 'warning',
+          confirmButtonText: this.$t('common.button.delete'),
+          cancelButtonText: this.$t('common.button.cancel'),
+          confirmButtonClass: 'el-button--danger'
+        });
+      } catch {
+        return; // user cancelled
+      }
+      try {
+        await this.$store.dispatch('maestro/deleteTask', { id });
+        ElMessage.success(this.$t('common.message.deleteTaskSuccess'));
+      } catch {
+        ElMessage.error(this.$t('common.message.deleteTaskFailed'));
+      }
+    },
     resetReferenceLoad(): void {
       if (this.referenceLoadTimer !== undefined) window.clearTimeout(this.referenceLoadTimer);
       this.referenceLoadTimer = undefined;
@@ -482,6 +516,8 @@ $left-width: 70px;
     padding: 10px 10px 0 10px;
 
     .bot {
+      display: flex;
+      align-items: center;
       font-size: 16px;
       font-weight: bold;
       color: var(--el-color-primary);
@@ -490,9 +526,32 @@ $left-width: 70px;
       white-space: nowrap;
       .datetime {
         font-size: 12px;
+        overflow: hidden;
+        text-overflow: ellipsis;
         font-weight: normal;
         color: var(--el-text-color-secondary);
         margin-left: 10px;
+      }
+      .btn-delete {
+        margin-left: auto;
+        padding: 4px 6px;
+        border: none;
+        background: transparent;
+        cursor: pointer;
+        line-height: 1;
+        color: var(--el-text-color-secondary);
+        // Hover-reveal on pointer devices; keep it out of the way until wanted.
+        opacity: 0;
+        transition:
+          opacity 0.15s ease,
+          color 0.15s ease;
+        &:hover {
+          color: var(--el-color-danger);
+        }
+        // Touch devices have no hover — always show the control.
+        @media (hover: none) {
+          opacity: 1;
+        }
       }
     }
 
@@ -547,6 +606,11 @@ $left-width: 70px;
         margin-bottom: 10px;
       }
     }
+  }
+
+  // Reveal the trash icon when hovering anywhere on the card.
+  &:hover .main .bot .btn-delete {
+    opacity: 1;
   }
 }
 </style>

--- a/src/components/nanobanana/task/Preview.vue
+++ b/src/components/nanobanana/task/Preview.vue
@@ -9,6 +9,17 @@
         <span class="datetime">
           {{ $dayjs.format('' + new Date(parseFloat((modelValue?.created_at || '').toString()) * 1000)) }}
         </span>
+        <el-tooltip effect="dark" :content="$t('common.button.delete')" placement="top">
+          <button
+            v-if="modelValue?.id"
+            type="button"
+            class="btn-delete"
+            :aria-label="$t('common.button.delete')"
+            @click.stop="onDelete"
+          >
+            <delete-icon :size="'1em' as any" aria-hidden="true" focusable="false" />
+          </button>
+        </el-tooltip>
       </div>
       <div class="info">
         <div
@@ -185,6 +196,7 @@
 import {
   ApplicationIcon,
   ChannelIcon,
+  DeleteIcon,
   ExternalLinkIcon,
   ImageIcon,
   InfoIcon,
@@ -194,7 +206,7 @@ import {
   WarningIcon
 } from '@acedatacloud/core/icons/components';
 import { defineComponent } from 'vue';
-import { ElAlert, ElButton, ElTooltip } from 'element-plus';
+import { ElAlert, ElButton, ElMessageBox, ElMessage, ElTooltip } from 'element-plus';
 import { INanobananaTask, INanobananaImage } from '@/models';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 import ImageWrapper from '@/components/common/ImageWrapper.vue';
@@ -206,6 +218,7 @@ export default defineComponent({
   components: {
     ApplicationIcon,
     ChannelIcon,
+    DeleteIcon,
     ExternalLinkIcon,
     ImageIcon,
     InfoIcon,
@@ -262,6 +275,26 @@ export default defineComponent({
       delete (nextConfig as any).action;
       (nextConfig as any).image_urls = [imageUrl];
       this.$store.commit('nanobanana/setConfig', nextConfig);
+    },
+    async onDelete() {
+      const id = this.modelValue?.id;
+      if (!id) return;
+      try {
+        await ElMessageBox.confirm(this.$t('common.message.deleteTaskConfirm'), this.$t('common.button.delete'), {
+          type: 'warning',
+          confirmButtonText: this.$t('common.button.delete'),
+          cancelButtonText: this.$t('common.button.cancel'),
+          confirmButtonClass: 'el-button--danger'
+        });
+      } catch {
+        return; // user cancelled
+      }
+      try {
+        await this.$store.dispatch('nanobanana/deleteTask', { id });
+        ElMessage.success(this.$t('common.message.deleteTaskSuccess'));
+      } catch {
+        ElMessage.error(this.$t('common.message.deleteTaskFailed'));
+      }
     }
   }
 });
@@ -293,19 +326,43 @@ $left-width: 70px;
     padding: 10px 10px 0 10px;
 
     .bot {
+      display: flex;
+      align-items: center;
       font-size: 16px;
       font-weight: bold;
       color: var(--el-color-primary);
       margin-bottom: 0;
       margin-top: 0;
       overflow: hidden;
-      text-overflow: ellipsis;
       white-space: nowrap;
       .datetime {
         font-size: 12px;
         font-weight: normal;
         color: var(--el-text-color-secondary);
         margin-left: 10px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      .btn-delete {
+        margin-left: auto;
+        padding: 4px 6px;
+        border: none;
+        background: transparent;
+        cursor: pointer;
+        line-height: 1;
+        color: var(--el-text-color-secondary);
+        // Hover-reveal on pointer devices; keep it out of the way until wanted.
+        opacity: 0;
+        transition:
+          opacity 0.15s ease,
+          color 0.15s ease;
+        &:hover {
+          color: var(--el-color-danger);
+        }
+        // Touch devices have no hover — always show the control.
+        @media (hover: none) {
+          opacity: 1;
+        }
       }
     }
 
@@ -360,6 +417,11 @@ $left-width: 70px;
         margin-bottom: 10px;
       }
     }
+  }
+
+  // Reveal the trash icon when hovering anywhere on the card.
+  &:hover .main .bot .btn-delete {
+    opacity: 1;
   }
 }
 </style>

--- a/src/components/omni/task/Preview.vue
+++ b/src/components/omni/task/Preview.vue
@@ -9,6 +9,17 @@
         <span class="datetime">
           {{ $dayjs.format('' + new Date(parseFloat((modelValue?.created_at || '').toString()) * 1000)) }}
         </span>
+        <el-tooltip effect="dark" :content="$t('common.button.delete')" placement="top">
+          <button
+            v-if="modelValue?.id"
+            type="button"
+            class="btn-delete"
+            :aria-label="$t('common.button.delete')"
+            @click.stop="onDelete"
+          >
+            <delete-icon :size="'1em' as any" aria-hidden="true" focusable="false" />
+          </button>
+        </el-tooltip>
       </div>
       <div class="info">
         <div v-if="inputImage" class="flex justify-start items-center gap-2 mt-2 w-full overflow-x-auto">
@@ -130,6 +141,7 @@
 import {
   ApplicationIcon,
   ChannelIcon,
+  DeleteIcon,
   ExpandIcon,
   InfoIcon,
   MagicIcon,
@@ -137,7 +149,7 @@ import {
   WarningIcon
 } from '@acedatacloud/core/icons/components';
 import { defineComponent } from 'vue';
-import { ElAlert, ElButton, ElTooltip } from 'element-plus';
+import { ElAlert, ElButton, ElTooltip, ElMessageBox, ElMessage } from 'element-plus';
 import { IOmniTask, IOmniVideo } from '@/models';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 import VideoPlayer from '@/components/common/VideoPlayer.vue';
@@ -147,6 +159,7 @@ import ApiCodeButton from '@/components/common/ApiCodeButton.vue';
 export default defineComponent({
   name: 'OmniTaskPreview',
   components: {
+    DeleteIcon,
     ApplicationIcon,
     ChannelIcon,
     CopyToClipboard,
@@ -211,6 +224,26 @@ export default defineComponent({
     this.stopTimer();
   },
   methods: {
+    async onDelete() {
+      const id = this.modelValue?.id;
+      if (!id) return;
+      try {
+        await ElMessageBox.confirm(this.$t('common.message.deleteTaskConfirm'), this.$t('common.button.delete'), {
+          type: 'warning',
+          confirmButtonText: this.$t('common.button.delete'),
+          cancelButtonText: this.$t('common.button.cancel'),
+          confirmButtonClass: 'el-button--danger'
+        });
+      } catch {
+        return; // user cancelled
+      }
+      try {
+        await this.$store.dispatch('omni/deleteTask', { id });
+        ElMessage.success(this.$t('common.message.deleteTaskSuccess'));
+      } catch {
+        ElMessage.error(this.$t('common.message.deleteTaskFailed'));
+      }
+    },
     stopTimer() {
       if (this.timer) {
         window.clearInterval(this.timer);
@@ -251,6 +284,8 @@ $left-width: 70px;
     padding: 10px 10px 0 10px;
 
     .bot {
+      display: flex;
+      align-items: center;
       font-size: 16px;
       font-weight: bold;
       color: var(--el-color-primary);
@@ -261,9 +296,32 @@ $left-width: 70px;
       white-space: nowrap;
       .datetime {
         font-size: 12px;
+        overflow: hidden;
+        text-overflow: ellipsis;
         font-weight: normal;
         color: var(--el-text-color-secondary);
         margin-left: 10px;
+      }
+      .btn-delete {
+        margin-left: auto;
+        padding: 4px 6px;
+        border: none;
+        background: transparent;
+        cursor: pointer;
+        line-height: 1;
+        color: var(--el-text-color-secondary);
+        // Hover-reveal on pointer devices; keep it out of the way until wanted.
+        opacity: 0;
+        transition:
+          opacity 0.15s ease,
+          color 0.15s ease;
+        &:hover {
+          color: var(--el-color-danger);
+        }
+        // Touch devices have no hover — always show the control.
+        @media (hover: none) {
+          opacity: 1;
+        }
       }
     }
 
@@ -300,6 +358,11 @@ $left-width: 70px;
         }
       }
     }
+  }
+
+  // Reveal the trash icon when hovering anywhere on the card.
+  &:hover .main .bot .btn-delete {
+    opacity: 1;
   }
 }
 </style>

--- a/src/components/openaiimage/task/Preview.test.ts
+++ b/src/components/openaiimage/task/Preview.test.ts
@@ -7,9 +7,19 @@ vi.mock('@/components/common/ImageWrapper.vue', () => ({
   default: { name: 'ImageWrapper', template: '<div />' }
 }));
 
+const confirm = vi.fn();
+vi.mock('element-plus', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('element-plus')>();
+  return {
+    ...actual,
+    ElMessageBox: { confirm: (...args: unknown[]) => confirm(...args) },
+    ElMessage: { success: vi.fn(), error: vi.fn() }
+  };
+});
+
 import Preview from './Preview.vue';
 
-const mountPreview = (response?: IOpenAIImageTask['response']) =>
+const mountPreview = (response?: IOpenAIImageTask['response'], dispatch = vi.fn()) =>
   shallowMount(Preview, {
     props: {
       modelValue: {
@@ -20,12 +30,13 @@ const mountPreview = (response?: IOpenAIImageTask['response']) =>
     },
     global: {
       stubs: {
-        ElAlert: { template: '<div><slot name="template" /><slot /></div>' }
+        ElAlert: { template: '<div><slot name="template" /><slot /></div>' },
+        ElTooltip: { template: '<div><slot /></div>' }
       },
       mocks: {
         $t: (key: string) => key,
         $dayjs: { format: () => '2026-07-19' },
-        $store: { state: { openaiimage: { config: {} } }, commit: () => undefined }
+        $store: { state: { openaiimage: { config: {} } }, commit: () => undefined, dispatch }
       }
     }
   });
@@ -45,5 +56,33 @@ describe('openaiimage/task/Preview', () => {
     expect(wrapper.text()).toContain('openaiimage.name.status');
     expect(wrapper.text()).not.toContain('openaiimage.name.failure');
     expect(wrapper.findComponent({ name: 'InfoIcon' }).exists()).toBe(true);
+  });
+
+  it('renders a delete button on every status (incl. pending)', () => {
+    const wrapper = mountPreview();
+    expect(wrapper.find('.btn-delete').exists()).toBe(true);
+  });
+
+  it('dispatches deleteTask after the user confirms', async () => {
+    confirm.mockResolvedValueOnce(undefined);
+    const dispatch = vi.fn().mockResolvedValue(undefined);
+    const wrapper = mountPreview(undefined, dispatch);
+
+    await wrapper.find('.btn-delete').trigger('click');
+    await Promise.resolve();
+
+    expect(confirm).toHaveBeenCalled();
+    expect(dispatch).toHaveBeenCalledWith('openaiimage/deleteTask', { id: 'task-1' });
+  });
+
+  it('does NOT dispatch when the user cancels the confirm dialog', async () => {
+    confirm.mockRejectedValueOnce(new Error('cancel'));
+    const dispatch = vi.fn();
+    const wrapper = mountPreview(undefined, dispatch);
+
+    await wrapper.find('.btn-delete').trigger('click');
+    await Promise.resolve();
+
+    expect(dispatch).not.toHaveBeenCalled();
   });
 });

--- a/src/components/openaiimage/task/Preview.vue
+++ b/src/components/openaiimage/task/Preview.vue
@@ -9,6 +9,17 @@
         <span class="datetime">
           {{ $dayjs.format('' + new Date(parseFloat((modelValue?.created_at || '').toString()) * 1000)) }}
         </span>
+        <el-tooltip effect="dark" :content="$t('common.button.delete')" placement="top">
+          <button
+            v-if="modelValue?.id"
+            type="button"
+            class="btn-delete"
+            :aria-label="$t('common.button.delete')"
+            @click.stop="onDelete"
+          >
+            <delete-icon :size="'1em' as any" aria-hidden="true" focusable="false" />
+          </button>
+        </el-tooltip>
       </div>
       <div class="info">
         <div
@@ -173,6 +184,7 @@
 import {
   ApplicationIcon,
   ChannelIcon,
+  DeleteIcon,
   ImageIcon,
   InfoIcon,
   LightningIcon,
@@ -181,7 +193,7 @@ import {
   WarningIcon
 } from '@acedatacloud/core/icons/components';
 import { defineComponent } from 'vue';
-import { ElAlert, ElButton, ElTooltip } from 'element-plus';
+import { ElAlert, ElButton, ElMessageBox, ElMessage, ElTooltip } from 'element-plus';
 import { IOpenAIImageTask, IOpenAIImageImage } from '@/models';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 import ImageWrapper from '@/components/common/ImageWrapper.vue';
@@ -193,6 +205,7 @@ export default defineComponent({
   components: {
     ApplicationIcon,
     ChannelIcon,
+    DeleteIcon,
     ImageIcon,
     InfoIcon,
     LightningIcon,
@@ -301,6 +314,26 @@ export default defineComponent({
       const nextConfig = { ...(this.$store.state.openaiimage?.config || {}) };
       (nextConfig as any).image_urls = [imageUrl];
       this.$store.commit('openaiimage/setConfig', nextConfig);
+    },
+    async onDelete() {
+      const id = this.modelValue?.id;
+      if (!id) return;
+      try {
+        await ElMessageBox.confirm(this.$t('common.message.deleteTaskConfirm'), this.$t('common.button.delete'), {
+          type: 'warning',
+          confirmButtonText: this.$t('common.button.delete'),
+          cancelButtonText: this.$t('common.button.cancel'),
+          confirmButtonClass: 'el-button--danger'
+        });
+      } catch {
+        return; // user cancelled
+      }
+      try {
+        await this.$store.dispatch('openaiimage/deleteTask', { id });
+        ElMessage.success(this.$t('common.message.deleteTaskSuccess'));
+      } catch {
+        ElMessage.error(this.$t('common.message.deleteTaskFailed'));
+      }
     }
   }
 });
@@ -332,19 +365,43 @@ $left-width: 70px;
     padding: 10px 10px 0 10px;
 
     .bot {
+      display: flex;
+      align-items: center;
       font-size: 16px;
       font-weight: bold;
       color: var(--el-color-primary);
       margin-bottom: 0;
       margin-top: 0;
       overflow: hidden;
-      text-overflow: ellipsis;
       white-space: nowrap;
       .datetime {
         font-size: 12px;
         font-weight: normal;
         color: var(--el-text-color-secondary);
         margin-left: 10px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      .btn-delete {
+        margin-left: auto;
+        padding: 4px 6px;
+        border: none;
+        background: transparent;
+        cursor: pointer;
+        line-height: 1;
+        color: var(--el-text-color-secondary);
+        // Hover-reveal on pointer devices; keep it out of the way until wanted.
+        opacity: 0;
+        transition:
+          opacity 0.15s ease,
+          color 0.15s ease;
+        &:hover {
+          color: var(--el-color-danger);
+        }
+        // Touch devices have no hover — always show the control.
+        @media (hover: none) {
+          opacity: 1;
+        }
       }
     }
 
@@ -399,6 +456,11 @@ $left-width: 70px;
         margin-bottom: 10px;
       }
     }
+  }
+
+  // Reveal the trash icon when hovering anywhere on the card.
+  &:hover .main .bot .btn-delete {
+    opacity: 1;
   }
 }
 </style>

--- a/src/components/pika/task/Preview.vue
+++ b/src/components/pika/task/Preview.vue
@@ -9,6 +9,17 @@
         <span class="datetime">
           {{ $dayjs.format('' + new Date(parseFloat((modelValue?.created_at || '').toString()) * 1000)) }}
         </span>
+        <el-tooltip effect="dark" :content="$t('common.button.delete')" placement="top">
+          <button
+            v-if="modelValue?.id"
+            type="button"
+            class="btn-delete"
+            :aria-label="$t('common.button.delete')"
+            @click.stop="onDelete"
+          >
+            <delete-icon :size="'1em' as any" aria-hidden="true" focusable="false" />
+          </button>
+        </el-tooltip>
       </div>
       <div class="info">
         <p v-if="modelValue?.request?.prompt" class="prompt mt-2">
@@ -105,9 +116,16 @@
 </template>
 
 <script lang="ts">
-import { ChannelIcon, InfoIcon, MagicIcon, TimeIcon, WarningIcon } from '@acedatacloud/core/icons/components';
+import {
+  ChannelIcon,
+  DeleteIcon,
+  InfoIcon,
+  MagicIcon,
+  TimeIcon,
+  WarningIcon
+} from '@acedatacloud/core/icons/components';
 import { defineComponent } from 'vue';
-import { ElAlert, ElButton, ElTooltip } from 'element-plus';
+import { ElAlert, ElButton, ElTooltip, ElMessageBox, ElMessage } from 'element-plus';
 import { IPikaTask, IPikaVideo } from '@/models';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 import VideoPlayer from '../VideoPlayer.vue';
@@ -115,6 +133,7 @@ import ApiCodeButton from '@/components/common/ApiCodeButton.vue';
 export default defineComponent({
   name: 'TaskPreview',
   components: {
+    DeleteIcon,
     ChannelIcon,
     InfoIcon,
     MagicIcon,
@@ -164,6 +183,26 @@ export default defineComponent({
     }
   },
   methods: {
+    async onDelete() {
+      const id = this.modelValue?.id;
+      if (!id) return;
+      try {
+        await ElMessageBox.confirm(this.$t('common.message.deleteTaskConfirm'), this.$t('common.button.delete'), {
+          type: 'warning',
+          confirmButtonText: this.$t('common.button.delete'),
+          cancelButtonText: this.$t('common.button.cancel'),
+          confirmButtonClass: 'el-button--danger'
+        });
+      } catch {
+        return; // user cancelled
+      }
+      try {
+        await this.$store.dispatch('pika/deleteTask', { id });
+        ElMessage.success(this.$t('common.message.deleteTaskSuccess'));
+      } catch {
+        ElMessage.error(this.$t('common.message.deleteTaskFailed'));
+      }
+    },
     isFailure(video: IPikaVideo): boolean {
       const response = this.modelValue?.response;
       return (
@@ -248,6 +287,8 @@ $left-width: 70px;
     padding: 10px 10px 0 10px;
 
     .bot {
+      display: flex;
+      align-items: center;
       font-size: 16px;
       font-weight: bold;
       color: var(--el-color-primary);
@@ -258,9 +299,32 @@ $left-width: 70px;
       white-space: nowrap;
       .datetime {
         font-size: 12px;
+        overflow: hidden;
+        text-overflow: ellipsis;
         font-weight: normal;
         color: var(--el-text-color-secondary);
         margin-left: 10px;
+      }
+      .btn-delete {
+        margin-left: auto;
+        padding: 4px 6px;
+        border: none;
+        background: transparent;
+        cursor: pointer;
+        line-height: 1;
+        color: var(--el-text-color-secondary);
+        // Hover-reveal on pointer devices; keep it out of the way until wanted.
+        opacity: 0;
+        transition:
+          opacity 0.15s ease,
+          color 0.15s ease;
+        &:hover {
+          color: var(--el-color-danger);
+        }
+        // Touch devices have no hover — always show the control.
+        @media (hover: none) {
+          opacity: 1;
+        }
       }
     }
 
@@ -363,6 +427,11 @@ $left-width: 70px;
         margin-bottom: 10px;
       }
     }
+  }
+
+  // Reveal the trash icon when hovering anywhere on the card.
+  &:hover .main .bot .btn-delete {
+    opacity: 1;
   }
 }
 </style>

--- a/src/components/pixverse/task/Preview.vue
+++ b/src/components/pixverse/task/Preview.vue
@@ -9,6 +9,17 @@
         <span class="datetime">
           {{ $dayjs.format('' + new Date(parseFloat((modelValue?.created_at || '').toString()) * 1000)) }}
         </span>
+        <el-tooltip effect="dark" :content="$t('common.button.delete')" placement="top">
+          <button
+            v-if="modelValue?.id"
+            type="button"
+            class="btn-delete"
+            :aria-label="$t('common.button.delete')"
+            @click.stop="onDelete"
+          >
+            <delete-icon :size="'1em' as any" aria-hidden="true" focusable="false" />
+          </button>
+        </el-tooltip>
       </div>
       <div class="info">
         <p v-if="modelValue?.request?.prompt" class="prompt mt-2">
@@ -106,9 +117,16 @@
 </template>
 
 <script lang="ts">
-import { ChannelIcon, InfoIcon, MagicIcon, TimeIcon, WarningIcon } from '@acedatacloud/core/icons/components';
+import {
+  ChannelIcon,
+  DeleteIcon,
+  InfoIcon,
+  MagicIcon,
+  TimeIcon,
+  WarningIcon
+} from '@acedatacloud/core/icons/components';
 import { defineComponent } from 'vue';
-import { ElAlert, ElButton, ElTooltip } from 'element-plus';
+import { ElAlert, ElButton, ElTooltip, ElMessageBox, ElMessage } from 'element-plus';
 import { IPixverseTask } from '@/models';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 import VideoPlayer from '@/components/common/VideoPlayer.vue';
@@ -117,6 +135,7 @@ import ApiCodeButton from '@/components/common/ApiCodeButton.vue';
 export default defineComponent({
   name: 'TaskPreview',
   components: {
+    DeleteIcon,
     ChannelIcon,
     InfoIcon,
     MagicIcon,
@@ -147,6 +166,26 @@ export default defineComponent({
     }
   },
   methods: {
+    async onDelete() {
+      const id = this.modelValue?.id;
+      if (!id) return;
+      try {
+        await ElMessageBox.confirm(this.$t('common.message.deleteTaskConfirm'), this.$t('common.button.delete'), {
+          type: 'warning',
+          confirmButtonText: this.$t('common.button.delete'),
+          cancelButtonText: this.$t('common.button.cancel'),
+          confirmButtonClass: 'el-button--danger'
+        });
+      } catch {
+        return; // user cancelled
+      }
+      try {
+        await this.$store.dispatch('pixverse/deleteTask', { id });
+        ElMessage.success(this.$t('common.message.deleteTaskSuccess'));
+      } catch {
+        ElMessage.error(this.$t('common.message.deleteTaskFailed'));
+      }
+    },
     onDownload(event: MouseEvent, video_url: string) {
       event?.stopPropagation();
       console.log('on download');
@@ -186,6 +225,8 @@ $left-width: 70px;
     padding: 10px 10px 0 10px;
 
     .bot {
+      display: flex;
+      align-items: center;
       font-size: 16px;
       font-weight: bold;
       color: var(--el-color-primary);
@@ -196,9 +237,32 @@ $left-width: 70px;
       white-space: nowrap;
       .datetime {
         font-size: 12px;
+        overflow: hidden;
+        text-overflow: ellipsis;
         font-weight: normal;
         color: var(--el-text-color-secondary);
         margin-left: 10px;
+      }
+      .btn-delete {
+        margin-left: auto;
+        padding: 4px 6px;
+        border: none;
+        background: transparent;
+        cursor: pointer;
+        line-height: 1;
+        color: var(--el-text-color-secondary);
+        // Hover-reveal on pointer devices; keep it out of the way until wanted.
+        opacity: 0;
+        transition:
+          opacity 0.15s ease,
+          color 0.15s ease;
+        &:hover {
+          color: var(--el-color-danger);
+        }
+        // Touch devices have no hover — always show the control.
+        @media (hover: none) {
+          opacity: 1;
+        }
       }
     }
 
@@ -259,6 +323,11 @@ $left-width: 70px;
         margin-bottom: 10px;
       }
     }
+  }
+
+  // Reveal the trash icon when hovering anywhere on the card.
+  &:hover .main .bot .btn-delete {
+    opacity: 1;
   }
 }
 </style>

--- a/src/components/qrart/task/Preview.vue
+++ b/src/components/qrart/task/Preview.vue
@@ -9,12 +9,25 @@
     </div>
     <div class="main flex-1 w-[calc(100%-70px)] min-w-0 pt-[10px] pr-[10px] pb-0 pl-[10px]">
       <div
-        class="bot text-[16px] font-bold text-[var(--el-color-primary)] overflow-hidden text-ellipsis whitespace-nowrap"
+        class="bot flex items-center text-[16px] font-bold text-[var(--el-color-primary)] overflow-hidden whitespace-nowrap"
       >
         <capability-presentation capability="qrart" part="name" />
-        <span class="datetime text-[12px] font-normal text-[var(--el-text-color-secondary)] ml-[10px]">
+        <span
+          class="datetime text-[12px] font-normal text-[var(--el-text-color-secondary)] ml-[10px] overflow-hidden text-ellipsis"
+        >
           {{ $dayjs.format('' + new Date(parseFloat((modelValue?.created_at || '').toString()) * 1000)) }}
         </span>
+        <el-tooltip effect="dark" :content="$t('common.button.delete')" placement="top">
+          <button
+            v-if="modelValue?.id"
+            type="button"
+            class="btn-delete ml-auto shrink-0 cursor-pointer border-none bg-transparent p-[4px_6px] leading-none"
+            :aria-label="$t('common.button.delete')"
+            @click.stop="onDelete"
+          >
+            <delete-icon :size="'1em' as any" aria-hidden="true" focusable="false" />
+          </button>
+        </el-tooltip>
       </div>
       <div class="info">
         <p
@@ -132,6 +145,7 @@
 <script lang="ts">
 import {
   ChannelIcon,
+  DeleteIcon,
   ExternalLinkIcon,
   GrowthIcon,
   InfoIcon,
@@ -142,7 +156,7 @@ import {
   WarningIcon
 } from '@acedatacloud/core/icons/components';
 import { defineComponent } from 'vue';
-import { ElAlert } from 'element-plus';
+import { ElAlert, ElMessageBox, ElMessage, ElTooltip } from 'element-plus';
 import { IQrartTask } from '@/models';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 import ImageWrapper from '@/components/common/ImageWrapper.vue';
@@ -152,6 +166,7 @@ export default defineComponent({
   name: 'TaskPreview',
   components: {
     ChannelIcon,
+    DeleteIcon,
     ExternalLinkIcon,
     GrowthIcon,
     InfoIcon,
@@ -162,6 +177,7 @@ export default defineComponent({
     WarningIcon,
     CopyToClipboard,
     ElAlert,
+    ElTooltip,
     ImageWrapper,
     ApiCodeButton
   },
@@ -180,6 +196,26 @@ export default defineComponent({
     }
   },
   methods: {
+    async onDelete() {
+      const id = this.modelValue?.id;
+      if (!id) return;
+      try {
+        await ElMessageBox.confirm(this.$t('common.message.deleteTaskConfirm'), this.$t('common.button.delete'), {
+          type: 'warning',
+          confirmButtonText: this.$t('common.button.delete'),
+          cancelButtonText: this.$t('common.button.cancel'),
+          confirmButtonClass: 'el-button--danger'
+        });
+      } catch {
+        return; // user cancelled
+      }
+      try {
+        await this.$store.dispatch('qrart/deleteTask', { id });
+        ElMessage.success(this.$t('common.message.deleteTaskSuccess'));
+      } catch {
+        ElMessage.error(this.$t('common.message.deleteTaskFailed'));
+      }
+    },
     onOpenLink(url: string) {
       window.open(url, '_blank');
     },
@@ -266,6 +302,22 @@ $left-width: 70px;
         color: var(--el-text-color-secondary);
         margin-left: 10px;
       }
+      .btn-delete {
+        margin-left: auto;
+        color: var(--el-text-color-secondary);
+        // Hover-reveal on pointer devices; keep it out of the way until wanted.
+        opacity: 0;
+        transition:
+          opacity 0.15s ease,
+          color 0.15s ease;
+        &:hover {
+          color: var(--el-color-danger);
+        }
+        // Touch devices have no hover — always show the control.
+        @media (hover: none) {
+          opacity: 1;
+        }
+      }
     }
 
     .info {
@@ -309,6 +361,11 @@ $left-width: 70px;
       font-size: 12px;
       margin-bottom: 8px;
     }
+  }
+
+  // Reveal the trash icon when hovering anywhere on the card.
+  &:hover .main .bot .btn-delete {
+    opacity: 1;
   }
 }
 </style>

--- a/src/components/seedance/task/Preview.vue
+++ b/src/components/seedance/task/Preview.vue
@@ -9,6 +9,17 @@
         <span class="datetime">
           {{ $dayjs.format('' + new Date(parseFloat((modelValue?.created_at || '').toString()) * 1000)) }}
         </span>
+        <el-tooltip effect="dark" :content="$t('common.button.delete')" placement="top">
+          <button
+            v-if="modelValue?.id"
+            type="button"
+            class="btn-delete"
+            :aria-label="$t('common.button.delete')"
+            @click.stop="onDelete"
+          >
+            <delete-icon :size="'1em' as any" aria-hidden="true" focusable="false" />
+          </button>
+        </el-tooltip>
       </div>
       <div class="info">
         <div
@@ -175,6 +186,7 @@
 import {
   ApplicationIcon,
   ChannelIcon,
+  DeleteIcon,
   FullscreenIcon,
   InfoIcon,
   MagicIcon,
@@ -183,7 +195,7 @@ import {
   WarningIcon
 } from '@acedatacloud/core/icons/components';
 import { defineComponent } from 'vue';
-import { ElAlert, ElButton, ElTooltip } from 'element-plus';
+import { ElAlert, ElButton, ElTooltip, ElMessageBox, ElMessage } from 'element-plus';
 import { ISeedanceTask, ISeedanceVideo, SeedanceImageRole } from '@/models';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 import VideoPlayer from '@/components/common/VideoPlayer.vue';
@@ -196,6 +208,7 @@ import ApiCodeButton from '@/components/common/ApiCodeButton.vue';
 export default defineComponent({
   name: 'SeedanceTaskPreview',
   components: {
+    DeleteIcon,
     ApplicationIcon,
     ChannelIcon,
     FullscreenIcon,
@@ -295,6 +308,26 @@ export default defineComponent({
     }
   },
   methods: {
+    async onDelete() {
+      const id = this.modelValue?.id;
+      if (!id) return;
+      try {
+        await ElMessageBox.confirm(this.$t('common.message.deleteTaskConfirm'), this.$t('common.button.delete'), {
+          type: 'warning',
+          confirmButtonText: this.$t('common.button.delete'),
+          cancelButtonText: this.$t('common.button.cancel'),
+          confirmButtonClass: 'el-button--danger'
+        });
+      } catch {
+        return; // user cancelled
+      }
+      try {
+        await this.$store.dispatch('seedance/deleteTask', { id });
+        ElMessage.success(this.$t('common.message.deleteTaskSuccess'));
+      } catch {
+        ElMessage.error(this.$t('common.message.deleteTaskFailed'));
+      }
+    },
     // Merge flat request.images with content[] image_url items (folded requests).
     collectImages(): { url?: string; role?: SeedanceImageRole }[] {
       const request = this.modelValue?.request;
@@ -342,6 +375,8 @@ $left-width: 70px;
     padding: 10px 10px 0 10px;
 
     .bot {
+      display: flex;
+      align-items: center;
       font-size: 16px;
       font-weight: bold;
       color: var(--el-color-primary);
@@ -352,9 +387,32 @@ $left-width: 70px;
       white-space: nowrap;
       .datetime {
         font-size: 12px;
+        overflow: hidden;
+        text-overflow: ellipsis;
         font-weight: normal;
         color: var(--el-text-color-secondary);
         margin-left: 10px;
+      }
+      .btn-delete {
+        margin-left: auto;
+        padding: 4px 6px;
+        border: none;
+        background: transparent;
+        cursor: pointer;
+        line-height: 1;
+        color: var(--el-text-color-secondary);
+        // Hover-reveal on pointer devices; keep it out of the way until wanted.
+        opacity: 0;
+        transition:
+          opacity 0.15s ease,
+          color 0.15s ease;
+        &:hover {
+          color: var(--el-color-danger);
+        }
+        // Touch devices have no hover — always show the control.
+        @media (hover: none) {
+          opacity: 1;
+        }
       }
     }
 
@@ -393,6 +451,11 @@ $left-width: 70px;
         }
       }
     }
+  }
+
+  // Reveal the trash icon when hovering anywhere on the card.
+  &:hover .main .bot .btn-delete {
+    opacity: 1;
   }
 }
 </style>

--- a/src/components/seedream/task/Preview.vue
+++ b/src/components/seedream/task/Preview.vue
@@ -9,6 +9,17 @@
         <span class="datetime">
           {{ $dayjs.format('' + new Date(parseFloat((modelValue?.created_at || '').toString()) * 1000)) }}
         </span>
+        <el-tooltip effect="dark" :content="$t('common.button.delete')" placement="top">
+          <button
+            v-if="modelValue?.id"
+            type="button"
+            class="btn-delete"
+            :aria-label="$t('common.button.delete')"
+            @click.stop="onDelete"
+          >
+            <delete-icon :size="'1em' as any" aria-hidden="true" focusable="false" />
+          </button>
+        </el-tooltip>
       </div>
       <div class="info">
         <div
@@ -169,6 +180,7 @@
 import {
   ApplicationIcon,
   ChannelIcon,
+  DeleteIcon,
   ImageIcon,
   InfoIcon,
   LightningIcon,
@@ -177,7 +189,7 @@ import {
   WarningIcon
 } from '@acedatacloud/core/icons/components';
 import { defineComponent } from 'vue';
-import { ElAlert, ElButton, ElTooltip } from 'element-plus';
+import { ElAlert, ElButton, ElTooltip, ElMessageBox, ElMessage } from 'element-plus';
 import { ISeedreamTask, ISeedreamImage } from '@/models';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 import ImageWrapper from '@/components/common/ImageWrapper.vue';
@@ -189,6 +201,7 @@ import { buildSeedreamRequest } from '@/utils/seedream/request';
 export default defineComponent({
   name: 'SeedreamTaskPreview',
   components: {
+    DeleteIcon,
     ApplicationIcon,
     ChannelIcon,
     ImageIcon,
@@ -230,6 +243,26 @@ export default defineComponent({
     }
   },
   methods: {
+    async onDelete() {
+      const id = this.modelValue?.id;
+      if (!id) return;
+      try {
+        await ElMessageBox.confirm(this.$t('common.message.deleteTaskConfirm'), this.$t('common.button.delete'), {
+          type: 'warning',
+          confirmButtonText: this.$t('common.button.delete'),
+          cancelButtonText: this.$t('common.button.cancel'),
+          confirmButtonClass: 'el-button--danger'
+        });
+      } catch {
+        return; // user cancelled
+      }
+      try {
+        await this.$store.dispatch('seedream/deleteTask', { id });
+        ElMessage.success(this.$t('common.message.deleteTaskSuccess'));
+      } catch {
+        ElMessage.error(this.$t('common.message.deleteTaskFailed'));
+      }
+    },
     shortModel(model?: string) {
       return getSeedreamShortModel(model) || model;
     },
@@ -270,6 +303,8 @@ $left-width: 70px;
     padding: 10px 10px 0 10px;
 
     .bot {
+      display: flex;
+      align-items: center;
       font-size: 16px;
       font-weight: bold;
       color: var(--el-color-primary);
@@ -280,9 +315,32 @@ $left-width: 70px;
       white-space: nowrap;
       .datetime {
         font-size: 12px;
+        overflow: hidden;
+        text-overflow: ellipsis;
         font-weight: normal;
         color: var(--el-text-color-secondary);
         margin-left: 10px;
+      }
+      .btn-delete {
+        margin-left: auto;
+        padding: 4px 6px;
+        border: none;
+        background: transparent;
+        cursor: pointer;
+        line-height: 1;
+        color: var(--el-text-color-secondary);
+        // Hover-reveal on pointer devices; keep it out of the way until wanted.
+        opacity: 0;
+        transition:
+          opacity 0.15s ease,
+          color 0.15s ease;
+        &:hover {
+          color: var(--el-color-danger);
+        }
+        // Touch devices have no hover — always show the control.
+        @media (hover: none) {
+          opacity: 1;
+        }
       }
     }
 
@@ -337,6 +395,11 @@ $left-width: 70px;
         margin-bottom: 10px;
       }
     }
+  }
+
+  // Reveal the trash icon when hovering anywhere on the card.
+  &:hover .main .bot .btn-delete {
+    opacity: 1;
   }
 }
 </style>

--- a/src/components/sora/task/Preview.vue
+++ b/src/components/sora/task/Preview.vue
@@ -9,6 +9,17 @@
         <span class="datetime">
           {{ $dayjs.format('' + new Date(parseFloat((modelValue?.created_at || '').toString()) * 1000)) }}
         </span>
+        <el-tooltip effect="dark" :content="$t('common.button.delete')" placement="top">
+          <button
+            v-if="modelValue?.id"
+            type="button"
+            class="btn-delete"
+            :aria-label="$t('common.button.delete')"
+            @click.stop="onDelete"
+          >
+            <delete-icon :size="'1em' as any" aria-hidden="true" focusable="false" />
+          </button>
+        </el-tooltip>
       </div>
       <div class="info">
         <p v-if="modelValue?.request?.prompt" class="prompt mt-2">
@@ -116,9 +127,16 @@
 </template>
 
 <script lang="ts">
-import { ChannelIcon, InfoIcon, MagicIcon, TimeIcon, WarningIcon } from '@acedatacloud/core/icons/components';
+import {
+  ChannelIcon,
+  DeleteIcon,
+  InfoIcon,
+  MagicIcon,
+  TimeIcon,
+  WarningIcon
+} from '@acedatacloud/core/icons/components';
 import { defineComponent } from 'vue';
-import { ElAlert, ElButton, ElTooltip } from 'element-plus';
+import { ElAlert, ElButton, ElTooltip, ElMessageBox, ElMessage } from 'element-plus';
 import { ISoraTask } from '@/models';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 import VideoPlayer from '@/components/common/VideoPlayer.vue';
@@ -127,6 +145,7 @@ import ApiCodeButton from '@/components/common/ApiCodeButton.vue';
 export default defineComponent({
   name: 'TaskPreview',
   components: {
+    DeleteIcon,
     ChannelIcon,
     InfoIcon,
     MagicIcon,
@@ -157,6 +176,26 @@ export default defineComponent({
     }
   },
   methods: {
+    async onDelete() {
+      const id = this.modelValue?.id;
+      if (!id) return;
+      try {
+        await ElMessageBox.confirm(this.$t('common.message.deleteTaskConfirm'), this.$t('common.button.delete'), {
+          type: 'warning',
+          confirmButtonText: this.$t('common.button.delete'),
+          cancelButtonText: this.$t('common.button.cancel'),
+          confirmButtonClass: 'el-button--danger'
+        });
+      } catch {
+        return; // user cancelled
+      }
+      try {
+        await this.$store.dispatch('sora/deleteTask', { id });
+        ElMessage.success(this.$t('common.message.deleteTaskSuccess'));
+      } catch {
+        ElMessage.error(this.$t('common.message.deleteTaskFailed'));
+      }
+    },
     onDownload(event: MouseEvent, video_url: string) {
       event?.stopPropagation();
       console.log('on download');
@@ -196,6 +235,8 @@ $left-width: 70px;
     padding: 10px 10px 0 10px;
 
     .bot {
+      display: flex;
+      align-items: center;
       font-size: 16px;
       font-weight: bold;
       color: var(--el-color-primary);
@@ -206,9 +247,32 @@ $left-width: 70px;
       white-space: nowrap;
       .datetime {
         font-size: 12px;
+        overflow: hidden;
+        text-overflow: ellipsis;
         font-weight: normal;
         color: var(--el-text-color-secondary);
         margin-left: 10px;
+      }
+      .btn-delete {
+        margin-left: auto;
+        padding: 4px 6px;
+        border: none;
+        background: transparent;
+        cursor: pointer;
+        line-height: 1;
+        color: var(--el-text-color-secondary);
+        // Hover-reveal on pointer devices; keep it out of the way until wanted.
+        opacity: 0;
+        transition:
+          opacity 0.15s ease,
+          color 0.15s ease;
+        &:hover {
+          color: var(--el-color-danger);
+        }
+        // Touch devices have no hover — always show the control.
+        @media (hover: none) {
+          opacity: 1;
+        }
       }
     }
 
@@ -270,6 +334,11 @@ $left-width: 70px;
         margin-bottom: 10px;
       }
     }
+  }
+
+  // Reveal the trash icon when hovering anywhere on the card.
+  &:hover .main .bot .btn-delete {
+    opacity: 1;
   }
 }
 </style>

--- a/src/components/veo/task/Preview.vue
+++ b/src/components/veo/task/Preview.vue
@@ -9,6 +9,17 @@
         <span class="datetime">
           {{ $dayjs.format('' + new Date(parseFloat((modelValue?.created_at || '').toString()) * 1000)) }}
         </span>
+        <el-tooltip effect="dark" :content="$t('common.button.delete')" placement="top">
+          <button
+            v-if="modelValue?.id"
+            type="button"
+            class="btn-delete"
+            :aria-label="$t('common.button.delete')"
+            @click.stop="onDelete"
+          >
+            <delete-icon :size="'1em' as any" aria-hidden="true" focusable="false" />
+          </button>
+        </el-tooltip>
       </div>
       <div class="info">
         <div
@@ -118,6 +129,7 @@
 import {
   ApplicationIcon,
   ChannelIcon,
+  DeleteIcon,
   ExpandIcon,
   InfoIcon,
   LanguageIcon,
@@ -127,7 +139,7 @@ import {
   WarningIcon
 } from '@acedatacloud/core/icons/components';
 import { defineComponent } from 'vue';
-import { ElAlert, ElButton, ElTooltip } from 'element-plus';
+import { ElAlert, ElButton, ElTooltip, ElMessageBox, ElMessage } from 'element-plus';
 import { IVeoTask } from '@/models';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 import VideoPlayer from '@/components/common/VideoPlayer.vue';
@@ -137,6 +149,7 @@ import ApiCodeButton from '@/components/common/ApiCodeButton.vue';
 export default defineComponent({
   name: 'TaskPreview',
   components: {
+    DeleteIcon,
     ApplicationIcon,
     ChannelIcon,
     ExpandIcon,
@@ -194,6 +207,26 @@ export default defineComponent({
     }
   },
   methods: {
+    async onDelete() {
+      const id = this.modelValue?.id;
+      if (!id) return;
+      try {
+        await ElMessageBox.confirm(this.$t('common.message.deleteTaskConfirm'), this.$t('common.button.delete'), {
+          type: 'warning',
+          confirmButtonText: this.$t('common.button.delete'),
+          cancelButtonText: this.$t('common.button.cancel'),
+          confirmButtonClass: 'el-button--danger'
+        });
+      } catch {
+        return; // user cancelled
+      }
+      try {
+        await this.$store.dispatch('veo/deleteTask', { id });
+        ElMessage.success(this.$t('common.message.deleteTaskSuccess'));
+      } catch {
+        ElMessage.error(this.$t('common.message.deleteTaskFailed'));
+      }
+    },
     onDownload(event: MouseEvent, video_url: string) {
       event?.stopPropagation();
       console.log('on download');
@@ -233,6 +266,8 @@ $left-width: 70px;
     padding: 10px 10px 0 10px;
 
     .bot {
+      display: flex;
+      align-items: center;
       font-size: 16px;
       font-weight: bold;
       color: var(--el-color-primary);
@@ -243,9 +278,32 @@ $left-width: 70px;
       white-space: nowrap;
       .datetime {
         font-size: 12px;
+        overflow: hidden;
+        text-overflow: ellipsis;
         font-weight: normal;
         color: var(--el-text-color-secondary);
         margin-left: 10px;
+      }
+      .btn-delete {
+        margin-left: auto;
+        padding: 4px 6px;
+        border: none;
+        background: transparent;
+        cursor: pointer;
+        line-height: 1;
+        color: var(--el-text-color-secondary);
+        // Hover-reveal on pointer devices; keep it out of the way until wanted.
+        opacity: 0;
+        transition:
+          opacity 0.15s ease,
+          color 0.15s ease;
+        &:hover {
+          color: var(--el-color-danger);
+        }
+        // Touch devices have no hover — always show the control.
+        @media (hover: none) {
+          opacity: 1;
+        }
       }
     }
 
@@ -311,6 +369,11 @@ $left-width: 70px;
         margin-bottom: 10px;
       }
     }
+  }
+
+  // Reveal the trash icon when hovering anywhere on the card.
+  &:hover .main .bot .btn-delete {
+    opacity: 1;
   }
 }
 </style>

--- a/src/components/wan/task/Preview.vue
+++ b/src/components/wan/task/Preview.vue
@@ -9,6 +9,17 @@
         <span class="datetime">
           {{ $dayjs.format('' + new Date(parseFloat((modelValue?.created_at || '').toString()) * 1000)) }}
         </span>
+        <el-tooltip effect="dark" :content="$t('common.button.delete')" placement="top">
+          <button
+            v-if="modelValue?.id"
+            type="button"
+            class="btn-delete"
+            :aria-label="$t('common.button.delete')"
+            @click.stop="onDelete"
+          >
+            <delete-icon :size="'1em' as any" aria-hidden="true" focusable="false" />
+          </button>
+        </el-tooltip>
       </div>
       <div class="info">
         <p v-if="modelValue?.request?.prompt" class="prompt mt-2">
@@ -103,9 +114,16 @@
 </template>
 
 <script lang="ts">
-import { ChannelIcon, InfoIcon, MagicIcon, TimeIcon, WarningIcon } from '@acedatacloud/core/icons/components';
+import {
+  ChannelIcon,
+  DeleteIcon,
+  InfoIcon,
+  MagicIcon,
+  TimeIcon,
+  WarningIcon
+} from '@acedatacloud/core/icons/components';
 import { defineComponent } from 'vue';
-import { ElAlert, ElButton, ElTooltip } from 'element-plus';
+import { ElAlert, ElButton, ElTooltip, ElMessageBox, ElMessage } from 'element-plus';
 import { IWanTask } from '@/models';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 import VideoPlayer from '@/components/common/VideoPlayer.vue';
@@ -114,6 +132,7 @@ import ApiCodeButton from '@/components/common/ApiCodeButton.vue';
 export default defineComponent({
   name: 'TaskPreview',
   components: {
+    DeleteIcon,
     ChannelIcon,
     InfoIcon,
     MagicIcon,
@@ -157,6 +176,26 @@ export default defineComponent({
     }
   },
   methods: {
+    async onDelete() {
+      const id = this.modelValue?.id;
+      if (!id) return;
+      try {
+        await ElMessageBox.confirm(this.$t('common.message.deleteTaskConfirm'), this.$t('common.button.delete'), {
+          type: 'warning',
+          confirmButtonText: this.$t('common.button.delete'),
+          cancelButtonText: this.$t('common.button.cancel'),
+          confirmButtonClass: 'el-button--danger'
+        });
+      } catch {
+        return; // user cancelled
+      }
+      try {
+        await this.$store.dispatch('wan/deleteTask', { id });
+        ElMessage.success(this.$t('common.message.deleteTaskSuccess'));
+      } catch {
+        ElMessage.error(this.$t('common.message.deleteTaskFailed'));
+      }
+    },
     onDownload(videoUrl: string) {
       console.debug('on download wan video', videoUrl);
       window.open(videoUrl, '_blank');
@@ -192,6 +231,8 @@ $left-width: 70px;
     padding: 10px 10px 0 10px;
 
     .bot {
+      display: flex;
+      align-items: center;
       font-size: 16px;
       font-weight: bold;
       color: var(--el-color-primary);
@@ -202,9 +243,32 @@ $left-width: 70px;
       white-space: nowrap;
       .datetime {
         font-size: 12px;
+        overflow: hidden;
+        text-overflow: ellipsis;
         font-weight: normal;
         color: var(--el-text-color-secondary);
         margin-left: 10px;
+      }
+      .btn-delete {
+        margin-left: auto;
+        padding: 4px 6px;
+        border: none;
+        background: transparent;
+        cursor: pointer;
+        line-height: 1;
+        color: var(--el-text-color-secondary);
+        // Hover-reveal on pointer devices; keep it out of the way until wanted.
+        opacity: 0;
+        transition:
+          opacity 0.15s ease,
+          color 0.15s ease;
+        &:hover {
+          color: var(--el-color-danger);
+        }
+        // Touch devices have no hover — always show the control.
+        @media (hover: none) {
+          opacity: 1;
+        }
       }
     }
 
@@ -243,6 +307,11 @@ $left-width: 70px;
         }
       }
     }
+  }
+
+  // Reveal the trash icon when hovering anywhere on the card.
+  &:hover .main .bot .btn-delete {
+    opacity: 1;
   }
 }
 </style>

--- a/src/i18n/ar/common.json
+++ b/src/i18n/ar/common.json
@@ -1642,5 +1642,17 @@
   "player.volume": {
     "message": "Volume",
     "description": "Accessible label for the player volume control"
+  },
+  "message.deleteTaskConfirm": {
+    "message": "Delete this generation record? It will be removed from all your devices and cannot be recovered.",
+    "description": "Confirmation message shown before deleting a single task record"
+  },
+  "message.deleteTaskSuccess": {
+    "message": "Record deleted.",
+    "description": "Message shown after a task record is successfully deleted"
+  },
+  "message.deleteTaskFailed": {
+    "message": "Failed to delete. Please try again later.",
+    "description": "Message shown when deleting a task record fails"
   }
 }

--- a/src/i18n/de/common.json
+++ b/src/i18n/de/common.json
@@ -1642,5 +1642,17 @@
   "player.volume": {
     "message": "Volume",
     "description": "Accessible label for the player volume control"
+  },
+  "message.deleteTaskConfirm": {
+    "message": "Delete this generation record? It will be removed from all your devices and cannot be recovered.",
+    "description": "Confirmation message shown before deleting a single task record"
+  },
+  "message.deleteTaskSuccess": {
+    "message": "Record deleted.",
+    "description": "Message shown after a task record is successfully deleted"
+  },
+  "message.deleteTaskFailed": {
+    "message": "Failed to delete. Please try again later.",
+    "description": "Message shown when deleting a task record fails"
   }
 }

--- a/src/i18n/el/common.json
+++ b/src/i18n/el/common.json
@@ -1642,5 +1642,17 @@
   "player.volume": {
     "message": "Volume",
     "description": "Accessible label for the player volume control"
+  },
+  "message.deleteTaskConfirm": {
+    "message": "Delete this generation record? It will be removed from all your devices and cannot be recovered.",
+    "description": "Confirmation message shown before deleting a single task record"
+  },
+  "message.deleteTaskSuccess": {
+    "message": "Record deleted.",
+    "description": "Message shown after a task record is successfully deleted"
+  },
+  "message.deleteTaskFailed": {
+    "message": "Failed to delete. Please try again later.",
+    "description": "Message shown when deleting a task record fails"
   }
 }

--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -439,6 +439,18 @@
     "message": "Are you sure you want to delete?",
     "description": "Message confirming that the user wants to delete an item"
   },
+  "message.deleteTaskConfirm": {
+    "message": "Delete this generation record? It will be removed from all your devices and cannot be recovered.",
+    "description": "Confirmation message shown before deleting a single task record"
+  },
+  "message.deleteTaskSuccess": {
+    "message": "Record deleted.",
+    "description": "Message shown after a task record is successfully deleted"
+  },
+  "message.deleteTaskFailed": {
+    "message": "Failed to delete. Please try again later.",
+    "description": "Message shown when deleting a task record fails"
+  },
   "message.expiredAt": {
     "message": "Expiration Time",
     "description": "Message displaying the expiration time of the service"

--- a/src/i18n/es/common.json
+++ b/src/i18n/es/common.json
@@ -1642,5 +1642,17 @@
   "player.volume": {
     "message": "Volume",
     "description": "Accessible label for the player volume control"
+  },
+  "message.deleteTaskConfirm": {
+    "message": "Delete this generation record? It will be removed from all your devices and cannot be recovered.",
+    "description": "Confirmation message shown before deleting a single task record"
+  },
+  "message.deleteTaskSuccess": {
+    "message": "Record deleted.",
+    "description": "Message shown after a task record is successfully deleted"
+  },
+  "message.deleteTaskFailed": {
+    "message": "Failed to delete. Please try again later.",
+    "description": "Message shown when deleting a task record fails"
   }
 }

--- a/src/i18n/fi/common.json
+++ b/src/i18n/fi/common.json
@@ -1642,5 +1642,17 @@
   "player.volume": {
     "message": "Volume",
     "description": "Accessible label for the player volume control"
+  },
+  "message.deleteTaskConfirm": {
+    "message": "Delete this generation record? It will be removed from all your devices and cannot be recovered.",
+    "description": "Confirmation message shown before deleting a single task record"
+  },
+  "message.deleteTaskSuccess": {
+    "message": "Record deleted.",
+    "description": "Message shown after a task record is successfully deleted"
+  },
+  "message.deleteTaskFailed": {
+    "message": "Failed to delete. Please try again later.",
+    "description": "Message shown when deleting a task record fails"
   }
 }

--- a/src/i18n/fr/common.json
+++ b/src/i18n/fr/common.json
@@ -1642,5 +1642,17 @@
   "player.volume": {
     "message": "Volume",
     "description": "Accessible label for the player volume control"
+  },
+  "message.deleteTaskConfirm": {
+    "message": "Delete this generation record? It will be removed from all your devices and cannot be recovered.",
+    "description": "Confirmation message shown before deleting a single task record"
+  },
+  "message.deleteTaskSuccess": {
+    "message": "Record deleted.",
+    "description": "Message shown after a task record is successfully deleted"
+  },
+  "message.deleteTaskFailed": {
+    "message": "Failed to delete. Please try again later.",
+    "description": "Message shown when deleting a task record fails"
   }
 }

--- a/src/i18n/it/common.json
+++ b/src/i18n/it/common.json
@@ -1642,5 +1642,17 @@
   "player.volume": {
     "message": "Volume",
     "description": "Accessible label for the player volume control"
+  },
+  "message.deleteTaskConfirm": {
+    "message": "Delete this generation record? It will be removed from all your devices and cannot be recovered.",
+    "description": "Confirmation message shown before deleting a single task record"
+  },
+  "message.deleteTaskSuccess": {
+    "message": "Record deleted.",
+    "description": "Message shown after a task record is successfully deleted"
+  },
+  "message.deleteTaskFailed": {
+    "message": "Failed to delete. Please try again later.",
+    "description": "Message shown when deleting a task record fails"
   }
 }

--- a/src/i18n/ja/common.json
+++ b/src/i18n/ja/common.json
@@ -1642,5 +1642,17 @@
   "player.volume": {
     "message": "Volume",
     "description": "Accessible label for the player volume control"
+  },
+  "message.deleteTaskConfirm": {
+    "message": "Delete this generation record? It will be removed from all your devices and cannot be recovered.",
+    "description": "Confirmation message shown before deleting a single task record"
+  },
+  "message.deleteTaskSuccess": {
+    "message": "Record deleted.",
+    "description": "Message shown after a task record is successfully deleted"
+  },
+  "message.deleteTaskFailed": {
+    "message": "Failed to delete. Please try again later.",
+    "description": "Message shown when deleting a task record fails"
   }
 }

--- a/src/i18n/ko/common.json
+++ b/src/i18n/ko/common.json
@@ -1642,5 +1642,17 @@
   "player.volume": {
     "message": "Volume",
     "description": "Accessible label for the player volume control"
+  },
+  "message.deleteTaskConfirm": {
+    "message": "Delete this generation record? It will be removed from all your devices and cannot be recovered.",
+    "description": "Confirmation message shown before deleting a single task record"
+  },
+  "message.deleteTaskSuccess": {
+    "message": "Record deleted.",
+    "description": "Message shown after a task record is successfully deleted"
+  },
+  "message.deleteTaskFailed": {
+    "message": "Failed to delete. Please try again later.",
+    "description": "Message shown when deleting a task record fails"
   }
 }

--- a/src/i18n/pl/common.json
+++ b/src/i18n/pl/common.json
@@ -1642,5 +1642,17 @@
   "player.volume": {
     "message": "Volume",
     "description": "Accessible label for the player volume control"
+  },
+  "message.deleteTaskConfirm": {
+    "message": "Delete this generation record? It will be removed from all your devices and cannot be recovered.",
+    "description": "Confirmation message shown before deleting a single task record"
+  },
+  "message.deleteTaskSuccess": {
+    "message": "Record deleted.",
+    "description": "Message shown after a task record is successfully deleted"
+  },
+  "message.deleteTaskFailed": {
+    "message": "Failed to delete. Please try again later.",
+    "description": "Message shown when deleting a task record fails"
   }
 }

--- a/src/i18n/pt/common.json
+++ b/src/i18n/pt/common.json
@@ -1642,5 +1642,17 @@
   "player.volume": {
     "message": "Volume",
     "description": "Accessible label for the player volume control"
+  },
+  "message.deleteTaskConfirm": {
+    "message": "Delete this generation record? It will be removed from all your devices and cannot be recovered.",
+    "description": "Confirmation message shown before deleting a single task record"
+  },
+  "message.deleteTaskSuccess": {
+    "message": "Record deleted.",
+    "description": "Message shown after a task record is successfully deleted"
+  },
+  "message.deleteTaskFailed": {
+    "message": "Failed to delete. Please try again later.",
+    "description": "Message shown when deleting a task record fails"
   }
 }

--- a/src/i18n/ru/common.json
+++ b/src/i18n/ru/common.json
@@ -1642,5 +1642,17 @@
   "player.volume": {
     "message": "Volume",
     "description": "Accessible label for the player volume control"
+  },
+  "message.deleteTaskConfirm": {
+    "message": "Delete this generation record? It will be removed from all your devices and cannot be recovered.",
+    "description": "Confirmation message shown before deleting a single task record"
+  },
+  "message.deleteTaskSuccess": {
+    "message": "Record deleted.",
+    "description": "Message shown after a task record is successfully deleted"
+  },
+  "message.deleteTaskFailed": {
+    "message": "Failed to delete. Please try again later.",
+    "description": "Message shown when deleting a task record fails"
   }
 }

--- a/src/i18n/sr/common.json
+++ b/src/i18n/sr/common.json
@@ -1642,5 +1642,17 @@
   "player.volume": {
     "message": "Volume",
     "description": "Accessible label for the player volume control"
+  },
+  "message.deleteTaskConfirm": {
+    "message": "Delete this generation record? It will be removed from all your devices and cannot be recovered.",
+    "description": "Confirmation message shown before deleting a single task record"
+  },
+  "message.deleteTaskSuccess": {
+    "message": "Record deleted.",
+    "description": "Message shown after a task record is successfully deleted"
+  },
+  "message.deleteTaskFailed": {
+    "message": "Failed to delete. Please try again later.",
+    "description": "Message shown when deleting a task record fails"
   }
 }

--- a/src/i18n/sv/common.json
+++ b/src/i18n/sv/common.json
@@ -1642,5 +1642,17 @@
   "player.volume": {
     "message": "Volume",
     "description": "Accessible label for the player volume control"
+  },
+  "message.deleteTaskConfirm": {
+    "message": "Delete this generation record? It will be removed from all your devices and cannot be recovered.",
+    "description": "Confirmation message shown before deleting a single task record"
+  },
+  "message.deleteTaskSuccess": {
+    "message": "Record deleted.",
+    "description": "Message shown after a task record is successfully deleted"
+  },
+  "message.deleteTaskFailed": {
+    "message": "Failed to delete. Please try again later.",
+    "description": "Message shown when deleting a task record fails"
   }
 }

--- a/src/i18n/uk/common.json
+++ b/src/i18n/uk/common.json
@@ -1642,5 +1642,17 @@
   "player.volume": {
     "message": "Volume",
     "description": "Accessible label for the player volume control"
+  },
+  "message.deleteTaskConfirm": {
+    "message": "Delete this generation record? It will be removed from all your devices and cannot be recovered.",
+    "description": "Confirmation message shown before deleting a single task record"
+  },
+  "message.deleteTaskSuccess": {
+    "message": "Record deleted.",
+    "description": "Message shown after a task record is successfully deleted"
+  },
+  "message.deleteTaskFailed": {
+    "message": "Failed to delete. Please try again later.",
+    "description": "Message shown when deleting a task record fails"
   }
 }

--- a/src/i18n/zh-CN/common.json
+++ b/src/i18n/zh-CN/common.json
@@ -443,6 +443,18 @@
     "message": "您确定要删除吗？",
     "description": "确认用户要删除某项内容的消息"
   },
+  "message.deleteTaskConfirm": {
+    "message": "确定要删除这条生成记录吗？删除后将从所有设备移除，且无法恢复。",
+    "description": "删除单条任务生成记录前显示的确认消息"
+  },
+  "message.deleteTaskSuccess": {
+    "message": "记录已删除。",
+    "description": "成功删除任务记录后显示的消息"
+  },
+  "message.deleteTaskFailed": {
+    "message": "删除失败，请稍后重试。",
+    "description": "删除任务记录失败时显示的消息"
+  },
   "message.expiredAt": {
     "message": "过期时间",
     "description": "用于显示服务的过期时间"

--- a/src/i18n/zh-TW/common.json
+++ b/src/i18n/zh-TW/common.json
@@ -1642,5 +1642,17 @@
   "player.volume": {
     "message": "Volume",
     "description": "Accessible label for the player volume control"
+  },
+  "message.deleteTaskConfirm": {
+    "message": "Delete this generation record? It will be removed from all your devices and cannot be recovered.",
+    "description": "Confirmation message shown before deleting a single task record"
+  },
+  "message.deleteTaskSuccess": {
+    "message": "Record deleted.",
+    "description": "Message shown after a task record is successfully deleted"
+  },
+  "message.deleteTaskFailed": {
+    "message": "Failed to delete. Please try again later.",
+    "description": "Message shown when deleting a task record fails"
   }
 }

--- a/src/operators/baseTaskOperator.ts
+++ b/src/operators/baseTaskOperator.ts
@@ -132,4 +132,21 @@ export class BaseTaskOperator<
       headers: { ...GENERATE_HEADERS, authorization: `Bearer ${options.token}` }
     });
   }
+
+  // Hard-delete one of the caller's own history tasks. The worker requires both
+  // id and user_id (scoped to the requester), so a leaked id alone can't wipe
+  // another user's record. Shared by every task service via createTaskActions.
+  async delete(
+    id: string,
+    options: { token: string; userId?: string; applicationId?: string }
+  ): Promise<AxiosResponse<{ id: string; deleted: boolean }>> {
+    return axios.post(
+      this.tasksPath,
+      { action: 'delete', id, user_id: options.userId, application_id: options.applicationId },
+      {
+        baseURL: BASE_URL_API,
+        headers: { ...TASK_HEADERS, authorization: `Bearer ${options.token}` }
+      }
+    );
+  }
 }

--- a/src/store/factories/createTaskActions.test.ts
+++ b/src/store/factories/createTaskActions.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createTaskActions } from './createTaskActions';
+
+// Minimal harness: invoke a single action from the bundle with a fake context.
+const invoke = async (
+  action: unknown,
+  ctx: { state?: any; rootState?: any; commits?: Array<[string, unknown]> },
+  payload?: unknown
+) => {
+  const commits = ctx.commits ?? [];
+  const context = {
+    state: ctx.state ?? {},
+    rootState: ctx.rootState ?? {},
+    commit: (type: string, p: unknown) => commits.push([type, p])
+  };
+  return (action as (c: unknown, p: unknown) => Promise<unknown>)(context, payload);
+};
+
+const makeActions = (operator: any) =>
+  createTaskActions<unknown, { id: string }, Record<string, unknown>>({
+    serviceId: 'svc-1',
+    operator
+  });
+
+describe('createTaskActions/deleteTask', () => {
+  it('optimistically removes the task and calls the operator with id + user_id', async () => {
+    const del = vi.fn().mockResolvedValue({ data: { id: 'b', deleted: true } });
+    const actions: any = makeActions({ tasks: vi.fn(), delete: del });
+    const commits: Array<[string, unknown]> = [];
+    const state = {
+      credential: { token: 'tok' },
+      tasks: { items: [{ id: 'a' }, { id: 'b' }, { id: 'c' }], total: 3 }
+    };
+
+    await invoke(actions.deleteTask, { state, rootState: { user: { id: 'user-1' } }, commits }, { id: 'b' });
+
+    // Card + total updated BEFORE the request resolves (optimistic).
+    expect(commits[0]).toEqual(['setTasksItems', [{ id: 'a' }, { id: 'c' }]]);
+    expect(commits[1]).toEqual(['setTasksTotal', 2]);
+    expect(del).toHaveBeenCalledWith('b', { token: 'tok', userId: 'user-1' });
+  });
+
+  it('rolls back the list and rethrows when the server reports deleted:false', async () => {
+    // Skip-auth worker answers 200 even when nothing matched (foreign/blank
+    // user_id) — the card must NOT stay dropped.
+    const del = vi.fn().mockResolvedValue({ data: { id: 'a', deleted: false } });
+    const actions: any = makeActions({ tasks: vi.fn(), delete: del });
+    const commits: Array<[string, unknown]> = [];
+    const items = [{ id: 'a' }, { id: 'b' }];
+    const state = { credential: { token: 'tok' }, tasks: { items, total: 2 } };
+
+    await expect(
+      invoke(actions.deleteTask, { state, rootState: { user: { id: 'u' } }, commits }, 'a')
+    ).rejects.toThrow();
+
+    expect(commits).toEqual([
+      ['setTasksItems', [{ id: 'b' }]],
+      ['setTasksTotal', 1],
+      ['setTasksItems', items],
+      ['setTasksTotal', 2]
+    ]);
+  });
+
+  it('rolls back the list and rethrows when the delete fails', async () => {
+    const del = vi.fn().mockRejectedValue(new Error('network'));
+    const actions: any = makeActions({ tasks: vi.fn(), delete: del });
+    const commits: Array<[string, unknown]> = [];
+    const items = [{ id: 'a' }, { id: 'b' }];
+    const state = { credential: { token: 'tok' }, tasks: { items, total: 2 } };
+
+    await expect(invoke(actions.deleteTask, { state, rootState: { user: { id: 'u' } }, commits }, 'a')).rejects.toThrow(
+      'network'
+    );
+
+    // optimistic remove, then rollback to the original snapshot.
+    expect(commits).toEqual([
+      ['setTasksItems', [{ id: 'b' }]],
+      ['setTasksTotal', 1],
+      ['setTasksItems', items],
+      ['setTasksTotal', 2]
+    ]);
+  });
+
+  it('is a no-op when no id is supplied', async () => {
+    const del = vi.fn();
+    const actions: any = makeActions({ tasks: vi.fn(), delete: del });
+    const commits: Array<[string, unknown]> = [];
+
+    await invoke(actions.deleteTask, { state: { credential: { token: 't' }, tasks: { items: [] } }, commits }, {});
+
+    expect(del).not.toHaveBeenCalled();
+    expect(commits).toEqual([]);
+  });
+
+  it('throws without touching the list when the operator cannot delete', async () => {
+    const actions: any = makeActions({ tasks: vi.fn() }); // no delete()
+    const commits: Array<[string, unknown]> = [];
+    const state = { credential: { token: 't' }, tasks: { items: [{ id: 'a' }], total: 1 } };
+
+    await expect(invoke(actions.deleteTask, { state, rootState: {}, commits }, 'a')).rejects.toThrow();
+    expect(commits).toEqual([]);
+  });
+});

--- a/src/store/factories/createTaskActions.ts
+++ b/src/store/factories/createTaskActions.ts
@@ -35,6 +35,10 @@ export interface ITaskServiceState<TConfig, TTask> {
 /** Minimal contract every per-service operator must satisfy. */
 export interface ITaskOperator<TFilter, TTask> {
   tasks(filter: TFilter, options: { token: string }): Promise<{ data: { items: TTask[]; count?: number } }>;
+  delete?(
+    id: string,
+    options: { token: string; userId?: string; applicationId?: string }
+  ): Promise<{ data: { id: string; deleted: boolean } }>;
 }
 
 /** Optional argument bag the page-level `dispatch('xxx/getTasks', ...)` passes. */
@@ -196,6 +200,46 @@ export function createTaskActions<TConfig, TTask, TFilter>(opts: {
     return response.data.items;
   };
 
+  // Hard-delete one of the caller's own tasks and drop it from the list.
+  // Optimistic: remove the card + decrement total FIRST so the ≤5s poll can't
+  // flash it back mid-flight; on failure, roll the snapshot back and rethrow.
+  const deleteTask = async (
+    { commit, state, rootState }: ActionContext<S, IRootState>,
+    payload: { id: string } | string
+  ): Promise<void> => {
+    const id = typeof payload === 'string' ? payload : payload?.id;
+    if (!id) {
+      return;
+    }
+    const token = state.credential?.token;
+    if (!token || !opts.operator.delete) {
+      throw new Error('delete not available');
+    }
+    const prevItems = state?.tasks?.items || [];
+    const prevTotal = state?.tasks?.total;
+    const nextItems = (prevItems as Array<{ id?: string }>).filter((t) => t?.id !== id) as TTask[];
+    commit('setTasksItems', nextItems);
+    if (typeof prevTotal === 'number') {
+      commit('setTasksTotal', Math.max(0, prevTotal - (prevItems.length - nextItems.length)));
+    }
+    try {
+      const response = await opts.operator.delete(id, { token, userId: rootState?.user?.id });
+      // A skip-auth worker answers 200 even when nothing matched {id, user_id}
+      // (blank/foreign user_id, or already gone). Treat only deleted===true as
+      // success so the row isn't optimistically dropped while it still exists
+      // server-side (the next poll would flash it back and the toast would lie).
+      if (!response?.data?.deleted) {
+        throw new Error('task not deleted');
+      }
+    } catch (error) {
+      commit('setTasksItems', prevItems);
+      if (typeof prevTotal === 'number') {
+        commit('setTasksTotal', prevTotal);
+      }
+      throw error;
+    }
+  };
+
   // Trivial setters — match the per-service spelling exactly.
   const resetAll = ({ commit }: ActionContext<S, IRootState>): void => commit('resetAll');
   const setApplications = ({ commit }: ActionContext<S, IRootState>, payload: IApplication[]): void =>
@@ -227,6 +271,7 @@ export function createTaskActions<TConfig, TTask, TFilter>(opts: {
     setTasksItems,
     setTasksTotal,
     setTasksActive,
-    getTasks
+    getTasks,
+    deleteTask
   };
 }


### PR DESCRIPTION
## What & why

A customer (office user) asked how to delete GPT-image generation history — the web page syncs across devices, exposing private prompts to colleagues. History lives server-side in each worker's MongoDB `tasks` collection, so the only real fix is a **server-side hard delete**. PlatformService#1601 added `action:'delete'` to `/tasks`; this PR wires the **frontend**.

Scope of this PR (per the approved "GPT-image + Nano Banana first" rollout): shared plumbing + the delete button on **openaiimage** and **nanobanana** cards only. The other 19 scenarios (except chat) are a per-card copy in a follow-up PR.

## Changes

- **`baseTaskOperator.delete(id, {token, userId, applicationId})`** — `POST {action:'delete', id, user_id, application_id}` with Bearer auth. Shared base → every task operator inherits it.
- **`createTaskActions.deleteTask`** — optimistic remove of the card + `total` decrement, then `await operator.delete(...)`. Requires `response.data.deleted === true`: a skip-auth worker answers `200 {deleted:false}` on a no-op (foreign/blank `user_id`, or already gone), which must **roll back**, not toast success. Any failure rolls the snapshot back and rethrows.
- **`components/{openaiimage,nanobanana}/task/Preview.vue`** — hover-reveal red trash button in the `.bot` header (visible for pending/failed/success alike; always shown on touch via `@media (hover: none)`). `ElMessageBox.confirm` → dispatch `<svc>/deleteTask` → success/fail toast. Card stays presentational otherwise; each dispatches to its OWN namespaced module.
- **i18n** — `common.message.deleteTask{Confirm,Success,Failed}` in zh-CN + en, backfilled to the other 15 locales (coverage gate green).
- **Tests** — `createTaskActions` (optimistic remove; `deleted:false` rollback; network-error rollback; no-id no-op; missing-operator guard) + `openaiimage` Preview (button on every status, dispatch after confirm, no dispatch on cancel).

## Dependency

E2E works only once **PlatformService#1601** (the `/tasks` delete action) is deployed to the affected workers. UI is safe before then — a failed delete rolls back and toasts an error.

## Verification

- `npx vue-tsc --noEmit` — clean
- `npx eslint` — clean on all changed files
- `npx vitest run` — 14 tests pass (createTaskActions + both Preview suites)
- `python3 scripts/check_i18n_coverage.py` — OK (17 locales × 45 namespaces)

## 🤖 对抗评审

Reviewer: Claude `general-purpose` subagent (codex `exec` timed out locally, per protocol fallback). One review round; converged.

| # | Severity | Finding | Resolution |
|---|---|---|---|
| 1 | med | Success inferred from HTTP 2xx, never `response.data.deleted`. A no-op delete (blank/foreign `user_id`, id already gone) resolves 200 → card optimistically dropped **and** false "deleted" toast, then the next ≤5s poll flashes it back. Also covers the guest/undefined-`user_id` case. | **FIXED** — `deleteTask` now throws unless `response.data.deleted === true`, so it rolls back + shows the error toast. Added a `deleted:false` rollback test. |
| 2 | low | The "optimistic-remove-first can't flash it back" claim doesn't hold for a poll already **in flight** before the delete commits: its `retrieve_batch` response may still carry the id, and `mergeAndSortLists` re-adds it. | **ACCEPTED (rebut)** — transient only; self-heals on the next clean poll (~5s) once the server-side delete is committed. Not data loss. Adding request-generation tracking to `getTasks` is disproportionate for a ≤5s cosmetic flicker. |
| 3 | low | Rollback restores the pre-delete snapshot, so a task the poll appended between optimistic-remove and a **delete failure** is dropped from the list. | **ACCEPTED (rebut)** — failure-path only and self-healed by the next poll; a targeted single-id re-insert would add complexity for an edge that reconciles within 5s. |

CLEAN on: wrong-store dispatch (each card targets its own module), total drift (`Math.max(0,…)` guard, delta 0 when absent), Vue/Element correctness (`@click.stop`, `type="button"` needs no `emits`, `aria-label` + `aria-hidden` icon, tooltip teleported so header `overflow:hidden` doesn't clip, SCSS hover selector resolves, `ElButton` still used), i18n key coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
