### PR TITLE
feat(chat): show whether a scheduled run achieved its goal

### DIFF
--- a/change/@acedatacloud-nexior-1d1a0e25-f6cf-4f9f-aacb-cecd4d9e192e.json
+++ b/change/@acedatacloud-nexior-1d1a0e25-f6cf-4f9f-aacb-cecd4d9e192e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "show whether a scheduled run achieved its goal",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/i18n/ar/chat.json
+++ b/src/i18n/ar/chat.json
@@ -1202,5 +1202,11 @@
   },
   "scheduledTasks.form.connectionAccount": "Account for {connector}",
   "scheduledTasks.form.connectionAccountDefault": "Use the default account",
-  "scheduledTasks.form.accountIsDefault": "default"
+  "scheduledTasks.form.accountIsDefault": "default",
+  "scheduledTasks.run.reason.goal_not_achieved": {
+    "message": "Goal not achieved"
+  },
+  "scheduledTasks.run.reason.outcome_unknown": {
+    "message": "Result unconfirmed"
+  }
 }

--- a/src/i18n/de/chat.json
+++ b/src/i18n/de/chat.json
@@ -1163,5 +1163,11 @@
   },
   "scheduledTasks.form.connectionAccount": "Account for {connector}",
   "scheduledTasks.form.connectionAccountDefault": "Use the default account",
-  "scheduledTasks.form.accountIsDefault": "default"
+  "scheduledTasks.form.accountIsDefault": "default",
+  "scheduledTasks.run.reason.goal_not_achieved": {
+    "message": "Goal not achieved"
+  },
+  "scheduledTasks.run.reason.outcome_unknown": {
+    "message": "Result unconfirmed"
+  }
 }

--- a/src/i18n/el/chat.json
+++ b/src/i18n/el/chat.json
@@ -1163,5 +1163,11 @@
   },
   "scheduledTasks.form.connectionAccount": "Account for {connector}",
   "scheduledTasks.form.connectionAccountDefault": "Use the default account",
-  "scheduledTasks.form.accountIsDefault": "default"
+  "scheduledTasks.form.accountIsDefault": "default",
+  "scheduledTasks.run.reason.goal_not_achieved": {
+    "message": "Goal not achieved"
+  },
+  "scheduledTasks.run.reason.outcome_unknown": {
+    "message": "Result unconfirmed"
+  }
 }

--- a/src/i18n/en/chat.json
+++ b/src/i18n/en/chat.json
@@ -1143,5 +1143,11 @@
   "share.footerNote": {
     "message": "You are viewing a shared conversation. To chat with AI yourself, click above.",
     "description": "Footer note shown on the public share page under the conversation"
+  },
+  "scheduledTasks.run.reason.goal_not_achieved": {
+    "message": "Goal not achieved"
+  },
+  "scheduledTasks.run.reason.outcome_unknown": {
+    "message": "Result unconfirmed"
   }
 }

--- a/src/i18n/es/chat.json
+++ b/src/i18n/es/chat.json
@@ -1163,5 +1163,11 @@
   },
   "scheduledTasks.form.connectionAccount": "Account for {connector}",
   "scheduledTasks.form.connectionAccountDefault": "Use the default account",
-  "scheduledTasks.form.accountIsDefault": "default"
+  "scheduledTasks.form.accountIsDefault": "default",
+  "scheduledTasks.run.reason.goal_not_achieved": {
+    "message": "Goal not achieved"
+  },
+  "scheduledTasks.run.reason.outcome_unknown": {
+    "message": "Result unconfirmed"
+  }
 }

--- a/src/i18n/fi/chat.json
+++ b/src/i18n/fi/chat.json
@@ -1163,5 +1163,11 @@
   },
   "scheduledTasks.form.connectionAccount": "Account for {connector}",
   "scheduledTasks.form.connectionAccountDefault": "Use the default account",
-  "scheduledTasks.form.accountIsDefault": "default"
+  "scheduledTasks.form.accountIsDefault": "default",
+  "scheduledTasks.run.reason.goal_not_achieved": {
+    "message": "Goal not achieved"
+  },
+  "scheduledTasks.run.reason.outcome_unknown": {
+    "message": "Result unconfirmed"
+  }
 }

