### PR TITLE
fix(chat): stop send-time OOM crash from references reactive infinite loop

### DIFF
--- a/src/components/chat/Composer.loop.test.ts
+++ b/src/components/chat/Composer.loop.test.ts
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import Composer from './Composer.vue';
+
+function mountComposer() {
+  return mount(Composer, {
+    props: { question: '', references: [], answering: false, ready: true },
+    global: {
+      mocks: {
+        $t: (key: string) => key,
+        $router: { push: () => undefined },
+        $store: { state: { chat: { model: { name: 'gpt-5.5', capabilities: [] } }, token: { access: 't' } } }
+      },
+      stubs: {
+        'el-upload': true,
+        'el-input': true,
+        'el-button': true,
+        'el-tooltip': true,
+        FilePreview: true,
+        ImagePreview: true
+      }
+    }
+  });
+}
+
+describe('Composer references loop guard', () => {
+  // Regression: #1398 dropped the `refs` watcher's length guard, so an empty
+  // `references` reset the fileList → recomputed `refs` → re-emitted
+  // `update:references([])` → parent reset references → back here forever
+  // (107K iterations → OOM on every send). We reproduce the parent back-edge
+  // explicitly: feed every emitted value back in as the prop, exactly like
+  // `@update:references="references = $event"` in Conversation.vue.
+  it('does not ping-pong when references is reset to empty (parent back-edge wired)', async () => {
+    const wrapper = mountComposer();
+    let emitCount = 0;
+    let stop = false;
+    // Simulate a fileList that just got cleared on send, then wire the loop.
+    (wrapper.vm as unknown as { fileList: unknown[] }).fileList = [{ uid: 1 } as never];
+    await wrapper.vm.$nextTick();
+
+    // Re-feed emitted references back as the prop until it settles or blows up.
+    for (let i = 0; i < 50 && !stop; i++) {
+      const emits = wrapper.emitted('update:references') ?? [];
+      if (emits.length === emitCount) {
+        stop = true; // settled — no new emit this round
+        break;
+      }
+      emitCount = emits.length;
+      const latest = emits[emits.length - 1][0] as unknown[];
+      await wrapper.setProps({ references: latest });
+      await wrapper.vm.$nextTick();
+    }
+
+    expect(stop).toBe(true); // must settle, not run to the 50-round cap
+    expect(emitCount).toBeLessThan(5);
+    expect((wrapper.vm as unknown as { fileList: unknown[] }).fileList).toHaveLength(0);
+  });
+
+  it('clears a non-empty fileList exactly once when references empty', async () => {
+    const wrapper = mountComposer();
+    (wrapper.vm as unknown as { fileList: unknown[] }).fileList = [
+      { uid: 1, status: 'success', response: { file_url: 'u' } } as never
+    ];
+    await wrapper.setProps({ references: [] });
+    await wrapper.vm.$nextTick();
+    expect((wrapper.vm as unknown as { fileList: unknown[] }).fileList).toHaveLength(0);
+  });
+
+  // An in-flight upload puts a file in fileList before it has a response, so
+  // `refs` is still [] and the parent momentarily holds references=[]. The
+  // guard must NOT clear the pending upload in that window.
+  it('does not clear an in-flight upload when references is empty', async () => {
+    const wrapper = mountComposer();
+    (wrapper.vm as unknown as { fileList: unknown[] }).fileList = [{ uid: 1, status: 'uploading' } as never];
+    await wrapper.setProps({ references: [] });
+    await wrapper.vm.$nextTick();
+    expect((wrapper.vm as unknown as { fileList: unknown[] }).fileList).toHaveLength(1);
+  });
+});

