### PR TITLE
feat(scheduled): 运行记录显示这次运行指定的连接账号

### DIFF
--- a/change/@acedatacloud-nexior-run-account-tags-2026-07-27.json
+++ b/change/@acedatacloud-nexior-run-account-tags-2026-07-27.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Show which connector account each scheduled run used: run rows now carry a tag per pinned account (e.g. `zhihu · Germey`), falling back to the connector alone once the account is gone.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/operators/scheduledTasks.ts
+++ b/src/operators/scheduledTasks.ts
@@ -53,6 +53,19 @@ export interface IScheduledRun {
   outcome?: 'achieved' | 'not_achieved' | 'unknown';
   /** One-line, user-facing explanation of `outcome`. */
   outcome_reason?: string;
+  /** Which connector accounts this run actually used, snapshotted when it
+   *  started. Absent on runs that used each connector's default account, and
+   *  on runs predating the snapshot. */
+  run_accounts?: IRunConnectionAccount[];
+}
+
+/** One connector account a run ran as. `label` / `account_name` are resolved at
+ *  read time and are both absent once the account is deleted. */
+export interface IRunConnectionAccount {
+  connector_identifier: string;
+  provider_alias?: string;
+  label?: string;
+  account_name?: string;
 }
 
 export type IScheduledRunStatus = 'queued' | 'running' | 'success' | 'failed';

--- a/src/pages/chat/ScheduledTasks.test.ts
+++ b/src/pages/chat/ScheduledTasks.test.ts
@@ -354,6 +354,52 @@ describe('chat/ScheduledTasks', () => {
       expect(tags[0].text()).toBe('Gmail digest');
     });
 