--- a/src/i18n/fr/chat.json
+++ b/src/i18n/fr/chat.json
@@ -1163,5 +1163,11 @@
   },
   "scheduledTasks.form.connectionAccount": "Account for {connector}",
   "scheduledTasks.form.connectionAccountDefault": "Use the default account",
-  "scheduledTasks.form.accountIsDefault": "default"
+  "scheduledTasks.form.accountIsDefault": "default",
+  "scheduledTasks.run.reason.goal_not_achieved": {
+    "message": "Goal not achieved"
+  },
+  "scheduledTasks.run.reason.outcome_unknown": {
+    "message": "Result unconfirmed"
+  }
 }

--- a/src/i18n/it/chat.json
+++ b/src/i18n/it/chat.json
@@ -1163,5 +1163,11 @@
   },
   "scheduledTasks.form.connectionAccount": "Account for {connector}",
   "scheduledTasks.form.connectionAccountDefault": "Use the default account",
-  "scheduledTasks.form.accountIsDefault": "default"
+  "scheduledTasks.form.accountIsDefault": "default",
+  "scheduledTasks.run.reason.goal_not_achieved": {
+    "message": "Goal not achieved"
+  },
+  "scheduledTasks.run.reason.outcome_unknown": {
+    "message": "Result unconfirmed"
+  }
 }

--- a/src/i18n/ja/chat.json
+++ b/src/i18n/ja/chat.json
@@ -1163,5 +1163,11 @@
   },
   "scheduledTasks.form.connectionAccount": "Account for {connector}",
   "scheduledTasks.form.connectionAccountDefault": "Use the default account",
-  "scheduledTasks.form.accountIsDefault": "default"
+  "scheduledTasks.form.accountIsDefault": "default",
+  "scheduledTasks.run.reason.goal_not_achieved": {
+    "message": "Goal not achieved"
+  },
+  "scheduledTasks.run.reason.outcome_unknown": {
+    "message": "Result unconfirmed"
+  }
 }

--- a/src/i18n/ko/chat.json
+++ b/src/i18n/ko/chat.json
@@ -1163,5 +1163,11 @@
   },
   "scheduledTasks.form.connectionAccount": "Account for {connector}",
   "scheduledTasks.form.connectionAccountDefault": "Use the default account",
-  "scheduledTasks.form.accountIsDefault": "default"
+  "scheduledTasks.form.accountIsDefault": "default",
+  "scheduledTasks.run.reason.goal_not_achieved": {
+    "message": "Goal not achieved"
+  },
+  "scheduledTasks.run.reason.outcome_unknown": {
+    "message": "Result unconfirmed"
+  }
 }

--- a/src/i18n/pl/chat.json
+++ b/src/i18n/pl/chat.json
@@ -1163,5 +1163,11 @@
   },
   "scheduledTasks.form.connectionAccount": "Account for {connector}",
   "scheduledTasks.form.connectionAccountDefault": "Use the default account",
-  "scheduledTasks.form.accountIsDefault": "default"
+  "scheduledTasks.form.accountIsDefault": "default",
+  "scheduledTasks.run.reason.goal_not_achieved": {
+    "message": "Goal not achieved"
+  },
+  "scheduledTasks.run.reason.outcome_unknown": {
+    "message": "Result unconfirmed"
+  }
 }

--- a/src/i18n/pt/chat.json
+++ b/src/i18n/pt/chat.json
@@ -1163,5 +1163,11 @@
   },
   "scheduledTasks.form.connectionAccount": "Account for {connector}",
   "scheduledTasks.form.connectionAccountDefault": "Use the default account",
-  "scheduledTasks.form.accountIsDefault": "default"
+  "scheduledTasks.form.accountIsDefault": "default",
+  "scheduledTasks.run.reason.goal_not_achieved": {
+    "message": "Goal not achieved"
+  },
+  "scheduledTasks.run.reason.outcome_unknown": {
+    "message": "Result unconfirmed"
+  }
 }

--- a/src/i18n/ru/chat.json
+++ b/src/i18n/ru/chat.json
@@ -1202,5 +1202,11 @@
   },
   "scheduledTasks.form.connectionAccount": "Account for {connector}",
   "scheduledTasks.form.connectionAccountDefault": "Use the default account",
