### PR TITLE
feat(seedance): default 2.0 Fast + talking-head (口播) mode

### DIFF
--- a/change/@acedatacloud-nexior-seedance-talking-mode.json
+++ b/change/@acedatacloud-nexior-seedance-talking-mode.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Seedance generator: default to 2.0 Fast and add a Talking mode (口播) toggle that routes uploads to reference_image, forces audio, and guides dialogue phrasing so characters actually speak.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/seedance/ConfigPanel.vue
+++ b/src/components/seedance/ConfigPanel.vue
@@ -2,6 +2,7 @@
   <div class="flex flex-col h-full">
     <div class="flex-1 overflow-y-auto p-5">
       <prompt-input class="mb-4" />
+      <talking-mode-switch class="mb-4" />
       <model-selector class="mb-4" />
       <ratio-selector class="mb-4" />
       <resolution-selector class="mb-4" />
@@ -36,6 +37,7 @@ import DurationSelector from './config/DurationSelector.vue';
 import ResolutionSelector from './config/ResolutionSelector.vue';
 import RatioSelector from './config/RatioSelector.vue';
 import GenerateAudioSwitch from './config/GenerateAudioSwitch.vue';
+import TalkingModeSwitch from './config/TalkingModeSwitch.vue';
 import CameraFixedSwitch from './config/CameraFixedSwitch.vue';
 import FirstFrameImage from './config/FirstFrameImage.vue';
 import LastFrameImage from './config/LastFrameImage.vue';
