### PR TITLE
feat(order): Card pay-way replaces Stripe when ENABLE_CARD is on

### DIFF
--- a/src/i18n/ar/order.json
+++ b/src/i18n/ar/order.json
@@ -159,6 +159,10 @@
     "message": "Stripe",
     "description": "العنوان المعروض كعنوان للموقع، يشير إلى دفع Stripe، وهو نوع من الدفع عبر الإنترنت."
   },
+  "title.card": {
+    "message": "Card",
+    "description": "Title displayed on the website indicating card payment (credit/debit card)."
+  },
   "title.manageOrder": {
     "message": "إدارة الطلب",
     "description": "العنوان المعروض كعنوان للموقع، يشير إلى إدارة الطلب."

--- a/src/i18n/de/order.json
+++ b/src/i18n/de/order.json
@@ -159,6 +159,10 @@
     "message": "Stripe",
     "description": "Titel, der auf der Website angezeigt wird und die Stripe-Zahlung darstellt, Stripe ist eine Online-Zahlung."
   },
+  "title.card": {
+    "message": "Card",
+    "description": "Title displayed on the website indicating card payment (credit/debit card)."
+  },
   "title.manageOrder": {
     "message": "Bestellung verwalten",
     "description": "Titel, der auf der Website angezeigt wird und die Verwaltung von Bestellungen darstellt."

--- a/src/i18n/el/order.json
+++ b/src/i18n/el/order.json
@@ -159,6 +159,10 @@
     "message": "Πληρωμή μέσω Stripe",
     "description": "Τίτλος που εμφανίζεται στην ιστοσελίδα, που υποδηλώνει πληρωμή μέσω Stripe."
   },
+  "title.card": {
+    "message": "Card",
+    "description": "Title displayed on the website indicating card payment (credit/debit card)."
+  },
   "title.manageOrder": {
     "message": "Διαχείριση Παραγγελίας",
     "description": "Τίτλος που εμφανίζεται στην ιστοσελίδα, που υποδηλώνει διαχείριση παραγγελίας."

--- a/src/i18n/en/order.json
+++ b/src/i18n/en/order.json
@@ -159,6 +159,10 @@
     "message": "Stripe",
     "description": "Title displayed on the website indicating Stripe payment, which is an online payment method."
   },
+  "title.card": {
+    "message": "Card",
+    "description": "Title displayed on the website indicating card payment (credit/debit card)."
+  },
   "title.manageOrder": {
     "message": "Manage Orders",
     "description": "Title displayed on the website indicating order management."

--- a/src/i18n/es/order.json
+++ b/src/i18n/es/order.json
@@ -159,6 +159,10 @@
     "message": "Stripe",
     "description": "Título que se muestra en el sitio web, indica pago con Stripe, que es un método de pago en línea."
   },
+  "title.card": {
+    "message": "Card",
+    "description": "Title displayed on the website indicating card payment (credit/debit card)."
+  },
   "title.manageOrder": {
     "message": "Gestionar pedido",
     "description": "Título que se muestra en el sitio web, indica gestión de pedidos."

--- a/src/i18n/fi/order.json
+++ b/src/i18n/fi/order.json
@@ -159,6 +159,10 @@
     "message": "Stripe",
     "description": "Otsikko, joka näytetään verkkosivustolla ja tarkoittaa Stripe-maksua, Stripe on verkkopankkimaksu."
   },
+  "title.card": {
+    "message": "Card",
+    "description": "Title displayed on the website indicating card payment (credit/debit card)."
+  },
   "title.manageOrder": {
     "message": "Hallitse tilausta",
     "description": "Otsikko, joka näytetään verkkosivustolla ja tarkoittaa tilauksen hallintaa."

--- a/src/i18n/fr/order.json
+++ b/src/i18n/fr/order.json
@@ -159,6 +159,10 @@
     "message": "Stripe",
     "description": "Titre affiché sur le site, indiquant le paiement Stripe, qui est un paiement en ligne."
   },
