### PR TITLE
fix(auth): release login iframe listeners

### DIFF
--- a/change/@acedatacloud-nexior-auth-message-listener-leak.json
+++ b/change/@acedatacloud-nexior-auth-message-listener-leak.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove stale auth iframe message listeners when login panels close",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/common/AuthPanel.test.ts
+++ b/src/components/common/AuthPanel.test.ts
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import AuthPanel from './AuthPanel.vue';
+
+const addBrowserListenerMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@capacitor/browser', () => ({
+  Browser: {
+    addListener: addBrowserListenerMock
+  }
+}));
+
+describe('AuthPanel message listener lifecycle', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    addBrowserListenerMock.mockReset();
+  });
+
+  it('removes the exact window listener registered during mount', async () => {
+    const addSpy = vi.spyOn(window, 'addEventListener');
+    const removeSpy = vi.spyOn(window, 'removeEventListener');
+    const context = {
+      isNative: false,
+      messageHandler: null as ((event: MessageEvent) => Promise<void>) | null,
+      browserFinishedHandle: null,
+      unmounted: false
+    };
+
+    await (AuthPanel.mounted as () => Promise<void>).call(context);
+
+    expect(context.messageHandler).toBeTypeOf('function');
+    expect(addSpy).toHaveBeenCalledWith('message', context.messageHandler);
+
+    await (AuthPanel.beforeUnmount as () => Promise<void>).call(context);
+
+    expect(removeSpy).toHaveBeenCalledWith('message', expect.any(Function));
+    expect(removeSpy.mock.calls[0]?.[1]).toBe(addSpy.mock.calls[0]?.[1]);
+    expect(context.messageHandler).toBeNull();
+  });
+
+  it('removes the native browser listener during unmount', async () => {
+    const remove = vi.fn();
+    addBrowserListenerMock.mockResolvedValue({ remove });
+    const context = {
+      isNative: true,
+      useBrowser: false,
+      messageHandler: null as ((event: MessageEvent) => Promise<void>) | null,
+      browserFinishedHandle: null as { remove: () => Promise<void> } | null,
+      unmounted: false
+    };
+
+    await (AuthPanel.mounted as () => Promise<void>).call(context);
+    await (AuthPanel.beforeUnmount as () => Promise<void>).call(context);
+
+    expect(addBrowserListenerMock).toHaveBeenCalledWith('browserFinished', expect.any(Function));
+    expect(remove).toHaveBeenCalledOnce();
+    expect(context.browserFinishedHandle).toBeNull();
+  });
+
+  it('removes a native listener that resolves after unmount', async () => {
+    let resolveHandle: ((handle: { remove: () => Promise<void> }) => void) | undefined;
+    const remove = vi.fn();
+    const addWindowListenerSpy = vi.spyOn(window, 'addEventListener');
+    addBrowserListenerMock.mockReturnValue(
+      new Promise((resolve) => {
+        resolveHandle = resolve;
+      })
+    );
+    const context = {
+      isNative: true,
+      useBrowser: false,
+      messageHandler: null as ((event: MessageEvent) => Promise<void>) | null,
+      browserFinishedHandle: null as { remove: () => Promise<void> } | null,
+      unmounted: false
+    };
+
+    const mounting = (AuthPanel.mounted as () => Promise<void>).call(context);
+    await (AuthPanel.beforeUnmount as () => Promise<void>).call(context);
+    resolveHandle?.({ remove });
+    await mounting;
+
+    expect(remove).toHaveBeenCalledOnce();
+    expect(context.browserFinishedHandle).toBeNull();
+    expect(addWindowListenerSpy).not.toHaveBeenCalledWith('message', expect.any(Function));
+  });
+});

--- a/src/components/common/AuthPanel.vue
+++ b/src/components/common/AuthPanel.vue
@@ -49,6 +49,7 @@ import { SignInWithApple } from '@capacitor-community/apple-sign-in';
 import { isNative as isNativeSurface, isIOS, isDesktop } from '@/utils/surface';
 import { desktopBridge } from '@/utils/desktop';
 import { track } from '@/plugins/telemetry';
