### PR TITLE
fix(order): use new bank-card icon for Card pay-way

### DIFF
--- a/change/@acedatacloud-nexior-a784406e-15be-4e69-8c3d-4f0f97d3e4a4.json
+++ b/change/@acedatacloud-nexior-a784406e-15be-4e69-8c3d-4f0f97d3e4a4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Use new bank-card icon for Card pay-way",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/pages/console/order/Detail.vue
+++ b/src/pages/console/order/Detail.vue
@@ -836,7 +836,7 @@ export default defineComponent({
     &.card {
       width: 22px;
       height: 22px;
-      background-image: url(//cdn.acedata.cloud/card.webp);
+      background-image: url(//cdn.acedata.cloud/jensvf.png);
       background-size: contain;
     }
     &.x402 {

--- a/src/pages/order/Pay.vue
+++ b/src/pages/order/Pay.vue
@@ -407,7 +407,7 @@ export default defineComponent({
           background-size: contain;
         }
         &.card {
-          background-image: url(//cdn.acedata.cloud/card.webp);
+          background-image: url(//cdn.acedata.cloud/jensvf.png);
           background-size: contain;
         }
       }


### PR DESCRIPTION
## What

Swap the **Card** pay-way icon from `//cdn.acedata.cloud/card.webp` to `//cdn.acedata.cloud/jensvf.png` (a clearer bank-card graphic) in the `.payicon.card` scoped style, on both:

- `src/pages/console/order/Detail.vue` (authenticated console order page)
- `src/pages/order/Pay.vue` (anonymous public pay page)

Pure asset-URL swap in scoped CSS — no logic, no markup, no i18n change. New URL verified reachable (200, image/png).

## 🤖 对抗评审

Trivial one-line CSS `url()` swap of a verified-valid CDN asset — no logic/behavior change. `VERDICT: CLEAN`.