+  "title.card": {
+    "message": "Card",
+    "description": "Title displayed on the website indicating card payment (credit/debit card)."
+  },
   "title.manageOrder": {
     "message": "Gérer la commande",
     "description": "Titre affiché sur le site, indiquant la gestion des commandes."

--- a/src/i18n/it/order.json
+++ b/src/i18n/it/order.json
@@ -159,6 +159,10 @@
     "message": "Stripe",
     "description": "Titolo visualizzato sul sito, indica il pagamento Stripe, un metodo di pagamento online."
   },
+  "title.card": {
+    "message": "Card",
+    "description": "Title displayed on the website indicating card payment (credit/debit card)."
+  },
   "title.manageOrder": {
     "message": "Gestisci Ordine",
     "description": "Titolo visualizzato sul sito, indica la gestione degli ordini."

--- a/src/i18n/ja/order.json
+++ b/src/i18n/ja/order.json
@@ -159,6 +159,10 @@
     "message": "ストライプ",
     "description": "ウェブサイトのタイトルとして表示されるタイトルで、ストライプ支払いを示します。ストライプ支払いはオンライン支払いの一種です。"
   },
+  "title.card": {
+    "message": "Card",
+    "description": "Title displayed on the website indicating card payment (credit/debit card)."
+  },
   "title.manageOrder": {
     "message": "注文管理",
     "description": "ウェブサイトのタイトルとして表示されるタイトルで、注文管理を示します。"

--- a/src/i18n/ko/order.json
+++ b/src/i18n/ko/order.json
@@ -159,6 +159,10 @@
     "message": "스트라이프",
     "description": "웹사이트 제목으로 표시되는 제목으로, 스트라이프 결제를 나타냅니다."
   },
+  "title.card": {
+    "message": "Card",
+    "description": "Title displayed on the website indicating card payment (credit/debit card)."
+  },
   "title.manageOrder": {
     "message": "주문 관리",
     "description": "웹사이트 제목으로 표시되는 제목으로, 주문 관리를 나타냅니다."

--- a/src/i18n/pl/order.json
+++ b/src/i18n/pl/order.json
@@ -159,6 +159,10 @@
     "message": "Stripe",
     "description": "Tytuł wyświetlany na stronie, który oznacza płatność Stripe, Stripe to metoda płatności online."
   },
+  "title.card": {
+    "message": "Card",
+    "description": "Title displayed on the website indicating card payment (credit/debit card)."
+  },
   "title.manageOrder": {
     "message": "Zarządzaj zamówieniem",
     "description": "Tytuł wyświetlany na stronie, który oznacza zarządzanie zamówieniem."

--- a/src/i18n/pt/order.json
+++ b/src/i18n/pt/order.json
@@ -159,6 +159,10 @@
     "message": "Stripe",
     "description": "Título exibido no site, indicando pagamento via Stripe, que é um método de pagamento online."
   },
+  "title.card": {
+    "message": "Card",
+    "description": "Title displayed on the website indicating card payment (credit/debit card)."
+  },
   "title.manageOrder": {
     "message": "Gerenciar Pedido",
     "description": "Título exibido no site, indicando gerenciamento de pedidos."

--- a/src/i18n/ru/order.json
+++ b/src/i18n/ru/order.json
@@ -159,6 +159,10 @@
     "message": "Stripe",
     "description": "Заголовок, отображаемый на сайте, указывающий на оплату через Stripe."
   },
+  "title.card": {
+    "message": "Card",
+    "description": "Title displayed on the website indicating card payment (credit/debit card)."
+  },
   "title.manageOrder": {
     "message": "Управление заказом",
     "description": "Заголовок, отображаемый на сайте, указывающий на управление заказом."

--- a/src/i18n/sr/order.json
+++ b/src/i18n/sr/order.json
@@ -159,6 +159,10 @@
     "message": "Stripe",
     "description": "Naslov koji se prikazuje kao naslov stranice, označava Stripe plaćanje, Stripe je online plaćanje."
   },