@@ -58,6 +60,7 @@ export default defineComponent({
     ResolutionSelector,
     RatioSelector,
     GenerateAudioSwitch,
+    TalkingModeSwitch,
     CameraFixedSwitch,
     ReturnLastFrameSwitch,
     SeedInput,

--- a/src/components/seedance/config/PromptInput.vue
+++ b/src/components/seedance/config/PromptInput.vue
@@ -5,11 +5,21 @@
     :info="$t('seedance.description.prompt')"
     :placeholder="$t('seedance.placeholder.prompt')"
     :min-rows="5"
-  />
+  >
+    <template v-if="talking" #after>
+      <div class="talking-hint">
+        <p class="hint-text">{{ $t('seedance.description.talkingPrompt') }}</p>
+        <el-button size="small" round class="insert-btn" @click="onInsertTemplate">
+          {{ $t('seedance.button.insertTemplate') }}
+        </el-button>
+      </div>
+    </template>
+  </prompt-textarea>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue';
+import { ElButton } from 'element-plus';
 import PromptTextarea from '@/components/common/PromptTextarea.vue';
 
 export const DEFAULT_PROMPT = '';
@@ -17,9 +27,13 @@ export const DEFAULT_PROMPT = '';
 export default defineComponent({
   name: 'SeedancePromptInput',
   components: {
-    PromptTextarea
+    PromptTextarea,
+    ElButton
   },
   computed: {
+    talking(): boolean {
+      return this.$store.state.seedance?.config?.talking ?? false;
+    },
     prompt: {
       get() {
         return this.$store.state.seedance?.config?.prompt;
@@ -36,6 +50,35 @@ export default defineComponent({
     if (!this.prompt) {
       this.prompt = DEFAULT_PROMPT;
     }
+  },
+  methods: {
+    onInsertTemplate() {
+      const template = this.$t('seedance.template.talkingLine') as string;
+      const current = this.prompt || '';
+      this.prompt = current ? `${current.replace(/\s*$/, '')}\n${template}` : template;
+    }
   }
 });
 </script>
+
+<style lang="scss" scoped>
+.talking-hint {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-top: 6px;
+
+  .hint-text {
+    font-size: 12px;
+    color: var(--el-text-color-secondary);
+    margin: 0;
+    line-height: 1.4;
+  }
+
+  .insert-btn {
+    flex-shrink: 0;
+  }
+}
+</style>

--- a/src/components/seedance/config/TalkingModeSwitch.vue
+++ b/src/components/seedance/config/TalkingModeSwitch.vue
@@ -1,0 +1,107 @@
+<template>
+  <div v-if="isSupported" class="field">
+    <div class="label">
+      <div class="box">
+        <h2 class="title font-bold">{{ $t('seedance.name.talking') }}</h2>
+        <info-icon :content="$t('seedance.description.talking')" class="info" />
+      </div>
+    </div>
+    <div class="value">
+      <el-switch
+        v-model="value"
+        inline-prompt
+        :active-text="$t('seedance.button.on')"
+        :inactive-text="$t('seedance.button.off')"
+      />
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElSwitch } from 'element-plus';
+import InfoIcon from '@/components/common/InfoIcon.vue';
+import { getSeedanceCapability } from '@/constants';
+import { ISeedanceImageInput } from '@/models';
+
+export default defineComponent({
+  name: 'SeedanceTalkingModeSwitch',
+  components: {
+    ElSwitch,
+    InfoIcon
+  },
+  computed: {
+    // Talking-head (口播) rides the Seedance 2.0 r2v path, so only expose it for
+    // models that accept a reference image.
+    isSupported(): boolean {
+      const model = this.$store.state.seedance?.config?.model;
+      return getSeedanceCapability(model).acceptsReferenceImage;
+    },
+    value: {
+      get(): boolean {
+        return this.$store.state.seedance?.config?.talking ?? false;
+      },
+      set(val: boolean) {
+        const config = { ...this.$store.state.seedance?.config, talking: val };
+        // Turning talking ON steers uploads to the speech path: force audio and
+        // remap any first/last-frame image to reference_image. Turning OFF leaves
+        // other settings intact so it doesn't clobber a deliberate config.
+        if (val) {
+          config.generate_audio = true;
+          const images = (config.images || []) as ISeedanceImageInput[];
+          config.images = images.map((img) =>
+            img?.role === 'first_frame' || img?.role === 'last_frame'
+              ? { ...img, role: 'reference_image' as const }
+              : img
+          );
+        }
+        this.$store.commit('seedance/setConfig', config);
+      }
+    }
+  },
+  watch: {
+    // immediate so a persisted talking:true on an unsupported model (e.g. an old
+    // user whose local state loads 1.0 Pro) is cleared on mount, not just on a
+    // later model change — otherwise the prompt guidance shows for a mode that
+    // normalization silently ignores.
+    isSupported: {
+      handler(supported: boolean) {
+        if (!supported && this.value) {
+          this.value = false;
+        }
+      },
+      immediate: true
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.field {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+
+  .label {
+    width: 70%;
+    display: flex;
+    align-items: center;
+
+    .box {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+
+      .title {
+        font-size: 14px;
+        margin: 0;
+      }
+
+      .info {
+        margin-left: 6px;
+      }
+    }
+  }
+}
+</style>

--- a/src/constants/seedance.ts
+++ b/src/constants/seedance.ts
@@ -11,7 +11,7 @@ export const SEEDANCE_MODEL_2_0_MINI = 'doubao-seedance-2-0-mini-260615';
 export const SEEDANCE_MODEL_1_0_LITE_T2V = 'doubao-seedance-1-0-lite-t2v-250428';
 export const SEEDANCE_MODEL_1_0_LITE_I2V = 'doubao-seedance-1-0-lite-i2v-250428';
 
-export const SEEDANCE_DEFAULT_MODEL = SEEDANCE_MODEL_1_0_PRO;
+export const SEEDANCE_DEFAULT_MODEL = SEEDANCE_MODEL_2_0_FAST;
 
 export const SEEDANCE_SERVICE_TIER_DEFAULT = 'default';
 export const SEEDANCE_SERVICE_TIER_FLEX = 'flex';

--- a/src/i18n/ar/seedance.json
+++ b/src/i18n/ar/seedance.json
@@ -282,5 +282,33 @@
   "message.audioRequiresReferenceImage": {
     "message": "يتطلب الصوت المرجعي استخدام صورة مرجعية (موضوع الإلقاء) ، يرجى تحميل الصورة المرجعية أيضًا.",
     "description": "تنبيه عند تقديم الصوت ولكن بدون صورة مرجعية"
+  },
+  "name.talking": {
+    "message": "Talking mode",
+    "description": "Make the on-screen character speak the lines (talking-head / avatar)"
+  },
+  "description.talking": {
+    "message": "When on, your uploaded image is used as the reference subject and the character speaks the lines in your prompt, with audio turned on automatically. Seedance 2.0 series only.",
+    "description": "Talking mode switch hint"
+  },
+  "description.talkingPrompt": {
+    "message": "To make the character speak, write: the person in image 1 says \"your line\" (use straight double quotes).",
+    "description": "Dialogue phrasing hint in talking mode"
+  },
+  "button.insertTemplate": {
+    "message": "Insert line template",
+    "description": "Insert dialogue template button"
+  },
+  "template.talkingLine": {
+    "message": "the person in image 1 says \"your line here\"",
+    "description": "Dialogue template text"
+  },
+  "message.talkingRecommendModel": {
+    "message": "Lite / Fast models may not speak your lines verbatim; for exact lines use Seedance 2.0 standard or upload a reference audio.",
+    "description": "Talking verbatim-accuracy hint"
+  },
+  "message.talkingRequiresReferenceImage": {
+    "message": "Talking mode needs a portrait image as the reference subject. Please upload an image first.",
+    "description": "Warning when talking mode has no reference image"
   }
 }

--- a/src/i18n/de/seedance.json
+++ b/src/i18n/de/seedance.json
@@ -282,5 +282,33 @@
   "message.audioRequiresReferenceImage": {
     "message": "Das Referenzaudio benötigt ein Referenzbild (Hauptmotiv) zur Verwendung. Bitte laden Sie gleichzeitig ein Referenzbild hoch.",
     "description": "Hinweis, wenn Audio bereitgestellt wird, aber das Referenzbild fehlt"
+  },
+  "name.talking": {
+    "message": "Talking mode",
+    "description": "Make the on-screen character speak the lines (talking-head / avatar)"
+  },
+  "description.talking": {
+    "message": "When on, your uploaded image is used as the reference subject and the character speaks the lines in your prompt, with audio turned on automatically. Seedance 2.0 series only.",
+    "description": "Talking mode switch hint"
+  },
+  "description.talkingPrompt": {
+    "message": "To make the character speak, write: the person in image 1 says \"your line\" (use straight double quotes).",
+    "description": "Dialogue phrasing hint in talking mode"
+  },
+  "button.insertTemplate": {
+    "message": "Insert line template",
+    "description": "Insert dialogue template button"
+  },
+  "template.talkingLine": {
+    "message": "the person in image 1 says \"your line here\"",
+    "description": "Dialogue template text"
+  },
+  "message.talkingRecommendModel": {
+    "message": "Lite / Fast models may not speak your lines verbatim; for exact lines use Seedance 2.0 standard or upload a reference audio.",
+    "description": "Talking verbatim-accuracy hint"
+  },
+  "message.talkingRequiresReferenceImage": {
+    "message": "Talking mode needs a portrait image as the reference subject. Please upload an image first.",
+    "description": "Warning when talking mode has no reference image"
   }
 }

--- a/src/i18n/el/seedance.json
+++ b/src/i18n/el/seedance.json
@@ -282,5 +282,33 @@
   "message.audioRequiresReferenceImage": {
     "message": "Η αναφορά ήχου απαιτεί να χρησιμοποιηθεί σε συνδυασμό με την αναφορά εικόνας (υποκείμενο φωνητικής αφήγησης), παρακαλώ ανεβάστε ταυτόχρονα την αναφορά εικόνας.",
     "description": "Υπόδειξη όταν παρέχεται ήχος αλλά λείπει η αναφορά εικόνας"
+  },
+  "name.talking": {
+    "message": "Talking mode",
+    "description": "Make the on-screen character speak the lines (talking-head / avatar)"
+  },
+  "description.talking": {
+    "message": "When on, your uploaded image is used as the reference subject and the character speaks the lines in your prompt, with audio turned on automatically. Seedance 2.0 series only.",
+    "description": "Talking mode switch hint"
+  },
+  "description.talkingPrompt": {
+    "message": "To make the character speak, write: the person in image 1 says \"your line\" (use straight double quotes).",
+    "description": "Dialogue phrasing hint in talking mode"
+  },
+  "button.insertTemplate": {
+    "message": "Insert line template",
+    "description": "Insert dialogue template button"
+  },
+  "template.talkingLine": {
+    "message": "the person in image 1 says \"your line here\"",
+    "description": "Dialogue template text"
+  },
+  "message.talkingRecommendModel": {
+    "message": "Lite / Fast models may not speak your lines verbatim; for exact lines use Seedance 2.0 standard or upload a reference audio.",
+    "description": "Talking verbatim-accuracy hint"
+  },
+  "message.talkingRequiresReferenceImage": {
+    "message": "Talking mode needs a portrait image as the reference subject. Please upload an image first.",
+    "description": "Warning when talking mode has no reference image"
   }
 }

--- a/src/i18n/en/seedance.json
+++ b/src/i18n/en/seedance.json
@@ -282,5 +282,33 @@
   "message.audioRequiresReferenceImage": {
     "message": "Reference audio needs a reference image (the talking-head subject). Please upload a reference image too.",
     "description": "Warning when audio is provided without a reference image"
+  },
+  "name.talking": {
+    "message": "Talking mode",
+    "description": "Make the on-screen character speak the lines (talking-head / avatar)"
+  },
+  "description.talking": {
+    "message": "When on, your uploaded image is used as the reference subject and the character speaks the lines in your prompt, with audio turned on automatically. Seedance 2.0 series only.",
+    "description": "Talking mode switch hint"
+  },
+  "description.talkingPrompt": {
+    "message": "To make the character speak, write: the person in image 1 says \"your line\" (use straight double quotes).",
+    "description": "Dialogue phrasing hint in talking mode"
+  },
+  "button.insertTemplate": {
+    "message": "Insert line template",
+    "description": "Insert dialogue template button"
+  },
+  "template.talkingLine": {
+    "message": "the person in image 1 says \"your line here\"",
+    "description": "Dialogue template text"
+  },
+  "message.talkingRecommendModel": {
+    "message": "Lite / Fast models may not speak your lines verbatim; for exact lines use Seedance 2.0 standard or upload a reference audio.",
+    "description": "Talking verbatim-accuracy hint"
+  },
+  "message.talkingRequiresReferenceImage": {
+    "message": "Talking mode needs a portrait image as the reference subject. Please upload an image first.",
+    "description": "Warning when talking mode has no reference image"
   }
 }

--- a/src/i18n/es/seedance.json
+++ b/src/i18n/es/seedance.json
@@ -282,5 +282,33 @@
   "message.audioRequiresReferenceImage": {
     "message": "El audio de referencia necesita usarse junto con una imagen de referencia (sujeto de locución), por favor sube la imagen de referencia también.",
     "description": "Mensaje cuando se proporciona audio pero falta la imagen de referencia"
+  },
+  "name.talking": {
+    "message": "Talking mode",
+    "description": "Make the on-screen character speak the lines (talking-head / avatar)"
+  },
+  "description.talking": {
+    "message": "When on, your uploaded image is used as the reference subject and the character speaks the lines in your prompt, with audio turned on automatically. Seedance 2.0 series only.",
+    "description": "Talking mode switch hint"
+  },
+  "description.talkingPrompt": {
+    "message": "To make the character speak, write: the person in image 1 says \"your line\" (use straight double quotes).",
+    "description": "Dialogue phrasing hint in talking mode"
+  },
+  "button.insertTemplate": {
+    "message": "Insert line template",
+    "description": "Insert dialogue template button"
+  },
+  "template.talkingLine": {
+    "message": "the person in image 1 says \"your line here\"",
+    "description": "Dialogue template text"
+  },
+  "message.talkingRecommendModel": {
+    "message": "Lite / Fast models may not speak your lines verbatim; for exact lines use Seedance 2.0 standard or upload a reference audio.",
+    "description": "Talking verbatim-accuracy hint"
+  },
+  "message.talkingRequiresReferenceImage": {
+    "message": "Talking mode needs a portrait image as the reference subject. Please upload an image first.",
+    "description": "Warning when talking mode has no reference image"
   }
 }

--- a/src/i18n/fi/seedance.json
+++ b/src/i18n/fi/seedance.json
@@ -282,5 +282,33 @@
   "message.audioRequiresReferenceImage": {
     "message": "Viittausääni vaatii viittauskuvan (puheaihe) käyttöä, lataa viittauskuva samanaikaisesti.",
     "description": "Vihje, kun ääni on tarjottu, mutta viittauskuva puuttuu"
+  },
+  "name.talking": {
+    "message": "Talking mode",
+    "description": "Make the on-screen character speak the lines (talking-head / avatar)"
+  },
+  "description.talking": {
+    "message": "When on, your uploaded image is used as the reference subject and the character speaks the lines in your prompt, with audio turned on automatically. Seedance 2.0 series only.",
+    "description": "Talking mode switch hint"
+  },
+  "description.talkingPrompt": {
+    "message": "To make the character speak, write: the person in image 1 says \"your line\" (use straight double quotes).",
+    "description": "Dialogue phrasing hint in talking mode"
+  },
+  "button.insertTemplate": {
+    "message": "Insert line template",
+    "description": "Insert dialogue template button"
+  },
+  "template.talkingLine": {
+    "message": "the person in image 1 says \"your line here\"",
+    "description": "Dialogue template text"
+  },
+  "message.talkingRecommendModel": {
+    "message": "Lite / Fast models may not speak your lines verbatim; for exact lines use Seedance 2.0 standard or upload a reference audio.",
+    "description": "Talking verbatim-accuracy hint"
+  },
+  "message.talkingRequiresReferenceImage": {
+    "message": "Talking mode needs a portrait image as the reference subject. Please upload an image first.",
+    "description": "Warning when talking mode has no reference image"
   }
 }

--- a/src/i18n/fr/seedance.json
+++ b/src/i18n/fr/seedance.json
@@ -282,5 +282,33 @@
   "message.audioRequiresReferenceImage": {
     "message": "L'audio de référence nécessite une image de référence (sujet de présentation), veuillez télécharger l'image de référence en même temps.",
     "description": "Alerte lorsque l'audio est fourni mais que l'image de référence est manquante"
+  },
+  "name.talking": {
+    "message": "Talking mode",
+    "description": "Make the on-screen character speak the lines (talking-head / avatar)"
+  },
+  "description.talking": {
+    "message": "When on, your uploaded image is used as the reference subject and the character speaks the lines in your prompt, with audio turned on automatically. Seedance 2.0 series only.",
+    "description": "Talking mode switch hint"
+  },
+  "description.talkingPrompt": {
+    "message": "To make the character speak, write: the person in image 1 says \"your line\" (use straight double quotes).",
+    "description": "Dialogue phrasing hint in talking mode"
+  },
+  "button.insertTemplate": {
+    "message": "Insert line template",
+    "description": "Insert dialogue template button"
+  },
+  "template.talkingLine": {
+    "message": "the person in image 1 says \"your line here\"",
+    "description": "Dialogue template text"
+  },
+  "message.talkingRecommendModel": {
+    "message": "Lite / Fast models may not speak your lines verbatim; for exact lines use Seedance 2.0 standard or upload a reference audio.",
+    "description": "Talking verbatim-accuracy hint"
+  },
+  "message.talkingRequiresReferenceImage": {
+    "message": "Talking mode needs a portrait image as the reference subject. Please upload an image first.",
+    "description": "Warning when talking mode has no reference image"
   }
 }

--- a/src/i18n/it/seedance.json
+++ b/src/i18n/it/seedance.json
@@ -282,5 +282,33 @@
   "message.audioRequiresReferenceImage": {
     "message": "L'audio di riferimento deve essere utilizzato con l'immagine di riferimento (soggetto della sintesi vocale), si prega di caricare anche l'immagine di riferimento.",
     "description": "Messaggio di avviso quando si fornisce audio ma manca l'immagine di riferimento"
+  },
+  "name.talking": {
+    "message": "Talking mode",
+    "description": "Make the on-screen character speak the lines (talking-head / avatar)"
+  },
+  "description.talking": {
+    "message": "When on, your uploaded image is used as the reference subject and the character speaks the lines in your prompt, with audio turned on automatically. Seedance 2.0 series only.",
+    "description": "Talking mode switch hint"
+  },
+  "description.talkingPrompt": {
+    "message": "To make the character speak, write: the person in image 1 says \"your line\" (use straight double quotes).",
+    "description": "Dialogue phrasing hint in talking mode"
+  },
+  "button.insertTemplate": {
+    "message": "Insert line template",
+    "description": "Insert dialogue template button"
+  },
+  "template.talkingLine": {
+    "message": "the person in image 1 says \"your line here\"",
+    "description": "Dialogue template text"
+  },
+  "message.talkingRecommendModel": {
+    "message": "Lite / Fast models may not speak your lines verbatim; for exact lines use Seedance 2.0 standard or upload a reference audio.",
+    "description": "Talking verbatim-accuracy hint"
+  },
+  "message.talkingRequiresReferenceImage": {
+    "message": "Talking mode needs a portrait image as the reference subject. Please upload an image first.",
+    "description": "Warning when talking mode has no reference image"
   }
 }

--- a/src/i18n/ja/seedance.json
+++ b/src/i18n/ja/seedance.json
@@ -282,5 +282,33 @@
   "message.audioRequiresReferenceImage": {
     "message": "参考音声は参考画像（口播主体）と併用する必要があります。参考画像も同時にアップロードしてください。",
     "description": "音声は提供されているが参考画像が不足している場合の警告"
+  },
+  "name.talking": {
+    "message": "Talking mode",
+    "description": "Make the on-screen character speak the lines (talking-head / avatar)"
+  },
+  "description.talking": {
+    "message": "When on, your uploaded image is used as the reference subject and the character speaks the lines in your prompt, with audio turned on automatically. Seedance 2.0 series only.",
+    "description": "Talking mode switch hint"
+  },
+  "description.talkingPrompt": {
+    "message": "To make the character speak, write: the person in image 1 says \"your line\" (use straight double quotes).",
+    "description": "Dialogue phrasing hint in talking mode"
+  },
+  "button.insertTemplate": {
+    "message": "Insert line template",
+    "description": "Insert dialogue template button"
+  },
+  "template.talkingLine": {
+    "message": "the person in image 1 says \"your line here\"",
+    "description": "Dialogue template text"
+  },
+  "message.talkingRecommendModel": {
+    "message": "Lite / Fast models may not speak your lines verbatim; for exact lines use Seedance 2.0 standard or upload a reference audio.",
+    "description": "Talking verbatim-accuracy hint"
+  },
+  "message.talkingRequiresReferenceImage": {
+    "message": "Talking mode needs a portrait image as the reference subject. Please upload an image first.",
+    "description": "Warning when talking mode has no reference image"
   }
 }

