### PR TITLE
feat(grokvideo): expose ttapi :reverse/:official grok video models

### DIFF
--- a/change/@acedatacloud-nexior-grok-official-models.json
+++ b/change/@acedatacloud-nexior-grok-official-models.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Grok video: add the ttapi Official endpoint via new :reverse / :official model variants (grok-imagine-video-1.5-fast:reverse, grok-imagine-video:reverse, grok-imagine-video:official, grok-imagine-video-1.5:official) with per-model duration bounds and updated pricing copy.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/grokvideo/ConfigPanel.vue
+++ b/src/components/grokvideo/ConfigPanel.vue
@@ -53,8 +53,8 @@ export default defineComponent({
     config() {
       return this.$store.state.grokvideo?.config;
     },
-    // grok-imagine-video (1.0) accepts multiple reference images;
-    // grok-imagine-video-1.5-preview is single-image only.
+    // Most models accept reference images; grok-imagine-video-1.5:official is
+    // image-to-video only (single input image).
     supportsReferenceImages(): boolean {
       return !isGrokVideoImageOnlyModel(this.$store.state.grokvideo?.config?.model);
     },

--- a/src/components/grokvideo/config/DurationSelector.vue
+++ b/src/components/grokvideo/config/DurationSelector.vue
@@ -16,7 +16,12 @@
 import { defineComponent } from 'vue';
 import { ElSelect, ElOption } from 'element-plus';
 import InfoIcon from '@/components/common/InfoIcon.vue';
-import { GROKVIDEO_DEFAULT_DURATION, GROKVIDEO_DURATION_OPTIONS, getGrokVideoMaxDuration } from '@/constants';
+import {
+  GROKVIDEO_DEFAULT_DURATION,
+  GROKVIDEO_DURATION_OPTIONS,
+  getGrokVideoMaxDuration,
+  getGrokVideoMinDuration
+} from '@/constants';
 
 export default defineComponent({
   name: 'GrokVideoDurationSelector',
@@ -29,12 +34,18 @@ export default defineComponent({
     model(): string | undefined {
       return this.$store.state.grokvideo?.config?.model;
     },
-    // grok-imagine-video supports up to 30s; grok-imagine-video-1.5-preview up to 15s.
+    // reverse 1.5-fast is 6-30s; every other variant is 1-15s.
     maxDuration(): number {
       return getGrokVideoMaxDuration(this.model);
     },
+    minDuration(): number {
+      return getGrokVideoMinDuration(this.model);
+    },
     options(): { value: number; label: string }[] {
-      return GROKVIDEO_DURATION_OPTIONS.filter((d) => d <= this.maxDuration).map((d) => ({ value: d, label: `${d}s` }));
+      return GROKVIDEO_DURATION_OPTIONS.filter((d) => d >= this.minDuration && d <= this.maxDuration).map((d) => ({
+        value: d,
+        label: `${d}s`
+      }));
     },
     value: {
       get(): number | undefined {
@@ -49,10 +60,15 @@ export default defineComponent({
     }
   },
   watch: {
-    // Switching to a model with a lower cap (e.g. 1.5-preview) clamps the value.
+    // Switching models clamps the value into the new model's [min, max] range.
     maxDuration(max: number) {
       if (this.value && this.value > max) {
         this.value = max;
+      }
+    },
+    minDuration(min: number) {
+      if (this.value && this.value < min) {
+        this.value = min;
       }
     }
   },

--- a/src/components/grokvideo/config/ModelSelector.vue
+++ b/src/components/grokvideo/config/ModelSelector.vue
@@ -16,7 +16,13 @@
 import { defineComponent } from 'vue';
 import { ElSelect, ElOption } from 'element-plus';
 import InfoIcon from '@/components/common/InfoIcon.vue';
-import { GROKVIDEO_DEFAULT_MODEL, GROKVIDEO_MODEL_1_5_PREVIEW, GROKVIDEO_MODEL_DEFAULT } from '@/constants';
+import {
+  GROKVIDEO_DEFAULT_MODEL,
+  GROKVIDEO_MODEL_FAST_REVERSE,
+  GROKVIDEO_MODEL_REVERSE,
+  GROKVIDEO_MODEL_OFFICIAL,
+  GROKVIDEO_MODEL_1_5_OFFICIAL
+} from '@/constants';
 
 export default defineComponent({
   name: 'GrokVideoModelSelector',
@@ -28,8 +34,10 @@ export default defineComponent({
   data() {
     return {
       options: [
-        { value: GROKVIDEO_MODEL_DEFAULT, label: this.$t('grokvideo.model.default') },
-        { value: GROKVIDEO_MODEL_1_5_PREVIEW, label: this.$t('grokvideo.model.preview15') }
+        { value: GROKVIDEO_MODEL_FAST_REVERSE, label: this.$t('grokvideo.model.fastReverse') },
+        { value: GROKVIDEO_MODEL_REVERSE, label: this.$t('grokvideo.model.reverse') },
+        { value: GROKVIDEO_MODEL_OFFICIAL, label: this.$t('grokvideo.model.official') },
+        { value: GROKVIDEO_MODEL_1_5_OFFICIAL, label: this.$t('grokvideo.model.official15') }
       ]
     };
   },

--- a/src/constants/grokvideo.ts
+++ b/src/constants/grokvideo.ts
@@ -3,9 +3,14 @@ export const GROKVIDEO_SERVICE_ID = 'cbfe0ade-0b4e-4c42-83f4-3e2d5b429545';
 
 export const GROKVIDEO_LOGO = 'https://cdn.acedata.cloud/p1ge98.png';
 
-export const GROKVIDEO_MODEL_DEFAULT = 'grok-imagine-video';
-export const GROKVIDEO_MODEL_1_5_PREVIEW = 'grok-imagine-video-1.5-preview';
-export const GROKVIDEO_DEFAULT_MODEL = GROKVIDEO_MODEL_DEFAULT;
+// TTAPI exposes two grok-video backends; the model suffix selects the endpoint:
+//   :reverse  -> UnOfficial (grok-imagine-video-1.5-fast is the cheap flat-tier model)
+//   :official -> Official (higher fidelity, per-second pricing)
+export const GROKVIDEO_MODEL_FAST_REVERSE = 'grok-imagine-video-1.5-fast:reverse';
+export const GROKVIDEO_MODEL_REVERSE = 'grok-imagine-video:reverse';
+export const GROKVIDEO_MODEL_OFFICIAL = 'grok-imagine-video:official';
+export const GROKVIDEO_MODEL_1_5_OFFICIAL = 'grok-imagine-video-1.5:official';
+export const GROKVIDEO_DEFAULT_MODEL = GROKVIDEO_MODEL_FAST_REVERSE;
 
 export const GROKVIDEO_RATIO_1_1 = '1:1';
 export const GROKVIDEO_RATIO_16_9 = '16:9';
@@ -23,19 +28,25 @@ export const GROKVIDEO_DEFAULT_RESOLUTION = GROKVIDEO_RESOLUTION_480P;
 
 export const GROKVIDEO_DEFAULT_DURATION = 6;
 
-// grok-imagine-video (1.0) supports up to 30s; grok-imagine-video-1.5-preview up to 15s.
-export const GROKVIDEO_MAX_DURATION_DEFAULT = 30;
-export const GROKVIDEO_MAX_DURATION_1_5_PREVIEW = 15;
+// Duration bounds per model: reverse 1.5-fast is 6-30s; every other variant is 1-15s.
+export const GROKVIDEO_MAX_DURATION_FAST = 30;
+export const GROKVIDEO_MAX_DURATION_OTHER = 15;
+export const GROKVIDEO_MIN_DURATION_FAST = 6;
+export const GROKVIDEO_MIN_DURATION_OTHER = 1;
 
-/** All selectable clip durations (seconds); filtered per-model by max duration. */
-export const GROKVIDEO_DURATION_OPTIONS = [3, 5, 6, 8, 10, 12, 15, 20, 25, 30];
+/** All selectable clip durations (seconds); filtered per-model by min/max. */
+export const GROKVIDEO_DURATION_OPTIONS = [1, 3, 5, 6, 8, 10, 12, 15, 20, 25, 30];
 
 /** Models that only support image-to-video (require an input image). */
-export const GROKVIDEO_IMAGE_ONLY_MODELS = [GROKVIDEO_MODEL_1_5_PREVIEW];
+export const GROKVIDEO_IMAGE_ONLY_MODELS = [GROKVIDEO_MODEL_1_5_OFFICIAL];
 
 export const isGrokVideoImageOnlyModel = (model?: string): boolean =>
   !!model && GROKVIDEO_IMAGE_ONLY_MODELS.includes(model);
 
 /** Max clip duration (seconds) for the given model. */
 export const getGrokVideoMaxDuration = (model?: string): number =>
-  model === GROKVIDEO_MODEL_1_5_PREVIEW ? GROKVIDEO_MAX_DURATION_1_5_PREVIEW : GROKVIDEO_MAX_DURATION_DEFAULT;
+  model === GROKVIDEO_MODEL_FAST_REVERSE ? GROKVIDEO_MAX_DURATION_FAST : GROKVIDEO_MAX_DURATION_OTHER;
+
+/** Min clip duration (seconds) for the given model. */
+export const getGrokVideoMinDuration = (model?: string): number =>
+  model === GROKVIDEO_MODEL_FAST_REVERSE ? GROKVIDEO_MIN_DURATION_FAST : GROKVIDEO_MIN_DURATION_OTHER;

--- a/src/i18n/ar/grokvideo.json
+++ b/src/i18n/ar/grokvideo.json
@@ -64,8 +64,8 @@
     "description": "تعليمات حول إدخال النص"
   },
   "description.model": {
-    "message": "اختر نموذج Grok Imagine. يدعم grok-imagine-video الفيديو الناتج عن النص والصورة؛ بينما 1.5-preview يدعم فقط الفيديو الناتج عن الصورة.",
-    "description": "تعليمات حول اختيار النموذج"
+    "message": "Choose the Grok Imagine model. :reverse variants use the fast/standard endpoint; :official variants use the official endpoint (higher fidelity, per-second pricing). grok-imagine-video-1.5:official is image-to-video only.",
+    "description": "Instructions for model selection"
   },
   "description.ratio": {
     "message": "اختر نسبة عرض إلى ارتفاع الإخراج.",
@@ -76,16 +76,16 @@
     "description": "تعليمات حول الدقة"
   },
   "description.duration": {
-    "message": "مدة الفيديو (بالثواني)، يتم احتساب الرسوم حسب عدد الثواني.",
-    "description": "تعليمات حول المدة"
+    "message": "Video duration in seconds. 1.5-fast (reverse) supports 6-30s with banded pricing; the other variants support 1-15s billed per output second.",
+    "description": "Instructions for duration"
   },
   "description.image": {
-    "message": "صورة إدخال اختيارية، تستخدم لإنشاء الفيديو. grok-imagine-video-1.5-preview إلزامية.",
-    "description": "تعليمات حول إدخال الصورة"
+    "message": "Optional input image to animate (image-to-video). Required for grok-imagine-video-1.5:official.",
+    "description": "Instructions for image input"
   },
   "description.referenceImages": {
-    "message": "صور مرجعية اختيارية، تستخدم لتوجيه أسلوب أو محتوى الفيديو المُنتَج (يدعم فقط grok-imagine-video).",
-    "description": "تعليمات لصور المرجعية"
+    "message": "Optional reference images to guide the style or content of the generated video.",
+    "description": "Instructions for reference images"
   },
   "placeholder.prompt": {
     "message": "وصف الفيديو الخاص بك…",
@@ -94,14 +94,6 @@
   "placeholder.select": {
     "message": "يرجى الاختيار",
     "description": "نص بديل للاختيارات"
-  },
-  "model.default": {
-    "message": "فيديو Grok Imagine",
-    "description": "تسمية النموذج الافتراضي"
-  },
-  "model.preview15": {
-    "message": "فيديو Grok Imagine 1.5 (معاينة، فيديو ناتج عن الصورة)",
-    "description": "تسمية نموذج المعاينة 1.5"
   },
   "button.upload": {
     "message": "رفع",
@@ -162,5 +154,21 @@
   "message.usedUp": {
     "message": "تم استهلاك الرصيد، يرجى الشراء للاستمرار في الاستخدام.",
     "description": "استهلاك الرصيد"
+  },
+  "model.fastReverse": {
+    "message": "Grok Imagine Video 1.5 Fast (fast, 6–30s)",
+    "description": "1.5-fast reverse model label"
+  },
+  "model.reverse": {
+    "message": "Grok Imagine Video (standard, 1–15s)",
+    "description": "grok-imagine-video reverse model label"
+  },
+  "model.official": {
+    "message": "Grok Imagine Video · Official (higher fidelity, per-second)",
+    "description": "grok-imagine-video official model label"
+  },
+  "model.official15": {
+    "message": "Grok Imagine Video 1.5 · Official (image-to-video, up to 1080p)",
+    "description": "1.5 official model label"
   }
 }

--- a/src/i18n/de/grokvideo.json
+++ b/src/i18n/de/grokvideo.json
@@ -64,8 +64,8 @@
     "description": "Anweisungen zur Eingabe des Prompts"
   },
   "description.model": {
-    "message": "Wählen Sie das Grok Imagine Modell. grok-imagine-video unterstützt Text-zu-Video und Bild-zu-Video; 1.5-preview unterstützt nur Bild-zu-Video.",
-    "description": "Anweisungen zur Modellauswahl"
+    "message": "Choose the Grok Imagine model. :reverse variants use the fast/standard endpoint; :official variants use the official endpoint (higher fidelity, per-second pricing). grok-imagine-video-1.5:official is image-to-video only.",
+    "description": "Instructions for model selection"
   },
   "description.ratio": {
     "message": "Wählen Sie das Ausgabe-Seitenverhältnis.",
@@ -76,16 +76,16 @@
     "description": "Anweisungen zur Auflösung"
   },
   "description.duration": {
-    "message": "Videodauer (Sekunden), Abrechnung nach ausgegebenen Sekunden.",
-    "description": "Anweisungen zur Dauer"
+    "message": "Video duration in seconds. 1.5-fast (reverse) supports 6-30s with banded pricing; the other variants support 1-15s billed per output second.",
+    "description": "Instructions for duration"
   },
   "description.image": {
-    "message": "Optionales Eingabebild für die Videoerstellung. grok-imagine-video-1.5-preview ist erforderlich.",
-    "description": "Anweisungen für die Bild-Eingabe"
+    "message": "Optional input image to animate (image-to-video). Required for grok-imagine-video-1.5:official.",
+    "description": "Instructions for image input"
   },
   "description.referenceImages": {
-    "message": "Optionale Referenzbilder zur Steuerung von Stil oder Inhalt des generierten Videos (nur grok-imagine-video).",
-    "description": "Anweisungen für Referenzbilder"
+    "message": "Optional reference images to guide the style or content of the generated video.",
+    "description": "Instructions for reference images"
   },
   "placeholder.prompt": {
     "message": "Beschreibe dein Video…",
@@ -94,14 +94,6 @@
   "placeholder.select": {
     "message": "Bitte auswählen",
     "description": "Platzhalter für Auswahlfelder"
-  },
-  "model.default": {
-    "message": "Grok Imagine Video",
-    "description": "Standardmodellbezeichnung"
-  },
-  "model.preview15": {
-    "message": "Grok Imagine Video 1.5 (Vorschau, Bild-zu-Video)",
-    "description": "1.5 Vorschau Modellbezeichnung"
   },
   "button.upload": {
     "message": "Hochladen",
@@ -162,5 +154,21 @@
   "message.usedUp": {
     "message": "Kontingent erschöpft, bitte kaufen Sie, um fortzufahren.",
     "description": "Erschöpft"
+  },
+  "model.fastReverse": {
+    "message": "Grok Imagine Video 1.5 Fast (fast, 6–30s)",
+    "description": "1.5-fast reverse model label"
+  },
+  "model.reverse": {
+    "message": "Grok Imagine Video (standard, 1–15s)",
+    "description": "grok-imagine-video reverse model label"
+  },
+  "model.official": {
+    "message": "Grok Imagine Video · Official (higher fidelity, per-second)",
+    "description": "grok-imagine-video official model label"
+  },
+  "model.official15": {
+    "message": "Grok Imagine Video 1.5 · Official (image-to-video, up to 1080p)",
+    "description": "1.5 official model label"
   }
 }

--- a/src/i18n/el/grokvideo.json
+++ b/src/i18n/el/grokvideo.json
@@ -64,8 +64,8 @@
     "description": "Οδηγίες για την είσοδο προτροπής"
   },
   "description.model": {
-    "message": "Επιλέξτε το μοντέλο Grok Imagine. Το grok-imagine-video υποστηρίζει βίντεο που δημιουργούνται από κείμενο και εικόνες; το 1.5-preview υποστηρίζει μόνο βίντεο που δημιουργούνται από εικόνες.",
-    "description": "Οδηγίες για την επιλογή μοντέλου"
+    "message": "Choose the Grok Imagine model. :reverse variants use the fast/standard endpoint; :official variants use the official endpoint (higher fidelity, per-second pricing). grok-imagine-video-1.5:official is image-to-video only.",
+    "description": "Instructions for model selection"
   },
   "description.ratio": {
     "message": "Επιλέξτε την αναλογία εξόδου.",
@@ -76,15 +76,15 @@
     "description": "Οδηγίες για την ανάλυση"
   },
   "description.duration": {
-    "message": "Διάρκεια βίντεο (δευτερόλεπτα), χρεώνεται ανά δευτερόλεπτο εξόδου.",
-    "description": "Οδηγίες για τη διάρκεια"
+    "message": "Video duration in seconds. 1.5-fast (reverse) supports 6-30s with banded pricing; the other variants support 1-15s billed per output second.",
+    "description": "Instructions for duration"
   },
   "description.image": {
-    "message": "Προαιρετική είσοδος εικόνας, για βίντεο που δημιουργούνται από εικόνες. Το grok-imagine-video-1.5-preview είναι υποχρεωτικό.",
-    "description": "Οδηγίες για την είσοδο εικόνας"
+    "message": "Optional input image to animate (image-to-video). Required for grok-imagine-video-1.5:official.",
+    "description": "Instructions for image input"
   },
   "description.referenceImages": {
-    "message": "Optional reference images to guide the style or content of the generated video (grok-imagine-video only).",
+    "message": "Optional reference images to guide the style or content of the generated video.",
     "description": "Instructions for reference images"
   },
   "placeholder.prompt": {
@@ -94,14 +94,6 @@
   "placeholder.select": {
     "message": "Επιλέξτε",
     "description": "Placeholder για επιλογές"
-  },
-  "model.default": {
-    "message": "Grok Imagine βίντεο",
-    "description": "Ετικέτα προεπιλεγμένου μοντέλου"
-  },
-  "model.preview15": {
-    "message": "Grok Imagine βίντεο 1.5 (προεπισκόπηση, βίντεο που δημιουργούνται από εικόνες)",
-    "description": "Ετικέτα μοντέλου προεπισκόπησης 1.5"
   },
   "button.upload": {
     "message": "Ανέβασμα",
@@ -162,5 +154,21 @@
   "message.usedUp": {
     "message": "Η ποσόστωση έχει εξαντληθεί, παρακαλώ αγοράστε για να συνεχίσετε τη χρήση.",
     "description": "Εξαντλημένο"
+  },
+  "model.fastReverse": {
+    "message": "Grok Imagine Video 1.5 Fast (fast, 6–30s)",
+    "description": "1.5-fast reverse model label"
+  },
+  "model.reverse": {
+    "message": "Grok Imagine Video (standard, 1–15s)",
+    "description": "grok-imagine-video reverse model label"
+  },
+  "model.official": {
+    "message": "Grok Imagine Video · Official (higher fidelity, per-second)",
+    "description": "grok-imagine-video official model label"
+  },
+  "model.official15": {
+    "message": "Grok Imagine Video 1.5 · Official (image-to-video, up to 1080p)",
+    "description": "1.5 official model label"
   }
 }

--- a/src/i18n/en/grokvideo.json
+++ b/src/i18n/en/grokvideo.json
@@ -1,57 +1,152 @@
 {
-  "name.bot": { "message": "Grok Video Bot", "description": "Name of the Grok video generator" },
-  "name.prompt": { "message": "Prompt", "description": "Prompt for generating the video" },
-  "name.model": { "message": "Model", "description": "Label for model selection" },
-  "name.ratio": { "message": "Aspect Ratio", "description": "Label for aspect ratio" },
-  "name.resolution": { "message": "Resolution", "description": "Label for resolution" },
-  "name.duration": { "message": "Duration", "description": "Label for duration" },
-  "name.image": { "message": "Image", "description": "Label for input image" },
-  "name.referenceImages": { "message": "Reference Images", "description": "Label for reference images" },
-  "name.required": { "message": "Required", "description": "Required badge" },
-  "name.taskId": { "message": "Task ID", "description": "Task id label" },
-  "name.elapsed": { "message": "Elapsed", "description": "Elapsed time label" },
-  "name.traceId": { "message": "Trace ID", "description": "Trace id label" },
-  "name.failure": { "message": "Generation Failed", "description": "Failure title" },
-  "name.failureReason": { "message": "Reason", "description": "Failure reason label" },
-  "name.status": { "message": "Status", "description": "Status title" },
+  "name.bot": {
+    "message": "Grok Video Bot",
+    "description": "Name of the Grok video generator"
+  },
+  "name.prompt": {
+    "message": "Prompt",
+    "description": "Prompt for generating the video"
+  },
+  "name.model": {
+    "message": "Model",
+    "description": "Label for model selection"
+  },
+  "name.ratio": {
+    "message": "Aspect Ratio",
+    "description": "Label for aspect ratio"
+  },
+  "name.resolution": {
+    "message": "Resolution",
+    "description": "Label for resolution"
+  },
+  "name.duration": {
+    "message": "Duration",
+    "description": "Label for duration"
+  },
+  "name.image": {
+    "message": "Image",
+    "description": "Label for input image"
+  },
+  "name.referenceImages": {
+    "message": "Reference Images",
+    "description": "Label for reference images"
+  },
+  "name.required": {
+    "message": "Required",
+    "description": "Required badge"
+  },
+  "name.taskId": {
+    "message": "Task ID",
+    "description": "Task id label"
+  },
+  "name.elapsed": {
+    "message": "Elapsed",
+    "description": "Elapsed time label"
+  },
+  "name.traceId": {
+    "message": "Trace ID",
+    "description": "Trace id label"
+  },
+  "name.failure": {
+    "message": "Generation Failed",
+    "description": "Failure title"
+  },
+  "name.failureReason": {
+    "message": "Reason",
+    "description": "Failure reason label"
+  },
+  "name.status": {
+    "message": "Status",
+    "description": "Status title"
+  },
   "description.prompt": {
     "message": "Describe the video you want to generate (scene, subject, motion, camera, lighting, style).",
     "description": "Instructions for prompt input"
   },
   "description.model": {
-    "message": "Choose the Grok Imagine model. grok-imagine-video supports text and image up to 30s; 1.5-preview is image-to-video only up to 15s.",
+    "message": "Choose the Grok Imagine model. :reverse variants use the fast/standard endpoint; :official variants use the official endpoint (higher fidelity, per-second pricing). grok-imagine-video-1.5:official is image-to-video only.",
     "description": "Instructions for model selection"
   },
-  "description.ratio": { "message": "Select the output aspect ratio.", "description": "Instructions for aspect ratio" },
+  "description.ratio": {
+    "message": "Select the output aspect ratio.",
+    "description": "Instructions for aspect ratio"
+  },
   "description.resolution": {
     "message": "Select the output resolution. 480p / 720p / 1080p are supported; higher resolution costs more.",
     "description": "Instructions for resolution"
   },
   "description.duration": {
-    "message": "Video duration in seconds. grok-imagine-video supports 1-30s with banded pricing; 1.5-preview supports 1-15s and is billed per output second.",
+    "message": "Video duration in seconds. 1.5-fast (reverse) supports 6-30s with banded pricing; the other variants support 1-15s billed per output second.",
     "description": "Instructions for duration"
   },
   "description.image": {
-    "message": "Optional input image to animate (image-to-video). Required for grok-imagine-video-1.5-preview.",
+    "message": "Optional input image to animate (image-to-video). Required for grok-imagine-video-1.5:official.",
     "description": "Instructions for image input"
   },
   "description.referenceImages": {
-    "message": "Optional reference images to guide the style or content of the generated video (grok-imagine-video only).",
+    "message": "Optional reference images to guide the style or content of the generated video.",
     "description": "Instructions for reference images"
   },
-  "placeholder.prompt": { "message": "Describe your video…", "description": "Placeholder for prompt" },
-  "placeholder.select": { "message": "Please select", "description": "Placeholder for selects" },
-  "model.default": { "message": "Grok Imagine Video", "description": "Default model label" },
-  "model.preview15": { "message": "Grok Imagine Video 1.5 (Preview, image-to-video)", "description": "1.5 preview model label" },
-  "button.upload": { "message": "Upload", "description": "Upload button" },
-  "button.generate": { "message": "Generate", "description": "Generate button" },
-  "button.download": { "message": "Download", "description": "Download button" },
-  "status.pending": { "message": "Pending", "description": "Pending status" },
-  "status.processing": { "message": "Processing", "description": "Processing status" },
-  "message.uploadExceed": { "message": "You can upload only one image.", "description": "Upload exceed warning" },
-  "message.uploadReferenceExceed": { "message": "You can upload up to 4 reference images.", "description": "Reference images upload exceed warning" },
-  "message.uploadError": { "message": "Image upload failed, please try again.", "description": "Upload error" },
-  "message.downloadVideo": { "message": "Download video", "description": "Download tooltip" },
+  "placeholder.prompt": {
+    "message": "Describe your video…",
+    "description": "Placeholder for prompt"
+  },
+  "placeholder.select": {
+    "message": "Please select",
+    "description": "Placeholder for selects"
+  },
+  "model.fastReverse": {
+    "message": "Grok Imagine Video 1.5 Fast (fast, 6–30s)",
+    "description": "1.5-fast reverse model label"
+  },
+  "model.reverse": {
+    "message": "Grok Imagine Video (standard, 1–15s)",
+    "description": "grok-imagine-video reverse model label"
+  },
+  "model.official": {
+    "message": "Grok Imagine Video · Official (higher fidelity, per-second)",
+    "description": "grok-imagine-video official model label"
+  },
+  "model.official15": {
+    "message": "Grok Imagine Video 1.5 · Official (image-to-video, up to 1080p)",
+    "description": "1.5 official model label"
+  },
+  "button.upload": {
+    "message": "Upload",
+    "description": "Upload button"
+  },
+  "button.generate": {
+    "message": "Generate",
+    "description": "Generate button"
+  },
+  "button.download": {
+    "message": "Download",
+    "description": "Download button"
+  },
+  "status.pending": {
+    "message": "Pending",
+    "description": "Pending status"
+  },
+  "status.processing": {
+    "message": "Processing",
+    "description": "Processing status"
+  },
+  "message.uploadExceed": {
+    "message": "You can upload only one image.",
+    "description": "Upload exceed warning"
+  },
+  "message.uploadReferenceExceed": {
+    "message": "You can upload up to 4 reference images.",
+    "description": "Reference images upload exceed warning"
+  },
+  "message.uploadError": {
+    "message": "Image upload failed, please try again.",
+    "description": "Upload error"
+  },
+  "message.downloadVideo": {
+    "message": "Download video",
+    "description": "Download tooltip"
+  },
   "message.modelRequiresImage": {
     "message": "This model requires an input image (image-to-video).",
     "description": "Model requires image warning"
@@ -60,8 +155,20 @@
     "message": "Please enter a prompt or upload an image.",
     "description": "Prompt or image required warning"
   },
-  "message.startingTask": { "message": "Submitting your video generation task…", "description": "Starting task" },
-  "message.startTaskSuccess": { "message": "Task submitted successfully.", "description": "Task success" },
-  "message.startTaskFailed": { "message": "Failed to submit task: ", "description": "Task failed" },
-  "message.usedUp": { "message": "Your quota has been used up. Please purchase more to continue.", "description": "Used up" }
+  "message.startingTask": {
+    "message": "Submitting your video generation task…",
+    "description": "Starting task"
+  },
+  "message.startTaskSuccess": {
+    "message": "Task submitted successfully.",
+    "description": "Task success"
+  },
+  "message.startTaskFailed": {
+    "message": "Failed to submit task: ",
+    "description": "Task failed"
+  },
+  "message.usedUp": {
+    "message": "Your quota has been used up. Please purchase more to continue.",
+    "description": "Used up"
+  }
 }

--- a/src/i18n/es/grokvideo.json
+++ b/src/i18n/es/grokvideo.json
@@ -64,8 +64,8 @@
     "description": "Instrucciones para la entrada de prompt"
   },
   "description.model": {
-    "message": "Selecciona el modelo Grok Imagine. grok-imagine-video admite video generado por texto e imagen; 1.5-preview solo admite video generado por imagen.",
-    "description": "Instrucciones para la selección de modelo"
+    "message": "Choose the Grok Imagine model. :reverse variants use the fast/standard endpoint; :official variants use the official endpoint (higher fidelity, per-second pricing). grok-imagine-video-1.5:official is image-to-video only.",
+    "description": "Instructions for model selection"
   },
   "description.ratio": {
     "message": "Selecciona la relación de aspecto de salida.",
@@ -76,15 +76,15 @@
     "description": "Instrucciones para la resolución"
   },
   "description.duration": {
-    "message": "Duración del video (segundos), facturado por el número de segundos de salida.",
-    "description": "Instrucciones para la duración"
+    "message": "Video duration in seconds. 1.5-fast (reverse) supports 6-30s with banded pricing; the other variants support 1-15s billed per output second.",
+    "description": "Instructions for duration"
   },
   "description.image": {
-    "message": "Imagen de entrada opcional, utilizada para generar video. grok-imagine-video-1.5-preview es obligatorio.",
-    "description": "Instrucciones para la entrada de imagen"
+    "message": "Optional input image to animate (image-to-video). Required for grok-imagine-video-1.5:official.",
+    "description": "Instructions for image input"
   },
   "description.referenceImages": {
-    "message": "Optional reference images to guide the style or content of the generated video (grok-imagine-video only).",
+    "message": "Optional reference images to guide the style or content of the generated video.",
     "description": "Instructions for reference images"
   },
   "placeholder.prompt": {
@@ -94,14 +94,6 @@
   "placeholder.select": {
     "message": "Por favor selecciona",
     "description": "Placeholder para selecciones"
-  },
-  "model.default": {
-    "message": "Grok Imagine Video",
-    "description": "Etiqueta del modelo por defecto"
-  },
-  "model.preview15": {
-    "message": "Grok Imagine Video 1.5 (vista previa, video generado por imagen)",
-    "description": "Etiqueta del modelo de vista previa 1.5"
   },
   "button.upload": {
     "message": "Subir",
@@ -162,5 +154,21 @@
   "message.usedUp": {
     "message": "Crédito agotado, por favor compra más para continuar usando.",
     "description": "Agotado"
+  },
+  "model.fastReverse": {
+    "message": "Grok Imagine Video 1.5 Fast (fast, 6–30s)",
+    "description": "1.5-fast reverse model label"
+  },
+  "model.reverse": {
+    "message": "Grok Imagine Video (standard, 1–15s)",
+    "description": "grok-imagine-video reverse model label"
+  },
+  "model.official": {
+    "message": "Grok Imagine Video · Official (higher fidelity, per-second)",
+    "description": "grok-imagine-video official model label"
+  },
+  "model.official15": {
+    "message": "Grok Imagine Video 1.5 · Official (image-to-video, up to 1080p)",
+    "description": "1.5 official model label"
   }
 }

--- a/src/i18n/fi/grokvideo.json
+++ b/src/i18n/fi/grokvideo.json
@@ -64,8 +64,8 @@
     "description": "Ohjeet kehotteen syöttämiseen"
   },
   "description.model": {
-    "message": "Valitse Grok Imagine -malli. grok-imagine-video tukee tekstistä kuvaan -videoita; 1.5-preview tukee vain kuvaan perustuvia videoita.",
-    "description": "Ohjeet mallin valintaan"
+    "message": "Choose the Grok Imagine model. :reverse variants use the fast/standard endpoint; :official variants use the official endpoint (higher fidelity, per-second pricing). grok-imagine-video-1.5:official is image-to-video only.",
+    "description": "Instructions for model selection"
   },
   "description.ratio": {
     "message": "Valitse ulostulojen kuvasuhde.",
@@ -76,15 +76,15 @@
     "description": "Ohjeet resoluution valintaan"
   },
   "description.duration": {
-    "message": "Videon kesto (sekunteina), laskutetaan ulostulojen sekuntien mukaan.",
-    "description": "Ohjeet keston syöttämiseen"
+    "message": "Video duration in seconds. 1.5-fast (reverse) supports 6-30s with banded pricing; the other variants support 1-15s billed per output second.",
+    "description": "Instructions for duration"
   },
   "description.image": {
-    "message": "Valinnainen syötekuva videon tuottamiseen. grok-imagine-video-1.5-preview on pakollinen.",
-    "description": "Ohjeet kuva syötteelle"
+    "message": "Optional input image to animate (image-to-video). Required for grok-imagine-video-1.5:official.",
+    "description": "Instructions for image input"
   },
   "description.referenceImages": {
-    "message": "Optional reference images to guide the style or content of the generated video (grok-imagine-video only).",
+    "message": "Optional reference images to guide the style or content of the generated video.",
     "description": "Instructions for reference images"
   },
   "placeholder.prompt": {
@@ -94,14 +94,6 @@
   "placeholder.select": {
     "message": "Valitse",
     "description": "Valintojen paikkamerkki"
-  },
-  "model.default": {
-    "message": "Grok Imagine -video",
-    "description": "Oletusmallin etiketti"
-  },
-  "model.preview15": {
-    "message": "Grok Imagine -video 1.5 (esikatselu, kuvaan perustuva video)",
-    "description": "1.5 esikatselumallin etiketti"
   },
   "button.upload": {
     "message": "Lataa",
@@ -162,5 +154,21 @@
   "message.usedUp": {
     "message": "Varat on käytetty loppuun, osta lisää jatkaaksesi käyttöä.",
     "description": "Loppu"
+  },
+  "model.fastReverse": {
+    "message": "Grok Imagine Video 1.5 Fast (fast, 6–30s)",
+    "description": "1.5-fast reverse model label"
+  },
+  "model.reverse": {
+    "message": "Grok Imagine Video (standard, 1–15s)",
+    "description": "grok-imagine-video reverse model label"
+  },
+  "model.official": {
+    "message": "Grok Imagine Video · Official (higher fidelity, per-second)",
+    "description": "grok-imagine-video official model label"
+  },
+  "model.official15": {
+    "message": "Grok Imagine Video 1.5 · Official (image-to-video, up to 1080p)",
+    "description": "1.5 official model label"
   }
 }

--- a/src/i18n/fr/grokvideo.json
+++ b/src/i18n/fr/grokvideo.json
@@ -64,8 +64,8 @@
     "description": "Instructions pour l'entrée de prompt"
   },
   "description.model": {
-    "message": "Sélectionnez le modèle Grok Imagine. grok-imagine-video prend en charge les vidéos générées par texte et par image ; 1.5-preview prend uniquement en charge les vidéos générées par image.",
-    "description": "Instructions pour la sélection du modèle"
+    "message": "Choose the Grok Imagine model. :reverse variants use the fast/standard endpoint; :official variants use the official endpoint (higher fidelity, per-second pricing). grok-imagine-video-1.5:official is image-to-video only.",
+    "description": "Instructions for model selection"
   },
   "description.ratio": {
     "message": "Sélectionnez le rapport d'aspect de sortie.",
@@ -76,15 +76,15 @@
     "description": "Instructions pour la résolution"
   },
   "description.duration": {
-    "message": "Durée de la vidéo (secondes), facturée par seconde de sortie.",
-    "description": "Instructions pour la durée"
+    "message": "Video duration in seconds. 1.5-fast (reverse) supports 6-30s with banded pricing; the other variants support 1-15s billed per output second.",
+    "description": "Instructions for duration"
   },
   "description.image": {
-    "message": "Image d'entrée optionnelle pour générer une vidéo. grok-imagine-video-1.5-preview est requis.",
-    "description": "Instructions pour l'entrée d'image"
+    "message": "Optional input image to animate (image-to-video). Required for grok-imagine-video-1.5:official.",
+    "description": "Instructions for image input"
   },
   "description.referenceImages": {
-    "message": "Optional reference images to guide the style or content of the generated video (grok-imagine-video only).",
+    "message": "Optional reference images to guide the style or content of the generated video.",
     "description": "Instructions for reference images"
   },
   "placeholder.prompt": {
@@ -94,14 +94,6 @@
   "placeholder.select": {
     "message": "Veuillez sélectionner",
     "description": "Espace réservé pour les sélections"
-  },
-  "model.default": {
-    "message": "Grok Imagine Vidéo",
-    "description": "Étiquette du modèle par défaut"
-  },
-  "model.preview15": {
-    "message": "Grok Imagine Vidéo 1.5 (aperçu, vidéo générée par image)",
-    "description": "Étiquette du modèle 1.5 aperçu"
   },
   "button.upload": {
     "message": "Téléverser",
@@ -162,5 +154,21 @@
   "message.usedUp": {
     "message": "Quota épuisé, veuillez acheter pour continuer à utiliser.",
     "description": "Épuisé"
+  },
+  "model.fastReverse": {
+    "message": "Grok Imagine Video 1.5 Fast (fast, 6–30s)",
+    "description": "1.5-fast reverse model label"
+  },
+  "model.reverse": {
+    "message": "Grok Imagine Video (standard, 1–15s)",
+    "description": "grok-imagine-video reverse model label"
+  },
+  "model.official": {
+    "message": "Grok Imagine Video · Official (higher fidelity, per-second)",
+    "description": "grok-imagine-video official model label"
+  },
+  "model.official15": {
+    "message": "Grok Imagine Video 1.5 · Official (image-to-video, up to 1080p)",
+    "description": "1.5 official model label"
   }
 }

--- a/src/i18n/it/grokvideo.json
+++ b/src/i18n/it/grokvideo.json
@@ -64,8 +64,8 @@
     "description": "Istruzioni per l'input del prompt"
   },
   "description.model": {
-    "message": "Seleziona il modello Grok Imagine. grok-imagine-video supporta video generati da testo e da immagini; 1.5-preview supporta solo video generati da immagini.",
-    "description": "Istruzioni per la selezione del modello"
+    "message": "Choose the Grok Imagine model. :reverse variants use the fast/standard endpoint; :official variants use the official endpoint (higher fidelity, per-second pricing). grok-imagine-video-1.5:official is image-to-video only.",
+    "description": "Instructions for model selection"
   },
   "description.ratio": {
     "message": "Seleziona il rapporto d'aspetto dell'output.",
@@ -76,15 +76,15 @@
     "description": "Istruzioni per la risoluzione"
   },
   "description.duration": {
-    "message": "Durata del video (secondi), addebitato in base ai secondi di output.",
-    "description": "Istruzioni per la durata"
+    "message": "Video duration in seconds. 1.5-fast (reverse) supports 6-30s with banded pricing; the other variants support 1-15s billed per output second.",
+    "description": "Instructions for duration"
   },
   "description.image": {
-    "message": "Immagine di input opzionale, utilizzata per generare video. grok-imagine-video-1.5-preview è obbligatorio.",
-    "description": "Istruzioni per l'input dell'immagine"
+    "message": "Optional input image to animate (image-to-video). Required for grok-imagine-video-1.5:official.",
+    "description": "Instructions for image input"
   },
   "description.referenceImages": {
-    "message": "Optional reference images to guide the style or content of the generated video (grok-imagine-video only).",
+    "message": "Optional reference images to guide the style or content of the generated video.",
     "description": "Instructions for reference images"
   },
   "placeholder.prompt": {
@@ -94,14 +94,6 @@
   "placeholder.select": {
     "message": "Seleziona",
     "description": "Placeholder per le selezioni"
-  },
-  "model.default": {
-    "message": "Grok Imagine Video",
-    "description": "Etichetta del modello predefinito"
-  },
-  "model.preview15": {
-    "message": "Grok Imagine Video 1.5 (anteprima, video generato da immagini)",
-    "description": "Etichetta del modello anteprima 1.5"
   },
   "button.upload": {
     "message": "Carica",
@@ -162,5 +154,21 @@
   "message.usedUp": {
     "message": "Credito esaurito, acquista per continuare a utilizzare.",
     "description": "Esaurito"
+  },
+  "model.fastReverse": {
+    "message": "Grok Imagine Video 1.5 Fast (fast, 6–30s)",
+    "description": "1.5-fast reverse model label"
+  },
+  "model.reverse": {
+    "message": "Grok Imagine Video (standard, 1–15s)",
+    "description": "grok-imagine-video reverse model label"
+  },
+  "model.official": {
+    "message": "Grok Imagine Video · Official (higher fidelity, per-second)",
+    "description": "grok-imagine-video official model label"
+  },
+  "model.official15": {
+    "message": "Grok Imagine Video 1.5 · Official (image-to-video, up to 1080p)",
+    "description": "1.5 official model label"
   }
 }

--- a/src/i18n/ja/grokvideo.json
+++ b/src/i18n/ja/grokvideo.json
@@ -64,8 +64,8 @@
     "description": "プロンプト入力に関する指示"
   },
   "description.model": {
-    "message": "Grok Imagineモデルを選択します。grok-imagine-videoはテキストから画像生成と画像から動画生成をサポートします；1.5-previewは画像から動画生成のみサポートします。",
-    "description": "モデル選択に関する指示"
+    "message": "Choose the Grok Imagine model. :reverse variants use the fast/standard endpoint; :official variants use the official endpoint (higher fidelity, per-second pricing). grok-imagine-video-1.5:official is image-to-video only.",
+    "description": "Instructions for model selection"
   },
   "description.ratio": {
     "message": "出力画面のアスペクト比を選択します。",
@@ -76,16 +76,16 @@
     "description": "解像度に関する指示"
   },
   "description.duration": {
-    "message": "動画の長さ（秒）、出力秒数に基づいて課金されます。",
-    "description": "長さに関する指示"
+    "message": "Video duration in seconds. 1.5-fast (reverse) supports 6-30s with banded pricing; the other variants support 1-15s billed per output second.",
+    "description": "Instructions for duration"
   },
   "description.image": {
-    "message": "オプションの入力画像、動画生成に使用します。grok-imagine-video-1.5-previewは必須です。",
-    "description": "画像入力に関する指示"
+    "message": "Optional input image to animate (image-to-video). Required for grok-imagine-video-1.5:official.",
+    "description": "Instructions for image input"
   },
   "description.referenceImages": {
-    "message": "生成動画のスタイルや内容をガイドするオプションの参考画像（最大4枚）。",
-    "description": "参考画像の使い方の説明"
+    "message": "Optional reference images to guide the style or content of the generated video.",
+    "description": "Instructions for reference images"
   },
   "placeholder.prompt": {
     "message": "あなたのビデオを説明してください…",
@@ -94,14 +94,6 @@
   "placeholder.select": {
     "message": "選択してください",
     "description": "選択のプレースホルダー"
-  },
-  "model.default": {
-    "message": "Grok Imagine 動画",
-    "description": "デフォルトモデルラベル"
-  },
-  "model.preview15": {
-    "message": "Grok Imagine 動画 1.5（プレビュー、画像から動画生成）",
-    "description": "1.5プレビューモデルラベル"
   },
   "button.upload": {
     "message": "アップロード",
@@ -162,5 +154,21 @@
   "message.usedUp": {
     "message": "利用可能な額が使い切られました。購入後に続行してください。",
     "description": "使い切り"
+  },
+  "model.fastReverse": {
+    "message": "Grok Imagine Video 1.5 Fast (fast, 6–30s)",
+    "description": "1.5-fast reverse model label"
+  },
+  "model.reverse": {
+    "message": "Grok Imagine Video (standard, 1–15s)",
+    "description": "grok-imagine-video reverse model label"
+  },
+  "model.official": {
+    "message": "Grok Imagine Video · Official (higher fidelity, per-second)",
+    "description": "grok-imagine-video official model label"
+  },
+  "model.official15": {
+    "message": "Grok Imagine Video 1.5 · Official (image-to-video, up to 1080p)",
+    "description": "1.5 official model label"
   }
 }

--- a/src/i18n/ko/grokvideo.json
+++ b/src/i18n/ko/grokvideo.json
@@ -64,8 +64,8 @@
     "description": "프롬프트 입력에 대한 설명"
   },
   "description.model": {
-    "message": "Grok Imagine 모델을 선택하세요. grok-imagine-video는 텍스트와 이미지 기반 비디오를 지원하며; 1.5-preview는 이미지 기반 비디오만 지원합니다.",
-    "description": "모델 선택에 대한 설명"
+    "message": "Choose the Grok Imagine model. :reverse variants use the fast/standard endpoint; :official variants use the official endpoint (higher fidelity, per-second pricing). grok-imagine-video-1.5:official is image-to-video only.",
+    "description": "Instructions for model selection"
   },
   "description.ratio": {
     "message": "출력 화면 비율을 선택하세요.",
@@ -76,16 +76,16 @@
     "description": "해상도에 대한 설명"
   },
   "description.duration": {
-    "message": "비디오 길이(초), 출력 초 수에 따라 요금이 청구됩니다.",
-    "description": "길이에 대한 설명"
+    "message": "Video duration in seconds. 1.5-fast (reverse) supports 6-30s with banded pricing; the other variants support 1-15s billed per output second.",
+    "description": "Instructions for duration"
   },
   "description.image": {
-    "message": "비디오 생성을 위한 선택적 입력 이미지. grok-imagine-video-1.5-preview는 필수입니다.",
-    "description": "이미지 입력에 대한 설명"
+    "message": "Optional input image to animate (image-to-video). Required for grok-imagine-video-1.5:official.",
+    "description": "Instructions for image input"
   },
   "description.referenceImages": {
-    "message": "생성된 비디오의 스타일이나 내용을 안내하는 선택적 참조 이미지 (grok-imagine-video 전용).",
-    "description": "참조 이미지 안내"
+    "message": "Optional reference images to guide the style or content of the generated video.",
+    "description": "Instructions for reference images"
   },
   "placeholder.prompt": {
     "message": "비디오를 설명하세요…",
@@ -94,14 +94,6 @@
   "placeholder.select": {
     "message": "선택하세요",
     "description": "선택을 위한 플레이스홀더"
-  },
-  "model.default": {
-    "message": "Grok Imagine 비디오",
-    "description": "기본 모델 레이블"
-  },
-  "model.preview15": {
-    "message": "Grok Imagine 비디오 1.5(미리보기, 이미지 기반 비디오)",
-    "description": "1.5 미리보기 모델 레이블"
   },
   "button.upload": {
     "message": "업로드",
@@ -162,5 +154,21 @@
   "message.usedUp": {
     "message": "크레딧이 소진되었습니다. 구매 후 계속 사용하세요.",
     "description": "소진됨"
+  },
+  "model.fastReverse": {
+    "message": "Grok Imagine Video 1.5 Fast (fast, 6–30s)",
+    "description": "1.5-fast reverse model label"
+  },
+  "model.reverse": {
+    "message": "Grok Imagine Video (standard, 1–15s)",
+    "description": "grok-imagine-video reverse model label"
+  },
+  "model.official": {
+    "message": "Grok Imagine Video · Official (higher fidelity, per-second)",
+    "description": "grok-imagine-video official model label"
+  },
+  "model.official15": {
+    "message": "Grok Imagine Video 1.5 · Official (image-to-video, up to 1080p)",
+    "description": "1.5 official model label"
   }
 }

--- a/src/i18n/pl/grokvideo.json
+++ b/src/i18n/pl/grokvideo.json
@@ -64,8 +64,8 @@
     "description": "Instrukcje dotyczące wprowadzenia podpowiedzi"
   },
   "description.model": {
-    "message": "Wybierz model Grok Imagine. grok-imagine-video obsługuje wideo generowane z tekstu i obrazu; 1.5-preview obsługuje tylko wideo generowane z obrazu.",
-    "description": "Instrukcje dotyczące wyboru modelu"
+    "message": "Choose the Grok Imagine model. :reverse variants use the fast/standard endpoint; :official variants use the official endpoint (higher fidelity, per-second pricing). grok-imagine-video-1.5:official is image-to-video only.",
+    "description": "Instructions for model selection"
   },
   "description.ratio": {
     "message": "Wybierz proporcje wyjściowego obrazu.",
@@ -76,15 +76,15 @@
     "description": "Instrukcje dotyczące rozdzielczości"
   },
   "description.duration": {
-    "message": "Czas trwania wideo (sekundy), rozliczany według liczby sekund.",
-    "description": "Instrukcje dotyczące czasu trwania"
+    "message": "Video duration in seconds. 1.5-fast (reverse) supports 6-30s with banded pricing; the other variants support 1-15s billed per output second.",
+    "description": "Instructions for duration"
   },
   "description.image": {
-    "message": "Opcjonalny obraz wejściowy do generowania wideo. grok-imagine-video-1.5-preview jest wymagany.",
-    "description": "Instrukcje dotyczące obrazu wejściowego"
+    "message": "Optional input image to animate (image-to-video). Required for grok-imagine-video-1.5:official.",
+    "description": "Instructions for image input"
   },
   "description.referenceImages": {
-    "message": "Optional reference images to guide the style or content of the generated video (grok-imagine-video only).",
+    "message": "Optional reference images to guide the style or content of the generated video.",
     "description": "Instructions for reference images"
   },
   "placeholder.prompt": {
@@ -94,14 +94,6 @@
   "placeholder.select": {
     "message": "Wybierz",
     "description": "Miejsce na wybór"
-  },
-  "model.default": {
-    "message": "Grok Imagine wideo",
-    "description": "Etykieta domyślnego modelu"
-  },
-  "model.preview15": {
-    "message": "Grok Imagine wideo 1.5 (podgląd, wideo generowane z obrazu)",
-    "description": "Etykieta modelu podglądu 1.5"
   },
   "button.upload": {
     "message": "Prześlij",
@@ -162,5 +154,21 @@
   "message.usedUp": {
     "message": "Limit został wykorzystany, proszę zakupić więcej, aby kontynuować korzystanie.",
     "description": "Wykorzystano limit"
+  },
+  "model.fastReverse": {
+    "message": "Grok Imagine Video 1.5 Fast (fast, 6–30s)",
+    "description": "1.5-fast reverse model label"
+  },
+  "model.reverse": {
+    "message": "Grok Imagine Video (standard, 1–15s)",
+    "description": "grok-imagine-video reverse model label"
+  },
+  "model.official": {
+    "message": "Grok Imagine Video · Official (higher fidelity, per-second)",
+    "description": "grok-imagine-video official model label"
+  },
+  "model.official15": {
+    "message": "Grok Imagine Video 1.5 · Official (image-to-video, up to 1080p)",
+    "description": "1.5 official model label"
   }
 }

--- a/src/i18n/pt/grokvideo.json
+++ b/src/i18n/pt/grokvideo.json
@@ -64,8 +64,8 @@
     "description": "Instruções para entrada de prompt"
   },
   "description.model": {
-    "message": "Escolha o modelo Grok Imagine. grok-imagine-video suporta vídeos gerados por texto e imagem; 1.5-preview suporta apenas vídeos gerados por imagem.",
-    "description": "Instruções para seleção de modelo"
+    "message": "Choose the Grok Imagine model. :reverse variants use the fast/standard endpoint; :official variants use the official endpoint (higher fidelity, per-second pricing). grok-imagine-video-1.5:official is image-to-video only.",
+    "description": "Instructions for model selection"
   },
   "description.ratio": {
     "message": "Escolha a proporção da saída.",
@@ -76,15 +76,15 @@
     "description": "Instruções para resolução"
   },
   "description.duration": {
-    "message": "Duração do vídeo (segundos), cobrado por segundo de saída.",
-    "description": "Instruções para a duração"
+    "message": "Video duration in seconds. 1.5-fast (reverse) supports 6-30s with banded pricing; the other variants support 1-15s billed per output second.",
+    "description": "Instructions for duration"
   },
   "description.image": {
-    "message": "Imagem de entrada opcional, usada para gerar vídeo. grok-imagine-video-1.5-preview é obrigatório.",
-    "description": "Instruções para a entrada de imagem"
+    "message": "Optional input image to animate (image-to-video). Required for grok-imagine-video-1.5:official.",
+    "description": "Instructions for image input"
   },
   "description.referenceImages": {
-    "message": "Optional reference images to guide the style or content of the generated video (grok-imagine-video only).",
+    "message": "Optional reference images to guide the style or content of the generated video.",
     "description": "Instructions for reference images"
   },
   "placeholder.prompt": {
@@ -94,14 +94,6 @@
   "placeholder.select": {
     "message": "Selecione",
     "description": "Texto de espaço reservado para seleções"
-  },
-  "model.default": {
-    "message": "Grok Imagine Vídeo",
-    "description": "Rótulo do modelo padrão"
-  },
-  "model.preview15": {
-    "message": "Grok Imagine Vídeo 1.5 (prévia, vídeo gerado por imagem)",
-    "description": "Rótulo do modelo prévia 1.5"
   },
   "button.upload": {
     "message": "Enviar",
@@ -162,5 +154,21 @@
   "message.usedUp": {
     "message": "Créditos esgotados, por favor compre mais para continuar usando.",
     "description": "Esgotado"
+  },
+  "model.fastReverse": {
+    "message": "Grok Imagine Video 1.5 Fast (fast, 6–30s)",
+    "description": "1.5-fast reverse model label"
+  },
+  "model.reverse": {
+    "message": "Grok Imagine Video (standard, 1–15s)",
+    "description": "grok-imagine-video reverse model label"
+  },
+  "model.official": {
+    "message": "Grok Imagine Video · Official (higher fidelity, per-second)",
+    "description": "grok-imagine-video official model label"
+  },
+  "model.official15": {
+    "message": "Grok Imagine Video 1.5 · Official (image-to-video, up to 1080p)",
+    "description": "1.5 official model label"
   }
 }

--- a/src/i18n/ru/grokvideo.json
+++ b/src/i18n/ru/grokvideo.json
@@ -64,8 +64,8 @@
     "description": "Инструкции по вводу подсказки"
   },
   "description.model": {
-    "message": "Выберите модель Grok Imagine. grok-imagine-video поддерживает генерацию видео по тексту и изображению; 1.5-preview поддерживает только генерацию по изображению.",
-    "description": "Инструкции по выбору модели"
+    "message": "Choose the Grok Imagine model. :reverse variants use the fast/standard endpoint; :official variants use the official endpoint (higher fidelity, per-second pricing). grok-imagine-video-1.5:official is image-to-video only.",
+    "description": "Instructions for model selection"
   },
   "description.ratio": {
     "message": "Выберите соотношение сторон выходного видео.",
@@ -76,16 +76,16 @@
     "description": "Инструкции по разрешению"
   },
   "description.duration": {
-    "message": "Длительность видео (в секундах), оплата по количеству секунд.",
-    "description": "Инструкции по длительности"
+    "message": "Video duration in seconds. 1.5-fast (reverse) supports 6-30s with banded pricing; the other variants support 1-15s billed per output second.",
+    "description": "Instructions for duration"
   },
   "description.image": {
-    "message": "Необязательное входное изображение для генерации видео. grok-imagine-video-1.5-preview обязательно.",
-    "description": "Инструкции по входному изображению"
+    "message": "Optional input image to animate (image-to-video). Required for grok-imagine-video-1.5:official.",
+    "description": "Instructions for image input"
   },
   "description.referenceImages": {
-    "message": "Необязательные референсные изображения для управления стилем или содержанием создаваемого видео (только для grok-imagine-video).",
-    "description": "Подсказка для референсных изображений."
+    "message": "Optional reference images to guide the style or content of the generated video.",
+    "description": "Instructions for reference images"
   },
   "placeholder.prompt": {
     "message": "Опишите ваше видео…",
@@ -94,14 +94,6 @@
   "placeholder.select": {
     "message": "Пожалуйста, выберите",
     "description": "Заполнитель для выбора"
-  },
-  "model.default": {
-    "message": "Grok Imagine Видео",
-    "description": "Этикетка по умолчанию для модели"
-  },
-  "model.preview15": {
-    "message": "Grok Imagine Видео 1.5 (предварительный просмотр, генерация по изображению)",
-    "description": "Этикетка модели 1.5 предварительного просмотра"
   },
   "button.upload": {
     "message": "Загрузить",
@@ -162,5 +154,21 @@
   "message.usedUp": {
     "message": "Кредиты исчерпаны, пожалуйста, купите больше для продолжения использования.",
     "description": "Исчерпано"
+  },
+  "model.fastReverse": {
+    "message": "Grok Imagine Video 1.5 Fast (fast, 6–30s)",
+    "description": "1.5-fast reverse model label"
+  },
+  "model.reverse": {
+    "message": "Grok Imagine Video (standard, 1–15s)",
+    "description": "grok-imagine-video reverse model label"
+  },
+  "model.official": {
+    "message": "Grok Imagine Video · Official (higher fidelity, per-second)",
+    "description": "grok-imagine-video official model label"
+  },
+  "model.official15": {
+    "message": "Grok Imagine Video 1.5 · Official (image-to-video, up to 1080p)",
+    "description": "1.5 official model label"
   }
 }

--- a/src/i18n/sr/grokvideo.json
+++ b/src/i18n/sr/grokvideo.json
@@ -64,8 +64,8 @@
     "description": "Uputstvo za unos prompta"
   },
   "description.model": {
-    "message": "Izaberite Grok Imagine model. grok-imagine-video podržava generisanje videa iz teksta i slike; 1.5-preview podržava samo generisanje videa iz slike.",
-    "description": "Uputstvo za izbor modela"
+    "message": "Choose the Grok Imagine model. :reverse variants use the fast/standard endpoint; :official variants use the official endpoint (higher fidelity, per-second pricing). grok-imagine-video-1.5:official is image-to-video only.",
+    "description": "Instructions for model selection"
   },
   "description.ratio": {
     "message": "Izaberite odnos stranica izlaznog videa.",
@@ -76,16 +76,16 @@
     "description": "Uputstvo za rezoluciju"
   },
   "description.duration": {
-    "message": "Trajanje videa (sekunde), naplaćuje se po broju sekundi.",
-    "description": "Uputstvo za trajanje"
+    "message": "Video duration in seconds. 1.5-fast (reverse) supports 6-30s with banded pricing; the other variants support 1-15s billed per output second.",
+    "description": "Instructions for duration"
   },
   "description.image": {
-    "message": "Opcionalna ulazna slika, koristi se za generisanje videa. grok-imagine-video-1.5-preview je obavezno.",
-    "description": "Uputstvo za ulaznu sliku"
+    "message": "Optional input image to animate (image-to-video). Required for grok-imagine-video-1.5:official.",
+    "description": "Instructions for image input"
   },
   "description.referenceImages": {
-    "message": "Опционе референтне слике које усмеравају стил или садржај генерисаног видеа (само за grok-imagine-video).",
-    "description": "Упутства за референтне слике"
+    "message": "Optional reference images to guide the style or content of the generated video.",
+    "description": "Instructions for reference images"
   },
   "placeholder.prompt": {
     "message": "Опишите ваш видео…",
@@ -94,14 +94,6 @@
   "placeholder.select": {
     "message": "Изаберите",
     "description": "Плацехолдер за избор"
-  },
-  "model.default": {
-    "message": "Grok Imagine video",
-    "description": "Oznaka za podrazumevani model"
-  },
-  "model.preview15": {
-    "message": "Grok Imagine video 1.5 (preview, generisanje videa iz slike)",
-    "description": "Oznaka za 1.5 preview model"
   },
   "button.upload": {
     "message": "Otpremi",
@@ -162,5 +154,21 @@
   "message.usedUp": {
     "message": "Kredit je iskorišćen, molimo kupite više da biste nastavili sa korišćenjem.",
     "description": "Iskorišćeno"
+  },
+  "model.fastReverse": {
+    "message": "Grok Imagine Video 1.5 Fast (fast, 6–30s)",
+    "description": "1.5-fast reverse model label"
+  },
+  "model.reverse": {
+    "message": "Grok Imagine Video (standard, 1–15s)",
+    "description": "grok-imagine-video reverse model label"
+  },
+  "model.official": {
+    "message": "Grok Imagine Video · Official (higher fidelity, per-second)",
+    "description": "grok-imagine-video official model label"
+  },
+  "model.official15": {
+    "message": "Grok Imagine Video 1.5 · Official (image-to-video, up to 1080p)",
+    "description": "1.5 official model label"
   }
 }

--- a/src/i18n/sv/grokvideo.json
+++ b/src/i18n/sv/grokvideo.json
@@ -64,8 +64,8 @@
     "description": "Instruktioner för promptinmatning"
   },
   "description.model": {
-    "message": "Välj Grok Imagine-modell. grok-imagine-video stöder text-till-video och bild-till-video; 1.5-preview stöder endast bild-till-video.",
-    "description": "Instruktioner för modellval"
+    "message": "Choose the Grok Imagine model. :reverse variants use the fast/standard endpoint; :official variants use the official endpoint (higher fidelity, per-second pricing). grok-imagine-video-1.5:official is image-to-video only.",
+    "description": "Instructions for model selection"
   },
   "description.ratio": {
     "message": "Välj utgångsbildförhållande.",
@@ -76,15 +76,15 @@
     "description": "Instruktioner för upplösning"
   },
   "description.duration": {
-    "message": "Videons längd (sekunder), debiteras baserat på utgångssekunder.",
-    "description": "Instruktioner för längd"
+    "message": "Video duration in seconds. 1.5-fast (reverse) supports 6-30s with banded pricing; the other variants support 1-15s billed per output second.",
+    "description": "Instructions for duration"
   },
   "description.image": {
-    "message": "Valfri inmatningsbild för att generera video. grok-imagine-video-1.5-preview är obligatorisk.",
-    "description": "Instruktioner för bildinmatning"
+    "message": "Optional input image to animate (image-to-video). Required for grok-imagine-video-1.5:official.",
+    "description": "Instructions for image input"
   },
   "description.referenceImages": {
-    "message": "Optional reference images to guide the style or content of the generated video (grok-imagine-video only).",
+    "message": "Optional reference images to guide the style or content of the generated video.",
     "description": "Instructions for reference images"
   },
   "placeholder.prompt": {
@@ -94,14 +94,6 @@
   "placeholder.select": {
     "message": "Vänligen välj",
     "description": "Platsinnehåll för val"
-  },
-  "model.default": {
-    "message": "Grok Imagine Video",
-    "description": "Standardmodellens etikett"
-  },
-  "model.preview15": {
-    "message": "Grok Imagine Video 1.5 (förhandsvisning, bild-till-video)",
-    "description": "1.5 förhandsvisningsmodellens etikett"
   },
   "button.upload": {
     "message": "Ladda upp",
@@ -162,5 +154,21 @@
   "message.usedUp": {
     "message": "Krediten är slut, vänligen köp mer för att fortsätta använda.",
     "description": "Användning slut"
+  },
+  "model.fastReverse": {
+    "message": "Grok Imagine Video 1.5 Fast (fast, 6–30s)",
+    "description": "1.5-fast reverse model label"
+  },
+  "model.reverse": {
+    "message": "Grok Imagine Video (standard, 1–15s)",
+    "description": "grok-imagine-video reverse model label"
+  },
+  "model.official": {
+    "message": "Grok Imagine Video · Official (higher fidelity, per-second)",
+    "description": "grok-imagine-video official model label"
+  },
+  "model.official15": {
+    "message": "Grok Imagine Video 1.5 · Official (image-to-video, up to 1080p)",
+    "description": "1.5 official model label"
   }
 }

--- a/src/i18n/uk/grokvideo.json
+++ b/src/i18n/uk/grokvideo.json
@@ -64,8 +64,8 @@
     "description": "Інструкції щодо введення підказки"
   },
   "description.model": {
-    "message": "Виберіть модель Grok Imagine. grok-imagine-video підтримує текстове та зображення відео; 1.5-preview підтримує лише зображення відео.",
-    "description": "Інструкції щодо вибору моделі"
+    "message": "Choose the Grok Imagine model. :reverse variants use the fast/standard endpoint; :official variants use the official endpoint (higher fidelity, per-second pricing). grok-imagine-video-1.5:official is image-to-video only.",
+    "description": "Instructions for model selection"
   },
   "description.ratio": {
     "message": "Виберіть співвідношення сторін виходу.",
@@ -76,15 +76,15 @@
     "description": "Інструкції щодо роздільної здатності"
   },
   "description.duration": {
-    "message": "Тривалість відео (секунди), оплата за вихідну кількість секунд.",
-    "description": "Інструкції щодо тривалості"
+    "message": "Video duration in seconds. 1.5-fast (reverse) supports 6-30s with banded pricing; the other variants support 1-15s billed per output second.",
+    "description": "Instructions for duration"
   },
   "description.image": {
-    "message": "Додаткове зображення для генерації відео. grok-imagine-video-1.5-preview є обов'язковим.",
-    "description": "Інструкції щодо введення зображення"
+    "message": "Optional input image to animate (image-to-video). Required for grok-imagine-video-1.5:official.",
+    "description": "Instructions for image input"
   },
   "description.referenceImages": {
-    "message": "Optional reference images to guide the style or content of the generated video (grok-imagine-video only).",
+    "message": "Optional reference images to guide the style or content of the generated video.",
     "description": "Instructions for reference images"
   },
   "placeholder.prompt": {
@@ -94,14 +94,6 @@
   "placeholder.select": {
     "message": "Будь ласка, виберіть",
     "description": "Заповнювач для вибору"
-  },
-  "model.default": {
-    "message": "Grok Imagine відео",
-    "description": "Мітка за замовчуванням для моделі"
-  },
-  "model.preview15": {
-    "message": "Grok Imagine відео 1.5 (попередній перегляд, зображення відео)",
-    "description": "Мітка для моделі попереднього перегляду 1.5"
   },
   "button.upload": {
     "message": "Завантажити",
@@ -162,5 +154,21 @@
   "message.usedUp": {
     "message": "Ліміт вичерпано, будь ласка, купіть, щоб продовжити використання.",
     "description": "Вичерпано"
+  },
+  "model.fastReverse": {
+    "message": "Grok Imagine Video 1.5 Fast (fast, 6–30s)",
+    "description": "1.5-fast reverse model label"
+  },
+  "model.reverse": {
+    "message": "Grok Imagine Video (standard, 1–15s)",
+    "description": "grok-imagine-video reverse model label"
+  },
+  "model.official": {
+    "message": "Grok Imagine Video · Official (higher fidelity, per-second)",
+    "description": "grok-imagine-video official model label"
+  },
+  "model.official15": {
+    "message": "Grok Imagine Video 1.5 · Official (image-to-video, up to 1080p)",
+    "description": "1.5 official model label"
   }
 }

--- a/src/i18n/zh-CN/grokvideo.json
+++ b/src/i18n/zh-CN/grokvideo.json
@@ -1,57 +1,152 @@
 {
-  "name.bot": { "message": "Grok 视频机器人", "description": "Name of the Grok video generator" },
-  "name.prompt": { "message": "提示词", "description": "Prompt for generating the video" },
-  "name.model": { "message": "模型", "description": "Label for model selection" },
-  "name.ratio": { "message": "画面比例", "description": "Label for aspect ratio" },
-  "name.resolution": { "message": "分辨率", "description": "Label for resolution" },
-  "name.duration": { "message": "时长", "description": "Label for duration" },
-  "name.image": { "message": "图片", "description": "Label for input image" },
-  "name.referenceImages": { "message": "参考图", "description": "Label for reference images" },
-  "name.required": { "message": "必填", "description": "Required badge" },
-  "name.taskId": { "message": "任务 ID", "description": "Task id label" },
-  "name.elapsed": { "message": "耗时", "description": "Elapsed time label" },
-  "name.traceId": { "message": "追踪 ID", "description": "Trace id label" },
-  "name.failure": { "message": "生成失败", "description": "Failure title" },
-  "name.failureReason": { "message": "失败原因", "description": "Failure reason label" },
-  "name.status": { "message": "状态", "description": "Status title" },
+  "name.bot": {
+    "message": "Grok 视频机器人",
+    "description": "Name of the Grok video generator"
+  },
+  "name.prompt": {
+    "message": "提示词",
+    "description": "Prompt for generating the video"
+  },
+  "name.model": {
+    "message": "模型",
+    "description": "Label for model selection"
+  },
+  "name.ratio": {
+    "message": "画面比例",
+    "description": "Label for aspect ratio"
+  },
+  "name.resolution": {
+    "message": "分辨率",
+    "description": "Label for resolution"
+  },
+  "name.duration": {
+    "message": "时长",
+    "description": "Label for duration"
+  },
+  "name.image": {
+    "message": "图片",
+    "description": "Label for input image"
+  },
+  "name.referenceImages": {
+    "message": "参考图",
+    "description": "Label for reference images"
+  },
+  "name.required": {
+    "message": "必填",
+    "description": "Required badge"
+  },
+  "name.taskId": {
+    "message": "任务 ID",
+    "description": "Task id label"
+  },
+  "name.elapsed": {
+    "message": "耗时",
+    "description": "Elapsed time label"
+  },
+  "name.traceId": {
+    "message": "追踪 ID",
+    "description": "Trace id label"
+  },
+  "name.failure": {
+    "message": "生成失败",
+    "description": "Failure title"
+  },
+  "name.failureReason": {
+    "message": "失败原因",
+    "description": "Failure reason label"
+  },
+  "name.status": {
+    "message": "状态",
+    "description": "Status title"
+  },
   "description.prompt": {
     "message": "描述你想生成的视频（场景、主体、动作、镜头、光线、风格）。",
     "description": "Instructions for prompt input"
   },
   "description.model": {
-    "message": "选择 Grok Imagine 模型。grok-imagine-video 支持文生与图生视频，时长最长 30 秒；1.5-preview 仅支持图生视频，时长最长 15 秒。",
+    "message": "选择 Grok Imagine 模型。:reverse 走快速/标准端点；:official 走官方端点（画质更高，按秒计费）。grok-imagine-video-1.5:official 仅支持图生视频。",
     "description": "Instructions for model selection"
   },
-  "description.ratio": { "message": "选择输出画面比例。", "description": "Instructions for aspect ratio" },
+  "description.ratio": {
+    "message": "选择输出画面比例。",
+    "description": "Instructions for aspect ratio"
+  },
   "description.resolution": {
     "message": "选择输出分辨率，支持 480p / 720p / 1080p。分辨率越高，消耗的额度越多。",
     "description": "Instructions for resolution"
   },
   "description.duration": {
-    "message": "视频时长（秒）。grok-imagine-video 支持 1-30 秒，按时长分档计费；1.5-preview 支持 1-15 秒，按输出秒数计费。",
+    "message": "视频时长（秒）。1.5-fast（reverse）支持 6-30 秒，按时长分档计费；其余变体支持 1-15 秒，按输出秒数计费。",
     "description": "Instructions for duration"
   },
   "description.image": {
-    "message": "可选的输入图片，用于图生视频。grok-imagine-video-1.5-preview 为必填。",
+    "message": "可选的输入图片，用于图生视频。grok-imagine-video-1.5:official 为必填。",
     "description": "Instructions for image input"
   },
   "description.referenceImages": {
-    "message": "可选的参考图，用于引导生成视频的风格或内容（仅 grok-imagine-video 支持）。",
+    "message": "可选的参考图，用于引导生成视频的风格或内容。",
     "description": "Instructions for reference images"
   },
-  "placeholder.prompt": { "message": "描述你的视频…", "description": "Placeholder for prompt" },
-  "placeholder.select": { "message": "请选择", "description": "Placeholder for selects" },
-  "model.default": { "message": "Grok Imagine 视频", "description": "Default model label" },
-  "model.preview15": { "message": "Grok Imagine 视频 1.5（预览，图生视频）", "description": "1.5 preview model label" },
-  "button.upload": { "message": "上传", "description": "Upload button" },
-  "button.generate": { "message": "生成", "description": "Generate button" },
-  "button.download": { "message": "下载", "description": "Download button" },
-  "status.pending": { "message": "排队中", "description": "Pending status" },
-  "status.processing": { "message": "生成中", "description": "Processing status" },
-  "message.uploadExceed": { "message": "只能上传一张图片。", "description": "Upload exceed warning" },
-  "message.uploadReferenceExceed": { "message": "最多可上传 4 张参考图。", "description": "Reference images upload exceed warning" },
-  "message.uploadError": { "message": "图片上传失败，请重试。", "description": "Upload error" },
-  "message.downloadVideo": { "message": "下载视频", "description": "Download tooltip" },
+  "placeholder.prompt": {
+    "message": "描述你的视频…",
+    "description": "Placeholder for prompt"
+  },
+  "placeholder.select": {
+    "message": "请选择",
+    "description": "Placeholder for selects"
+  },
+  "model.fastReverse": {
+    "message": "Grok Imagine 视频 1.5 Fast（快速，6–30 秒）",
+    "description": "1.5-fast reverse model label"
+  },
+  "model.reverse": {
+    "message": "Grok Imagine 视频（标准，1–15 秒）",
+    "description": "grok-imagine-video reverse model label"
+  },
+  "model.official": {
+    "message": "Grok Imagine 视频 · 官方（更高画质，按秒计费）",
+    "description": "grok-imagine-video official model label"
+  },
+  "model.official15": {
+    "message": "Grok Imagine 视频 1.5 · 官方（图生视频，最高 1080p）",
+    "description": "1.5 official model label"
+  },
+  "button.upload": {
+    "message": "上传",
+    "description": "Upload button"
+  },
+  "button.generate": {
+    "message": "生成",
+    "description": "Generate button"
+  },
+  "button.download": {
+    "message": "下载",
+    "description": "Download button"
+  },
+  "status.pending": {
+    "message": "排队中",
+    "description": "Pending status"
+  },
+  "status.processing": {
+    "message": "生成中",
+    "description": "Processing status"
+  },
+  "message.uploadExceed": {
+    "message": "只能上传一张图片。",
+    "description": "Upload exceed warning"
+  },
+  "message.uploadReferenceExceed": {
+    "message": "最多可上传 4 张参考图。",
+    "description": "Reference images upload exceed warning"
+  },
+  "message.uploadError": {
+    "message": "图片上传失败，请重试。",
+    "description": "Upload error"
+  },
+  "message.downloadVideo": {
+    "message": "下载视频",
+    "description": "Download tooltip"
+  },
   "message.modelRequiresImage": {
     "message": "该模型需要输入图片（图生视频）。",
     "description": "Model requires image warning"
@@ -60,8 +155,20 @@
     "message": "请输入提示词或上传图片。",
     "description": "Prompt or image required warning"
   },
-  "message.startingTask": { "message": "正在提交视频生成任务…", "description": "Starting task" },
-  "message.startTaskSuccess": { "message": "任务提交成功。", "description": "Task success" },
-  "message.startTaskFailed": { "message": "任务提交失败：", "description": "Task failed" },
-  "message.usedUp": { "message": "额度已用尽，请购买后继续使用。", "description": "Used up" }
+  "message.startingTask": {
+    "message": "正在提交视频生成任务…",
+    "description": "Starting task"
+  },
+  "message.startTaskSuccess": {
+    "message": "任务提交成功。",
+    "description": "Task success"
+  },
+  "message.startTaskFailed": {
+    "message": "任务提交失败：",
+    "description": "Task failed"
+  },
+  "message.usedUp": {
+    "message": "额度已用尽，请购买后继续使用。",
+    "description": "Used up"
+  }
 }

--- a/src/i18n/zh-TW/grokvideo.json
+++ b/src/i18n/zh-TW/grokvideo.json
@@ -64,8 +64,8 @@
     "description": "有關提示輸入的說明"
   },
   "description.model": {
-    "message": "選擇 Grok Imagine 模型。grok-imagine-video 支援文生與圖生影片；1.5-preview 僅支援圖生影片。",
-    "description": "有關模型選擇的說明"
+    "message": "Choose the Grok Imagine model. :reverse variants use the fast/standard endpoint; :official variants use the official endpoint (higher fidelity, per-second pricing). grok-imagine-video-1.5:official is image-to-video only.",
+    "description": "Instructions for model selection"
   },
   "description.ratio": {
     "message": "選擇輸出畫面比例。",
@@ -76,15 +76,15 @@
     "description": "有關解析度的說明"
   },
   "description.duration": {
-    "message": "影片時長（秒），按輸出秒數計費。",
-    "description": "有關時長的說明"
+    "message": "Video duration in seconds. 1.5-fast (reverse) supports 6-30s with banded pricing; the other variants support 1-15s billed per output second.",
+    "description": "Instructions for duration"
   },
   "description.image": {
-    "message": "可選的輸入圖片，用於圖生影片。grok-imagine-video-1.5-preview 為必填。",
-    "description": "有關圖片輸入的說明"
+    "message": "Optional input image to animate (image-to-video). Required for grok-imagine-video-1.5:official.",
+    "description": "Instructions for image input"
   },
   "description.referenceImages": {
-    "message": "可選的參考圖，用於引導生成影片的風格或內容（僅 grok-imagine-video 支援）。",
+    "message": "Optional reference images to guide the style or content of the generated video.",
     "description": "Instructions for reference images"
   },
   "placeholder.prompt": {
@@ -94,14 +94,6 @@
   "placeholder.select": {
     "message": "請選擇",
     "description": "選擇的佔位符"
-  },
-  "model.default": {
-    "message": "Grok Imagine 影片",
-    "description": "預設模型標籤"
-  },
-  "model.preview15": {
-    "message": "Grok Imagine 影片 1.5（預覽，圖生影片）",
-    "description": "1.5 預覽模型標籤"
   },
   "button.upload": {
     "message": "上傳",
@@ -162,5 +154,21 @@
   "message.usedUp": {
     "message": "額度已用盡，請購買後繼續使用。",
     "description": "已用盡"
+  },
+  "model.fastReverse": {
+    "message": "Grok Imagine Video 1.5 Fast (fast, 6–30s)",
+    "description": "1.5-fast reverse model label"
+  },
+  "model.reverse": {
+    "message": "Grok Imagine Video (standard, 1–15s)",
+    "description": "grok-imagine-video reverse model label"
+  },
+  "model.official": {
+    "message": "Grok Imagine Video · Official (higher fidelity, per-second)",
+    "description": "grok-imagine-video official model label"
+  },
+  "model.official15": {
+    "message": "Grok Imagine Video 1.5 · Official (image-to-video, up to 1080p)",
+    "description": "1.5 official model label"
   }
 }

--- a/src/pages/grokvideo/Index.vue
+++ b/src/pages/grokvideo/Index.vue
@@ -141,8 +141,8 @@ export default defineComponent({
       if (typeof cfg?.image_url === 'string' && !cfg.image_url.trim()) {
         delete cfg.image_url;
       }
-      // Reference images are only supported by grok-imagine-video (1.0). Drop
-      // stale refs (e.g. uploaded on 1.0 then switched to 1.5-preview) and empties.
+      // Drop stale reference images (e.g. uploaded then switched to an
+      // image-only model) and empty arrays.
       if (
         isGrokVideoImageOnlyModel(cfg?.model) ||
         !(Array.isArray(cfg?.reference_image_urls) && cfg.reference_image_urls.length)
@@ -151,7 +151,7 @@ export default defineComponent({
       }
 
       const hasImage = !!cfg?.image_url;
-      // grok-imagine-video-1.5-preview is image-to-video only.
+      // grok-imagine-video-1.5:official is image-to-video only.
       if (isGrokVideoImageOnlyModel(cfg?.model) && !hasImage) {
         ElMessage.warning(this.$t('grokvideo.message.modelRequiresImage'));
         return;


### PR DESCRIPTION
## What

Replaces the old bare `grok-imagine-video` / `-1.5-preview` picker with the four endpoint-suffixed models the ttapi worker now routes:

- `grok-imagine-video-1.5-fast:reverse` (default, fast, 6–30s, flat tiers)
- `grok-imagine-video:reverse` (standard, 1–15s, per-second)
- `grok-imagine-video:official` (official, per-second)
- `grok-imagine-video-1.5:official` (official image-to-video only, up to 1080p)

## Changes

- `constants/grokvideo.ts`: new model ids + per-model min/max duration helpers; default = the cheap fast:reverse tier; image-only set → `grok-imagine-video-1.5:official`.
- `ModelSelector` lists all four; `DurationSelector` filters options and clamps the value to the model's `[min, max]` range.
- i18n: new model labels + refreshed descriptions in zh-CN/en, seeded into all other locales. **Coverage check passes (17 locales × 45 namespaces).**
- Beachball change file added.

`vue-tsc --noEmit` clean; ESLint clean on all changed files.

Depends on the PlatformService worker + PlatformBackend cost/openapi PRs (the new model names + billing).
