### PR TITLE
Fix tool progress splitting assistant text

### DIFF
--- a/change/@acedatacloud-nexior-aichat-tool-content-order.json
+++ b/change/@acedatacloud-nexior-aichat-tool-content-order.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Keep assistant text contiguous when an early tool announcement arrives mid-stream, while preserving live tool progress",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/chat/chatStreamContent.test.ts
+++ b/src/components/chat/chatStreamContent.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import {
+  commitStreamTool,
+  createChatStreamContentState,
+  getStreamDisplayParts,
+  setStreamText,
+  upsertPendingTool
+} from './chatStreamContent';
+
+describe('chatStreamContent', () => {
+  it('keeps text contiguous around an early tool announcement across turns', () => {
+    const state = createChatStreamContentState();
+
+    setStreamText(state, 'AceDat');
+    upsertPendingTool(state, { tool_id: 'tool_1', tool_name: 'Bash', input: {} });
+    setStreamText(state, 'AceDataCloud');
+
+    expect(getStreamDisplayParts(state)).toEqual([
+      { type: 'text', text: 'AceDataCloud' },
+      expect.objectContaining({ type: 'tool_use', tool_id: 'tool_1' })
+    ]);
+
+    commitStreamTool(state, 'tool_1', 'AceDataCloud'.length);
+    setStreamText(state, 'AceDataCloudChecking status');
+    upsertPendingTool(state, { tool_id: 'tool_2', tool_name: 'Bash', input: {} });
+
+    expect(getStreamDisplayParts(state)).toEqual([
+      { type: 'text', text: 'AceDataCloud' },
+      expect.objectContaining({ type: 'tool_use', tool_id: 'tool_1' }),
+      { type: 'text', text: 'Checking status' },
+      expect.objectContaining({ type: 'tool_use', tool_id: 'tool_2' })
+    ]);
+  });
+
+  it('keeps parallel pending tools ordered after the complete turn text', () => {
+    const state = createChatStreamContentState();
+
+    setStreamText(state, 'Checking');
+    upsertPendingTool(state, { tool_id: 'tool_1', tool_name: 'first', input: {} });
+    upsertPendingTool(state, { tool_id: 'tool_2', tool_name: 'second', input: {} });
+    setStreamText(state, 'Checking both services');
+
+    expect(getStreamDisplayParts(state)).toEqual([
+      { type: 'text', text: 'Checking both services' },
+      expect.objectContaining({ tool_id: 'tool_1' }),
+      expect.objectContaining({ tool_id: 'tool_2' })
+    ]);
+
+    commitStreamTool(state, 'tool_1', 'Checking both services'.length);
+    commitStreamTool(state, 'tool_2', 'Checking both services'.length);
+    expect(state.contentParts).toEqual([
+      { type: 'text', text: 'Checking both services' },
+      expect.objectContaining({ tool_id: 'tool_1' }),
+      expect.objectContaining({ tool_id: 'tool_2' })
+    ]);
+  });
+});

--- a/src/components/chat/chatStreamContent.ts
+++ b/src/components/chat/chatStreamContent.ts
@@ -1,0 +1,81 @@
+import type { IChatMessageContentItem } from '@/models';
+
+export interface ChatStreamContentState {
+  contentParts: IChatMessageContentItem[];
+  toolMap: Map<string, IChatMessageContentItem>;
+  pendingToolIds: string[];
+  committedToolIds: Set<string>;
+  currentText: string;
+  answerOffset: number;
+}
+
+export type StreamToolPatch = Omit<Partial<IChatMessageContentItem>, 'tool_id' | 'type'> & { tool_id: string };
+
+export function createChatStreamContentState(): ChatStreamContentState {
+  return {
+    contentParts: [],
+    toolMap: new Map(),
+    pendingToolIds: [],
+    committedToolIds: new Set(),
+    currentText: '',
+    answerOffset: 0
+  };
+}
+
+export function upsertPendingTool(state: ChatStreamContentState, patch: StreamToolPatch): IChatMessageContentItem {
+  let tool = state.toolMap.get(patch.tool_id);
+  const definedPatch = Object.fromEntries(Object.entries(patch).filter(([, value]) => value !== undefined));
+
+  if (tool) {
+    Object.assign(tool, definedPatch);
+    return tool;
+  }
+
+  tool = {
+    type: 'tool_use',
+    status: 'running',
+    ...definedPatch
+  };
+  state.toolMap.set(patch.tool_id, tool);
+  state.pendingToolIds.push(patch.tool_id);
+  return tool;
+}
+
+export function setStreamText(state: ChatStreamContentState, answer: string): void {
+  state.currentText = answer.slice(state.answerOffset);
+}
+
+export function flushStreamText(state: ChatStreamContentState, answerLength: number): void {
+  if (state.currentText) {
+    state.contentParts.push({ type: 'text', text: state.currentText });
+    state.currentText = '';
+  }
+  state.answerOffset = answerLength;
+}
+
+export function commitStreamTool(
+  state: ChatStreamContentState,
+  toolId: string,
+  answerLength: number
+): IChatMessageContentItem | undefined {
+  const tool = state.toolMap.get(toolId);
+  if (!tool || state.committedToolIds.has(toolId)) return tool;
+
+  flushStreamText(state, answerLength);
+  state.contentParts.push(tool);
+  state.committedToolIds.add(toolId);
+  state.pendingToolIds = state.pendingToolIds.filter((id) => id !== toolId);
+  return tool;
+}
+
+export function getStreamDisplayParts(state: ChatStreamContentState): IChatMessageContentItem[] {
+  const parts = [...state.contentParts];
+  if (state.currentText) {
+    parts.push({ type: 'text', text: state.currentText });
+  }
+  for (const toolId of state.pendingToolIds) {
+    const tool = state.toolMap.get(toolId);
+    if (tool) parts.push(tool);
+  }
+  return parts;
+}

