### PR TITLE
fix(chat): 把 ChatGPT 默认模型改为 GPT-5.6 Sol

### DIFF
--- a/change/@acedatacloud-nexior-06b68efe-2af5-4650-91dc-38bf67cc5a57.json
+++ b/change/@acedatacloud-nexior-06b68efe-2af5-4650-91dc-38bf67cc5a57.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "default the ChatGPT model picker to GPT-5.6 Sol",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/chat/ModelSelector.vue
+++ b/src/components/chat/ModelSelector.vue
@@ -49,7 +49,8 @@ import {
   CHAT_MODEL_GROUP_GROK,
   CHAT_MODEL_GROUP_GEMINI,
   CHAT_MODEL_GROUP_CLAUDE,
-  CHAT_MODEL_GROUP_KIMI
+  CHAT_MODEL_GROUP_KIMI,
+  getDefaultChatModel
 } from '@/constants';
 
 interface IData {
@@ -92,7 +93,7 @@ export default defineComponent({
     modelGroup(newValue: IChatModelGroup) {
       console.debug('modelGroup from route changed', newValue);
       this.$store.dispatch('chat/setModelGroup', newValue);
-      this.$store.dispatch('chat/setModel', newValue.models[0]);
+      this.$store.dispatch('chat/setModel', getDefaultChatModel(newValue));
     }
   },
   mounted() {
@@ -103,7 +104,7 @@ export default defineComponent({
     //
     // We also reconcile `chat.model` (which IS persisted): if the
     // remembered model belongs to a different group than the route, fall
-    // back to the new group's first model. Otherwise leave the user's
+    // back to the new group's default model. Otherwise leave the user's
     // selection alone \u2014 a refresh shouldn't snap them from gpt-5-mini
     // back to gpt-5.
     const route = this.modelGroup;
@@ -112,7 +113,7 @@ export default defineComponent({
     }
     const persistedModel = this.$store.state.chat?.model;
     if (!route.models.some((m) => m.name === persistedModel?.name)) {
-      this.$store.dispatch('chat/setModel', route.models[0]);
+      this.$store.dispatch('chat/setModel', getDefaultChatModel(route));
     }
   },
   methods: {

--- a/src/constants/chat.test.ts
+++ b/src/constants/chat.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, it } from 'vitest';
 
 import {
   CHAT_MODEL_GPT_5_6_LUNA,
+  CHAT_MODEL_GPT_5_6_SOL,
   CHAT_MODEL_GROUP_CHATGPT,
   CHAT_MODEL_GROUP_KIMI,
   CHAT_MODEL_KIMI_K2_6,
   CHAT_MODEL_KIMI_K3,
-  CHAT_MODELS
+  CHAT_MODELS,
+  getDefaultChatModel
 } from './chat';
 
 describe('chat models', () => {
@@ -18,6 +20,14 @@ describe('chat models', () => {
     ]);
     expect(CHAT_MODEL_GPT_5_6_LUNA.isFree).toBe(true);
     expect(CHAT_MODEL_GROUP_CHATGPT.models.filter((model) => model.isFree)).toEqual([CHAT_MODEL_GPT_5_6_LUNA]);
+  });
+
+  it('defaults the ChatGPT group to Sol, not the first listed model', () => {
+    expect(getDefaultChatModel(CHAT_MODEL_GROUP_CHATGPT)).toBe(CHAT_MODEL_GPT_5_6_SOL);
+  });
+
+  it('falls back to the first model for groups without an explicit default', () => {
+    expect(getDefaultChatModel(CHAT_MODEL_GROUP_KIMI)).toBe(CHAT_MODEL_GROUP_KIMI.models[0]);
   });
 
   it('lists K3 first and registers both current Kimi models', () => {

--- a/src/constants/chat.ts
+++ b/src/constants/chat.ts
@@ -317,6 +317,7 @@ export const CHAT_MODEL_GROUP_CHATGPT: IChatModelGroup = {
   getDisplayName: () => i18n.global.t('chat.modelGroup.chatgpt'),
   getDescription: () => i18n.global.t('chat.modelGroup.chatgptDescription'),
   models: [CHAT_MODEL_GPT_5_6_LUNA, CHAT_MODEL_GPT_5_6_SOL, CHAT_MODEL_GPT_5_6_TERRA],
+  defaultModel: CHAT_MODEL_GPT_5_6_SOL,
   isVoiceCallSupported: true
 };
 
@@ -425,3 +426,5 @@ export const CHAT_MODEL_GROUPS: IChatModelGroup[] = [
   CHAT_MODEL_GROUP_KIMI,
   CHAT_MODEL_GROUP_GLM
 ];
+
+export const getDefaultChatModel = (group: IChatModelGroup): IChatModel => group.defaultModel ?? group.models[0];

--- a/src/models/chat.ts
+++ b/src/models/chat.ts
@@ -77,6 +77,8 @@ export interface IChatModelGroup {
   getDisplayName: () => string;
   getDescription: () => string;
   models: IChatModel[];
+  // Pre-selected model for new users / on group switch. Falls back to models[0].
+  defaultModel?: IChatModel;
   // Realtime voice call is only wired up for the OpenAI (ChatGPT) service.
   isVoiceCallSupported?: boolean;
 }

--- a/src/pages/chat/ScheduledTasks.test.ts
+++ b/src/pages/chat/ScheduledTasks.test.ts
@@ -2,7 +2,7 @@
 import { flushPromises, shallowMount } from '@vue/test-utils';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { CHAT_MODEL_NAME_GPT_5_6_LUNA } from '@/constants';
+import { CHAT_MODEL_NAME_GPT_5_6_SOL } from '@/constants';
 import {
   SCHEDULED_TASK_ERROR_BROWSER_AUTHORIZATION_STALE,
   SCHEDULED_TASK_ERROR_BROWSER_DEVICE_OFFLINE,
@@ -137,7 +137,7 @@ describe('chat/ScheduledTasks', () => {
     expect(vm.form).toEqual({
       name: '',
       question: '',
-      model: CHAT_MODEL_NAME_GPT_5_6_LUNA,
+      model: CHAT_MODEL_NAME_GPT_5_6_SOL,
       scheduleType: 'daily',
       intervalValue: 4,
       intervalUnit: 'hour',

--- a/src/pages/chat/ScheduledTasks.vue
+++ b/src/pages/chat/ScheduledTasks.vue
@@ -520,7 +520,7 @@ import type {
   IAuthorizableConnectionAccount,
   IScheduledBrowserBinding
 } from '@/operators/scheduledTasks';
-import { CHAT_MODEL_GROUPS, CHAT_MODEL_NAME_GPT_5_6_LUNA } from '@/constants';
+import { CHAT_MODEL_GROUPS, CHAT_MODEL_NAME_GPT_5_6_SOL } from '@/constants';
 import { IChatModelGroup } from '@/models';
 
 const USER_TZ = Intl.DateTimeFormat().resolvedOptions().timeZone || 'Asia/Shanghai';
@@ -698,7 +698,7 @@ export default defineComponent({
       return {
         name: '',
         question: '',
-        model: CHAT_MODEL_NAME_GPT_5_6_LUNA,
+        model: CHAT_MODEL_NAME_GPT_5_6_SOL,
         scheduleType: 'daily',
         intervalValue: 4,
         intervalUnit: 'hour',

--- a/src/store/chat/state.ts
+++ b/src/store/chat/state.ts
@@ -1,10 +1,10 @@
-import { CHAT_MODEL_GPT_5_6_LUNA, CHAT_MODEL_GROUP_CHATGPT } from '@/constants';
+import { CHAT_MODEL_GROUP_CHATGPT, getDefaultChatModel } from '@/constants';
 import { IChatState } from './models';
 import { Status } from '@/models';
 
 export default (): IChatState => {
   return {
-    model: CHAT_MODEL_GPT_5_6_LUNA,
+    model: getDefaultChatModel(CHAT_MODEL_GROUP_CHATGPT),
     modelGroup: CHAT_MODEL_GROUP_CHATGPT,
     applications: undefined,
     application: undefined,


### PR DESCRIPTION
## 背景

`studio.acedata.cloud/chatgpt` 对新用户默认打开的是免费的 `gpt-5.6-luna`，因为默认模型来自两处硬编码的 `models[0]`（store 初始 state + ModelSelector 的 watch/mounted），而列表第一项是带「免费」标的 Luna —— 产品上希望它留在第一位。

## 改动

给 `IChatModelGroup` 加可选 `defaultModel` 字段 + `getDefaultChatModel()`，把「列表顺序」和「默认选中项」解耦：

- ChatGPT 组设 `defaultModel: CHAT_MODEL_GPT_5_6_SOL`
- store 初始值与 ModelSelector 两处调用点走 `getDefaultChatModel()`
- 定时任务新建表单默认模型同步改为 Sol
- 其余模型组未设 `defaultModel`，行为不变（回退 `models[0]`）

**下拉顺序不变**：Luna（免费）→ Sol → Terra，只是默认选中 Sol。

`chat.model` 是持久化的，本 PR **不做迁移** —— 老用户保留自己选过的模型，只影响全新用户和切换模型组时。

## 验证

722/722 通过；`eslint` 与 `vue-tsc --noEmit` 干净。

## 🤖 对抗评审

Codex 额度耗尽，改用 Claude `general-purpose` subagent 评审，每条发现都做过突变验证（改代码看测试是否变红）。

**已采纳：** 评审者实测把 `state.ts` / `ModelSelector.vue` 的调用点改回 `models[0]` 后 722/722 仍全绿 —— 说明改动的核心行为没有任何测试保护。已加两条针对 `getDefaultChatModel` 的断言。

**已驳回（overdesign）：** 评审者另提出 helper 应过滤 `enabled` 为假的模型，防止「将来某天 Sol 退役时默认模型在下拉里不可见」。该场景需要有人主动把 Sol 标记退役却不更新 `defaultModel` 才会发生，属于假想的未来失误；为它引入过滤分支 + 两个不变量测试 + 两个新测试文件（其中 57 行是 ModelSelector 的 mock 脚手架），与「换一个默认值」的改动量严重不成比例。已回退，保持 helper 为一行 `defaultModel ?? models[0]`。真到退役那天，改常量的人自然会一并处理。

评审者另查证并排除了一个疑点：定时任务改用 Sol 不存在「只允许免费模型」的白名单或计费差异 —— `platform-scheduler` 无模型白名单，aichat2/scheduled-run 的 cost 文件只对 `gpt-5.6-luna` 特判 `consumption: 0`，Sol 走共享目录定价，与手动对话一致。

🤖 Generated with [Claude Code](https://claude.com/claude-code)