### PR TITLE
feat(chat): 定时任务页新增「运行记录」标签页

### DIFF
--- a/change/@acedatacloud-nexior-scheduled-runs-tab-2026-07-26.json
+++ b/change/@acedatacloud-nexior-scheduled-runs-tab-2026-07-26.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add a Runs tab to the scheduled tasks page: a cross-task feed of every scheduled run, newest first, each row tagged with its parent task name and filterable by status.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/i18n/ar/chat.json
+++ b/src/i18n/ar/chat.json
@@ -587,6 +587,18 @@
     "message": "المهام المجدولة",
     "description": "مدخل المهام المجدولة في الشريط الجانبي"
   },
+  "scheduledTasks.tab.tasks": {
+    "message": "المهام المجدولة",
+    "description": "صفحة المهام المجدولة - علامة تبويب المهام"
+  },
+  "scheduledTasks.tab.runs": {
+    "message": "سجلات التشغيل",
+    "description": "صفحة المهام المجدولة - علامة تبويب جميع سجلات التشغيل"
+  },
+  "scheduledTasks.filterAll": {
+    "message": "الكل",
+    "description": "تصفية حالة سجل التشغيل - الكل"
+  },
   "scheduledTasks.title": {
     "message": "المهام المجدولة",
     "description": "عنوان الصفحة"

--- a/src/i18n/de/chat.json
+++ b/src/i18n/de/chat.json
@@ -586,6 +586,18 @@
   "scheduledTasks.navTitle": {
     "message": "Scheduled Tasks"
   },
+  "scheduledTasks.tab.tasks": {
+    "message": "Geplante Aufgaben",
+    "description": "Seite für geplante Aufgaben - Registerkarte für Aufgaben"
+  },
+  "scheduledTasks.tab.runs": {
+    "message": "Ausführungsprotokolle",
+    "description": "Seite für geplante Aufgaben - Registerkarte für alle Ausführungsprotokolle"
+  },
+  "scheduledTasks.filterAll": {
+    "message": "Alle",
+    "description": "Filter für den Status der Ausführungsprotokolle - Alle"
+  },
   "scheduledTasks.title": {
     "message": "Scheduled Tasks"
   },

--- a/src/i18n/el/chat.json
+++ b/src/i18n/el/chat.json
@@ -586,6 +586,18 @@
   "scheduledTasks.navTitle": {
     "message": "Scheduled Tasks"
   },
+  "scheduledTasks.tab.tasks": {
+    "message": "Προγραμματισμένες Εργασίες",
+    "description": "Σελίδα προγραμματισμένων εργασιών - Καρτέλα εργασιών"
+  },
+  "scheduledTasks.tab.runs": {
+    "message": "Καταγραφή Εκτελέσεων",
+    "description": "Σελίδα προγραμματισμένων εργασιών - Καρτέλα όλων των καταγραφών εκτέλεσης"
+  },
+  "scheduledTasks.filterAll": {
+    "message": "Όλα",
+    "description": "Φίλτρο κατάστασης εκτέλεσης - Όλα"
+  },
   "scheduledTasks.title": {
     "message": "Scheduled Tasks"
   },

--- a/src/i18n/en/chat.json
+++ b/src/i18n/en/chat.json
@@ -660,6 +660,18 @@
   "scheduledTasks.navTitle": {
     "message": "Scheduled Tasks"
   },
+  "scheduledTasks.tab.tasks": {
+    "message": "Tasks",
+    "description": "Scheduled tasks page - tasks tab"
+  },
+  "scheduledTasks.tab.runs": {
+    "message": "Runs",
+    "description": "Scheduled tasks page - all runs tab"
+  },
+  "scheduledTasks.filterAll": {
+    "message": "All",
+    "description": "Run status filter - all"
+  },
   "scheduledTasks.title": {
     "message": "Scheduled Tasks"
   },

--- a/src/i18n/es/chat.json
+++ b/src/i18n/es/chat.json
@@ -586,6 +586,18 @@
   "scheduledTasks.navTitle": {
     "message": "Scheduled Tasks"
   },
+  "scheduledTasks.tab.tasks": {
+    "message": "Tareas programadas",
+    "description": "Página de tareas programadas - pestaña de tareas"
+  },
+  "scheduledTasks.tab.runs": {
+    "message": "Registros de ejecución",
+    "description": "Página de tareas programadas - pestaña de todos los registros de ejecución"
+  },
+  "scheduledTasks.filterAll": {
+    "message": "Todo",
+    "description": "Filtro de estado de registros de ejecución - Todo"
+  },
   "scheduledTasks.title": {
     "message": "Scheduled Tasks"
   },

--- a/src/i18n/fi/chat.json
+++ b/src/i18n/fi/chat.json
@@ -586,6 +586,18 @@
   "scheduledTasks.navTitle": {
     "message": "Ajoitetut tehtävät"
   },
+  "scheduledTasks.tab.tasks": {
+    "message": "Aikataulutetut tehtävät",
+    "description": "Aikataulutetut tehtävät - Tehtävien välilehti"
+  },
+  "scheduledTasks.tab.runs": {
+    "message": "Suoritusrekisteri",
+    "description": "Aikataulutetut tehtävät - Kaikki suoritusrekisterin välilehti"
+  },
+  "scheduledTasks.filterAll": {
+    "message": "Kaikki",
+    "description": "Suoritusrekisterin tila suodatus - Kaikki"
+  },
   "scheduledTasks.title": {
     "message": "Ajoitetut tehtävät"
   },

--- a/src/i18n/fr/chat.json
+++ b/src/i18n/fr/chat.json
@@ -586,6 +586,18 @@
   "scheduledTasks.navTitle": {
     "message": "Scheduled Tasks"
   },
+  "scheduledTasks.tab.tasks": {
+    "message": "Tâches planifiées",
+    "description": "Page des tâches planifiées - Onglet des tâches"
+  },
+  "scheduledTasks.tab.runs": {
+    "message": "Enregistrements d'exécution",
+    "description": "Page des tâches planifiées - Onglet de tous les enregistrements d'exécution"
+  },
+  "scheduledTasks.filterAll": {
+    "message": "Tout",
+    "description": "Filtre d'état des enregistrements d'exécution - Tout"
+  },
   "scheduledTasks.title": {
     "message": "Scheduled Tasks"
   },

--- a/src/i18n/it/chat.json
+++ b/src/i18n/it/chat.json
@@ -586,6 +586,18 @@
   "scheduledTasks.navTitle": {
     "message": "Scheduled Tasks"
   },
+  "scheduledTasks.tab.tasks": {
+    "message": "Compiti programmati",
+    "description": "Pagina dei compiti programmati - Scheda dei compiti"
+  },
+  "scheduledTasks.tab.runs": {
+    "message": "Registrazioni di esecuzione",
+    "description": "Pagina dei compiti programmati - Scheda di tutte le registrazioni di esecuzione"
+  },
+  "scheduledTasks.filterAll": {
+    "message": "Tutti",
+    "description": "Filtro dello stato delle registrazioni - Tutti"
+  },
   "scheduledTasks.title": {
     "message": "Scheduled Tasks"
   },

--- a/src/i18n/ja/chat.json
+++ b/src/i18n/ja/chat.json
@@ -586,6 +586,18 @@
   "scheduledTasks.navTitle": {
     "message": "スケジュールタスク"
   },
+  "scheduledTasks.tab.tasks": {
+    "message": "定期タスク",
+    "description": "定期タスクページ - タスクタブ"
+  },
+  "scheduledTasks.tab.runs": {
+    "message": "実行記録",
+    "description": "定期タスクページ - すべての実行記録タブ"
+  },
+  "scheduledTasks.filterAll": {
+    "message": "すべて",
+    "description": "実行記録の状態フィルタ - すべて"
+  },
   "scheduledTasks.title": {
     "message": "スケジュールタスク"
   },

--- a/src/i18n/ko/chat.json
+++ b/src/i18n/ko/chat.json
@@ -586,6 +586,18 @@
   "scheduledTasks.navTitle": {
     "message": "Scheduled Tasks"
   },
+  "scheduledTasks.tab.tasks": {
+    "message": "정기 작업",
+    "description": "정기 작업 페이지 - 작업 탭"
+  },
+  "scheduledTasks.tab.runs": {
+    "message": "실행 기록",
+    "description": "정기 작업 페이지 - 전체 실행 기록 탭"
+  },
+  "scheduledTasks.filterAll": {
+    "message": "전체",
+    "description": "실행 기록 상태 필터 - 전체"
+  },
   "scheduledTasks.title": {
     "message": "Scheduled Tasks"
   },

--- a/src/i18n/pl/chat.json
+++ b/src/i18n/pl/chat.json
@@ -586,6 +586,18 @@
   "scheduledTasks.navTitle": {
     "message": "Scheduled Tasks"
   },
+  "scheduledTasks.tab.tasks": {
+    "message": "Zadania zaplanowane",
+    "description": "Strona zadań zaplanowanych - zakładka zadań"
+  },
+  "scheduledTasks.tab.runs": {
+    "message": "Rekordy uruchomień",
+    "description": "Strona zadań zaplanowanych - zakładka wszystkich rekordów uruchomień"
+  },
+  "scheduledTasks.filterAll": {
+    "message": "Wszystko",
+    "description": "Filtr stanu rekordów uruchomień - Wszystko"
+  },
   "scheduledTasks.title": {
     "message": "Scheduled Tasks"
   },

--- a/src/i18n/pt/chat.json
+++ b/src/i18n/pt/chat.json
@@ -586,6 +586,18 @@
   "scheduledTasks.navTitle": {
     "message": "Scheduled Tasks"
   },
+  "scheduledTasks.tab.tasks": {
+    "message": "Tarefas Agendadas",
+    "description": "Página de tarefas agendadas - Aba de tarefas"
+  },
+  "scheduledTasks.tab.runs": {
+    "message": "Registros de Execução",
+    "description": "Página de tarefas agendadas - Aba de todos os registros de execução"
+  },
+  "scheduledTasks.filterAll": {
+    "message": "Todos",
+    "description": "Filtro de status de registros de execução - Todos"
+  },
   "scheduledTasks.title": {
     "message": "Scheduled Tasks"
   },

--- a/src/i18n/ru/chat.json
+++ b/src/i18n/ru/chat.json
@@ -587,6 +587,18 @@
     "message": "Запланированные задачи",
     "description": ""
   },