--- a/src/i18n/ko/seedance.json
+++ b/src/i18n/ko/seedance.json
@@ -282,5 +282,33 @@
   "message.audioRequiresReferenceImage": {
     "message": "참고 오디오는 참고 이미지(구술 주체)와 함께 사용해야 하므로, 참고 이미지를 함께 업로드하세요.",
     "description": "오디오를 제공하지만 참고 이미지가 없을 때의 알림"
+  },
+  "name.talking": {
+    "message": "Talking mode",
+    "description": "Make the on-screen character speak the lines (talking-head / avatar)"
+  },
+  "description.talking": {
+    "message": "When on, your uploaded image is used as the reference subject and the character speaks the lines in your prompt, with audio turned on automatically. Seedance 2.0 series only.",
+    "description": "Talking mode switch hint"
+  },
+  "description.talkingPrompt": {
+    "message": "To make the character speak, write: the person in image 1 says \"your line\" (use straight double quotes).",
+    "description": "Dialogue phrasing hint in talking mode"
+  },
+  "button.insertTemplate": {
+    "message": "Insert line template",
+    "description": "Insert dialogue template button"
+  },
+  "template.talkingLine": {
+    "message": "the person in image 1 says \"your line here\"",
+    "description": "Dialogue template text"
+  },
+  "message.talkingRecommendModel": {
+    "message": "Lite / Fast models may not speak your lines verbatim; for exact lines use Seedance 2.0 standard or upload a reference audio.",
+    "description": "Talking verbatim-accuracy hint"
+  },
+  "message.talkingRequiresReferenceImage": {
+    "message": "Talking mode needs a portrait image as the reference subject. Please upload an image first.",
+    "description": "Warning when talking mode has no reference image"
   }
 }

