### PR TITLE
feat(coding-bridge): render TodoWrite calls as a checklist

### DIFF
--- a/change/@acedatacloud-nexior-a9ad86d6-9380-46f8-b151-0f43285b4851.json
+++ b/change/@acedatacloud-nexior-a9ad86d6-9380-46f8-b151-0f43285b4851.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "render coding bridge TodoWrite calls as a checklist instead of raw JSON",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/codingBridge/TranscriptItem.vue
+++ b/src/components/codingBridge/TranscriptItem.vue
@@ -92,6 +92,29 @@
           <div class="whitespace-pre-wrap break-words text-[var(--app-text-subtle)]">{{ line.question }}</div>
         </div>
       </div>
+      <!-- TodoWrite: a checklist, not the raw `{todos:[...]}` JSON. -->
+      <div v-else-if="todoItems.length" class="px-2.5 pb-2">
+        <div :id="todoProgressId" class="mb-1.5 text-xs text-[var(--app-text-subtle)]">{{ todoProgressLabel }}</div>
+        <ul class="flex flex-col gap-1" :aria-labelledby="todoProgressId">
+          <li v-for="(todo, index) in todoItems" :key="index" class="flex items-start gap-2 text-xs">
+            <component
+              :is="todo.icon"
+              class="mt-0.5 flex-none"
+              :class="todo.iconClass"
+              :size="'1em' as any"
+              aria-hidden="true"
+              focusable="false"
+            />
+            <!-- Status is otherwise icon/colour/strikethrough only; name it for
+                 screen readers so completed and pending rows aren't identical. -->
+            <span class="sr-only">{{ todo.statusLabel }}</span>
+            <span class="min-w-0 break-words" :class="todo.textClass">{{ todo.text }}</span>
+          </li>
+        </ul>
+        <div v-if="todoOverflow" class="mt-1 text-xs text-[var(--app-text-subtle)]">
+          {{ $t('codingBridge.transcript.todoOverflow', { count: todoOverflow }) }}
+        </div>
+      </div>
       <!-- Shell-style tools render as a highlighted, copyable command block. -->
       <div v-else-if="commandText" class="px-2.5 pb-2">
         <code-snippet :code="commandText" lang="bash" copyable />
@@ -166,8 +189,11 @@ import {
   FileIcon,
   FileTextIcon,
   InfoIcon,
+  LoadingIcon,
   SearchIcon,
-  TerminalIcon
+  StopIcon,
+  TerminalIcon,
+  WriteIcon
 } from '@acedatacloud/core/icons/components';
 import { defineComponent, type Component, PropType } from 'vue';
 import VueMarkdown from '@/components/common/VueMarkdown.vue';
@@ -192,6 +218,9 @@ const STREAM_RENDER_MS = 100;
 const MAX_TEXT_CHARS = 40000;
 const MAX_RESULT_CHARS = 12000;
 const MAX_INPUT_CHARS = 6000;