-  "scheduledTasks.form.accountIsDefault": "default"
+  "scheduledTasks.form.accountIsDefault": "default",
+  "scheduledTasks.run.reason.goal_not_achieved": {
+    "message": "Goal not achieved"
+  },
+  "scheduledTasks.run.reason.outcome_unknown": {
+    "message": "Result unconfirmed"
+  }
 }

--- a/src/i18n/sr/chat.json
+++ b/src/i18n/sr/chat.json
@@ -1163,5 +1163,11 @@
   },
   "scheduledTasks.form.connectionAccount": "Account for {connector}",
   "scheduledTasks.form.connectionAccountDefault": "Use the default account",
-  "scheduledTasks.form.accountIsDefault": "default"
+  "scheduledTasks.form.accountIsDefault": "default",
+  "scheduledTasks.run.reason.goal_not_achieved": {
+    "message": "Goal not achieved"
+  },
+  "scheduledTasks.run.reason.outcome_unknown": {
+    "message": "Result unconfirmed"
+  }
 }

--- a/src/i18n/sv/chat.json
+++ b/src/i18n/sv/chat.json
@@ -1163,5 +1163,11 @@
   },
   "scheduledTasks.form.connectionAccount": "Account for {connector}",
   "scheduledTasks.form.connectionAccountDefault": "Use the default account",
-  "scheduledTasks.form.accountIsDefault": "default"
+  "scheduledTasks.form.accountIsDefault": "default",
+  "scheduledTasks.run.reason.goal_not_achieved": {
+    "message": "Goal not achieved"
+  },
+  "scheduledTasks.run.reason.outcome_unknown": {
+    "message": "Result unconfirmed"
+  }
 }

--- a/src/i18n/uk/chat.json
+++ b/src/i18n/uk/chat.json
@@ -1163,5 +1163,11 @@
   },
   "scheduledTasks.form.connectionAccount": "Account for {connector}",
   "scheduledTasks.form.connectionAccountDefault": "Use the default account",
-  "scheduledTasks.form.accountIsDefault": "default"
+  "scheduledTasks.form.accountIsDefault": "default",
+  "scheduledTasks.run.reason.goal_not_achieved": {
+    "message": "Goal not achieved"
+  },
+  "scheduledTasks.run.reason.outcome_unknown": {
+    "message": "Result unconfirmed"
+  }
 }

--- a/src/i18n/zh-CN/chat.json
+++ b/src/i18n/zh-CN/chat.json
@@ -1209,5 +1209,11 @@
   "share.footerNote": {
     "message": "您正在查看一段分享的对话。点击上方即可自己与 AI 对话。",
     "description": "分享公开页面对话下方的说明"
+  },
+  "scheduledTasks.run.reason.goal_not_achieved": {
+    "message": "未达成目标"
+  },
+  "scheduledTasks.run.reason.outcome_unknown": {
+    "message": "结果待确认"
   }
 }

--- a/src/i18n/zh-TW/chat.json
+++ b/src/i18n/zh-TW/chat.json
@@ -1163,5 +1163,11 @@
   },
   "scheduledTasks.form.connectionAccount": "Account for {connector}",
   "scheduledTasks.form.connectionAccountDefault": "Use the default account",
-  "scheduledTasks.form.accountIsDefault": "default"
+  "scheduledTasks.form.accountIsDefault": "default",
+  "scheduledTasks.run.reason.goal_not_achieved": {
+    "message": "Goal not achieved"
+  },
+  "scheduledTasks.run.reason.outcome_unknown": {
+    "message": "Result unconfirmed"
+  }
 }

--- a/src/operators/scheduledTasks.ts
+++ b/src/operators/scheduledTasks.ts
@@ -48,6 +48,11 @@ export interface IScheduledRun {
   conversation_model_group?: string;
   error_code?: string;
   error_message?: string;
+  /** Did the run achieve the user's goal? Judged from tool evidence, not from
+   *  whether the agent loop merely terminated. Absent on pre-judge runs. */
+  outcome?: 'achieved' | 'not_achieved' | 'unknown';
+  /** One-line, user-facing explanation of `outcome`. */
+  outcome_reason?: string;
 }
 
 export type IScheduledRunStatus = 'queued' | 'running' | 'success' | 'failed';