+  "scheduledTasks.tab.tasks": {
+    "message": "Расписанные задачи",
+    "description": "Страница расписанных задач - Вкладка задач"
+  },
+  "scheduledTasks.tab.runs": {
+    "message": "Записи выполнения",
+    "description": "Страница расписанных задач - Вкладка всех записей выполнения"
+  },
+  "scheduledTasks.filterAll": {
+    "message": "Все",
+    "description": "Фильтр состояния записей - Все"
+  },
   "scheduledTasks.title": {
     "message": "Запланированные задачи",
     "description": ""

--- a/src/i18n/sr/chat.json
+++ b/src/i18n/sr/chat.json
@@ -586,6 +586,18 @@
   "scheduledTasks.navTitle": {
     "message": "Заказани задаци"
   },
+  "scheduledTasks.tab.tasks": {
+    "message": "Zakazani zadaci",
+    "description": "Stranica zakazanih zadataka - kartica zadataka"
+  },
+  "scheduledTasks.tab.runs": {
+    "message": "Izvršenja",
+    "description": "Stranica zakazanih zadataka - kartica svih izvršenja"
+  },
+  "scheduledTasks.filterAll": {
+    "message": "Sve",
+    "description": "Filter statusa izvršenih zadataka - Sve"
+  },
   "scheduledTasks.title": {
     "message": "Заказани задаци"
   },

--- a/src/i18n/sv/chat.json
+++ b/src/i18n/sv/chat.json
@@ -586,6 +586,18 @@
   "scheduledTasks.navTitle": {
     "message": "Scheduled Tasks"
   },
+  "scheduledTasks.tab.tasks": {
+    "message": "Schemalagda uppgifter",
+    "description": "Schemalagda uppgifter sida - Flik för uppgifter"
+  },
+  "scheduledTasks.tab.runs": {
+    "message": "Körningshistorik",
+    "description": "Schemalagda uppgifter sida - Flik för alla körningshistorik"
+  },
+  "scheduledTasks.filterAll": {
+    "message": "Alla",
+    "description": "Körningshistorikens statusfilter - Alla"
+  },
   "scheduledTasks.title": {
     "message": "Scheduled Tasks"
   },

--- a/src/i18n/uk/chat.json
+++ b/src/i18n/uk/chat.json
@@ -586,6 +586,18 @@
   "scheduledTasks.navTitle": {
     "message": "Scheduled Tasks"
   },
+  "scheduledTasks.tab.tasks": {
+    "message": "Заплановані завдання",
+    "description": "Сторінка запланованих завдань - вкладка завдань"
+  },
+  "scheduledTasks.tab.runs": {
+    "message": "Записи виконання",
+    "description": "Сторінка запланованих завдань - вкладка всіх записів виконання"
+  },
+  "scheduledTasks.filterAll": {
+    "message": "Усе",
+    "description": "Фільтр статусу виконання записів - Усе"
+  },
   "scheduledTasks.title": {
     "message": "Scheduled Tasks"
   },

--- a/src/i18n/zh-CN/chat.json
+++ b/src/i18n/zh-CN/chat.json
@@ -665,6 +665,18 @@
     "message": "定时任务",
     "description": "侧边栏定时任务入口"
   },