+// Same rationale for todo lists: agents occasionally emit very long plans.
+const MAX_TODO_ITEMS = 50;
+const MAX_TODO_TEXT_CHARS = 200;
 const capForRender = (value: string, max: number): string => {
   if (value.length <= max) {
     return value;
@@ -268,6 +297,9 @@ export default defineComponent({
       return typeof description === 'string' ? description : '';
     },
     toolIcon(): Component {
+      if (this.todoList.length) {
+        return WriteIcon;
+      }
       if (this.commandText) {
         return TerminalIcon;
       }
@@ -298,6 +330,88 @@ export default defineComponent({
           header: typeof q.header === 'string' ? q.header : '',
           question: q.question as string
         }));
+    },
+    // TodoWrite relays a `{todos:[{content,status,activeForm}]}` payload — the
+    // most structured input any tool sends, and the least readable as raw JSON.
+    todoList(): { content: string; status: string; activeForm?: string }[] {
+      const todos = this.event.input?.todos;
+      if (!Array.isArray(todos)) {
+        return [];
+      }
+      // Match on the tool name first. For a differently-named provider tool,
+      // only claim the payload when `todos` is essentially all of it —
+      // this branch renders no other key, so hijacking a richer payload would
+      // hide what the tool actually did (a command, a path, an API mutation).
+      const tool = (this.event.tool ?? '').toLowerCase();
+      if (!tool.includes('todo')) {
+        const meaningful = Object.keys(this.event.input ?? {}).filter(
+          (key) => key !== 'todos' && key !== 'description'
+        );
+        if (meaningful.length) {
+          return [];
+        }
+      }
+      return todos
+        .filter((todo) => todo && typeof todo.content === 'string')
+        .map((todo) => ({
+          content: todo.content as string,
+          status: typeof todo.status === 'string' ? todo.status : 'pending',
+          activeForm: typeof todo.activeForm === 'string' ? todo.activeForm : undefined
+        }));
+    },
+    todoItems(): {
+      text: string;
+      status: string;
+      statusLabel: string;
+      icon: Component;
+      iconClass: string;
+      textClass: string;
+    }[] {
+      return this.todoList.slice(0, MAX_TODO_ITEMS).map((todo) => {
+        // In-progress rows read better in the present continuous the agent supplies.
+        const raw = todo.status === 'in_progress' && todo.activeForm ? todo.activeForm : todo.content;
+        const text = raw.length > MAX_TODO_TEXT_CHARS ? `${raw.slice(0, MAX_TODO_TEXT_CHARS)}…` : raw;
+        if (todo.status === 'completed') {
+          return {
+            text,
+            status: 'completed',
+            statusLabel: this.$t('codingBridge.transcript.todoCompleted') as string,
+            icon: ConfirmIcon,
+            iconClass: 'text-[var(--el-color-success)]',
+            textClass: 'text-[var(--app-text-subtle)] line-through'
+          };
+        }
+        if (todo.status === 'in_progress') {
+          return {
+            text,
+            status: 'in_progress',
+            statusLabel: this.$t('codingBridge.transcript.todoInProgress') as string,
+            icon: LoadingIcon,
+            iconClass: 'text-[var(--el-color-primary)]',
+            textClass: 'text-[var(--app-text)] font-medium'
+          };
+        }
+        return {
+          text,
+          status: 'pending',
+          statusLabel: this.$t('codingBridge.transcript.todoPending') as string,
+          icon: StopIcon,
+          iconClass: 'text-[var(--app-text-subtle)] opacity-60',
+          textClass: 'text-[var(--app-text-subtle)]'
+        };
+      });
+    },
+    todoProgressLabel(): string {
+      const done = this.todoList.filter((todo) => todo.status === 'completed').length;
+      return this.$t('codingBridge.transcript.todoProgress', { done, total: this.todoList.length }) as string;
+    },
+    // Ties the <ul> to its progress line for assistive tech. `event.id` is
+    // required and already the transcript's v-for key, so it's unique per page.
+    todoProgressId(): string {
+      return `cb-todo-progress-${this.event.id}`;
+    },
+    todoOverflow(): number {
+      return Math.max(0, this.todoList.length - MAX_TODO_ITEMS);
     },
     inputText(): string {
       const input = this.event.input;

--- a/src/i18n/ar/codingBridge.json
+++ b/src/i18n/ar/codingBridge.json
@@ -446,5 +446,25 @@
   "notify.failed": {
     "message": "تعذّر تحديث إعدادات الإشعارات.",
     "description": "Toast when enabling or disabling notifications errors"
+  },
+  "transcript.todoProgress": {
+    "message": "{done}/{total} completed",
+    "description": "Todo list progress"
+  },
+  "transcript.todoOverflow": {
+    "message": "…and {count} more",
+    "description": "Todo list overflow hint"
+  },
+  "transcript.todoCompleted": {
+    "message": "Completed",
+    "description": "Todo list: completed status for screen readers"
+  },
+  "transcript.todoInProgress": {
+    "message": "In progress",
+    "description": "Todo list: in-progress status for screen readers"
+  },
+  "transcript.todoPending": {
+    "message": "Pending",
+    "description": "Todo list: pending status for screen readers"
   }
 }

--- a/src/i18n/de/codingBridge.json
+++ b/src/i18n/de/codingBridge.json
@@ -446,5 +446,25 @@
   "notify.failed": {
     "message": "Benachrichtigungseinstellungen konnten nicht aktualisiert werden.",
     "description": "Toast when enabling or disabling notifications errors"
+  },
+  "transcript.todoProgress": {
+    "message": "{done}/{total} completed",
+    "description": "Todo list progress"
+  },
+  "transcript.todoOverflow": {
+    "message": "…and {count} more",
+    "description": "Todo list overflow hint"
+  },
+  "transcript.todoCompleted": {
+    "message": "Completed",
+    "description": "Todo list: completed status for screen readers"
+  },
+  "transcript.todoInProgress": {
+    "message": "In progress",
+    "description": "Todo list: in-progress status for screen readers"
+  },
+  "transcript.todoPending": {
+    "message": "Pending",
+    "description": "Todo list: pending status for screen readers"
   }
 }

--- a/src/i18n/el/codingBridge.json
+++ b/src/i18n/el/codingBridge.json
@@ -446,5 +446,25 @@
   "notify.failed": {
     "message": "Δεν ήταν δυνατή η ενημέρωση των ρυθμίσεων ειδοποιήσεων.",
     "description": "Toast when enabling or disabling notifications errors"
+  },
+  "transcript.todoProgress": {
+    "message": "{done}/{total} completed",
+    "description": "Todo list progress"
+  },
+  "transcript.todoOverflow": {
+    "message": "…and {count} more",
+    "description": "Todo list overflow hint"
+  },
+  "transcript.todoCompleted": {
+    "message": "Completed",
+    "description": "Todo list: completed status for screen readers"
+  },
+  "transcript.todoInProgress": {
+    "message": "In progress",
+    "description": "Todo list: in-progress status for screen readers"
+  },
+  "transcript.todoPending": {
+    "message": "Pending",
+    "description": "Todo list: pending status for screen readers"
   }
 }