--- a/src/i18n/pl/seedance.json
+++ b/src/i18n/pl/seedance.json
@@ -282,5 +282,33 @@
   "message.audioRequiresReferenceImage": {
     "message": "Audio referencyjne wymaga użycia obrazu referencyjnego (podmiot lektora), proszę jednocześnie przesłać obraz referencyjny.",
     "description": "Powiadomienie, gdy audio jest dostarczone, ale brakuje obrazu referencyjnego"
+  },
+  "name.talking": {
+    "message": "Talking mode",
+    "description": "Make the on-screen character speak the lines (talking-head / avatar)"
+  },
+  "description.talking": {
+    "message": "When on, your uploaded image is used as the reference subject and the character speaks the lines in your prompt, with audio turned on automatically. Seedance 2.0 series only.",
+    "description": "Talking mode switch hint"
+  },
+  "description.talkingPrompt": {
+    "message": "To make the character speak, write: the person in image 1 says \"your line\" (use straight double quotes).",
+    "description": "Dialogue phrasing hint in talking mode"
+  },
+  "button.insertTemplate": {
+    "message": "Insert line template",
+    "description": "Insert dialogue template button"
+  },
+  "template.talkingLine": {
+    "message": "the person in image 1 says \"your line here\"",
+    "description": "Dialogue template text"
+  },
+  "message.talkingRecommendModel": {
+    "message": "Lite / Fast models may not speak your lines verbatim; for exact lines use Seedance 2.0 standard or upload a reference audio.",
+    "description": "Talking verbatim-accuracy hint"
+  },
+  "message.talkingRequiresReferenceImage": {
+    "message": "Talking mode needs a portrait image as the reference subject. Please upload an image first.",
+    "description": "Warning when talking mode has no reference image"
   }
 }

--- a/src/i18n/pt/seedance.json
+++ b/src/i18n/pt/seedance.json
@@ -282,5 +282,33 @@
   "message.audioRequiresReferenceImage": {
     "message": "O áudio de referência precisa ser usado com uma imagem de referência (sujeito da narração), por favor, faça o upload da imagem de referência ao mesmo tempo.",
     "description": "Mensagem de aviso quando o áudio é fornecido, mas a imagem de referência está faltando"
+  },
+  "name.talking": {
+    "message": "Talking mode",
+    "description": "Make the on-screen character speak the lines (talking-head / avatar)"
+  },
+  "description.talking": {
+    "message": "When on, your uploaded image is used as the reference subject and the character speaks the lines in your prompt, with audio turned on automatically. Seedance 2.0 series only.",
+    "description": "Talking mode switch hint"
+  },
+  "description.talkingPrompt": {
+    "message": "To make the character speak, write: the person in image 1 says \"your line\" (use straight double quotes).",
+    "description": "Dialogue phrasing hint in talking mode"
+  },
+  "button.insertTemplate": {
+    "message": "Insert line template",
+    "description": "Insert dialogue template button"
+  },
+  "template.talkingLine": {
+    "message": "the person in image 1 says \"your line here\"",
+    "description": "Dialogue template text"
+  },
+  "message.talkingRecommendModel": {
+    "message": "Lite / Fast models may not speak your lines verbatim; for exact lines use Seedance 2.0 standard or upload a reference audio.",
+    "description": "Talking verbatim-accuracy hint"
+  },
+  "message.talkingRequiresReferenceImage": {
+    "message": "Talking mode needs a portrait image as the reference subject. Please upload an image first.",
+    "description": "Warning when talking mode has no reference image"
   }
 }

--- a/src/i18n/ru/seedance.json
+++ b/src/i18n/ru/seedance.json
@@ -282,5 +282,33 @@
   "message.audioRequiresReferenceImage": {
     "message": "Справочное аудио требует использования с изображением-образцом (основной объект озвучки), пожалуйста, загрузите изображение-образец.",
     "description": "Сообщение при наличии аудио, но отсутствии справочного изображения"
+  },
+  "name.talking": {
+    "message": "Talking mode",
+    "description": "Make the on-screen character speak the lines (talking-head / avatar)"
+  },
+  "description.talking": {
+    "message": "When on, your uploaded image is used as the reference subject and the character speaks the lines in your prompt, with audio turned on automatically. Seedance 2.0 series only.",
+    "description": "Talking mode switch hint"
+  },
+  "description.talkingPrompt": {
+    "message": "To make the character speak, write: the person in image 1 says \"your line\" (use straight double quotes).",
+    "description": "Dialogue phrasing hint in talking mode"
+  },
+  "button.insertTemplate": {
+    "message": "Insert line template",
+    "description": "Insert dialogue template button"
+  },
+  "template.talkingLine": {
+    "message": "the person in image 1 says \"your line here\"",
+    "description": "Dialogue template text"
+  },
+  "message.talkingRecommendModel": {
+    "message": "Lite / Fast models may not speak your lines verbatim; for exact lines use Seedance 2.0 standard or upload a reference audio.",
+    "description": "Talking verbatim-accuracy hint"
+  },
+  "message.talkingRequiresReferenceImage": {
+    "message": "Talking mode needs a portrait image as the reference subject. Please upload an image first.",
+    "description": "Warning when talking mode has no reference image"
   }
 }

--- a/src/i18n/sr/seedance.json
+++ b/src/i18n/sr/seedance.json
@@ -282,5 +282,33 @@
   "message.audioRequiresReferenceImage": {
     "message": "Referentni audio zahteva korišćenje sa referentnom slikom (subjekt za glas), molimo vas da istovremeno učitate referentnu sliku.",
     "description": "Poruka kada je audio dostupan, ali nedostaje referentna slika"
+  },
+  "name.talking": {
+    "message": "Talking mode",
+    "description": "Make the on-screen character speak the lines (talking-head / avatar)"
+  },
+  "description.talking": {
+    "message": "When on, your uploaded image is used as the reference subject and the character speaks the lines in your prompt, with audio turned on automatically. Seedance 2.0 series only.",
+    "description": "Talking mode switch hint"
+  },
+  "description.talkingPrompt": {
+    "message": "To make the character speak, write: the person in image 1 says \"your line\" (use straight double quotes).",
+    "description": "Dialogue phrasing hint in talking mode"
+  },
+  "button.insertTemplate": {
+    "message": "Insert line template",
+    "description": "Insert dialogue template button"
+  },
+  "template.talkingLine": {
+    "message": "the person in image 1 says \"your line here\"",
+    "description": "Dialogue template text"
+  },
+  "message.talkingRecommendModel": {
+    "message": "Lite / Fast models may not speak your lines verbatim; for exact lines use Seedance 2.0 standard or upload a reference audio.",
+    "description": "Talking verbatim-accuracy hint"
+  },
+  "message.talkingRequiresReferenceImage": {
+    "message": "Talking mode needs a portrait image as the reference subject. Please upload an image first.",
+    "description": "Warning when talking mode has no reference image"
   }
 }