+  "scheduledTasks.tab.tasks": {
+    "message": "定时任务",
+    "description": "定时任务页-任务标签页"
+  },
+  "scheduledTasks.tab.runs": {
+    "message": "运行记录",
+    "description": "定时任务页-全部运行记录标签页"
+  },
+  "scheduledTasks.filterAll": {
+    "message": "全部",
+    "description": "运行记录状态筛选-全部"
+  },
   "scheduledTasks.title": {
     "message": "定时任务",
     "description": "页面标题"

--- a/src/i18n/zh-TW/chat.json
+++ b/src/i18n/zh-TW/chat.json
@@ -586,6 +586,18 @@
   "scheduledTasks.navTitle": {
     "message": "定時任務"
   },
+  "scheduledTasks.tab.tasks": {
+    "message": "定時任務",
+    "description": "定時任務頁-任務標籤頁"
+  },
+  "scheduledTasks.tab.runs": {
+    "message": "運行記錄",
+    "description": "定時任務頁-全部運行記錄標籤頁"
+  },
+  "scheduledTasks.filterAll": {
+    "message": "全部",
+    "description": "運行記錄狀態篩選-全部"
+  },
   "scheduledTasks.title": {
     "message": "定時任務"
   },

--- a/src/operators/scheduledTasks.ts
+++ b/src/operators/scheduledTasks.ts
@@ -37,6 +37,7 @@ export interface IScheduledTask {
 export interface IScheduledRun {
   id: string;
   task_id: string;
+  task_name?: string;
   status: 'queued' | 'running' | 'success' | 'failed' | 'needs_user_input';
   scheduled_at: number;
   llm_started_at?: number;
@@ -47,6 +48,14 @@ export interface IScheduledRun {
   conversation_model_group?: string;
   error_code?: string;
   error_message?: string;
+}
+
+export type IScheduledRunStatus = 'queued' | 'running' | 'success' | 'failed';
+
+export interface IScheduledRunFilter {
+  status?: IScheduledRunStatus;
+  offset?: number;
+  limit?: number;
 }
 
 export type IScheduleSpec =
@@ -191,6 +200,15 @@ class ScheduledTasksOperator {
   async listRuns(token: string, id: string): Promise<IScheduledRun[]> {
     const { data } = await axios.post(BASE, { action: 'retrieve_runs', id }, { headers: headers(token) });
     return data?.items ?? [];
+  }
+
+  // Every run the user owns, across all tasks, newest first.
+  async listAllRuns(
+    token: string,
+    filter: IScheduledRunFilter = {}
+  ): Promise<{ items: IScheduledRun[]; count: number }> {
+    const { data } = await axios.post(BASE, { action: 'retrieve_runs_batch', ...filter }, { headers: headers(token) });
+    return { items: data?.items ?? [], count: data?.count ?? 0 };
   }
 
   async listAuthorizableSkills(token: string): Promise<IAuthorizableSkill[]> {

--- a/src/pages/chat/ScheduledTasks.test.ts
+++ b/src/pages/chat/ScheduledTasks.test.ts
@@ -1,14 +1,15 @@
 // @vitest-environment jsdom
-import { shallowMount } from '@vue/test-utils';
-import { describe, expect, it } from 'vitest';
+import { flushPromises, shallowMount } from '@vue/test-utils';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { CHAT_MODEL_NAME_GPT_5_6_LUNA } from '@/constants';
 import {
   SCHEDULED_TASK_ERROR_BROWSER_AUTHORIZATION_STALE,
   SCHEDULED_TASK_ERROR_BROWSER_DEVICE_OFFLINE,
+  scheduledTasksOperator,
   validateScheduledBrowserBinding
 } from '@/operators/scheduledTasks';
-import type { IAuthorizableSkill, IScheduledTask } from '@/operators/scheduledTasks';
+import type { IAuthorizableSkill, IScheduledRun, IScheduledTask } from '@/operators/scheduledTasks';
 import ScheduledTasks from './ScheduledTasks.vue';
 
 const editedTask: IScheduledTask = {
@@ -201,4 +202,117 @@ describe('chat/ScheduledTasks', () => {
       expect(wrapper.text()).not.toContain('waiting');
     }
   );
+
+  describe('runs tab', () => {
+    const listAllRuns = () => vi.spyOn(scheduledTasksOperator, 'listAllRuns');
+
+    afterEach(() => vi.restoreAllMocks());
+
+    const withToken = () =>
+      shallowMount(ScheduledTasks, {
+        global: {
+          stubs: {
+            ElCard: { template: '<div><slot /></div>' },
+            ElDrawer: { template: '<div><slot /></div>' },
+            ElTag: { template: '<span><slot /></span>' }
+          },
+          mocks: {
+            $t: (key: string) => errorMessages[key] ?? key,
+            $te: (key: string) => key in errorMessages,
+            $store: {
+              state: { chat: { credential: { token: 'tok' } }, site: { features: {} } }
+            }
+          }
+        }
+      });
+
+    it('fetches the feed on entry, and refetches on every re-entry', async () => {
+      const spy = listAllRuns().mockResolvedValue({ items: [], count: 0 });
+      const wrapper = withToken();
+      const vm = wrapper.vm as unknown as { switchTab: (t: 'tasks' | 'runs') => void };
+
+      // Nothing loads until the tab is opened.
+      expect(spy).not.toHaveBeenCalled();
+      vm.switchTab('runs');
+      await flushPromises();
+      expect(spy).toHaveBeenCalledTimes(1);
+
+      // Re-entry must refetch: runs land in the background and a task rename or
+      // delete on the tasks tab changes the task_name tag on existing rows.
+      vm.switchTab('tasks');
+      vm.switchTab('runs');
+      await flushPromises();
+      expect(spy).toHaveBeenCalledTimes(2);
+
+      // Switching to the tab you are already on is a no-op.
+      vm.switchTab('runs');
+      await flushPromises();
+      expect(spy).toHaveBeenCalledTimes(2);
+    });
+
+    it('tags each run row with its parent task name', async () => {
+      const wrapper = withToken();
+      await wrapper.setData({
+        activeTab: 'runs',
+        allRuns: [
+          { id: 'r1', task_id: 't1', task_name: 'Gmail digest', status: 'success', scheduled_at: 1 },
+          { id: 'r2', task_id: 't2', status: 'failed', scheduled_at: 2 }
+        ],
+        allRunsCount: 2
+      });
+
+      const tags = wrapper.findAll('.run-task-tag');
+      expect(tags).toHaveLength(1);
+      expect(tags[0].text()).toBe('Gmail digest');
+    });
+
+    it('resets to page 1 and refetches when the status filter changes', async () => {
+      const spy = listAllRuns().mockResolvedValue({ items: [], count: 0 });
+      const wrapper = withToken();
+      await wrapper.setData({ activeTab: 'runs', allRunsPage: 3 });
+
+      (wrapper.vm as unknown as { onStatusFilter: (s: string) => void }).onStatusFilter('failed');
+      await flushPromises();
+
+      expect(spy).toHaveBeenCalledWith('tok', { status: 'failed', offset: 0, limit: 20 });
+      expect((wrapper.vm as unknown as { allRunsPage: number }).allRunsPage).toBe(1);
+    });
+
+    it('sends no status for the "all" filter', async () => {
+      const spy = listAllRuns().mockResolvedValue({ items: [], count: 0 });
+      const wrapper = withToken();
+      await wrapper.setData({ activeTab: 'runs', allRunsStatus: 'failed' });
+
+      (wrapper.vm as unknown as { onStatusFilter: (s: string) => void }).onStatusFilter('all');
+      await flushPromises();
+
+      expect(spy).toHaveBeenCalledWith('tok', { status: undefined, offset: 0, limit: 20 });
+    });
+
+    it('drops a stale in-flight response when the filter changed mid-flight', async () => {
+      let resolveStale: (v: { items: IScheduledRun[]; count: number }) => void = () => undefined;
+      const spy = listAllRuns()
+        .mockImplementationOnce(() => new Promise((resolve) => (resolveStale = resolve)))
+        .mockResolvedValue({ items: [{ id: 'fresh', task_id: 't1', status: 'failed', scheduled_at: 2 }], count: 1 });
+
+      const wrapper = withToken();
+      const vm = wrapper.vm as unknown as {
+        onStatusFilter: (s: string) => void;
+        allRuns: IScheduledRun[];
+        allRunsLoading: boolean;
+      };
+      await wrapper.setData({ activeTab: 'runs' });
+
+      vm.onStatusFilter('success');
+      vm.onStatusFilter('failed');
+      await flushPromises();
+
+      resolveStale({ items: [{ id: 'stale', task_id: 't9', status: 'success', scheduled_at: 1 }], count: 1 });
+      await flushPromises();
+
+      expect(spy).toHaveBeenCalledTimes(2);
+      expect(vm.allRuns.map((r) => r.id)).toEqual(['fresh']);
+      expect(vm.allRunsLoading).toBe(false);
+    });
+  });
 });

--- a/src/pages/chat/ScheduledTasks.vue
+++ b/src/pages/chat/ScheduledTasks.vue
@@ -3,95 +3,192 @@
     <div class="inner">
       <div class="header">
         <h2 class="title">{{ $t('chat.scheduledTasks.title') }}</h2>
-        <el-button type="primary" round :disabled="saving" @click="openCreate">
+        <el-button v-if="activeTab === 'tasks'" type="primary" round :disabled="saving" @click="openCreate">
           <add-icon :size="16" class="icon" aria-hidden="true" focusable="false" />
           {{ $t('chat.scheduledTasks.create') }}
         </el-button>
       </div>
 
-      <el-skeleton v-if="loading" :rows="4" animated class="loading-block" />
+      <div class="tabs" role="tablist" :aria-label="$t('chat.scheduledTasks.title')">
+        <button
+          v-for="tab in tabs"
+          :key="tab"
+          type="button"
+          role="tab"
+          class="tab"
+          :class="{ active: activeTab === tab }"
+          :aria-selected="activeTab === tab"
+          @click="switchTab(tab)"
+        >
+          {{ $t(`chat.scheduledTasks.tab.${tab}`) }}
+        </button>
+      </div>
 
-      <el-empty v-else-if="!tasks.length" :description="$t('chat.scheduledTasks.empty')" class="empty" />
+      <template v-if="activeTab === 'tasks'">
+        <el-skeleton v-if="loading" :rows="4" animated class="loading-block" />
+
+        <el-empty v-else-if="!tasks.length" :description="$t('chat.scheduledTasks.empty')" class="empty" />
+
+        <template v-else>
+          <div class="task-list">
+            <el-card
+              v-for="task in pagedTasks"
+              :key="task.id"
+              class="task-card"
+              shadow="hover"
+              @click="selectTask(task)"
+            >
+              <div class="task-top">
+                <div class="task-name">{{ task.name }}</div>
+                <div class="task-actions" @click.stop>
+                  <el-switch
+                    :model-value="task.state === 'enabled'"
+                    @change="(v: string | number | boolean) => toggleState(task, v === true)"
+                  />
+                  <el-tooltip :content="$t('chat.scheduledTasks.triggerNow')" placement="top">
+                    <el-button
+                      text
+                      class="icon-action"
+                      :loading="triggeringId === task.id"
+                      :aria-label="$t('chat.scheduledTasks.triggerNow')"
+                      :title="$t('chat.scheduledTasks.triggerNow')"
+                      @click="triggerNow(task)"
+                    >
+                      <play-icon
+                        v-if="triggeringId !== task.id"
+                        :size="'1em' as any"
+                        aria-hidden="true"
+                        focusable="false"
+                      />
+                    </el-button>
+                  </el-tooltip>
+                  <el-tooltip :content="$t('common.button.edit')" placement="top">
+                    <el-button text class="icon-action" :aria-label="$t('common.button.edit')" @click="openEdit(task)">
+                      <edit-icon :size="16" aria-hidden="true" focusable="false" />
+                    </el-button>
+                  </el-tooltip>
+                  <el-tooltip :content="$t('common.button.delete')" placement="top">
+                    <el-button
+                      text
+                      type="danger"
+                      class="icon-action"
+                      :aria-label="$t('common.button.delete')"
+                      @click="confirmDelete(task)"
+                    >
+                      <delete-icon :size="16" aria-hidden="true" focusable="false" />
+                    </el-button>
+                  </el-tooltip>
+                </div>
+              </div>
+              <div class="task-meta">
+                <el-tag size="small" :type="stateTagType(task.state)" effect="dark" round>
+                  {{ $t(`chat.scheduledTasks.state.${task.state}`) }}
+                </el-tag>
+                <span class="meta-chip">
+                  <time-icon class="meta-icon" :size="'1em' as any" aria-hidden="true" focusable="false" />
+                  {{ scheduleLabel(task.schedule) }}
+                </span>
+                <span class="meta-chip">
+                  <ai-icon class="meta-icon" :size="'1em' as any" aria-hidden="true" focusable="false" />
+                  {{ task.template.model }}
+                </span>
+              </div>
+              <div class="task-prompt">{{ task.template.question }}</div>
+              <div v-if="task.last_output_snippet" class="task-last-output">
+                {{ task.last_output_snippet }}
+              </div>
+              <div class="task-footer">
+                <span class="run-count">
+                  <refresh-icon :size="16" class="footer-icon" aria-hidden="true" focusable="false" />
+                  {{ $t('chat.scheduledTasks.runCount', { count: task.run_count }) }}
+                </span>
+                <span v-if="task.last_error" class="error-hint">{{ errorCodeText(task.last_error) }}</span>
+                <span class="open-hint">
+                  {{ $t('chat.scheduledTasks.viewRuns') }}
+                  <expand-right-icon :size="'1em' as any" aria-hidden="true" focusable="false" />
+                </span>
+              </div>
+            </el-card>
+          </div>
+
+          <div v-if="tasks.length > pageSize" class="pager">
+            <pagination :current-page="page" :page-size="pageSize" :total="tasks.length" @change="onPageChange" />
+          </div>
+        </template>
+      </template>
 
       <template v-else>
-        <div class="task-list">
-          <el-card v-for="task in pagedTasks" :key="task.id" class="task-card" shadow="hover" @click="selectTask(task)">
-            <div class="task-top">
-              <div class="task-name">{{ task.name }}</div>
-              <div class="task-actions" @click.stop>
-                <el-switch
-                  :model-value="task.state === 'enabled'"
-                  @change="(v: string | number | boolean) => toggleState(task, v === true)"
-                />
-                <el-tooltip :content="$t('chat.scheduledTasks.triggerNow')" placement="top">
-                  <el-button
-                    text
-                    class="icon-action"
-                    :loading="triggeringId === task.id"
-                    :aria-label="$t('chat.scheduledTasks.triggerNow')"
-                    :title="$t('chat.scheduledTasks.triggerNow')"
-                    @click="triggerNow(task)"
-                  >
-                    <play-icon
-                      v-if="triggeringId !== task.id"
-                      :size="'1em' as any"
-                      aria-hidden="true"
-                      focusable="false"
-                    />
-                  </el-button>
-                </el-tooltip>
-                <el-tooltip :content="$t('common.button.edit')" placement="top">
-                  <el-button text class="icon-action" :aria-label="$t('common.button.edit')" @click="openEdit(task)">
-                    <edit-icon :size="16" aria-hidden="true" focusable="false" />
-                  </el-button>
-                </el-tooltip>
-                <el-tooltip :content="$t('common.button.delete')" placement="top">
-                  <el-button
-                    text
-                    type="danger"
-                    class="icon-action"
-                    :aria-label="$t('common.button.delete')"
-                    @click="confirmDelete(task)"
-                  >
-                    <delete-icon :size="16" aria-hidden="true" focusable="false" />
-                  </el-button>
-                </el-tooltip>
-              </div>
-            </div>
-            <div class="task-meta">
-              <el-tag size="small" :type="stateTagType(task.state)" effect="dark" round>
-                {{ $t(`chat.scheduledTasks.state.${task.state}`) }}
-              </el-tag>
-              <span class="meta-chip">
-                <time-icon class="meta-icon" :size="'1em' as any" aria-hidden="true" focusable="false" />
-                {{ scheduleLabel(task.schedule) }}
-              </span>
-              <span class="meta-chip">
-                <ai-icon class="meta-icon" :size="'1em' as any" aria-hidden="true" focusable="false" />
-                {{ task.template.model }}
-              </span>
-            </div>
-            <div class="task-prompt">{{ task.template.question }}</div>
-            <div v-if="task.last_output_snippet" class="task-last-output">
-              {{ task.last_output_snippet }}
-            </div>
-            <div class="task-footer">
-              <span class="run-count">
-                <refresh-icon :size="16" class="footer-icon" aria-hidden="true" focusable="false" />
-                {{ $t('chat.scheduledTasks.runCount', { count: task.run_count }) }}
-              </span>
-              <span v-if="task.last_error" class="error-hint">{{ errorCodeText(task.last_error) }}</span>
-              <span class="open-hint">
-                {{ $t('chat.scheduledTasks.viewRuns') }}
-                <expand-right-icon :size="'1em' as any" aria-hidden="true" focusable="false" />
-              </span>
-            </div>
-          </el-card>
+        <div class="filters" role="group" :aria-label="$t('chat.scheduledTasks.tab.runs')">
+          <button
+            v-for="opt in statusFilters"
+            :key="opt"
+            type="button"
+            class="filter-chip"
+            :class="{ active: allRunsStatus === opt }"
+            :aria-pressed="allRunsStatus === opt"
+            @click="onStatusFilter(opt)"
+          >
+            {{ opt === 'all' ? $t('chat.scheduledTasks.filterAll') : $t(`chat.scheduledTasks.run.${opt}`) }}
+          </button>
         </div>
 
-        <div v-if="tasks.length > pageSize" class="pager">
-          <pagination :current-page="page" :page-size="pageSize" :total="tasks.length" @change="onPageChange" />
-        </div>
+        <el-skeleton v-if="allRunsLoading" :rows="4" animated class="loading-block" />
+
+        <el-empty v-else-if="!allRuns.length" :description="$t('chat.scheduledTasks.noRuns')" class="empty" />
+
+        <template v-else>
+          <div class="run-list">
+            <div
+              v-for="run in allRuns"
+              :key="run.id"
+              class="run-item"
+              :class="{ clickable: !!run.conversation_id }"
+              :tabindex="run.conversation_id ? 0 : -1"
+              :role="run.conversation_id ? 'button' : undefined"
+              @click="openRun(run)"
+              @keydown.enter="openRun(run)"
+              @keydown.space.prevent="openRun(run)"
+            >
+              <div class="run-body">
+                <div class="run-line">
+                  <span class="run-title">{{ run.conversation_title || formatTime(run.scheduled_at) }}</span>
+                  <el-tag size="small" :type="runTagType(run.status)" effect="dark" round class="run-tag">
+                    {{ $t(`chat.scheduledTasks.run.${run.status}`) }}
+                  </el-tag>
+                </div>
+                <div v-if="run.conversation_preview" class="run-preview">{{ run.conversation_preview }}</div>
+                <div class="run-sub">
+                  <el-tag v-if="run.task_name" size="small" type="info" round class="run-task-tag">
+                    {{ run.task_name }}
+                  </el-tag>
+                  <span class="run-time">{{ formatTime(run.scheduled_at) }}</span>
+                  <span v-if="run.error_code || run.error_message" class="run-error" :title="runErrorText(run)">
+                    {{ runErrorText(run) }}
+                  </span>
+                </div>
+              </div>
+              <div class="run-action">
+                <expand-right-icon
+                  v-if="run.conversation_id"
+                  class="run-arrow"
+                  :size="'1em' as any"
+                  aria-hidden="true"
+                  focusable="false"
+                />
+                <span v-else class="run-noconv">{{ $t('chat.scheduledTasks.noConversation') }}</span>
+              </div>
+            </div>
+          </div>
+
+          <div v-if="allRunsCount > allRunsPageSize" class="pager">
+            <pagination
+              :current-page="allRunsPage"
+              :page-size="allRunsPageSize"
+              :total="allRunsCount"
+              @change="onAllRunsPageChange"
+            />
+          </div>
+        </template>
       </template>
     </div>
 
@@ -376,6 +473,7 @@ import {
   scheduledTasksOperator,
   IScheduledTask,
   IScheduledRun,
+  IScheduledRunStatus,
   IScheduleSpec,
   IAuthorizableSkill,
   IAuthorizableMcpServer,
@@ -388,6 +486,9 @@ import { CHAT_MODEL_GROUPS, CHAT_MODEL_NAME_GPT_5_6_LUNA } from '@/constants';
 import { IChatModelGroup } from '@/models';
 
 const USER_TZ = Intl.DateTimeFormat().resolvedOptions().timeZone || 'Asia/Shanghai';
+
+type ScheduledTab = 'tasks' | 'runs';
+type RunStatusFilter = 'all' | IScheduledRunStatus;
 
 // Default agent turn budget for a scheduled task run. Mirrors the worker's
 // DEFAULT_SCHEDULED_MAX_TURNS; the worker clamps to [1, 50] regardless.
@@ -447,6 +548,18 @@ export default defineComponent({
     return {
       tasks: [] as IScheduledTask[],
       runs: [] as IScheduledRun[],
+      activeTab: 'tasks' as ScheduledTab,
+      tabs: ['tasks', 'runs'] as ScheduledTab[],
+      statusFilters: ['all', 'success', 'failed', 'running', 'queued'] as RunStatusFilter[],
+      allRuns: [] as IScheduledRun[],
+      allRunsCount: 0,
+      allRunsLoading: false,
+      allRunsStatus: 'all' as RunStatusFilter,
+      allRunsPage: 1,
+      allRunsPageSize: 20,
+      // Bumped on every all-runs request so a slow response from a stale
+      // filter/page can't overwrite the newest one.
+      allRunsRequestId: 0,
       loading: false,
       runsLoading: false,
       skillsLoading: false,
@@ -570,6 +683,44 @@ export default defineComponent({
     },
     onPageChange(p: number) {
       this.page = p;
+    },
+    switchTab(tab: ScheduledTab) {
+      if (this.activeTab === tab) return;
+      this.activeTab = tab;
+      // Always refetch on entry: runs land in the background from the scheduler,
+      // and task renames/deletes change the task_name tag on existing rows.
+      if (tab === 'runs') void this.loadAllRuns();
+    },
+    onStatusFilter(status: RunStatusFilter) {
+      if (this.allRunsStatus === status) return;
+      this.allRunsStatus = status;
+      this.allRunsPage = 1;
+      void this.loadAllRuns();
+    },
+    onAllRunsPageChange(p: number) {
+      this.allRunsPage = p;
+      void this.loadAllRuns();
+    },
+    async loadAllRuns() {
+      if (!this.token) return;
+      const requestId = ++this.allRunsRequestId;
+      this.allRunsLoading = true;
+      try {
+        const { items, count } = await scheduledTasksOperator.listAllRuns(this.token, {
+          status: this.allRunsStatus === 'all' ? undefined : this.allRunsStatus,
+          offset: (this.allRunsPage - 1) * this.allRunsPageSize,
+          limit: this.allRunsPageSize
+        });
+        // Drop the response if the user changed filter/page mid-flight.
+        if (requestId !== this.allRunsRequestId) return;
+        this.allRuns = items;
+        this.allRunsCount = count;
+      } catch {
+        if (requestId !== this.allRunsRequestId) return;
+        ElMessage.error(this.$t('chat.scheduledTasks.loadError') as string);
+      } finally {
+        if (requestId === this.allRunsRequestId) this.allRunsLoading = false;
+      }
     },
     onRunPageChange(p: number) {
       this.runPage = p;
@@ -975,6 +1126,77 @@ export default defineComponent({
 .header .icon {
   margin-right: 6px;
 }
+.tabs {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 16px;
+  border-bottom: 1px solid var(--app-border-subtle, var(--el-border-color-lighter));
+}
+.tab {
+  appearance: none;
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  padding: 8px 12px;
+  margin-bottom: -1px;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--el-text-color-secondary);
+  cursor: pointer;
+  transition:
+    color 0.16s,
+    border-color 0.16s;
+}
+.tab:hover {
+  color: var(--el-text-color-primary);
+}
+.tab:focus-visible {
+  outline: 2px solid var(--el-color-primary);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+.tab.active {
+  color: var(--el-color-primary);
+  border-bottom-color: var(--el-color-primary);
+}
+.filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+.filter-chip {
+  appearance: none;
+  border: 1px solid var(--app-border-subtle, var(--el-border-color-lighter));
+  background: var(--app-bg-surface, var(--el-bg-color-overlay));
+  border-radius: 999px;
+  padding: 5px 14px;
+  font-size: 13px;
+  color: var(--el-text-color-regular);
+  cursor: pointer;
+  transition:
+    background 0.16s,
+    border-color 0.16s,
+    color 0.16s;
+}
+.filter-chip:hover:not(.active) {
+  background: var(--el-fill-color-lighter);
+}
+.filter-chip:focus-visible {
+  outline: 2px solid var(--el-color-primary);
+  outline-offset: 2px;
+}
+.filter-chip.active {
+  background: var(--el-color-primary);
+  border-color: var(--el-color-primary);
+  color: #fff;
+}
+.run-task-tag {
+  flex-shrink: 0;
+  max-width: 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
 @media (max-width: 767px) {
   .inner {
     padding-top: 56px;
@@ -1202,6 +1424,9 @@ export default defineComponent({
   gap: 10px;
   align-items: center;
   min-width: 0;
+  /* The runs tab adds a task tag to this row; on narrow screens let the
+     time / error drop to a second line instead of squeezing to ellipsis. */
+  flex-wrap: wrap;
 }
 .run-time {
   font-size: 12px;


### PR DESCRIPTION
## 背景

`/chatgpt/scheduled` 此前只能一个任务一个任务地点开抽屉看运行历史，没有「所有定时任务的子任务按时间排序」的总览。本 PR 把页面拆成两个标签页。

依赖后端 https://github.com/AceDataCloud/PlatformService/pull/1671（`retrieve_runs_batch`）。**须先合它。**

## 改动

| 标签页 | 内容 |
|---|---|
| **定时任务** | 原有任务列表，行为完全不变（含「运行记录」抽屉、编辑、立即运行、删除） |
| **运行记录**（新） | 所有定时任务的运行按时间倒序汇总；每行 tag 标出所属任务名；可按 成功 / 失败 / 运行中 / 排队中 筛选；分页；点击直达对应会话 |

- `operators/scheduledTasks.ts` — `listAllRuns()` 调后端 `retrieve_runs_batch`，`IScheduledRun` 加 `task_name`
- 复用既有 `.run-item` 行样式与 `openRun()` 跳转逻辑，视觉与抽屉内一致
- 每次进入标签页都重取：后台会持续产生新运行，任务改名/删除也会影响行上的 `task_name`
- 请求带自增 `requestId`，快速切筛选时旧响应不会覆盖新结果
- `.run-sub` 改 `flex-wrap: wrap`：窄屏下多出的任务 tag 不再把时间/错误挤成三行并截断

## 本地验证

用真实组件 + mock 数据在本地渲染核对（非生产截图）：标签页切换、5 种状态筛选、任务名 tag、分页、点击跳转、390px 窄屏换行均正常；定时任务标签页与改动前一致。

## 测试

`src/pages/chat/ScheduledTasks.test.ts` 新增 5 例（7 → 12）：

- 进入标签页取数、再次进入重取、切到当前标签页 no-op
- 每行按 `task_name` 打 tag；任务已删则不渲染 tag
- 切筛选重置到第 1 页并按新条件重取
- `all` 筛选不传 `status`
- 中途切筛选时，先发出的旧响应被丢弃（`requestId` 守卫）

两处关键守卫都做了变异验证（故意改坏 → 对应用例转红 → 还原转绿）。

```
Test Files  100 passed (100)
     Tests  719 passed (719)
```

lint / build / `check_i18n_coverage.py` 均通过。

## i18n

`zh-CN` 与 `en` 手写，其余 17 语言经 `scripts/translate_i18n.py` 补齐后**只保留新增的 3 个 key**（脚本顺带重排了整个文件，已剔除该噪声）——每个 locale 净增 12 行、0 删除。

## 🤖 对抗评审

Reviewer: `codex exec --sandbox read-only`（gpt-5.5，跨模型）

**RISK 3：运行记录缓存陈旧。** 打开运行记录 → 切回定时任务 → 改名或删除某任务 → 再切回运行记录，因 `allRunsLoaded` 仍为 true，列表继续显示旧的（甚至已删任务的）`task_name`；后台调度产生的新运行也永远不会出现。

**已修**：删掉 `allRunsLoaded` 标志，改为每次进入标签页重取；测试相应从「只加载一次」改成「每次进入都重取，切到当前标签页则 no-op」。

RISK 1（分页未做有限性校验）、RISK 2（状态筛选缺索引）落在 PlatformService PR；RISK 4（文档示例自相矛盾）落在 PlatformBackend PR。

Round 2：`VERDICT: CLEAN`

🤖 Generated with [Claude Code](https://claude.com/claude-code)