--- a/src/i18n/en/codingBridge.json
+++ b/src/i18n/en/codingBridge.json
@@ -199,6 +199,26 @@
     "message": "Done",
     "description": "Turn result done label"
   },
+  "transcript.todoProgress": {
+    "message": "{done}/{total} completed",
+    "description": "Todo list progress"
+  },
+  "transcript.todoOverflow": {
+    "message": "…and {count} more",
+    "description": "Todo list overflow hint"
+  },
+  "transcript.todoCompleted": {
+    "message": "Completed",
+    "description": "Todo list: completed status for screen readers"
+  },
+  "transcript.todoInProgress": {
+    "message": "In progress",
+    "description": "Todo list: in-progress status for screen readers"
+  },
+  "transcript.todoPending": {
+    "message": "Pending",
+    "description": "Todo list: pending status for screen readers"
+  },
   "history.button": {
     "message": "History",
     "description": "Open the conversation history drawer"

--- a/src/i18n/es/codingBridge.json
+++ b/src/i18n/es/codingBridge.json
@@ -446,5 +446,25 @@
   "notify.failed": {
     "message": "No se pudo actualizar la configuración de notificaciones.",
     "description": "Toast when enabling or disabling notifications errors"
+  },
+  "transcript.todoProgress": {
+    "message": "{done}/{total} completed",
+    "description": "Todo list progress"
+  },
+  "transcript.todoOverflow": {
+    "message": "…and {count} more",
+    "description": "Todo list overflow hint"
+  },
+  "transcript.todoCompleted": {
+    "message": "Completed",
+    "description": "Todo list: completed status for screen readers"
+  },
+  "transcript.todoInProgress": {
+    "message": "In progress",
+    "description": "Todo list: in-progress status for screen readers"
+  },
+  "transcript.todoPending": {
+    "message": "Pending",
+    "description": "Todo list: pending status for screen readers"
   }
 }

--- a/src/i18n/fi/codingBridge.json
+++ b/src/i18n/fi/codingBridge.json
@@ -446,5 +446,25 @@
   "notify.failed": {
     "message": "Ilmoitusasetusten päivittäminen epäonnistui.",
     "description": "Ilmoitus, kun ilmoitusten käyttöönotto tai poistaminen epäonnistuu"
+  },
+  "transcript.todoProgress": {
+    "message": "{done}/{total} completed",
+    "description": "Todo list progress"
+  },
+  "transcript.todoOverflow": {
+    "message": "…and {count} more",
+    "description": "Todo list overflow hint"
+  },
+  "transcript.todoCompleted": {
+    "message": "Completed",
+    "description": "Todo list: completed status for screen readers"
+  },
+  "transcript.todoInProgress": {
+    "message": "In progress",
+    "description": "Todo list: in-progress status for screen readers"
+  },
+  "transcript.todoPending": {
+    "message": "Pending",
+    "description": "Todo list: pending status for screen readers"
   }
 }

