### PR TITLE
feat(scheduled-tasks): 定时任务可选用 connector 的哪个账号

### DIFF
--- a/change/@acedatacloud-nexior-f767154d-c941-4055-a36a-b0c748758aca.json
+++ b/change/@acedatacloud-nexior-f767154d-c941-4055-a36a-b0c748758aca.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "定时任务支持为每个 connector 指定使用哪个账号",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/constants/chat.ts
+++ b/src/constants/chat.ts
@@ -360,7 +360,12 @@ export const CHAT_MODEL_GROUP_CLAUDE: IChatModelGroup = {
   name: 'claude',
   getDisplayName: () => i18n.global.t('chat.modelGroup.claude'),
   getDescription: () => i18n.global.t('chat.modelGroup.claudeDescription'),
-  models: [CHAT_MODEL_CLAUDE_OPUS_5, CHAT_MODEL_CLAUDE_OPUS_4_8, CHAT_MODEL_CLAUDE_SONNET_4_6, CHAT_MODEL_CLAUDE_HAIKU_4_5]
+  models: [
+    CHAT_MODEL_CLAUDE_OPUS_5,
+    CHAT_MODEL_CLAUDE_OPUS_4_8,
+    CHAT_MODEL_CLAUDE_SONNET_4_6,
+    CHAT_MODEL_CLAUDE_HAIKU_4_5
+  ]
 };
 
 export const CHAT_MODEL_GROUP_KIMI: IChatModelGroup = {

--- a/src/i18n/ar/chat.json
+++ b/src/i18n/ar/chat.json
@@ -1199,5 +1199,8 @@
   },
   "scheduledTasks.form.browserBindingInvalid": {
     "message": "Select an online, compatible browser connection before saving"
-  }
+  },
+  "scheduledTasks.form.connectionAccount": "Account for {connector}",
+  "scheduledTasks.form.connectionAccountDefault": "Use the default account",
+  "scheduledTasks.form.accountIsDefault": "default"
 }

--- a/src/i18n/de/chat.json
+++ b/src/i18n/de/chat.json
@@ -1160,5 +1160,8 @@
   },
   "scheduledTasks.form.browserBindingInvalid": {
     "message": "Select an online, compatible browser connection before saving"
-  }
+  },
+  "scheduledTasks.form.connectionAccount": "Account for {connector}",
+  "scheduledTasks.form.connectionAccountDefault": "Use the default account",
+  "scheduledTasks.form.accountIsDefault": "default"
 }

--- a/src/i18n/el/chat.json
+++ b/src/i18n/el/chat.json
@@ -1160,5 +1160,8 @@
   },
   "scheduledTasks.form.browserBindingInvalid": {
     "message": "Select an online, compatible browser connection before saving"
-  }
+  },
+  "scheduledTasks.form.connectionAccount": "Account for {connector}",
+  "scheduledTasks.form.connectionAccountDefault": "Use the default account",
+  "scheduledTasks.form.accountIsDefault": "default"
 }

--- a/src/i18n/en/chat.json
+++ b/src/i18n/en/chat.json
@@ -926,6 +926,9 @@
   "scheduledTasks.form.browserBindingInvalid": {
     "message": "Select an online, compatible browser connection before saving"
   },
+  "scheduledTasks.form.connectionAccount": "Account for {connector}",
+  "scheduledTasks.form.connectionAccountDefault": "Use the default account",
+  "scheduledTasks.form.accountIsDefault": "default",
   "scheduledTasks.form.skillMissing": {
     "message": "Not connected"
   },

--- a/src/i18n/es/chat.json
+++ b/src/i18n/es/chat.json
@@ -1160,5 +1160,8 @@
   },
   "scheduledTasks.form.browserBindingInvalid": {
     "message": "Select an online, compatible browser connection before saving"
-  }
+  },
+  "scheduledTasks.form.connectionAccount": "Account for {connector}",
+  "scheduledTasks.form.connectionAccountDefault": "Use the default account",
+  "scheduledTasks.form.accountIsDefault": "default"
 }

--- a/src/i18n/fi/chat.json
+++ b/src/i18n/fi/chat.json
@@ -1160,5 +1160,8 @@
   },
   "scheduledTasks.form.browserBindingInvalid": {
     "message": "Select an online, compatible browser connection before saving"
-  }
+  },
+  "scheduledTasks.form.connectionAccount": "Account for {connector}",
+  "scheduledTasks.form.connectionAccountDefault": "Use the default account",
+  "scheduledTasks.form.accountIsDefault": "default"
 }