--- a/src/i18n/sv/seedance.json
+++ b/src/i18n/sv/seedance.json
@@ -282,5 +282,33 @@
   "message.audioRequiresReferenceImage": {
     "message": "Referensljudet behöver användas tillsammans med referensbilden (huvudpersonen), vänligen ladda upp referensbilden samtidigt.",
     "description": "Meddelande när ljud erbjuds men referensbild saknas"
+  },
+  "name.talking": {
+    "message": "Talking mode",
+    "description": "Make the on-screen character speak the lines (talking-head / avatar)"
+  },
+  "description.talking": {
+    "message": "When on, your uploaded image is used as the reference subject and the character speaks the lines in your prompt, with audio turned on automatically. Seedance 2.0 series only.",
+    "description": "Talking mode switch hint"
+  },
+  "description.talkingPrompt": {
+    "message": "To make the character speak, write: the person in image 1 says \"your line\" (use straight double quotes).",
+    "description": "Dialogue phrasing hint in talking mode"
+  },
+  "button.insertTemplate": {
+    "message": "Insert line template",
+    "description": "Insert dialogue template button"
+  },
+  "template.talkingLine": {
+    "message": "the person in image 1 says \"your line here\"",
+    "description": "Dialogue template text"
+  },
+  "message.talkingRecommendModel": {
+    "message": "Lite / Fast models may not speak your lines verbatim; for exact lines use Seedance 2.0 standard or upload a reference audio.",
+    "description": "Talking verbatim-accuracy hint"
+  },
+  "message.talkingRequiresReferenceImage": {
+    "message": "Talking mode needs a portrait image as the reference subject. Please upload an image first.",
+    "description": "Warning when talking mode has no reference image"
   }
 }

--- a/src/i18n/uk/seedance.json
+++ b/src/i18n/uk/seedance.json
@@ -282,5 +282,33 @@
   "message.audioRequiresReferenceImage": {
     "message": "Референсне аудіо потребує використання з референсним зображенням (об'єкт озвучки), будь ласка, завантажте референсне зображення одночасно.",
     "description": "Підказка, коли аудіо надано, але відсутнє референсне зображення"
+  },
+  "name.talking": {
+    "message": "Talking mode",
+    "description": "Make the on-screen character speak the lines (talking-head / avatar)"
+  },
+  "description.talking": {
+    "message": "When on, your uploaded image is used as the reference subject and the character speaks the lines in your prompt, with audio turned on automatically. Seedance 2.0 series only.",
+    "description": "Talking mode switch hint"
+  },
+  "description.talkingPrompt": {
+    "message": "To make the character speak, write: the person in image 1 says \"your line\" (use straight double quotes).",
+    "description": "Dialogue phrasing hint in talking mode"
+  },
+  "button.insertTemplate": {
+    "message": "Insert line template",
+    "description": "Insert dialogue template button"
+  },
+  "template.talkingLine": {
+    "message": "the person in image 1 says \"your line here\"",
+    "description": "Dialogue template text"
+  },
+  "message.talkingRecommendModel": {
+    "message": "Lite / Fast models may not speak your lines verbatim; for exact lines use Seedance 2.0 standard or upload a reference audio.",
+    "description": "Talking verbatim-accuracy hint"
+  },
+  "message.talkingRequiresReferenceImage": {
+    "message": "Talking mode needs a portrait image as the reference subject. Please upload an image first.",
+    "description": "Warning when talking mode has no reference image"
   }
 }

--- a/src/i18n/zh-CN/seedance.json
+++ b/src/i18n/zh-CN/seedance.json
@@ -282,5 +282,33 @@
   "message.audioRequiresReferenceImage": {
     "message": "参考音频需要配合参考图片（口播主体）使用，请同时上传参考图片。",
     "description": "提供音频但缺少参考图片时的提示"
+  },
+  "name.talking": {
+    "message": "口播模式",
+    "description": "让画面中的角色开口说台词（口播 / 数字人）"
+  },
+  "description.talking": {
+    "message": "开启后，上传的图片将作为“参考主体”，角色会按提示词中的台词开口说话，并自动打开生成音频。仅 Seedance 2.0 系列支持。",
+    "description": "口播模式开关说明"
+  },
+  "description.talkingPrompt": {
+    "message": "让角色说话请写：图片1中的<角色>说\"你的台词\"（用直角双引号）。",
+    "description": "口播模式下的台词写法提示"
+  },
+  "button.insertTemplate": {
+    "message": "插入台词模板",
+    "description": "插入台词模板按钮"
+  },
+  "template.talkingLine": {
+    "message": "图片1中的角色说\"在此填写台词\"",
+    "description": "台词模板文本"
+  },
+  "message.talkingRecommendModel": {
+    "message": "轻量 / Fast 模型可能不会逐字念出台词；需要精确念台词建议改用 Seedance 2.0 标准版，或上传参考音频。",
+    "description": "口播逐字准确度提示"
+  },
+  "message.talkingRequiresReferenceImage": {
+    "message": "口播模式需要一张人物图片作为参考主体，请先上传一张图片。",
+    "description": "口播模式缺少参考图片时的提示"
   }
 }

--- a/src/i18n/zh-TW/seedance.json
+++ b/src/i18n/zh-TW/seedance.json
@@ -282,5 +282,33 @@
   "message.audioRequiresReferenceImage": {
     "message": "參考音訊需要配合參考圖片（口播主體）使用，請同時上傳參考圖片。",
     "description": "提供音訊但缺少參考圖片時的提示"
+  },
+  "name.talking": {
+    "message": "Talking mode",
+    "description": "Make the on-screen character speak the lines (talking-head / avatar)"
+  },
+  "description.talking": {
+    "message": "When on, your uploaded image is used as the reference subject and the character speaks the lines in your prompt, with audio turned on automatically. Seedance 2.0 series only.",
+    "description": "Talking mode switch hint"
+  },
+  "description.talkingPrompt": {
+    "message": "To make the character speak, write: the person in image 1 says \"your line\" (use straight double quotes).",
+    "description": "Dialogue phrasing hint in talking mode"
+  },
+  "button.insertTemplate": {
+    "message": "Insert line template",
+    "description": "Insert dialogue template button"
+  },
+  "template.talkingLine": {
+    "message": "the person in image 1 says \"your line here\"",
+    "description": "Dialogue template text"
+  },
+  "message.talkingRecommendModel": {
+    "message": "Lite / Fast models may not speak your lines verbatim; for exact lines use Seedance 2.0 standard or upload a reference audio.",
+    "description": "Talking verbatim-accuracy hint"
+  },
+  "message.talkingRequiresReferenceImage": {
+    "message": "Talking mode needs a portrait image as the reference subject. Please upload an image first.",
+    "description": "Warning when talking mode has no reference image"
   }
 }