--- a/src/i18n/fr/codingBridge.json
+++ b/src/i18n/fr/codingBridge.json
@@ -446,5 +446,25 @@
   "notify.failed": {
     "message": "Impossible de mettre à jour les paramètres de notification.",
     "description": "Toast when enabling or disabling notifications errors"
+  },
+  "transcript.todoProgress": {
+    "message": "{done}/{total} completed",
+    "description": "Todo list progress"
+  },
+  "transcript.todoOverflow": {
+    "message": "…and {count} more",
+    "description": "Todo list overflow hint"
+  },
+  "transcript.todoCompleted": {
+    "message": "Completed",
+    "description": "Todo list: completed status for screen readers"
+  },
+  "transcript.todoInProgress": {
+    "message": "In progress",
+    "description": "Todo list: in-progress status for screen readers"
+  },
+  "transcript.todoPending": {
+    "message": "Pending",
+    "description": "Todo list: pending status for screen readers"
   }
 }

--- a/src/i18n/it/codingBridge.json
+++ b/src/i18n/it/codingBridge.json
@@ -446,5 +446,25 @@
   "notify.failed": {
     "message": "Impossibile aggiornare le impostazioni delle notifiche.",
     "description": "Toast when enabling or disabling notifications errors"
+  },
+  "transcript.todoProgress": {
+    "message": "{done}/{total} completed",
+    "description": "Todo list progress"
+  },
+  "transcript.todoOverflow": {
+    "message": "…and {count} more",
+    "description": "Todo list overflow hint"
+  },
+  "transcript.todoCompleted": {
+    "message": "Completed",
+    "description": "Todo list: completed status for screen readers"
+  },
+  "transcript.todoInProgress": {
+    "message": "In progress",
+    "description": "Todo list: in-progress status for screen readers"
+  },
+  "transcript.todoPending": {
+    "message": "Pending",
+    "description": "Todo list: pending status for screen readers"
   }
 }

--- a/src/i18n/ja/codingBridge.json
+++ b/src/i18n/ja/codingBridge.json
@@ -446,5 +446,25 @@
   "notify.failed": {
     "message": "通知設定を更新できませんでした。",
     "description": "通知の有効化または無効化でエラーが発生した場合のトースト"
+  },
+  "transcript.todoProgress": {
+    "message": "{done}/{total} completed",
+    "description": "Todo list progress"
+  },
+  "transcript.todoOverflow": {
+    "message": "…and {count} more",
+    "description": "Todo list overflow hint"
+  },
+  "transcript.todoCompleted": {
+    "message": "Completed",
+    "description": "Todo list: completed status for screen readers"
+  },
+  "transcript.todoInProgress": {
+    "message": "In progress",
+    "description": "Todo list: in-progress status for screen readers"
+  },
+  "transcript.todoPending": {
+    "message": "Pending",
+    "description": "Todo list: pending status for screen readers"
   }
 }

--- a/src/i18n/ko/codingBridge.json
+++ b/src/i18n/ko/codingBridge.json
@@ -446,5 +446,25 @@
   "notify.failed": {
     "message": "알림 설정을 업데이트하지 못했습니다.",
     "description": "Toast when enabling or disabling notifications errors"
+  },
+  "transcript.todoProgress": {
+    "message": "{done}/{total} completed",
+    "description": "Todo list progress"
+  },
+  "transcript.todoOverflow": {
+    "message": "…and {count} more",
+    "description": "Todo list overflow hint"
+  },
+  "transcript.todoCompleted": {
+    "message": "Completed",
+    "description": "Todo list: completed status for screen readers"
+  },
+  "transcript.todoInProgress": {
+    "message": "In progress",
+    "description": "Todo list: in-progress status for screen readers"
+  },
+  "transcript.todoPending": {
+    "message": "Pending",
+    "description": "Todo list: pending status for screen readers"
   }
 }