--- a/src/i18n/fr/chat.json
+++ b/src/i18n/fr/chat.json
@@ -1160,5 +1160,8 @@
   },
   "scheduledTasks.form.browserBindingInvalid": {
     "message": "Select an online, compatible browser connection before saving"
-  }
+  },
+  "scheduledTasks.form.connectionAccount": "Account for {connector}",
+  "scheduledTasks.form.connectionAccountDefault": "Use the default account",
+  "scheduledTasks.form.accountIsDefault": "default"
 }

--- a/src/i18n/it/chat.json
+++ b/src/i18n/it/chat.json
@@ -1160,5 +1160,8 @@
   },
   "scheduledTasks.form.browserBindingInvalid": {
     "message": "Select an online, compatible browser connection before saving"
-  }
+  },
+  "scheduledTasks.form.connectionAccount": "Account for {connector}",
+  "scheduledTasks.form.connectionAccountDefault": "Use the default account",
+  "scheduledTasks.form.accountIsDefault": "default"
 }

--- a/src/i18n/ja/chat.json
+++ b/src/i18n/ja/chat.json
@@ -1160,5 +1160,8 @@
   },
   "scheduledTasks.form.browserBindingInvalid": {
     "message": "Select an online, compatible browser connection before saving"
-  }
+  },
+  "scheduledTasks.form.connectionAccount": "Account for {connector}",
+  "scheduledTasks.form.connectionAccountDefault": "Use the default account",
+  "scheduledTasks.form.accountIsDefault": "default"
 }

--- a/src/i18n/ko/chat.json
+++ b/src/i18n/ko/chat.json
@@ -1160,5 +1160,8 @@
   },
   "scheduledTasks.form.browserBindingInvalid": {
     "message": "Select an online, compatible browser connection before saving"
-  }
+  },
+  "scheduledTasks.form.connectionAccount": "Account for {connector}",
+  "scheduledTasks.form.connectionAccountDefault": "Use the default account",
+  "scheduledTasks.form.accountIsDefault": "default"
 }

--- a/src/i18n/pl/chat.json
+++ b/src/i18n/pl/chat.json
@@ -1160,5 +1160,8 @@
   },
   "scheduledTasks.form.browserBindingInvalid": {
     "message": "Select an online, compatible browser connection before saving"
-  }
+  },
+  "scheduledTasks.form.connectionAccount": "Account for {connector}",
+  "scheduledTasks.form.connectionAccountDefault": "Use the default account",
+  "scheduledTasks.form.accountIsDefault": "default"
 }

--- a/src/i18n/pt/chat.json
+++ b/src/i18n/pt/chat.json
@@ -1160,5 +1160,8 @@
   },
   "scheduledTasks.form.browserBindingInvalid": {
     "message": "Select an online, compatible browser connection before saving"
-  }
+  },
+  "scheduledTasks.form.connectionAccount": "Account for {connector}",
+  "scheduledTasks.form.connectionAccountDefault": "Use the default account",
+  "scheduledTasks.form.accountIsDefault": "default"
 }

--- a/src/i18n/ru/chat.json
+++ b/src/i18n/ru/chat.json
@@ -1199,5 +1199,8 @@
   },
   "scheduledTasks.form.browserBindingInvalid": {
     "message": "Select an online, compatible browser connection before saving"
-  }
+  },
+  "scheduledTasks.form.connectionAccount": "Account for {connector}",
+  "scheduledTasks.form.connectionAccountDefault": "Use the default account",
+  "scheduledTasks.form.accountIsDefault": "default"
 }

--- a/src/i18n/sr/chat.json
+++ b/src/i18n/sr/chat.json
@@ -1160,5 +1160,8 @@
   },
   "scheduledTasks.form.browserBindingInvalid": {
     "message": "Select an online, compatible browser connection before saving"
-  }
+  },
+  "scheduledTasks.form.connectionAccount": "Account for {connector}",
+  "scheduledTasks.form.connectionAccountDefault": "Use the default account",
+  "scheduledTasks.form.accountIsDefault": "default"
 }

