### PR TITLE
Fix Fish TTS byte-based credit estimate

### DIFF
--- a/change/@acedatacloud-nexior-fish-byte-pricing.json
+++ b/change/@acedatacloud-nexior-fish-byte-pricing.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix Fish TTS credit estimates by pricing UTF-8 text bytes and showing small positive costs instead of rounding them to zero.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/common/Consumption.test.ts
+++ b/src/components/common/Consumption.test.ts
@@ -1,0 +1,29 @@
+// @vitest-environment jsdom
+import { shallowMount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+
+import Consumption from './Consumption.vue';
+
+const mountConsumption = (value: number) =>
+  shallowMount(Consumption, {
+    props: {
+      value,
+      service: { unit: 'credits' }
+    },
+    global: {
+      mocks: {
+        $t: (key: string) => key
+      }
+    }
+  });
+
+describe('common/Consumption', () => {
+  it('does not display a small positive estimate as zero', () => {
+    expect(mountConsumption(0.00011028).text()).toContain('0.0001');
+    expect(mountConsumption(0.000001).text()).toContain('<0.0001');
+  });
+
+  it('keeps standard two-decimal formatting for larger values', () => {
+    expect(mountConsumption(0.033084).text()).toContain('0.03');
+  });
+});

--- a/src/components/common/Consumption.vue
+++ b/src/components/common/Consumption.vue
@@ -8,7 +8,7 @@
         focusable="false"
       />
       <span class="font-medium">
-        {{ value.toFixed(2) }}
+        {{ formattedValue }}
         {{ $t(`service.unit.${service?.unit || 'credits'}`) }}<template v-if="rateUnit">/{{ rateUnit }}</template>
       </span>
     </span>
@@ -47,6 +47,17 @@ export default defineComponent({
       type: String,
       required: false,
       default: ''
+    }
+  },
+  computed: {
+    formattedValue(): string {
+      if (this.value > 0 && this.value < 0.0001) {
+        return '<0.0001';
+      }
+      if (this.value < 0.01) {
+        return this.value.toFixed(4);
+      }
+      return this.value.toFixed(2);
     }
   }
 });

--- a/src/components/fish/ConfigPanel.test.ts
+++ b/src/components/fish/ConfigPanel.test.ts
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+import { shallowMount } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import ConfigPanel from './ConfigPanel.vue';
+
+const getConsumptionMock = vi.hoisted(() => vi.fn(() => 0.033084));
+
+vi.mock('@/utils', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/utils')>()),
+  getConsumption: getConsumptionMock
+}));
+
+describe('fish/ConfigPanel', () => {
+  beforeEach(() => {
+    getConsumptionMock.mockClear();
+  });
+
+  it('prices text using its UTF-8 byte count and the default model', () => {
+    shallowMount(ConfigPanel, {
+      global: {
+        mocks: {
+          $t: (key: string) => key,
+          $store: {
+            state: {
+              fish: {
+                config: { text: `  ${'啦'.repeat(100)}  ` },
+                service: { cost: [] }
+              }
+            }
+          }
+        }
+      }
+    });
+
+    expect(getConsumptionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: 's2-pro',
+        byte_count: 300
+      }),
+      []
+    );
+  });
+});

--- a/src/components/fish/ConfigPanel.vue
+++ b/src/components/fish/ConfigPanel.vue
@@ -28,7 +28,7 @@ import ModelSelector from './config/ModelSelector.vue';
 import VoicePicker from './config/VoicePicker.vue';
 import Consumption from '../common/Consumption.vue';
 import { getConsumption } from '@/utils';
-import { FISH_DEFAULT_PROSODY_SPEED } from '@/constants';
+import { FISH_DEFAULT_PROSODY_SPEED, FISH_DEFAULT_TTS_MODEL } from '@/constants';
 
 export default defineComponent({
   name: 'FishConfigPanel',
@@ -47,7 +47,15 @@ export default defineComponent({
       return this.$store.state.fish?.config;
     },
     consumption() {
-      return getConsumption(this.config, this.service?.cost);
+      const text = this.config?.text?.trim() ?? '';
+      return getConsumption(
+        {
+          ...this.config,
+          model: this.config?.model ?? FISH_DEFAULT_TTS_MODEL,
+          byte_count: new TextEncoder().encode(text).byteLength
+        },
+        this.service?.cost
+      );
     },
     service() {
       return this.$store.state.fish?.service;


### PR DESCRIPTION
## Summary

- derive Fish TTS `byte_count` from the trimmed UTF-8 text sent to the API
- include the default `s2-pro` model when evaluating service cost rules
- show small positive credit estimates without rounding them to a misleading `0.00`
- add focused regression coverage for Chinese UTF-8 byte counts and sub-cent credit formatting

## Billing

Fish TTS is billed at `0.00011028 credits × UTF-8 byte count`. For example, 100 Chinese characters are 300 UTF-8 bytes, so the estimate is `0.033084` credits and displays as `0.03 credits`.

## Validation

- `vitest run src/components/fish/ConfigPanel.test.ts src/components/common/Consumption.test.ts` (3 passed)
- ESLint on changed Vue/test files
- `vue-tsc --noEmit`
- Prettier check on changed files
- `beachball check`
- `git diff --check`

## 🤖 对抗评审 (reviewer: codex, 2 rounds)

- RISK: estimate counted raw text while submission trims it → 已修，byte count now uses the same trimmed text
- RISK: values below `0.00005` could still render as zero → 已修，positive values below `0.0001` render as `<0.0001`
- Round 2: `VERDICT: CLEAN`