--- a/src/i18n/pl/codingBridge.json
+++ b/src/i18n/pl/codingBridge.json
@@ -446,5 +446,25 @@
   "notify.failed": {
     "message": "Nie udało się zaktualizować ustawień powiadomień.",
     "description": "Toast when enabling or disabling notifications errors"
+  },
+  "transcript.todoProgress": {
+    "message": "{done}/{total} completed",
+    "description": "Todo list progress"
+  },
+  "transcript.todoOverflow": {
+    "message": "…and {count} more",
+    "description": "Todo list overflow hint"
+  },
+  "transcript.todoCompleted": {
+    "message": "Completed",
+    "description": "Todo list: completed status for screen readers"
+  },
+  "transcript.todoInProgress": {
+    "message": "In progress",
+    "description": "Todo list: in-progress status for screen readers"
+  },
+  "transcript.todoPending": {
+    "message": "Pending",
+    "description": "Todo list: pending status for screen readers"
   }
 }

--- a/src/i18n/pt/codingBridge.json
+++ b/src/i18n/pt/codingBridge.json
@@ -446,5 +446,25 @@
   "notify.failed": {
     "message": "Não foi possível atualizar as configurações de notificação.",
     "description": "Toast when enabling or disabling notifications errors"
+  },
+  "transcript.todoProgress": {
+    "message": "{done}/{total} completed",
+    "description": "Todo list progress"
+  },
+  "transcript.todoOverflow": {
+    "message": "…and {count} more",
+    "description": "Todo list overflow hint"
+  },
+  "transcript.todoCompleted": {
+    "message": "Completed",
+    "description": "Todo list: completed status for screen readers"
+  },
+  "transcript.todoInProgress": {
+    "message": "In progress",
+    "description": "Todo list: in-progress status for screen readers"
+  },
+  "transcript.todoPending": {
+    "message": "Pending",
+    "description": "Todo list: pending status for screen readers"
   }
 }

--- a/src/i18n/ru/codingBridge.json
+++ b/src/i18n/ru/codingBridge.json
@@ -446,5 +446,25 @@
   "notify.failed": {
     "message": "Не удалось обновить настройки уведомлений.",
     "description": "Уведомление об ошибке при изменении настроек уведомлений"
+  },
+  "transcript.todoProgress": {
+    "message": "{done}/{total} completed",
+    "description": "Todo list progress"
+  },
+  "transcript.todoOverflow": {
+    "message": "…and {count} more",
+    "description": "Todo list overflow hint"
+  },
+  "transcript.todoCompleted": {
+    "message": "Completed",
+    "description": "Todo list: completed status for screen readers"
+  },
+  "transcript.todoInProgress": {
+    "message": "In progress",
+    "description": "Todo list: in-progress status for screen readers"
+  },
+  "transcript.todoPending": {
+    "message": "Pending",
+    "description": "Todo list: pending status for screen readers"
   }
 }

--- a/src/i18n/sr/codingBridge.json
+++ b/src/i18n/sr/codingBridge.json
@@ -446,5 +446,25 @@
   "notify.failed": {
     "message": "Ажурирање подешавања обавештења није успело.",
     "description": "Обавештење када укључивање или искључивање обавештења не успе"
+  },
+  "transcript.todoProgress": {
+    "message": "{done}/{total} completed",
+    "description": "Todo list progress"
+  },
+  "transcript.todoOverflow": {
+    "message": "…and {count} more",
+    "description": "Todo list overflow hint"
+  },
+  "transcript.todoCompleted": {
+    "message": "Completed",
+    "description": "Todo list: completed status for screen readers"
+  },
+  "transcript.todoInProgress": {
+    "message": "In progress",
+    "description": "Todo list: in-progress status for screen readers"
+  },
+  "transcript.todoPending": {
+    "message": "Pending",
+    "description": "Todo list: pending status for screen readers"
   }
 }