--- a/src/i18n/sv/chat.json
+++ b/src/i18n/sv/chat.json
@@ -1160,5 +1160,8 @@
   },
   "scheduledTasks.form.browserBindingInvalid": {
     "message": "Select an online, compatible browser connection before saving"
-  }
+  },
+  "scheduledTasks.form.connectionAccount": "Account for {connector}",
+  "scheduledTasks.form.connectionAccountDefault": "Use the default account",
+  "scheduledTasks.form.accountIsDefault": "default"
 }

--- a/src/i18n/uk/chat.json
+++ b/src/i18n/uk/chat.json
@@ -1160,5 +1160,8 @@
   },
   "scheduledTasks.form.browserBindingInvalid": {
     "message": "Select an online, compatible browser connection before saving"
-  }
+  },
+  "scheduledTasks.form.connectionAccount": "Account for {connector}",
+  "scheduledTasks.form.connectionAccountDefault": "Use the default account",
+  "scheduledTasks.form.accountIsDefault": "default"
 }

--- a/src/i18n/zh-CN/chat.json
+++ b/src/i18n/zh-CN/chat.json
@@ -983,6 +983,9 @@
   "scheduledTasks.form.browserBindingInvalid": {
     "message": "保存前请选择在线且兼容的浏览器连接"
   },
+  "scheduledTasks.form.connectionAccount": "{connector} 使用的账号",
+  "scheduledTasks.form.connectionAccountDefault": "使用默认账号",
+  "scheduledTasks.form.accountIsDefault": "默认",
   "scheduledTasks.form.skillMissing": {
     "message": "未连接",
     "description": "skill 缺少连接"

--- a/src/i18n/zh-TW/chat.json
+++ b/src/i18n/zh-TW/chat.json
@@ -1160,5 +1160,8 @@
   },
   "scheduledTasks.form.browserBindingInvalid": {
     "message": "Select an online, compatible browser connection before saving"
-  }
+  },
+  "scheduledTasks.form.connectionAccount": "Account for {connector}",
+  "scheduledTasks.form.connectionAccountDefault": "Use the default account",
+  "scheduledTasks.form.accountIsDefault": "default"
 }

