### PR TITLE
Remove redundant chat loading indicator

### DIFF
--- a/change/@acedatacloud-nexior-chat-loading-indicator.json
+++ b/change/@acedatacloud-nexior-chat-loading-indicator.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Chat conversations: remove the separate loading spinner and visible loading text while conversation history restores, leaving the message skeleton as the loading affordance.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/pages/chat/Conversation.test.ts
+++ b/src/pages/chat/Conversation.test.ts
@@ -64,6 +64,8 @@ describe('chat/Conversation loading state', () => {
     const loading = wrapper.get('.conversation-loading');
     expect(loading.attributes('role')).toBe('status');
     expect(loading.attributes('aria-label')).toBe('Loading...');
+    expect(wrapper.find('.conversation-loading-label').exists()).toBe(false);
+    expect(wrapper.find('.conversation-loading-spinner').exists()).toBe(false);
     expect(wrapper.get('.dialogue').classes()).not.toContain('empty');
     expect((wrapper.vm as unknown as { ready: boolean }).ready).toBe(false);
 

--- a/src/pages/chat/Conversation.vue
+++ b/src/pages/chat/Conversation.vue
@@ -34,10 +34,6 @@
           aria-live="polite"
           :aria-label="$t('common.status.loading')"
         >
-          <div class="conversation-loading-label">
-            <span class="conversation-loading-spinner" aria-hidden="true"></span>
-            <span>{{ $t('common.status.loading') }}</span>
-          </div>
           <el-skeleton v-for="item in 3" :key="item" animated class="conversation-loading-row">
             <template #template>
               <el-skeleton-item variant="circle" class="conversation-loading-avatar" />
@@ -1674,22 +1670,6 @@ export default defineComponent({
     padding: 0 12px;
     flex: 1;
   }
-  .conversation-loading-label {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    margin-bottom: 24px;
-    color: var(--el-text-color-secondary);
-    font-size: 13px;
-  }
-  .conversation-loading-spinner {
-    width: 14px;
-    height: 14px;
-    border: 2px solid var(--el-border-color);
-    border-top-color: var(--el-color-primary);
-    border-radius: 50%;
-    animation: conversation-loading-spin 0.8s linear infinite;
-  }
   .conversation-loading-row {
     display: flex;
     align-items: flex-start;
@@ -1718,12 +1698,6 @@ export default defineComponent({
       width: 100%;
       padding: 0 12px 8px;
     }
-  }
-}
-
-@keyframes conversation-loading-spin {
-  to {
-    transform: rotate(360deg);
   }
 }
 


### PR DESCRIPTION
## Summary
- remove the separate spinner and visible loading text while chat history restores
- keep the three-row conversation skeleton and accessible loading status
- add regression assertions and a patch Beachball entry

## Validation
- `npm run test:run -- src/pages/chat/Conversation.test.ts` (2 tests passed)
- `npx eslint src/pages/chat/Conversation.vue src/pages/chat/Conversation.test.ts`
- `npx prettier --check change/@acedatacloud-nexior-chat-loading-indicator.json src/pages/chat/Conversation.vue src/pages/chat/Conversation.test.ts`
- `npm run verify -- --branch origin/main`
- `git diff --check origin/main...HEAD`

## 🤖 对抗评审 (reviewer: codex + Explore, 2 rounds)
- Round 1: Codex returned `VERDICT: CLEAN`.
- Round 2: fixed-scope Explore review returned `VERDICT: CLEAN`; one optional spacing NIT was not adopted because removing the label and its reserved gap is the requested layout change.