--- a/src/i18n/sv/codingBridge.json
+++ b/src/i18n/sv/codingBridge.json
@@ -446,5 +446,25 @@
   "notify.failed": {
     "message": "Det gick inte att uppdatera aviseringsinställningarna.",
     "description": "Toast when enabling or disabling notifications errors"
+  },
+  "transcript.todoProgress": {
+    "message": "{done}/{total} completed",
+    "description": "Todo list progress"
+  },
+  "transcript.todoOverflow": {
+    "message": "…and {count} more",
+    "description": "Todo list overflow hint"
+  },
+  "transcript.todoCompleted": {
+    "message": "Completed",
+    "description": "Todo list: completed status for screen readers"
+  },
+  "transcript.todoInProgress": {
+    "message": "In progress",
+    "description": "Todo list: in-progress status for screen readers"
+  },
+  "transcript.todoPending": {
+    "message": "Pending",
+    "description": "Todo list: pending status for screen readers"
   }
 }

--- a/src/i18n/uk/codingBridge.json
+++ b/src/i18n/uk/codingBridge.json
@@ -446,5 +446,25 @@
   "notify.failed": {
     "message": "Не вдалося оновити налаштування сповіщень.",
     "description": "Toast when enabling or disabling notifications errors"
+  },
+  "transcript.todoProgress": {
+    "message": "{done}/{total} completed",
+    "description": "Todo list progress"
+  },
+  "transcript.todoOverflow": {
+    "message": "…and {count} more",
+    "description": "Todo list overflow hint"
+  },
+  "transcript.todoCompleted": {
+    "message": "Completed",
+    "description": "Todo list: completed status for screen readers"
+  },
+  "transcript.todoInProgress": {
+    "message": "In progress",
+    "description": "Todo list: in-progress status for screen readers"
+  },
+  "transcript.todoPending": {
+    "message": "Pending",
+    "description": "Todo list: pending status for screen readers"
   }
 }

--- a/src/i18n/zh-CN/codingBridge.json
+++ b/src/i18n/zh-CN/codingBridge.json
@@ -199,6 +199,26 @@
     "message": "完成",
     "description": "回合结果完成标签"
   },
+  "transcript.todoProgress": {
+    "message": "已完成 {done}/{total}",
+    "description": "任务清单进度"
+  },
+  "transcript.todoOverflow": {
+    "message": "…另有 {count} 项未显示",
+    "description": "任务清单超长省略提示"
+  },
+  "transcript.todoCompleted": {
+    "message": "已完成",
+    "description": "任务清单：已完成状态（无障碍朗读）"
+  },
+  "transcript.todoInProgress": {
+    "message": "进行中",
+    "description": "任务清单：进行中状态（无障碍朗读）"
+  },
+  "transcript.todoPending": {
+    "message": "待办",
+    "description": "任务清单：待办状态（无障碍朗读）"
+  },
   "history.button": {
     "message": "历史会话",
     "description": "打开历史会话抽屉"

--- a/src/i18n/zh-TW/codingBridge.json
+++ b/src/i18n/zh-TW/codingBridge.json
@@ -446,5 +446,25 @@
   "notify.failed": {
     "message": "無法更新通知設定。",
     "description": "Toast when enabling or disabling notifications errors"
+  },
+  "transcript.todoProgress": {
+    "message": "{done}/{total} completed",
+    "description": "Todo list progress"
+  },
+  "transcript.todoOverflow": {
+    "message": "…and {count} more",
+    "description": "Todo list overflow hint"
+  },
+  "transcript.todoCompleted": {
+    "message": "Completed",
+    "description": "Todo list: completed status for screen readers"
+  },
+  "transcript.todoInProgress": {
+    "message": "In progress",
+    "description": "Todo list: in-progress status for screen readers"
+  },
+  "transcript.todoPending": {
+    "message": "Pending",
+    "description": "Todo list: pending status for screen readers"
   }
 }


### PR DESCRIPTION
## 问题

Coding Bridge 的会话转录里，agent 的 `TodoWrite` 调用没有对应的渲染分支，直接掉进了兜底的原始 JSON 分支。

`TranscriptItem.vue` 的 `tool_use` 按顺序匹配 `questionLines → commandText → filePath → inputText(JSON)`。`TodoWrite` 的 input 既没有 `command` 也没有 `file_path`，于是落到最后一档。讽刺的是它是所有工具里**结构化程度最高**的 payload，却成了屏幕上最难读的一条。