--- a/src/operators/chat.test.ts
+++ b/src/operators/chat.test.ts
@@ -40,6 +40,7 @@ describe('chatOperator.chatConversation SSE forwarding', () => {
             'data: {"type":"tool_use_start","tool_id":"call_1","tool_name":"Bash","input":{}}\n',
             'data: {"type":"tool_progress","tool_id":"call_1","progress":"{\\"command\\":\\""}\n',
             'data: {"type":"tool_progress","tool_id":"call_1","progress":"echo hi\\"}"}\n',
+            'data: {"type":"tool_use_commit","tool_id":"call_1","tool_name":"Bash","input":{"command":"echo hi"}}\n',
             'data: [DONE]\n'
           ])
         )
@@ -56,6 +57,10 @@ describe('chatOperator.chatConversation SSE forwarding', () => {
     expect(progressEvents.every((e) => e.tool_id === 'call_1')).toBe(true);
     const argText = progressEvents.map((e) => e.progress ?? '').join('');
     expect(argText).toBe('{"command":"echo hi"}');
+    expect(events.find((e) => e.type === 'tool_use_commit')).toMatchObject({
+      tool_id: 'call_1',
+      input: { command: 'echo hi' }
+    });
   });
 
   it('forwards browser execution state with a sanitized origin', async () => {

--- a/src/pages/chat/Conversation.vue
+++ b/src/pages/chat/Conversation.vue
@@ -128,6 +128,14 @@ import { hasLoadedConversationMessages } from '@/components/chat/conversationRes
 import { reduceBrowserToolExecution } from '@/utils/browserToolExecution';
 import { chatOperator } from '@/operators';
 import { ElButton, ElSkeleton, ElSkeletonItem, ElTooltip } from 'element-plus';
+import {
+  commitStreamTool,
+  createChatStreamContentState,
+  flushStreamText,
+  getStreamDisplayParts,
+  setStreamText,
+  upsertPendingTool
+} from '@/components/chat/chatStreamContent';
 
 export interface IData {
   drawer: boolean;
@@ -1219,22 +1227,12 @@ export default defineComponent({
       // Messages are only appended during a turn, so this index stays valid for
       // the slot we own.
       const targetIndex = this.messages.length - 1;
-      // Track content parts for tool-calling interleaving
-      const contentParts: IChatMessageContentItem[] = [];
-      const toolMap = new Map<string, IChatMessageContentItem>();
+      const streamContent = createChatStreamContentState();
+      const { contentParts, toolMap } = streamContent;
       const pendingBrowserUpdates = new Map<
         string,
         Pick<IChatMessageContentItem, 'execution_state' | 'execution_sequence' | 'origin'>
       >();
-      let currentText = '';
-      // The aichat2 operator emits `response.answer` as the full
-      // accumulated text since the start of the turn. Whenever we flush
-      // currentText as its own content block (because a tool_use or a
-      // card arrives mid-stream and has to land between text segments),
-      // bump this offset so the next text_delta only contains the
-      // *remaining* text instead of duplicating everything we already
-      // pushed.
-      let answerOffset = 0;
       chatOperator
         .chatConversation(body, {
           token,
@@ -1263,46 +1261,25 @@ export default defineComponent({
               const target = this.messages[targetIndex];
               target.thinking = (target.thinking ?? '') + response.content;
             } else if (response.type === 'tool_use_start' && response.tool_id) {
-              // The worker announces a tool call the instant its name is known
-              // (arguments may still be streaming) and then re-emits
-              // tool_use_start once with the full parsed input / execution.
-              // UPSERT by tool_id so the two starts merge into ONE block
-              // instead of rendering a duplicate.
-              let toolItem = toolMap.get(response.tool_id);
-              if (toolItem) {
-                if (response.tool_name) toolItem.tool_name = response.tool_name;
-                if (response.tool_display_name) toolItem.tool_display_name = response.tool_display_name;
-                if (response.execution) toolItem.execution = response.execution;
-                if (response.execution === 'browser') {
-                  Object.assign(toolItem, reduceBrowserToolExecution(toolItem, response));
-                  const pending = pendingBrowserUpdates.get(response.tool_id);
-                  if (pending) {
-                    Object.assign(toolItem, reduceBrowserToolExecution(toolItem, pending));
-                    pendingBrowserUpdates.delete(response.tool_id);
-                  }
+              const toolItem = upsertPendingTool(streamContent, {
+                tool_id: response.tool_id,
+                tool_name: response.tool_name,
+                tool_display_name: response.tool_display_name,
+                execution: response.execution,
+                input: response.input
+              });
+              if (response.execution === 'browser') {
+                Object.assign(toolItem, reduceBrowserToolExecution(toolItem, response));
+                const pending = pendingBrowserUpdates.get(response.tool_id);
+                if (pending) {
+                  Object.assign(toolItem, reduceBrowserToolExecution(toolItem, pending));
+                  pendingBrowserUpdates.delete(response.tool_id);
                 }
-                if (response.input && Object.keys(response.input).length > 0) {
-                  toolItem.input = response.input;
-                }
-              } else {
-                // Flush any accumulated text before the new tool block.
-                if (currentText) {
-                  contentParts.push({ type: 'text', text: currentText });
-                  currentText = '';
-                  answerOffset = response.answer?.length ?? 0;
-                }
-                toolItem = {
-                  type: 'tool_use',
-                  tool_id: response.tool_id,
-                  tool_name: response.tool_name,
-                  tool_display_name: response.tool_display_name,
-                  execution: response.execution,
-                  ...(response.execution === 'browser' ? reduceBrowserToolExecution({}, response) : {}),
-                  input: response.input,
-                  status: 'running'
-                };
-                contentParts.push(toolItem);
-                toolMap.set(response.tool_id, toolItem);
+              }
+              // Older workers have no explicit commit event. Their late
+              // client/browser start arrives only after full input exists.
+              if (response.execution === 'client' || response.execution === 'browser') {
+                commitStreamTool(streamContent, response.tool_id, response.answer?.length ?? 0);
               }
               // Desktop: defer the local run until this paused stream fully
               // finalizes (so this.conversationId + route are settled for a
@@ -1324,6 +1301,18 @@ export default defineComponent({
                   input: response.input || {}
                 });
               }
+            } else if (response.type === 'tool_use_commit' && response.tool_id) {
+              const toolItem = upsertPendingTool(streamContent, {
+                tool_id: response.tool_id,
+                tool_name: response.tool_name,
+                tool_display_name: response.tool_display_name,
+                execution: response.execution,
+                input: response.input
+              });
+              if (response.execution === 'browser') {
+                Object.assign(toolItem, reduceBrowserToolExecution(toolItem, response));
+              }
+              commitStreamTool(streamContent, response.tool_id, response.answer?.length ?? 0);
             } else if (response.type === 'tool_progress' && response.tool_id) {
               // The worker streams the tool-call arguments text as the model
               // writes it. Surface it live on the running block so the user
@@ -1334,7 +1323,9 @@ export default defineComponent({
                 toolItem.input_stream = (toolItem.input_stream ?? '') + (response.progress ?? '');
               }
             } else if (response.type === 'tool_result' && response.tool_id) {
-              const toolItem = toolMap.get(response.tool_id);
+              const toolItem =
+                commitStreamTool(streamContent, response.tool_id, response.answer?.length ?? 0) ||
+                toolMap.get(response.tool_id);
               if (toolItem) {
                 toolItem.output = response.output;
                 toolItem.is_error = response.is_error;
@@ -1354,7 +1345,9 @@ export default defineComponent({
               // it to `awaiting_input`; the renderer will swap in
               // <AskUserQuestionCard>. SSE then ends with terminal_reason
               // 'awaiting_user_input'.
-              const toolItem = toolMap.get(response.tool_id);
+              const toolItem =
+                commitStreamTool(streamContent, response.tool_id, response.answer?.length ?? 0) ||
+                toolMap.get(response.tool_id);
               if (toolItem) {
                 toolItem.status = 'awaiting_input';
                 toolItem.pending_question = response.payload as IAskUserQuestionPayload;
@@ -1365,7 +1358,9 @@ export default defineComponent({
               // `awaiting_input`; the renderer swaps in
               // <ConnectorConsentCard>. SSE then ends with terminal_reason
               // 'awaiting_user_input'.
-              const toolItem = toolMap.get(response.tool_id);
+              const toolItem =
+                commitStreamTool(streamContent, response.tool_id, response.answer?.length ?? 0) ||
+                toolMap.get(response.tool_id);
               if (toolItem) {
                 toolItem.status = 'awaiting_input';
                 toolItem.pending_consent_request = response.payload as IConsentRequestPayload;
@@ -1392,11 +1387,7 @@ export default defineComponent({
               // point as its own block first so the card lands at the
               // right position in the message; this mirrors how
               // tool_use blocks bracket the text stream.
-              if (currentText) {
-                contentParts.push({ type: 'text', text: currentText });
-                currentText = '';
-                answerOffset = response.answer?.length ?? 0;
-              }
+              flushStreamText(streamContent, response.answer?.length ?? 0);
               contentParts.push({ type: 'card', card: response.card });
             } else if (response.type === 'citation' && response.citation) {
               // Source citation footnote from the worker's <acite>
@@ -1412,7 +1403,7 @@ export default defineComponent({
               const target = this.messages[targetIndex];
               target.citations = { ...(target.citations ?? {}), [response.citation.id]: response.citation };
             } else if (response.delta_answer) {
-              currentText = (response.answer || '').slice(answerOffset);
+              setStreamText(streamContent, response.answer || '');
             }
 
             // Build display content: parts + trailing text. Clone each part
@@ -1421,10 +1412,7 @@ export default defineComponent({
             // — yields a NEW object reference. Otherwise the child's `:item`
             // prop ref is unchanged and Vue skips its update, leaving the tool
             // row's spinner frozen until an unrelated re-render (expanding it).
-            const displayParts: IChatMessageContentItem[] = contentParts.map((part) => ({ ...part }));
-            if (currentText) {
-              displayParts.push({ type: 'text', text: currentText });
-            }
+            const displayParts = getStreamDisplayParts(streamContent).map((part) => ({ ...part }));
 
             if (displayParts.length > 0) {
               this.messages[targetIndex] = {


### PR DESCRIPTION
## Summary

- separate early tool lifecycle UI from canonical assistant message content
- keep in-progress tools visible after the current complete text without splitting words
- commit finalized tools through the new `tool_use_commit` event, with compatibility fallbacks for older workers
- cover mid-word, cross-turn, parallel-tool, and SSE forwarding behavior

## Root cause

`tool_use_start` is telemetry that can arrive before the model finishes its prose. The UI treated it as a semantic content boundary, flushing `AceDat`, inserting the tool card, then rendering `aCloud` after it.

This change models pending tools separately and only commits them to canonical content when the Worker confirms the complete tool call.

## Validation

- 89 chat tests passed
- `vue-tsc -b --pretty false`
- ESLint on touched files
- Prettier check
- `beachball check --no-fetch --since origin/main`

## Deployment

Deploy this PR before the paired PlatformService PR. With an older Worker, `tool_result` remains the compatibility commit boundary; after the Worker deploy, `tool_use_commit` provides the exact semantic boundary.

## 🤖 对抗评审 (reviewer: codex, 3 rounds)

- RISK: aborted pre-commit tools disappeared from persisted history → fixed in paired Worker by settling pending tools before persistence
- RISK: cleanly truncated streams could leave uncommitted tools missing or executable with empty input → fixed in paired Worker by settling them as explicit errors and preventing execution
- RISK: deferred client/browser starts were not internally tracked → fixed in paired Worker while preserving suppression of early start/progress events