+  "title.card": {
+    "message": "Card",
+    "description": "Title displayed on the website indicating card payment (credit/debit card)."
+  },
   "title.manageOrder": {
     "message": "Upravljanje narudžbinama",
     "description": "Naslov koji se prikazuje kao naslov stranice, označava upravljanje narudžbinama."

--- a/src/i18n/sv/order.json
+++ b/src/i18n/sv/order.json
@@ -159,6 +159,10 @@
     "message": "Stripe",
     "description": "Titel som visas på webbplatsen, vilket indikerar Stripe-betalning, Stripe är en typ av online-betalning."
   },
+  "title.card": {
+    "message": "Card",
+    "description": "Title displayed on the website indicating card payment (credit/debit card)."
+  },
   "title.manageOrder": {
     "message": "Hantera beställningar",
     "description": "Titel som visas på webbplatsen, vilket indikerar hantering av beställningar."

--- a/src/i18n/uk/order.json
+++ b/src/i18n/uk/order.json
@@ -159,6 +159,10 @@
     "message": "Stripe",
     "description": "Заголовок, що відображається на сайті, що вказує на оплату через Stripe."
   },
+  "title.card": {
+    "message": "Card",
+    "description": "Title displayed on the website indicating card payment (credit/debit card)."
+  },
   "title.manageOrder": {
     "message": "Управління замовленнями",
     "description": "Заголовок, що відображається на сайті, що вказує на управління замовленнями."

--- a/src/i18n/zh-CN/order.json
+++ b/src/i18n/zh-CN/order.json
@@ -159,6 +159,10 @@
     "message": "Stripe",
     "description": "作为网站标题显示的标题，表示Stripe支付，Stripe支付是一种在线支付。"
   },
+  "title.card": {
+    "message": "银行卡",
+    "description": "作为网站标题显示的标题，表示银行卡支付（信用卡/借记卡）。"
+  },
   "title.manageOrder": {
     "message": "管理订单",
     "description": "作为网站标题显示的标题，表示管理订单。"

--- a/src/i18n/zh-TW/order.json
+++ b/src/i18n/zh-TW/order.json
@@ -159,6 +159,10 @@
     "message": "Stripe",
     "description": "作為網站標題顯示的標題，表示Stripe支付，Stripe支付是一種線上支付。"
   },