## 改动

新增 todo 清单分支：状态图标、已完成划线、进行中显示 `activeForm`、`已完成 2/4` 进度行。沿用本组件既有的移动端 OOM 防护惯例（`MAX_TEXT_CHARS` 等）加了 `MAX_TODO_ITEMS=50` / `MAX_TODO_TEXT_CHARS=200` 上限。

新增 5 个 i18n key（zh-CN + en 手写，其余 17 语言按仓库惯例用 `i18n_backfill.py` 从 en 播种）。

## 验证

不只是编译通过 —— 把组件挂到临时页面用真实 payload 在浏览器里逐条断言：

| 场景 | 结果 |
|---|---|
| 真实 TodoWrite | 渲染为清单 ✅ |
| Bash / Edit 回归 | 命令块、文件路径未受影响 ✅ |
| `todos: "not-an-array"` | 不崩，回落 JSON ✅ |
| `[null, {content:{}}, {status:42}]` | 不崩，过滤出唯一有效行 ✅ |
| `sr-only` 布局影响 | 1×1 px，icon→text 间距仍为 8px ✅ |

`vue-tsc` / `eslint` / 25 个 codingBridge 测试 / `check_i18n_coverage.py` 全绿。

## 🤖 对抗评审

Codex 额度耗尽（`You've hit your usage limit`），按 `.claude/commands/auto-review.md` 回落 Claude `general-purpose` subagent。两轮收敛。

**第 1 轮 — 3 个 RISK，全部核实属实并修复：**

1. **无限旋转的 spinner。** `in_progress` 行用了 `animate-spin`，但 `appendEvent`（`src/store/codingBridge/mutations.ts:122`）只 push、从不修改已入列的 `tool_use` 事件 —— 动画永远停不下来，滚动区里每个历史 checkpoint 都在转（`RENDER_WINDOW=60`）。且本组件正是当年被移动端 Safari CPU-kill 的那个。**修复：** 去掉动画，改静态图标（比加 `prefers-reduced-motion` 更诚实 —— 状态本就不会再变）。
2. **分支顺序可隐藏 shell 命令。** 原实现只按 payload 形状匹配且排在 `commandText` 之前，一个同时带 `command` 和 `todos` 的调用会把 `rm -rf ./build && ./deploy.sh prod` 藏在清单后面。**修复 + 浏览器验证命令重新显示。**
3. **可访问性。** 状态只靠图标/颜色/划线传达，读屏下三种状态完全同音。**修复：** 每行加 `.sr-only` 状态词，`<ul>` 用 `aria-labelledby` 关联进度行。

**第 2 轮 — 1 个残留 RISK，接受并修复：**

我第 1 轮的护栏只挡了 `command`/`filePath`，评审指出还有更一般的情况：`{page_id, properties, todos}` 这类 MCP payload 仍会被清单劫持，而本分支**不渲染任何其他 key**，等于把工具真正做了什么藏起来。评审同时驳回了我「模仿 `questionLines` 按形状回退」的辩护 —— `questionLines` 回退后渲染的是 payload 的全部语义内容，不丢信息；todo 分支会丢弃所有兄弟 key，两者不对称。**这个论证成立，已改为：工具名不含 `todo` 时，要求 payload 除 `todos`/`description` 外没有其他 key 才认领。**

浏览器复验四种情形：真实 TodoWrite → 清单；MCP 多键 payload → 显示 JSON；Bash trojan → 显示命令；异名工具的干净 payload → 仍渲染清单（保留兼容性）。

**评审驳回/撤回的**（记录以免重复讨论）：`event.id` 安全性（全部经 `uid()` 生成，为 hex，且历史回放路径也会重新赋值，不来自不可信 payload）、`sr-only` 破坏 flex 间距（`position:absolute` 不在流内）、`toolIcon` 顺序 bug（护栏已使其自洽）、以及若干畸形输入（实测均安全过滤不抛异常）。

自查还发现一个**我自己引入的 bug**：`aria-labelledby` 用 `_uid` 取值为 `undefined`，多实例会 id 重复；已改用 `event.id` 并验证唯一可解析。

🤖 Generated with [Claude Code](https://claude.com/claude-code)