+    it('tags each run row with every connector account it ran as', async () => {
+      const wrapper = withToken();
+      await wrapper.setData({
+        activeTab: 'runs',
+        allRuns: [
+          {
+            id: 'r1',
+            task_id: 't1',
+            status: 'success',
+            scheduled_at: 1,
+            run_accounts: [
+              { connector_identifier: 'zhihu/zhihu', provider_alias: 'zhihu', label: '主号' },
+              { connector_identifier: 'medium/medium', provider_alias: 'medium', account_name: 'Germey' }
+            ]
+          }
+        ],
+        allRunsCount: 1
+      });
+
+      expect(wrapper.findAll('.run-account-tag').map((t) => t.text())).toEqual(['zhihu · 主号', 'medium · Germey']);
+    });
+
+    // A deleted account resolves to no name at all — the tag must not render a
+    // dangling separator, and rows without accounts must stay unchanged.
+    it('falls back to the connector alone when the account name is gone', async () => {
+      const wrapper = withToken();
+      await wrapper.setData({
+        activeTab: 'runs',
+        allRuns: [
+          {
+            id: 'r1',
+            task_id: 't1',
+            status: 'success',
+            scheduled_at: 1,
+            run_accounts: [{ connector_identifier: 'zhihu/zhihu', provider_alias: 'zhihu' }]
+          },
+          { id: 'r2', task_id: 't2', status: 'success', scheduled_at: 2 }
+        ],
+        allRunsCount: 2
+      });
+
+      const tags = wrapper.findAll('.run-account-tag');
+      expect(tags).toHaveLength(1);
+      expect(tags[0].text()).toBe('zhihu');
+    });
+
     it('resets to page 1 and refetches when the status filter changes', async () => {
       const spy = listAllRuns().mockResolvedValue({ items: [], count: 0 });
       const wrapper = withToken();

--- a/src/pages/chat/ScheduledTasks.vue
+++ b/src/pages/chat/ScheduledTasks.vue
@@ -161,6 +161,16 @@
                   <el-tag v-if="run.task_name" size="small" type="info" round class="run-task-tag">
                     {{ run.task_name }}
                   </el-tag>
+                  <el-tag
+                    v-for="(account, index) in run.run_accounts"
+                    :key="`${account.connector_identifier}-${index}`"
+                    size="small"
+                    type="info"
+                    round
+                    class="run-account-tag"
+                  >
+                    {{ accountTagText(account) }}
+                  </el-tag>
                   <span class="run-time">{{ formatTime(run.scheduled_at) }}</span>
                   <span
                     v-if="runOutcomeText(run)"
@@ -235,6 +245,16 @@
             </div>
             <div v-if="run.conversation_preview" class="run-preview">{{ run.conversation_preview }}</div>
             <div class="run-sub">
+              <el-tag
+                v-for="(account, index) in run.run_accounts"
+                :key="`${account.connector_identifier}-${index}`"
+                size="small"
+                type="info"
+                round
+                class="run-account-tag"
+              >
+                {{ accountTagText(account) }}
+              </el-tag>
               <span class="run-time">{{ formatTime(run.scheduled_at) }}</span>
               <span
                 v-if="runOutcomeText(run)"
@@ -518,6 +538,7 @@ import {
 import type {
   IAuthorizableBrowserConnection,
   IAuthorizableConnectionAccount,
+  IRunConnectionAccount,
   IScheduledBrowserBinding
 } from '@/operators/scheduledTasks';
 import { CHAT_MODEL_GROUPS, CHAT_MODEL_NAME_GPT_5_6_SOL } from '@/constants';
@@ -1141,6 +1162,14 @@ export default defineComponent({
     runTagType(status: string) {
       return status === 'success' ? 'success' : status === 'failed' ? 'danger' : 'warning';
     },
+    // Which account the run posted as, e.g. `zhihu · Germey`. The name half is
+    // resolved server-side and disappears once the account is deleted, so fall
+    // back to the connector alone rather than rendering a dangling separator.
+    accountTagText(account: IRunConnectionAccount) {
+      const connector = account.provider_alias || account.connector_identifier;
+      const name = account.label || account.account_name;
+      return name ? `${connector} · ${name}` : connector;
+    },
     // The judge's own sentence beats a bare code like `goal_not_achieved`, and
     // it is shown for successes too — so it is NOT read from `error_message`.
     runOutcomeText(run: IScheduledRun) {
@@ -1283,7 +1312,8 @@ export default defineComponent({
   border-color: var(--el-color-primary);
   color: #fff;
 }
-.run-task-tag {
+.run-task-tag,
+.run-account-tag {
   flex-shrink: 0;
   max-width: 200px;
   overflow: hidden;


### PR DESCRIPTION
## 背景

定时任务已经支持给每个 connector 钉一个账号，但「运行记录」列表看不出某条 run 用的是哪个 —— 用户有两个知乎号 / 两个 Medium 号时，排查「这篇发到哪个号了」只能靠把账号名手写进任务名（线上就有个任务叫 `Medium 宣传 - Germey`）。

## 改动

每条运行记录在任务名 tag 旁多渲染一组账号 tag（`zhihu · Germey`），**聚合 tab 和单任务抽屉两处一致** —— 后端 `retrieve_runs` 与 `retrieve_runs_batch` 共用 `enrichRuns`，两条路径都返回该字段。

账号被删除后名字取不到，此时只显示 connector 本身（`zhihu`）而不是留一个悬空的 `zhihu · `。

配套 [PlatformService#1703](https://github.com/AceDataCloud/PlatformService/pull/1703) 的 `run_accounts` 字段。历史 run 没有该字段，不渲染 tag（快照方案的固有代价）。

## 验证

全量 **724 tests / 100 files 通过**，`vue-tsc --noEmit` 干净。变异测试确认新测试非假阳性：停用 `.run-account-tag` 后两个新测试立刻失败。

## 🤖 对抗评审

Codex 额度耗尽，按协议回退到 Claude `general-purpose` subagent。**VERDICT: CLEAN**，无需修改。评审逐条核实并留痕：

- **「抽屉那处是死代码」的指控不成立** —— 评审读了后端源码确认 `enrichRuns` 有且仅有两个调用点（`handleListRuns` / `handleListRunsBatch`），两条路径拿到的字段形状一致，抽屉里的 tag 会正常显示。
- **渲染健壮性**：`v-for` 在 `undefined` 上是 no-op，历史数据不报错。`accountTagText` 用 `||` 而非 `??` 是必要的 —— 后端 `String(conn.label ?? '')` 会产出**空字符串**而非 undefined，`??` 会漏。
- **`:key` 用 index 无隐患**：后端 `parseConnectionBindings` 已按 connector 去重，一个任务里同一 connector 只能有一个绑定，且列表是整体替换不做局部增删。
- **XSS**：两处都是 `{{ }}` 插值，Vue 自动转义，无 `v-html`，也未设 `title` 属性。
- **布局**：Element Plus 的 `.el-tag__content` 自带 `overflow:hidden + ellipsis + min-width:0`，其省略号机制本就依赖父级限宽，`max-width:200px` 正是它期望的用法；`.run-sub` 已有 `flex-wrap: wrap`。
- **i18n/RTL**：项目全仓无 RTL 实现（ar 只做文案不做镜像布局），且 `·` 是本文件既有约定（L409/L449/L1472），保持一致。

评审提到一处覆盖率取舍（未要求修改）：测试只覆盖聚合 tab，未覆盖抽屉路径 —— 鉴于两条路径数据同源、模板片段逐字一致，不构成 RISK。

🤖 Generated with [Claude Code](https://claude.com/claude-code)