--- a/src/operators/scheduledTasks.ts
+++ b/src/operators/scheduledTasks.ts
@@ -68,15 +68,46 @@ export interface IScheduledTaskUnattendedPolicy {
   allowed_skills: string[];
   allowed_mcp_servers?: string[];
   browser_connections?: IScheduledBrowserBinding[];
+  /** Which account of each connector this task runs as. Omit to use the
+   *  connector's default account (what interactive chat always does). */
+  connection_bindings?: IScheduledConnectionBinding[];
   expires_at?: number;
+}
+
+export interface IScheduledConnectionBinding {
+  connector_identifier: string;
+  connection_id: string;
+  /** Server-derived; never sent by the client (the backend re-derives it
+   *  from the stored connection so a binding can't claim a provider it
+   *  doesn't belong to). */
+  provider_alias?: string;
+}
+
+/** One selectable account for a connector a skill needs. */
+export interface IAuthorizableConnectionAccount {
+  connection_id: string;
+  connector_identifier: string;
+  label: string;
+  is_default: boolean;
+  account_name: string;
 }
 
 export interface IScheduledBrowserBinding {
   connection_id: string;
-  revision: number;
+  /** Named to match the worker's `ScheduledBrowserBinding.connection_revision`
+   *  — the old `revision` never matched and the field was dropped on save. */
+  connection_revision: number;
   device_id: string;
   wire_contract_digest: string;
   policy_digest: string;
+  /** The worker treats these as REQUIRED and rejects a binding whose values
+   *  don't match the live skill authority. They stay optional here because
+   *  the server does not yet surface them on `IAuthorizableBrowserConnection`,
+   *  so the client has nothing to populate them from — the browser-binding
+   *  path is inert until it does. Closing that gap is a prerequisite for
+   *  shipping browser-backed scheduled tasks. */
+  skill_id?: string;
+  skill_revision?: string;
 }
 
 export interface IAuthorizableBrowserConnection extends IScheduledBrowserBinding {
@@ -99,6 +130,10 @@ export interface IAuthorizableSkill {
   connected: boolean;
   missing_connections: string[];
   browser_connections?: IAuthorizableBrowserConnection[];
+  /** Candidate accounts per required connector, keyed by the same strings
+   *  that appear in `required_connections`. Only present when the user has
+   *  at least one connection for that connector. */
+  connection_accounts?: Record<string, IAuthorizableConnectionAccount[]>;
 }
 
 export interface IAuthorizableMcpServer {

--- a/src/pages/chat/ScheduledTasks.test.ts
+++ b/src/pages/chat/ScheduledTasks.test.ts
@@ -73,7 +73,7 @@ describe('chat/ScheduledTasks', () => {
     browser_connections: [
       {
         connection_id: 'connection-1',
-        revision: 4,
+        connection_revision: 4,
         device_id: 'device-1',
         wire_contract_digest: 'sha256:wire',
         policy_digest: 'sha256:policy',
@@ -148,6 +148,7 @@ describe('chat/ScheduledTasks', () => {
       authorizedSkills: [],
       authorizedMcpServers: [],
       browserConnectionId: '',
+      connectionAccounts: {},
       authorizationExpiresAt: expect.any(Number),
       maxTurns: 50
     });
@@ -179,6 +180,93 @@ describe('chat/ScheduledTasks', () => {
     expect(vm.editingTask).toMatchObject({ id: editedTask.id });
     expect(vm.form).toMatchObject({ name: 'Existing task' });
     expect(vm.showCreateDialog).toBe(true);
+  });
+  it('offers an account picker only for connectors the user has several accounts of', async () => {
+    const wrapper = mountComponent();
+    const vm = wrapper.vm as unknown as {
+      authorizableSkills: unknown[];
+      form: { connectionAccounts: Record<string, string> } & Record<string, unknown>;
+      accountChoices: Array<{ identifier: string; label: string; accounts: Array<{ connection_id: string }> }>;
+    };
+    await wrapper.setData({
+      authorizableSkills: [
+        {
+          slug: 'multi',
+          name: 'multi',
+          description: '',
+          required_connections: ['zhihu/zhihu', 'github/github'],
+          allowed_tools: [],
+          source: 'installed',
+          connected: true,
+          missing_connections: [],
+          connection_accounts: {
+            // Server keys this map by the skill's frontmatter entry, which is
+            // the BARE name — the binding must still go out as the canonical
+            // `zhihu/zhihu` the server validates against.
+            zhihu: [
+              {
+                connection_id: 'z1',
+                connector_identifier: 'zhihu/zhihu',
+                label: '主号',
+                is_default: true,
+                account_name: 'A'
+              },
+              {
+                connection_id: 'z2',
+                connector_identifier: 'zhihu/zhihu',
+                label: '小号',
+                is_default: false,
+                account_name: 'B'
+              }
+            ],
+            // Single account → no choice needed, falls back to the default.
+            github: [
+              {
+                connection_id: 'g1',
+                connector_identifier: 'github/github',
+                label: '',
+                is_default: true,
+                account_name: 'C'
+              }
+            ]
+          }
+        }
+      ],
+      form: { ...(wrapper.vm as unknown as { form: Record<string, unknown> }).form, authorizedSkills: ['multi'] }
+    });
+
+    // Keyed on the canonical identifier, not the bare frontmatter name.
+    expect(vm.accountChoices.map((c) => c.identifier)).toEqual(['zhihu/zhihu']);
+    expect(vm.accountChoices[0].accounts).toHaveLength(2);
+
+    // A binding for a connector that is no longer relevant (skill deselected)
+    // or whose account no longer exists must not be shipped — the server
+    // rejects unverifiable bindings and `force` does not bypass that, which
+    // would otherwise leave the task unsavable.
+    await wrapper.setData({
+      form: {
+        ...(wrapper.vm as unknown as { form: Record<string, unknown> }).form,
+        connectionAccounts: { 'zhihu/zhihu': 'z2', 'gone/gone': 'x1' }
+      }
+    });
+    const bindings = (
+      wrapper.vm as unknown as {
+        accountChoices: Array<{ identifier: string; accounts: Array<{ connection_id: string }> }>;
+        form: { connectionAccounts: Record<string, string> };
+      }
+    ).accountChoices
+      .map((choice) => ({
+        connector_identifier: choice.identifier,
+        connection_id: vm.form.connectionAccounts[choice.identifier] || ''
+      }))
+      .filter(
+        (b) =>
+          !!b.connection_id &&
+          vm.accountChoices
+            .find((c) => c.identifier === b.connector_identifier)
+            ?.accounts.some((a) => a.connection_id === b.connection_id)
+      );
+    expect(bindings).toEqual([{ connector_identifier: 'zhihu/zhihu', connection_id: 'z2' }]);
   });
   it.each(['browser_device_offline', 'browser_authorization_stale'])(
     'shows typed browser run error %s without a waiting queue',

--- a/src/pages/chat/ScheduledTasks.vue
+++ b/src/pages/chat/ScheduledTasks.vue
@@ -400,6 +400,32 @@
           </div>
         </el-form-item>
 
+        <!-- Only rendered for connectors the user holds several accounts of;
+             everything else silently uses that connector's default account. -->
+        <el-form-item
+          v-for="choice in accountChoices"
+          :key="choice.identifier"
+          :label="$t('chat.scheduledTasks.form.connectionAccount', { connector: choice.label })"
+        >
+          <el-select
+            v-model="form.connectionAccounts[choice.identifier]"
+            clearable
+            :placeholder="$t('chat.scheduledTasks.form.connectionAccountDefault')"
+            style="width: 100%"
+          >
+            <el-option
+              v-for="account in choice.accounts"
+              :key="account.connection_id"
+              :label="
+                account.is_default
+                  ? `${account.label || account.account_name} · ${$t('chat.scheduledTasks.form.accountIsDefault')}`
+                  : account.label || account.account_name
+              "
+              :value="account.connection_id"
+            />
+          </el-select>
+        </el-form-item>
+
         <el-form-item :label="$t('chat.scheduledTasks.form.mcpServers')">
           <el-select
             v-model="form.authorizedMcpServers"
@@ -481,7 +507,11 @@ import {
   IScheduledTaskCapabilityDetail,
   extractSkillNotActive
 } from '@/operators/scheduledTasks';
-import type { IAuthorizableBrowserConnection, IScheduledBrowserBinding } from '@/operators/scheduledTasks';
+import type {
+  IAuthorizableBrowserConnection,
+  IAuthorizableConnectionAccount,
+  IScheduledBrowserBinding
+} from '@/operators/scheduledTasks';
 import { CHAT_MODEL_GROUPS, CHAT_MODEL_NAME_GPT_5_6_LUNA } from '@/constants';
 import { IChatModelGroup } from '@/models';
 
@@ -508,6 +538,9 @@ interface TaskForm {
   authorizedSkills: string[];
   authorizedMcpServers: string[];
   browserConnectionId: string;
+  /** connector_identifier → chosen connection_id. Empty value = use that
+   *  connector's default account. */
+  connectionAccounts: Record<string, string>;
   authorizationExpiresAt: number;
   maxTurns: number;
 }
@@ -626,6 +659,27 @@ export default defineComponent({
       return this.selectedBrowserConnections.find(
         (connection) => connection.connection_id === this.form.browserConnectionId
       );
+    },
+    /** Connectors the selected skills need where the user holds MORE THAN ONE
+     *  account — only those need a picker; a single account needs no choice
+     *  and stays on the connector's default. */
+    accountChoices(): Array<{ identifier: string; label: string; accounts: IAuthorizableConnectionAccount[] }> {
+      const selected = new Set(this.form.authorizedSkills);
+      // Key on the account's own `connector_identifier`, NOT the map key.
+      // Skills declare bare names in their frontmatter (`connections: [zhihu]`)
+      // so that's what the map is keyed by, but the server validates a binding
+      // against the canonical identifier (`zhihu/zhihu`) — posting the bare
+      // key back would fail every save.
+      const byConnector = new Map<string, { label: string; accounts: IAuthorizableConnectionAccount[] }>();
+      for (const skill of this.authorizableSkills) {
+        if (!selected.has(skill.slug)) continue;
+        for (const [key, accounts] of Object.entries(skill.connection_accounts ?? {})) {
+          if ((accounts?.length ?? 0) < 2) continue;
+          const identifier = accounts[0].connector_identifier || key;
+          if (!byConnector.has(identifier)) byConnector.set(identifier, { label: key, accounts });
+        }
+      }
+      return [...byConnector.entries()].map(([identifier, { label, accounts }]) => ({ identifier, label, accounts }));
     }
   },
   async mounted() {
@@ -647,6 +701,7 @@ export default defineComponent({
         authorizedSkills: [],
         authorizedMcpServers: [],
         browserConnectionId: '',
+        connectionAccounts: {},
         authorizationExpiresAt: Math.floor(Date.now() / 1000) + 30 * 24 * 60 * 60,
         maxTurns: DEFAULT_SCHEDULED_MAX_TURNS
       };
@@ -793,6 +848,9 @@ export default defineComponent({
             ? task.unattended_policy.allowed_mcp_servers || []
             : [],
         browserConnectionId: task.unattended_policy?.browser_connections?.[0]?.connection_id ?? '',
+        connectionAccounts: Object.fromEntries(
+          (task.unattended_policy?.connection_bindings ?? []).map((b) => [b.connector_identifier, b.connection_id])
+        ),
         authorizationExpiresAt: task.unattended_policy?.expires_at ?? Math.floor(Date.now() / 1000) + 30 * 24 * 60 * 60,
         maxTurns: task.template.max_turns ?? DEFAULT_SCHEDULED_MAX_TURNS
       };
@@ -855,13 +913,32 @@ export default defineComponent({
         browserConnections = [
           {
             connection_id: connection.connection_id,
-            revision: connection.revision,
+            connection_revision: connection.connection_revision,
             device_id: connection.device_id,
             wire_contract_digest: connection.wire_contract_digest,
             policy_digest: connection.policy_digest
           }
         ];
       }
+      // Which account of each connector this task runs as. Left empty for
+      // connectors where the user only has one account (or hasn't picked),
+      // which makes the run fall back to that connector's default account.
+      // Derived from the currently-relevant choices, not the raw form map, so
+      // deselecting a skill drops its binding instead of shipping a stale one.
+      // Also drops a saved account that no longer exists — otherwise the task
+      // would be unsavable with no picker rendered to clear it.
+      const connectionBindings = this.accountChoices
+        .map((choice) => ({
+          connector_identifier: choice.identifier,
+          connection_id: this.form.connectionAccounts[choice.identifier] || ''
+        }))
+        .filter(
+          (binding) =>
+            !!binding.connection_id &&
+            this.accountChoices
+              .find((choice) => choice.identifier === binding.connector_identifier)
+              ?.accounts.some((account) => account.connection_id === binding.connection_id)
+        );
       const payload: ScheduledTaskPayload = {
         name: this.form.name.trim() || this.deriveName(this.form.question),
         schedule: this.buildSchedule(),
@@ -879,6 +956,7 @@ export default defineComponent({
                 allowed_skills: authorizedSkills,
                 allowed_mcp_servers: authorizedMcpServers,
                 browser_connections: browserConnections,
+                connection_bindings: connectionBindings.length ? connectionBindings : undefined,
                 expires_at: this.form.authorizationExpiresAt
               }
             : { mode: 'deny_all' as const, allowed_skills: [], allowed_mcp_servers: [] }


### PR DESCRIPTION
> PR-5 / 7 — 多账号方案的定时任务 UI。设计见 [Index#304](https://github.com/AceDataCloud/Index/pull/304)，运行时契约见 [PlatformService#1673](https://github.com/AceDataCloud/PlatformService/pull/1673)。

## 为什么

用户能给同一个 connector 绑多个账号后，定时任务需要能固定用其中某一个 ——
每晚发文的任务应当始终以同一个身份发出，不能因为用户后来改了默认账号就换号。

## 改动

- **只有当某个 connector 真的有多个账号时**才渲染账号下拉；单账号连接器不出现选择项。
  留空即走该 connector 的默认账号（与交互式聊天一致）。
- 编辑任务时回填已保存的 `connection_bindings`。
- 候选账号来自 `retrieve_authorizable_skills` 返回的 `connection_accounts`。

## 顺带修一个既有的字段名错配

前端 `IScheduledBrowserBinding` 发的是 `revision`，而 worker 的
`ScheduledBrowserBinding` 要的是 `connection_revision` —— 两边对不上；
加上服务端此前根本没持久化 `browser_connections`（见 PlatformService#1673），
这个浏览器连接选择器一直是**死代码**。本 PR 改名与 worker 契约对齐。

## 测试

`npm run test:run` **100 files / 720 tests 全绿**（新增 1 项：验证只有多账号的
connector 才进入 `accountChoices`，单账号的不进）。
`vue-tsc --noEmit` 与 `npm run lint`（0 error）通过，i18n 17 个 locale 全覆盖，
已附 beachball change file。

🤖 Generated with [Claude Code](https://claude.com/claude-code)