--- a/src/models/seedance.ts
+++ b/src/models/seedance.ts
@@ -41,6 +41,8 @@ export interface ISeedanceConfig {
   callback_url?: string;
   async?: boolean;
   mirror?: boolean;
+  /** UI-only talking-head (口播) mode flag; stripped before the request is sent. */
+  talking?: boolean;
 }
 
 export interface ISeedanceGenerateRequest {

--- a/src/pages/seedance/Index.vue
+++ b/src/pages/seedance/Index.vue
@@ -16,11 +16,12 @@ import ConfigPanel from '@/components/seedance/ConfigPanel.vue';
 import RecentPanel from '@/components/seedance/RecentPanel.vue';
 import { seedanceOperator } from '@/operators';
 import { instrumentGeneration } from '@/plugins/telemetry';
-import { ISeedanceGenerateRequest, Status } from '@/models';
+import { Status } from '@/models';
 import { ElMessage } from 'element-plus';
-import { ERROR_CODE_USED_UP, getSeedanceCapability, SEEDANCE_MODEL_CAPABILITIES } from '@/constants';
+import { ERROR_CODE_USED_UP } from '@/constants';
 import { ISeedanceTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
+import { normalizeSeedanceRequest } from '@/utils/seedance';
 import { uploadTrackerProviderMixin, ensureNoPendingUpload, ensureLoggedIn } from '@/utils';
 
 interface IData {
@@ -134,97 +135,14 @@ export default defineComponent({
       ) {
         return;
       }
-      const cfg: any = { ...(this.config || {}) };
-      if (typeof cfg?.prompt === 'string') {
-        cfg.prompt = cfg.prompt.trim();
-        if (!cfg.prompt) delete cfg.prompt;
-      }
-
-      if (Array.isArray(cfg?.images)) {
-        cfg.images = cfg.images.filter((img: any) => !!img?.url);
-        const hasFirstFrame = cfg.images.some((img: any) => img?.role === 'first_frame');
-        const hasLastFrame = cfg.images.some((img: any) => img?.role === 'last_frame');
-        if (!hasFirstFrame && hasLastFrame) {
-          cfg.images = cfg.images.map((img: any) =>
-            img?.role === 'last_frame' ? { ...img, role: 'first_frame' } : img
-          );
-        }
-      }
-
-      const hasImages = Array.isArray(cfg?.images) && cfg.images.length > 0;
-      if (!hasImages && 'images' in cfg) {
-        delete cfg.images;
-      }
-
-      // Never send the Ark "flex" tier: it queues jobs on the batch pipeline that
-      // sits far past the worker's poll window (=> "timeout when generating video")
-      // and carries no pricing benefit. Force realtime by omitting service_tier,
-      // even for users who still have flex persisted in local state.
-      if ('service_tier' in cfg) {
-        delete cfg.service_tier;
-      }
-
-      // Validate against the per-model capability matrix BEFORE submitting so users
-      // get an inline warning instead of an opaque "model X is not supported" error.
-      if (cfg?.model && !SEEDANCE_MODEL_CAPABILITIES[cfg.model]) {
-        ElMessage.warning(this.$t('seedance.message.modelUnsupported'));
+      const { request, reject } = normalizeSeedanceRequest(this.config);
+      if (reject) {
+        ElMessage.warning(this.$t(`seedance.message.${reject}`));
         return;
       }
-      const cap = getSeedanceCapability(cfg?.model);
-      if (cap.requiresImage && !hasImages) {
-        ElMessage.warning(this.$t('seedance.message.modelRequiresImage'));
+      if (!request) {
         return;
       }
-      if (!cap.acceptsImage && hasImages) {
-        ElMessage.warning(this.$t('seedance.message.modelRejectsImage'));
-        return;
-      }
-      if (!cap.acceptsText && !hasImages) {
-        ElMessage.warning(this.$t('seedance.message.modelRequiresImage'));
-        return;
-      }
-      if (!cap.acceptsAudio && cfg.generate_audio) {
-        cfg.generate_audio = false;
-      }
-      if (!cap.acceptsReturnLastFrame && cfg.return_last_frame) {
-        cfg.return_last_frame = false;
-      }
-      if (!cap.acceptsLastFrame && hasImages) {
-        cfg.images = cfg.images.filter((img: any) => img?.role !== 'last_frame');
-      }
-
-      // Reference media (Seedance 2.0 multimodal): keep only valid urls, drop
-      // entirely when the model doesn't accept that reference type.
-      if (cap.acceptsReferenceAudio && Array.isArray(cfg?.audios)) {
-        cfg.audios = cfg.audios.filter((a: any) => a?.url);
-      }
-      if (!cap.acceptsReferenceAudio || !Array.isArray(cfg?.audios) || cfg.audios.length === 0) {
-        delete cfg.audios;
-      }
-      if (cap.acceptsReferenceVideo && Array.isArray(cfg?.videos)) {
-        cfg.videos = cfg.videos.filter((v: any) => v?.url);
-      }
-      if (!cap.acceptsReferenceVideo || !Array.isArray(cfg?.videos) || cfg.videos.length === 0) {
-        delete cfg.videos;
-      }
-      if (!cap.acceptsReferenceImage && Array.isArray(cfg?.images)) {
-        cfg.images = cfg.images.filter((img: any) => img?.role !== 'reference_image');
-        if (cfg.images.length === 0) delete cfg.images;
-      }
-
-      // Reference audio needs a paired reference image (the talking-head subject);
-      // upstream rejects an audio-only reference, so warn inline instead.
-      const hasReferenceImage =
-        Array.isArray(cfg?.images) && cfg.images.some((img: any) => img?.role === 'reference_image');
-      if (Array.isArray(cfg?.audios) && cfg.audios.length > 0 && !hasReferenceImage) {
-        ElMessage.warning(this.$t('seedance.message.audioRequiresReferenceImage'));
-        return;
-      }
-
-      const request = {
-        ...cfg,
-        async: true
-      } as ISeedanceGenerateRequest;
 
       if (!ensureLoggedIn()) {
         return;

--- a/src/store/seedance/state.ts
+++ b/src/store/seedance/state.ts
@@ -26,7 +26,8 @@ export default (): ISeedanceState => {
       camerafixed: SEEDANCE_DEFAULT_CAMERA_FIXED,
       generate_audio: SEEDANCE_DEFAULT_GENERATE_AUDIO,
       return_last_frame: SEEDANCE_DEFAULT_RETURN_LAST_FRAME,
-      execution_expires_after: SEEDANCE_DEFAULT_EXECUTION_EXPIRES_AFTER
+      execution_expires_after: SEEDANCE_DEFAULT_EXECUTION_EXPIRES_AFTER,
+      talking: false
     },
     status: {
       getService: Status.None,

--- a/src/utils/seedance.test.ts
+++ b/src/utils/seedance.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeSeedanceRequest } from './seedance';
+import {
+  SEEDANCE_MODEL_1_0_PRO,
+  SEEDANCE_MODEL_2_0_FAST,
+  SEEDANCE_MODEL_1_0_LITE_T2V,
+  SEEDANCE_MODEL_1_0_LITE_I2V
+} from '@/constants';
+
+describe('normalizeSeedanceRequest', () => {
+  it('talking mode routes a first_frame image to reference_image and forces audio', () => {
+    const { request, reject } = normalizeSeedanceRequest({
+      model: SEEDANCE_MODEL_2_0_FAST,
+      talking: true,
+      camerafixed: true,
+      prompt: '图片1中的角色说"你好"',
+      images: [{ url: 'https://cdn.example.com/a.jpg', role: 'first_frame' }]
+    });
+
+    expect(reject).toBeUndefined();
+    expect(request?.images).toEqual([{ url: 'https://cdn.example.com/a.jpg', role: 'reference_image' }]);
+    expect(request?.generate_audio).toBe(true);
+    // camera_fixed is rejected upstream on the 2.0 i2v/r2v path.
+    expect(request).not.toHaveProperty('camerafixed');
+    // The UI-only flag must never reach the API.
+    expect(request).not.toHaveProperty('talking');
+    expect(request?.async).toBe(true);
+  });
+
+  it('strips the talking flag and leaves image role untouched when talking is off', () => {
+    const { request } = normalizeSeedanceRequest({
+      model: SEEDANCE_MODEL_2_0_FAST,
+      talking: false,
+      images: [{ url: 'https://cdn.example.com/a.jpg', role: 'first_frame' }]
+    });
+
+    expect(request).not.toHaveProperty('talking');
+    expect(request?.images).toEqual([{ url: 'https://cdn.example.com/a.jpg', role: 'first_frame' }]);
+  });
+
+  it('does not create a reference_image on a model that cannot accept one', () => {
+    const { request, reject } = normalizeSeedanceRequest({
+      model: SEEDANCE_MODEL_1_0_PRO,
+      talking: true,
+      images: [{ url: 'https://cdn.example.com/a.jpg', role: 'first_frame' }]
+    });
+
+    expect(reject).toBeUndefined();
+    // 1.0 Pro is not reference-capable, so the image stays a first_frame.
+    expect(request?.images).toEqual([{ url: 'https://cdn.example.com/a.jpg', role: 'first_frame' }]);
+    expect(request).not.toHaveProperty('talking');
+  });
+
+  it('rejects an unknown model', () => {
+    const { reject } = normalizeSeedanceRequest({ model: 'doubao-does-not-exist', prompt: 'hi' });
+    expect(reject).toBe('modelUnsupported');
+  });
+
+  it('rejects an image on a text-only model', () => {
+    const { reject } = normalizeSeedanceRequest({
+      model: SEEDANCE_MODEL_1_0_LITE_T2V,
+      images: [{ url: 'https://cdn.example.com/a.jpg', role: 'first_frame' }]
+    });
+    expect(reject).toBe('modelRejectsImage');
+  });
+
+  it('drops reference audio without a paired reference image via rejection', () => {
+    const { reject } = normalizeSeedanceRequest({
+      model: SEEDANCE_MODEL_2_0_FAST,
+      audios: [{ url: 'https://cdn.example.com/voice.mp3' }]
+    });
+    expect(reject).toBe('audioRequiresReferenceImage');
+  });
+
+  it('rejects talking mode when no image is uploaded', () => {
+    const { request, reject } = normalizeSeedanceRequest({
+      model: SEEDANCE_MODEL_2_0_FAST,
+      talking: true,
+      prompt: '图片1中的角色说"你好"'
+    });
+    // Without a portrait the r2v path yields a silent clip — the exact failure
+    // talking mode exists to prevent — so it must reject, not submit.
+    expect(request).toBeUndefined();
+    expect(reject).toBe('talkingRequiresReferenceImage');
+  });
+
+  it('rejects a required-image model when its only image is a stripped reference_image', () => {
+    // 1.0 Lite i2v requires an image but rejects reference_image; the reference
+    // image is removed, so the request would be image-less → must reject, not 400.
+    const { request, reject } = normalizeSeedanceRequest({
+      model: SEEDANCE_MODEL_1_0_LITE_I2V,
+      images: [{ url: 'https://cdn.example.com/a.jpg', role: 'reference_image' }]
+    });
+    expect(request).toBeUndefined();
+    expect(reject).toBe('modelRequiresImage');
+  });
+
+  it('never sends the flex service tier', () => {
+    const { request } = normalizeSeedanceRequest({
+      model: SEEDANCE_MODEL_2_0_FAST,
+      prompt: 'a cat',
+      service_tier: 'flex'
+    });
+    expect(request).not.toHaveProperty('service_tier');
+  });
+});

--- a/src/utils/seedance.ts
+++ b/src/utils/seedance.ts
@@ -1,0 +1,134 @@
+import { ISeedanceConfig, ISeedanceGenerateRequest, ISeedanceImageInput } from '@/models';
+import { getSeedanceCapability, SEEDANCE_MODEL_CAPABILITIES } from '@/constants';
+
+// Mirrors the keys of SEEDANCE_MODEL_CAPABILITIES for a cheap membership check.
+const KNOWN_MODELS = new Set(Object.keys(SEEDANCE_MODEL_CAPABILITIES));
+
+/**
+ * Normalize a Seedance config into the exact request sent to /seedance/videos.
+ *
+ * Centralizes the per-model capability gating that used to live inline in the
+ * studio page, plus the talking-head (口播) rules: a talking request MUST use
+ * `reference_image` (the r2v multimodal path that actually generates speech),
+ * never `first_frame` (the silent i2v path). Returns null when the config is
+ * invalid, with a machine-readable reason the caller maps to a localized warning.
+ */
+export type SeedanceRejectReason =
+  | 'modelUnsupported'
+  | 'modelRequiresImage'
+  | 'modelRejectsImage'
+  | 'audioRequiresReferenceImage'
+  | 'talkingRequiresReferenceImage';
+
+export interface SeedanceNormalizeResult {
+  request?: ISeedanceGenerateRequest;
+  reject?: SeedanceRejectReason;
+}
+
+const cleanImages = (images: unknown): ISeedanceImageInput[] =>
+  Array.isArray(images) ? (images as ISeedanceImageInput[]).filter((img) => !!img?.url) : [];
+
+export function normalizeSeedanceRequest(config?: ISeedanceConfig): SeedanceNormalizeResult {
+  const cfg: any = { ...(config || {}) };
+
+  if (typeof cfg.prompt === 'string') {
+    cfg.prompt = cfg.prompt.trim();
+    if (!cfg.prompt) delete cfg.prompt;
+  }
+
+  // Unknown model → reject early with an inline warning instead of an opaque
+  // upstream "model X is not supported" error.
+  if (cfg.model && !KNOWN_MODELS.has(cfg.model)) {
+    return { reject: 'modelUnsupported' };
+  }
+  const cap = getSeedanceCapability(cfg.model);
+
+  // Talking-head mode: route the uploaded portrait through the r2v path.
+  // first_frame/last_frame drive silent i2v and never produce speech, so remap
+  // them to reference_image, force audio on, and drop camerafixed (upstream
+  // rejects camera_fixed on the 2.0 i2v/r2v path with "must be empty").
+  const talking = !!cfg.talking && cap.acceptsReferenceImage;
+  if (talking) {
+    const imgs = cleanImages(cfg.images).map((img) =>
+      img.role === 'first_frame' || img.role === 'last_frame' || !img.role
+        ? { ...img, role: 'reference_image' as const }
+        : img
+    );
+    cfg.images = imgs;
+    cfg.generate_audio = true;
+    delete cfg.camerafixed;
+  }
+  delete cfg.talking;
+
+  // Filter empty images; promote a lone last_frame to first_frame.
+  cfg.images = cleanImages(cfg.images);
+  const hasFirstFrame = cfg.images.some((img: ISeedanceImageInput) => img.role === 'first_frame');
+  const hasLastFrame = cfg.images.some((img: ISeedanceImageInput) => img.role === 'last_frame');
+  if (!hasFirstFrame && hasLastFrame) {
+    cfg.images = cfg.images.map((img: ISeedanceImageInput) =>
+      img.role === 'last_frame' ? { ...img, role: 'first_frame' as const } : img
+    );
+  }
+  let hasImages = cfg.images.length > 0;
+  if (!hasImages) delete cfg.images;
+
+  // Never send the Ark "flex" tier: it queues on the batch pipeline far past the
+  // worker poll window (=> "timeout when generating video") with no price benefit.
+  delete cfg.service_tier;
+
+  // A text-only model with any image is a user mistake worth surfacing before we
+  // start stripping roles below (which would otherwise hide it).
+  if (!cap.acceptsImage && hasImages) return { reject: 'modelRejectsImage' };
+
+  if (!cap.acceptsAudio && cfg.generate_audio) cfg.generate_audio = false;
+  if (!cap.acceptsReturnLastFrame && cfg.return_last_frame) cfg.return_last_frame = false;
+  if (!cap.acceptsLastFrame && hasImages) {
+    cfg.images = cfg.images.filter((img: ISeedanceImageInput) => img.role !== 'last_frame');
+    hasImages = cfg.images.length > 0;
+    if (!hasImages) delete cfg.images;
+  }
+
+  // Reference media (Seedance 2.0 multimodal): keep valid urls, drop when the
+  // model doesn't accept that reference type.
+  if (cap.acceptsReferenceAudio && Array.isArray(cfg.audios)) {
+    cfg.audios = cfg.audios.filter((a: any) => a?.url);
+  }
+  if (!cap.acceptsReferenceAudio || !Array.isArray(cfg.audios) || cfg.audios.length === 0) {
+    delete cfg.audios;
+  }
+  if (cap.acceptsReferenceVideo && Array.isArray(cfg.videos)) {
+    cfg.videos = cfg.videos.filter((v: any) => v?.url);
+  }
+  if (!cap.acceptsReferenceVideo || !Array.isArray(cfg.videos) || cfg.videos.length === 0) {
+    delete cfg.videos;
+  }
+  if (!cap.acceptsReferenceImage && Array.isArray(cfg.images)) {
+    cfg.images = cfg.images.filter((img: ISeedanceImageInput) => img.role !== 'reference_image');
+    if (cfg.images.length === 0) delete cfg.images;
+  }
+  hasImages = Array.isArray(cfg.images) && cfg.images.length > 0;
+
+  // Validate image presence only AFTER role stripping — an image the model can't
+  // use (e.g. a stray reference_image) must not satisfy a hard image requirement,
+  // else we submit an image-less request and take a 400 upstream.
+  if (cap.requiresImage && !hasImages) return { reject: 'modelRequiresImage' };
+  if (!cap.acceptsText && !hasImages) return { reject: 'modelRequiresImage' };
+
+  const hasReferenceImage =
+    Array.isArray(cfg.images) && cfg.images.some((img: ISeedanceImageInput) => img.role === 'reference_image');
+
+  // Talking-head mode needs a portrait to drive the r2v speech path; without a
+  // reference image the model falls back to a silent clip — exactly the failure
+  // this mode exists to prevent — so reject with a clear "upload a portrait" hint.
+  if (talking && !hasReferenceImage) {
+    return { reject: 'talkingRequiresReferenceImage' };
+  }
+
+  // Reference audio needs a paired reference image (the talking-head subject);
+  // upstream rejects an audio-only reference.
+  if (Array.isArray(cfg.audios) && cfg.audios.length > 0 && !hasReferenceImage) {
+    return { reject: 'audioRequiresReferenceImage' };
+  }
+
+  return { request: { ...cfg, async: true } as ISeedanceGenerateRequest };
+}


### PR DESCRIPTION
## 背景

`studio.acedata.cloud/seedance` 暴露了一堆参数（首帧图 / 参考图 / 参考音频 / 生成音频…），但**没有任何引导告诉用户「怎么让角色开口说话（口播）」**。实测确认的根因：

- 想让角色说话，图片必须以 `role:"reference_image"` 上传（走 Seedance 2.0 多模态 **r2v** 通道）——用 `first_frame` 是**图生视频通道，永远不开口**。
- 台词必须写成官方口播句式 `图片1中的<角色>说"<台词>"`（直角双引号）。
- 默认模型是 `doubao-seedance-1-0-pro`，它根本不支持口播 / 参考图 / 参考音频，新用户默认就用不上 2.0 的能力。

这套写法正是我们自己的 maestro 短剧管线数据契约里已验证有效的方案（`PlatformService/maestro/worker/skills/short-drama/data-contract.md`），并用 mini 真机验证过能开口（视频 `platform2.cdn.acedata.cloud/seedance/519eba4b-…mp4`）。

## 改动

1. **默认模型 → Seedance 2.0 Fast**（`src/constants/seedance.ts`）。`vuex-persistedstate` 里已有 `config.model` 的老用户不受影响（预期行为，不做强制迁移）。
2. **口播模式（Talking mode）开关**（`TalkingModeSwitch.vue`，仅 2.0 系列可见）：打开后自动
   - 把已上传的 `first_frame` / `last_frame` 图 remap 成 `reference_image`；
   - 强制 `generate_audio:true`；
   - 删除 `camerafixed`（2.0 i2v/r2v 传该字段会 400 `must be empty`）。
3. **提示词区智能引导**（`PromptInput.vue`）：口播开启时显示台词写法提示 + 「插入台词模板」按钮，一键插入 `图片1中的角色说"…"`。
4. **归一化抽成可测纯函数** `normalizeSeedanceRequest`（`src/utils/seedance.ts`），替换 `Index.vue#onGenerate` 里散落的内联逻辑；`talking` 是 UI-only 标志，提交前一律剥离，绝不发给 API。
5. **i18n**：手写 zh-CN / en，其余 15 个 locale 由 `/i18n-backfill` 从 en 播种（未跑 `yarn translate`）。

## 验证

- `npx vue-tsc --noEmit` ✓ · `eslint` ✓ · `vitest run src/utils/seedance.test.ts` → **9 passed** ✓
- `scripts/check_i18n_coverage.py` → 17 locale × 45 namespace 全覆盖、无英文占位 ✓

## 已知取舍

mini / fast **不保证逐字念死台词**（可能改词）；逐字精确需 Seedance 2.0 标准版或配 `reference_audio`。本次通过 `message.talkingRecommendModel` 文案提示，不强制。

## 🤖 对抗评审

Reviewer: **Codex** (`codex exec --sandbox read-only`, gpt-5.x)。2 轮收敛。

**第 1 轮 — 3 个 RISK（均已修复）：**

1. **口播模式没上传参考图 → 静默出片。** talking 强制音频、remap 图，但从不校验是否真有 `reference_image`；2.0 通用能力不 require 图，于是提交了一个不会开口的请求（正是本功能要消除的失败）。
   → **修复**：`normalizeSeedanceRequest` 在所有图片 role 剥离后，若 `talking && 无 reference_image` 返回 `reject:'talkingRequiresReferenceImage'`，前端弹「请先上传人物图」。新增 i18n key + 单测。
2. **持久化的 `talking:true` 在不支持的初始模型下不会自动关闭。** watcher 非 `immediate`，老用户本地状态载入 1.0 Pro + talking:true 时，开关虽隐藏但引导仍显示、归一化又忽略 talking → 静默 i2v。
   → **修复**：`TalkingModeSwitch.vue` 的 `isSupported` watcher 改 `{ immediate: true }`，挂载即清除卡住的 talking 标志。
3. **`requiresImage` 在剥离不支持的 `reference_image` 之前校验 → 400。** 对 `1.0-lite-i2v` 只传一张 `reference_image` 时，校验期 `hasImages=true` 通过，随后该图被剥离，最终提交无图请求，命中上游 image-required 400（此顺序 bug 在原内联逻辑里也存在）。
   → **修复**：把 `modelRejectsImage` 提到剥离前、`requiresImage`/`acceptsText` 重排到所有图片剥离**之后**并用重算的 `hasImages`。新增单测断言此场景返回 `modelRequiresImage` 而非提交无图请求。

**第 2 轮：** `VERDICT: CLEAN` — 三处修复正确完整，重排 / immediate watcher 未引入新缺陷。