+import type { PluginListenerHandle } from '@capacitor/core';
 
 // Native Sign In with Apple is keyed by the iOS bundle identifier, NOT
 // the web Services ID. The same Apple `sub` is returned for both, so
@@ -66,7 +67,10 @@ export default defineComponent({
     return {
       showQR: false,
       qrLink: '',
-      useBrowser: false
+      useBrowser: false,
+      messageHandler: null as ((event: MessageEvent) => Promise<void>) | null,
+      browserFinishedHandle: null as PluginListenerHandle | null,
+      unmounted: false
     };
   },
   computed: {
@@ -133,21 +137,27 @@ export default defineComponent({
       return !!this.$store.state.token.access;
     }
   },
-  mounted() {
+  async mounted() {
     if (this.isNative) {
       // Capacitor-only: if the user closes the in-app browser manually, fall
       // back to the iframe login UI. Desktop OAuth opens the SYSTEM browser
       // (no browserFinished event), so this listener must stay isNative-only —
       // never isInAppLogin — or desktop would get stuck on the loading screen.
-      Browser.addListener('browserFinished', () => {
+      const handle = await Browser.addListener('browserFinished', () => {
         console.debug('browser closed by user');
         this.useBrowser = false;
       });
+      if (this.unmounted) {
+        await handle.remove();
+        return;
+      } else {
+        this.browserFinishedHandle = handle;
+      }
     }
     // On native platforms, keep the iframe for regular login (email/password).
     // When the user clicks Google/GitHub, the iframe (AuthFrontend) sends a
     // postMessage asking us to open the OAuth flow in the in-app browser.
-    window.addEventListener('message', async (event: MessageEvent) => {
+    this.messageHandler = async (event: MessageEvent) => {
       const iframe = this.$refs.iframe as HTMLIFrameElement | undefined;
       if (event.origin !== this.authOrigin || event.source !== iframe?.contentWindow) {
         return;
@@ -291,7 +301,19 @@ export default defineComponent({
         this.qrLink = data.qrLink;
         this.showQR = true;
       }
-    });
+    };
+    window.addEventListener('message', this.messageHandler);
+  },
+  async beforeUnmount() {
+    this.unmounted = true;
+    if (this.messageHandler) {
+      window.removeEventListener('message', this.messageHandler);
+      this.messageHandler = null;
+    }
+    if (this.browserFinishedHandle) {
+      await this.browserFinishedHandle.remove();
+      this.browserFinishedHandle = null;
+    }
   },
   methods: {
     closeWebLogin() {


### PR DESCRIPTION
## P0 frame
When a Studio session has an expired token and the user repeatedly tries to send a chat message, the login popup closes/reopens while the browser heap grows until the tab crashes; each popup lifecycle should release its iframe and listeners.

## Root cause
`AuthPanel` is conditionally mounted with `v-if`. Every mount registered an anonymous `window.message` listener and, on native, a Capacitor `browserFinished` listener. Neither was removed. The callbacks retained stale component instances and cross-origin iframe state; native registration also had an async resolve-after-unmount race.

## Production reproduction
- aichat2: 104-110 MiB; Studio: 13-23 MiB; all pods ready, zero restarts
- no aichat 5xx in the incident window
- expired-session send opened AuthPanel before any conversation request
- six close/send cycles: message listeners `7 -> 13`
- forced-GC heap: `49.7 MiB -> 79.7 MiB`
- DOM nodes and iframe count stayed constant
- after login and send, the already-leaked browser target crashed

## Fix
- store and remove the exact window message callback in `beforeUnmount`
- retain/remove the Capacitor listener handle
- remove late handles and return if native registration resolves after unmount
- add web, native, and async-race regression tests

## Validation
- focused Vitest: `3 passed`
- ESLint, Prettier, `vue-tsc --noEmit`, `git diff --check`: passed
- Beachball `--no-fetch`: passed

## Rollout / rollback
Patch-only frontend release. Roll back the commit if auth callbacks fail; no schema or API changes.

## 🤖 对抗评审 (reviewer: claude-subagent, 3 rounds)
- fixed missing native Capacitor listener cleanup
- fixed resolve-after-unmount continuation that could re-register the web listener
- final: `VERDICT: CLEAN`