+  "title.card": {
+    "message": "Card",
+    "description": "Title displayed on the website indicating card payment (credit/debit card)."
+  },
   "title.manageOrder": {
     "message": "管理訂單",
     "description": "作為網站標題顯示的標題，表示管理訂單。"

--- a/src/models/config.ts
+++ b/src/models/config.ts
@@ -1,6 +1,9 @@
 export interface IConfigFeatures {
   DISCOUNT_FOR_X402?: number;
   ENABLE_PAYPAL?: boolean;
+  // When on, the Card pay-way (hosted Stripe PaymentLink, HK account)
+  // replaces Stripe in the payment picker.
+  ENABLE_CARD?: boolean;
 }
 
 export interface IConfigResponse {

--- a/src/pages/console/order/Detail.vue
+++ b/src/pages/console/order/Detail.vue
@@ -129,6 +129,7 @@
                     <span class="payname">{{ $t('order.title.aliPay') }}</span>
                   </div>
                   <div
+                    v-if="!enableCard"
                     :class="{
                       payway: true,
                       stripe: true,
@@ -138,6 +139,18 @@
                   >
                     <span class="payicon stripe"></span>
                     <span class="payname">{{ $t('order.title.stripe') }}</span>
+                  </div>
+                  <div
+                    v-if="enableCard"
+                    :class="{
+                      payway: true,
+                      creditcard: true,
+                      active: payWay === PayWay.Card
+                    }"
+                    @click="payWay = PayWay.Card"
+                  >
+                    <span class="payicon card" aria-hidden="true"></span>
+                    <span class="payname">{{ $t('order.title.card') }}</span>
                   </div>
                   <div
                     :class="{
@@ -197,7 +210,7 @@
             @hide="paying = false"
           />
           <stripe-pay-order
-            v-if="order && payWay === PayWay.Stripe"
+            v-if="order && (payWay === PayWay.Stripe || payWay === PayWay.Card)"
             v-model="order"
             :visible="paying"
             @hide="paying = false"
@@ -269,7 +282,8 @@ enum PayWay {
   AliPay = 'AliPay',
   X402 = 'X402',
   PayPal = 'PayPal',
-  Apple = 'AppleIAP'
+  Apple = 'AppleIAP',
+  Card = 'Card'
 }
 
 interface IData {
@@ -325,6 +339,10 @@ export default defineComponent({
     },
     enablePaypal(): boolean {
       return !!this.config?.features?.ENABLE_PAYPAL;
+    },
+    // When ENABLE_CARD is on, Card replaces Stripe in the payment picker.
+    enableCard(): boolean {
+      return !!this.config?.features?.ENABLE_CARD;
     },
     isIos(): boolean {
       return isIOS();
@@ -566,6 +584,8 @@ export default defineComponent({
           return this.$t('order.title.wechatPay') as string;
         case PayWay.Stripe:
           return this.$t('order.title.stripe') as string;
+        case PayWay.Card:
+          return this.$t('order.title.card') as string;
         case PayWay.AliPay:
           return this.$t('order.title.aliPay') as string;
         case PayWay.X402:
@@ -811,6 +831,12 @@ export default defineComponent({
       width: 22px;
       height: 22px;
       background-image: url(//cdn.acedata.cloud/alipay.webp);
+      background-size: contain;
+    }
+    &.card {
+      width: 22px;
+      height: 22px;
+      background-image: url(//cdn.acedata.cloud/card.webp);
       background-size: contain;
     }
     &.x402 {

--- a/src/pages/console/order/List.vue
+++ b/src/pages/console/order/List.vue
@@ -320,6 +320,7 @@ export default defineComponent({
       return [
         { value: 'WechatPay', label: this.$t('order.title.wechatPay') },
         { value: 'Stripe', label: this.$t('order.title.stripe') },
+        { value: 'Card', label: this.$t('order.title.card') },
         { value: 'AliPay', label: this.$t('order.title.aliPay') },
         { value: 'X402', label: this.$t('order.title.x402') },
         { value: 'PayPal', label: this.$t('order.title.paypal') }

--- a/src/pages/order/Pay.vue
+++ b/src/pages/order/Pay.vue
@@ -81,11 +81,20 @@
                     <span class="payname">{{ $t('order.title.aliPay') }}</span>
                   </div>
                   <div
+                    v-if="!enableCard"
                     :class="{ payway: true, stripe: true, active: payWay === PayWay.Stripe }"
                     @click="payWay = PayWay.Stripe"
                   >
                     <span class="payicon stripe"></span>
                     <span class="payname">{{ $t('order.title.stripe') }}</span>
+                  </div>
+                  <div
+                    v-if="enableCard"
+                    :class="{ payway: true, creditcard: true, active: payWay === PayWay.Card }"
+                    @click="payWay = PayWay.Card"
+                  >
+                    <span class="payicon card" aria-hidden="true"></span>
+                    <span class="payname">{{ $t('order.title.card') }}</span>
                   </div>
                 </div>
                 <div v-if="!order.pay_way">
@@ -111,14 +120,19 @@
     :visible="paying"
     @hide="paying = false"
   />
-  <public-stripe-pay v-if="order && payWay === PayWay.Stripe" :order="order" :visible="paying" @hide="paying = false" />
+  <public-stripe-pay
+    v-if="order && (payWay === PayWay.Stripe || payWay === PayWay.Card)"
+    :order="order"
+    :visible="paying"
+    @hide="paying = false"
+  />
   <public-alipay-pay v-if="order && payWay === PayWay.AliPay" :order="order" :visible="paying" @hide="paying = false" />
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue';
 import { orderOperator } from '@/operators';
-import { IOrder, IOrderDetailResponse, OrderState } from '@/models';
+import { IConfigResponse, IOrder, IOrderDetailResponse, OrderState } from '@/models';
 import {
   ElRow,
   ElCol,
@@ -144,10 +158,12 @@ const POLL_INITIAL_DELAY_MS = 2000;
 
 // Mirrors PlatformBackend's ANON_ALLOWED_PAY_WAYS. X402/PayPal need a
 // request.user the anonymous flow can't supply and would 403 server-side.
+// Card is the ENABLE_CARD-gated replacement for Stripe (hosted PaymentLink).
 enum PayWay {
   WechatPay = 'WechatPay',
   Stripe = 'Stripe',
-  AliPay = 'AliPay'
+  AliPay = 'AliPay',
+  Card = 'Card'
 }
 
 interface IData {
@@ -193,6 +209,13 @@ export default defineComponent({
     id(): string {
       return this.$route.params?.id?.toString() ?? '';
     },
+    config(): IConfigResponse | undefined {
+      return this.$store.getters.config as IConfigResponse | undefined;
+    },
+    // When ENABLE_CARD is on, Card replaces Stripe on the anonymous page too.
+    enableCard(): boolean {
+      return !!this.config?.features?.ENABLE_CARD;
+    },
     // App Store Review Guideline 3.1.1: no non-IAP payment UI on iOS.
     showPayment(): boolean {
       return !isIOS();
@@ -219,7 +242,8 @@ export default defineComponent({
       const map: Record<string, string> = {
         WechatPay: this.$t('order.title.wechatPay') as string,
         Stripe: this.$t('order.title.stripe') as string,
-        AliPay: this.$t('order.title.aliPay') as string
+        AliPay: this.$t('order.title.aliPay') as string,
+        Card: this.$t('order.title.card') as string
       };
       return map[payWay] || payWay;
     },
@@ -380,6 +404,10 @@ export default defineComponent({
         }
         &.alipay {
           background-image: url(//cdn.acedata.cloud/alipay.webp);
+          background-size: contain;
+        }
+        &.card {
+          background-image: url(//cdn.acedata.cloud/card.webp);
           background-size: contain;
         }
       }


### PR DESCRIPTION
## What

Mirror the PlatformFrontend behavior: when the server feature flag **`ENABLE_CARD`** is on, show the **Card** pay-way (hosted Stripe PaymentLink, HK account) and **hide Stripe** — on both the authenticated console order page and the anonymous public pay page.

Card did **not** previously exist in Nexior, so this ports the full pay-way from scratch. Companion PRs: PlatformBackend #1138, PlatformFrontend #903.

## Changes

- `models/config.ts`: add `ENABLE_CARD?: boolean` to `IConfigFeatures`.
- `pages/console/order/Detail.vue` + `pages/order/Pay.vue`: add the `Card` enum member, an `enableCard` computed (`config.features.ENABLE_CARD`), the Card grid option (`v-if="enableCard"`), gate Stripe on `!enableCard`, and extend the Stripe dialog `v-if` to mount for Card too. Card returns only `pay_url` (no `stripe_client_secret`), so it correctly skips `StripePay.vue`'s Android native-PaymentSheet branch and falls through to `window.open(pay_url)` on all surfaces.
- `payWayLabel` + `.payicon.card` style; `pages/console/order/List.vue` filter-dropdown parity.
- i18n: add `order.title.card` to zh-CN + en, seed the other 16 locales from en (translate CronJob localizes later).

## Behavior / reversibility

- `ENABLE_CARD` **off** (default): Card hidden, Stripe unchanged — zero behavior change.
- `ENABLE_CARD` **on**: Card shown, Stripe hidden.
- iOS is unaffected (payment grid already hidden on iOS → Apple IAP only). Default selected pay-way is WeChat, never Stripe, so hiding Stripe strands no default.

## Verification

`vue-tsc --noEmit` → 0 errors. `eslint` on touched files → clean. `check_i18n_coverage.py` → OK (17 locales cover zh-CN). `beachball check` → no change file needed.

## 🤖 对抗评审

Independent reviewer (Codex hit usage limit → Claude `general-purpose` subagent). **No high/medium defects.** Specifically confirmed the Nexior Android path: Card has no `stripe_client_secret`, so `StripePay.vue`'s `isAndroid() && clientSecret` branch is skipped and it opens `pay_url` — no silent no-op. Repay of a pre-existing Stripe order still works (dialog `v-if` keyed on `Stripe || Card`, `payWay` re-hydrated from `order.pay_way`). One **low-severity** parity gap it flagged — order-list filter missing Card — is **fixed in this PR**. `VERDICT: CLEAN` after fix.