--- a/src/components/chat/Composer.vue
+++ b/src/components/chat/Composer.vue
@@ -303,7 +303,6 @@ export default defineComponent({
   },
   watch: {
     refs(val: IChatReference[]) {
-      console.debug('References:', val);
       this.$emit('update:references', val);
     },
     questionValue(val: string) {
@@ -315,8 +314,16 @@ export default defineComponent({
       }
     },
     references(val: IChatReference[]) {
-      console.debug('References updated:', val);
-      if (val.length === 0) {
+      // Only reset when there's something to clear AND nothing is mid-upload.
+      //  - `fileList.length > 0`: assigning a fresh `[]` when already empty would
+      //    recompute `refs` → re-emit `update:references([])` → parent resets
+      //    `references` → back here: an infinite loop (the `refs` watcher lost its
+      //    length guard in #1398, so it now echoes empty values).
+      //  - `!uploading`: while a file is still uploading, `refs` is empty (no
+      //    `response.file_url` yet) so the parent momentarily holds `[]`; clearing
+      //    here would wipe the in-flight upload. Send is gated on `!uploading`, so
+      //    the post-send reset (the case we DO want to clear) always passes this.
+      if (val.length === 0 && this.fileList.length > 0 && !this.uploading) {
         this.fileList = [];
       }
     },

--- a/src/pages/chat/Conversation.vue
+++ b/src/pages/chat/Conversation.vue
@@ -265,9 +265,6 @@ export default defineComponent({
     }
   },
   watch: {
-    async references(val) {
-      console.log('references changed', val);
-    },
     /**
      * Mirror the unsubmitted composer text into vuex on every
      * keystroke so a route-level remount (clicking ChatGPT in the


### PR DESCRIPTION
## P0 — 发消息卡死/OOM 的真正原因

发任何一条消息(哪怕只是 \`hi\`,任何账号)都会**冻结并 OOM 崩溃标签页**。Console 是铁证:一次发送打印了 **107,725 条 \`references changed\`** —— Composer ↔ Conversation 之间的**响应式无限循环**:

1. 发送 → \`Conversation.vue\` \`this.references = []\`(新数组)
2. Composer \`references\` watcher → \`this.fileList = []\`(无条件,新数组)
3. \`fileList\` 变 → \`refs\` computed → 新 \`[]\`
4. \`refs\` watcher → \`$emit('update:references', [])\` —— **PR #1398 删掉了它原有的 \`if (val.length > 0)\` 守卫**,导致空值也回传
5. 父组件 \`@update:references="references = $event"\` → \`references = []\` → 回到第 2 步 → **∞**

第 4 步守卫的移除就是"昨天还行今天崩"的**真正回归点**(#1398 于 7/23 01:33 凌晨合并),且**与账号轻重无关,人人发消息都崩**。

## 修复

在 Composer 的 \`references\` watcher 上给回边加守卫 —— 仅当有内容可清 **且没有上传进行中** 时才重置 \`fileList\`:

\`\`\`js
if (val.length === 0 && this.fileList.length > 0 && !this.uploading) {
  this.fileList = [];
}
\`\`\`

- \`fileList.length > 0\`:断开空数组 ping-pong(核心)。
- \`!uploading\`:上传进行中时 \`fileList\` 非空但 \`refs\` 仍是 \`[]\`(还没拿到 \`response.file_url\`),父组件会短暂持有 \`[]\` —— 若此时清空会**误删正在上传的文件**。发送按钮本就 gated on \`!uploading\`,所以发送后的合法清空一定通过此守卫。

同时删掉两处放大损害的 debug 日志(\`references changed\`、\`References:\`)。

## 回归测试 \`Composer.loop.test.ts\`(3 个,每个都验证过"改回 bug 就挂")
- (a) 显式接上父组件回边,断言 emit 次数有界、必须收敛(改回无守卫 → 挂)
- (b) 已完成上传在空重置时正常清空
- (c) **进行中的上传不被误清**(改回无 \`!uploading\` → 挂)

## 验证
- \`vitest run src/components/chat/ src/store/chat/\` → 93 passed
- \`vue-tsc --noEmit\` + \`eslint\` 干净

## 🤖 对抗评审
Codex (\`gpt-5.5\`, \`codex exec --sandbox read-only\`) 复核。**发现一个真实 RISK(已采纳修复)**:初版守卫 \`if(val.length===0 && fileList.length>0)\` 会在**文件上传进行中**误删附件 —— 因为此时 \`fileList\` 非空但 \`refs\` 为空,父组件短暂持有 \`[]\` 触发清空。据此加了 \`!uploading\` 守卫,并补了上传保护回归测试 (c)。Codex 同时确认:单独恢复 \`refs\` watcher 的 \`if(val.length>0)\` 会破坏"用户删掉最后一个附件、父组件需被告知"的合法场景 —— 故不采用该方案。收敛后无残留 RISK。

## 与 #1415 的关系
本 PR 是**发消息崩溃的真正修复**。先前 #1415(持久化只存 summary)修的是**另一个真实但独立的性能问题**(重账号持久化全量历史,序列化 158ms),不是本次崩溃主因,保留无害。

🤖 Generated with [Claude Code](https://claude.com/claude-code)