--- a/src/pages/chat/ScheduledTasks.vue
+++ b/src/pages/chat/ScheduledTasks.vue
@@ -162,8 +162,12 @@
                     {{ run.task_name }}
                   </el-tag>
                   <span class="run-time">{{ formatTime(run.scheduled_at) }}</span>
-                  <span v-if="run.error_code || run.error_message" class="run-error" :title="runErrorText(run)">
-                    {{ runErrorText(run) }}
+                  <span
+                    v-if="runOutcomeText(run)"
+                    :class="run.status === 'success' ? 'run-outcome' : 'run-error'"
+                    :title="runOutcomeText(run)"
+                  >
+                    {{ runOutcomeText(run) }}
                   </span>
                 </div>
               </div>
@@ -232,8 +236,12 @@
             <div v-if="run.conversation_preview" class="run-preview">{{ run.conversation_preview }}</div>
             <div class="run-sub">
               <span class="run-time">{{ formatTime(run.scheduled_at) }}</span>
-              <span v-if="run.error_code || run.error_message" class="run-error" :title="runErrorText(run)">
-                {{ runErrorText(run) }}
+              <span
+                v-if="runOutcomeText(run)"
+                :class="run.status === 'success' ? 'run-outcome' : 'run-error'"
+                :title="runOutcomeText(run)"
+              >
+                {{ runOutcomeText(run) }}
               </span>
             </div>
           </div>
@@ -1133,6 +1141,12 @@ export default defineComponent({
     runTagType(status: string) {
       return status === 'success' ? 'success' : status === 'failed' ? 'danger' : 'warning';
     },
+    // The judge's own sentence beats a bare code like `goal_not_achieved`, and
+    // it is shown for successes too — so it is NOT read from `error_message`.
+    runOutcomeText(run: IScheduledRun) {
+      if (run.outcome_reason) return run.outcome_reason;
+      return this.runErrorText(run);
+    },
     runErrorText(run: IScheduledRun) {
       if (run.error_message) return run.error_message;
       const code = run.error_code;
@@ -1510,7 +1524,8 @@ export default defineComponent({
   font-size: 12px;
   color: var(--el-text-color-secondary);
 }
-.run-error {
+.run-error,
+.run-outcome {
   min-width: 0;
   font-size: 11px;
   color: var(--el-text-color-secondary);


### PR DESCRIPTION
配套 https://github.com/AceDataCloud/PlatformService/pull/1680。

## 背景

后端此前把「agent 循环正常结束」当成功，实测假成功率 **47%**（任务 `af5fba4b` 49 次运行中 23 次实际失败仍记 `success`；14 个任务 ~2900 次运行熔断计数全 0，从未触发）。后端改为跑完后单独发一次 LLM 调用，从**工具执行记录**判定，并给出一句人话理由。本 PR 把这个判定展示出来。

## 改动

- `IScheduledRun` 增加 `outcome` / `outcome_reason`
- 运行列表（两处渲染点）显示 judge 的原话：成功用中性色，其余用错误色
- 新增两个后端可能下发的 code 的 i18n：`goal_not_achieved`、`outcome_unknown`（后端只给 code 不给原话时用）

## 一个刻意的取舍

理由读的是 **`outcome_reason` 而不是 `error_message`**。

后端最初把 judge 的理由塞进 `error_message`，但对抗评审指出：这个理由**成功时也要显示**，而列表里 `error_message` 渲染在错误槽里 —— 绿色的运行会把「已成功发布到 Medium」显示成一条错误。后端因此改用独立字段，前端跟着读它。

## 验证

- `npx vue-tsc --noEmit` 干净
- `npm run lint` 0 error（2 个 warning 来自无关文件 `dropUploadMixin.test.ts`，改动前就有）
- `python3 scripts/check_i18n_coverage.py` → 17 locale × 45 namespace 全覆盖（用 `/i18n-backfill` 从 en 回填，未跑 `yarn translate`）

## 上线顺序

**先 PlatformService 再 Nexior。** 后端未上线时 `outcome_reason` 缺省，列表回退到原有的 `error_message` / code 展示，行为与现在一致。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
