### PR TITLE
feat(scheduled-tasks): 复制已有定时任务，预填新建表单

### DIFF
--- a/change/@acedatacloud-nexior-scheduled-task-duplicate-2026-07-28.json
+++ b/change/@acedatacloud-nexior-scheduled-task-duplicate-2026-07-28.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "add a duplicate action to scheduled tasks that prefills the create form from an existing task",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/i18n/ar/chat.json
+++ b/src/i18n/ar/chat.json
@@ -1211,5 +1211,8 @@
   },
   "scheduledTasks.run.reason.run_abandoned": {
     "message": "حالة التشغيل غير معروفة"
+  },
+  "scheduledTasks.duplicate": {
+    "message": "Duplicate Task"
   }
 }

--- a/src/i18n/de/chat.json
+++ b/src/i18n/de/chat.json
@@ -1172,5 +1172,8 @@
   },
   "scheduledTasks.run.reason.run_abandoned": {
     "message": "Ausführungsstatus unbekannt"
+  },
+  "scheduledTasks.duplicate": {
+    "message": "Duplicate Task"
   }
 }

--- a/src/i18n/el/chat.json
+++ b/src/i18n/el/chat.json
@@ -1172,5 +1172,8 @@
   },
   "scheduledTasks.run.reason.run_abandoned": {
     "message": "Άγνωστη κατάσταση εκτέλεσης"
+  },
+  "scheduledTasks.duplicate": {
+    "message": "Duplicate Task"
   }
 }

--- a/src/i18n/en/chat.json
+++ b/src/i18n/en/chat.json
@@ -681,6 +681,9 @@
   "scheduledTasks.edit": {
     "message": "Edit Task"
   },
+  "scheduledTasks.duplicate": {
+    "message": "Duplicate Task"
+  },
   "scheduledTasks.empty": {
     "message": "No scheduled tasks yet. Click \"New\" to create one."
   },

--- a/src/i18n/es/chat.json
+++ b/src/i18n/es/chat.json
@@ -1172,5 +1172,8 @@
   },
   "scheduledTasks.run.reason.run_abandoned": {
     "message": "Estado de ejecución desconocido"
+  },
+  "scheduledTasks.duplicate": {
+    "message": "Duplicate Task"
   }
 }

--- a/src/i18n/fi/chat.json
+++ b/src/i18n/fi/chat.json
@@ -1172,5 +1172,8 @@
   },
   "scheduledTasks.run.reason.run_abandoned": {
     "message": "Suorituksen tila tuntematon"
+  },
+  "scheduledTasks.duplicate": {
+    "message": "Duplicate Task"
   }
 }

--- a/src/i18n/fr/chat.json
+++ b/src/i18n/fr/chat.json
@@ -1172,5 +1172,8 @@
   },
   "scheduledTasks.run.reason.run_abandoned": {
     "message": "État d'exécution inconnu"
+  },
+  "scheduledTasks.duplicate": {
+    "message": "Duplicate Task"
   }
 }

--- a/src/i18n/it/chat.json
+++ b/src/i18n/it/chat.json
@@ -1172,5 +1172,8 @@
   },
   "scheduledTasks.run.reason.run_abandoned": {
     "message": "Stato dell'esecuzione sconosciuto"
+  },
+  "scheduledTasks.duplicate": {
+    "message": "Duplicate Task"
   }
 }

--- a/src/i18n/ja/chat.json
+++ b/src/i18n/ja/chat.json
@@ -1172,5 +1172,8 @@
   },
   "scheduledTasks.run.reason.run_abandoned": {
     "message": "実行状態が不明です"
+  },
+  "scheduledTasks.duplicate": {
+    "message": "Duplicate Task"
   }
 }

--- a/src/i18n/ko/chat.json
+++ b/src/i18n/ko/chat.json
@@ -1172,5 +1172,8 @@
   },
   "scheduledTasks.run.reason.run_abandoned": {
     "message": "실행 상태를 알 수 없음"
+  },
+  "scheduledTasks.duplicate": {
+    "message": "Duplicate Task"
   }
 }

--- a/src/i18n/pl/chat.json
+++ b/src/i18n/pl/chat.json
@@ -1172,5 +1172,8 @@
   },
   "scheduledTasks.run.reason.run_abandoned": {
     "message": "Nieznany stan wykonania"
+  },
+  "scheduledTasks.duplicate": {
+    "message": "Duplicate Task"
   }
 }

--- a/src/i18n/pt/chat.json
+++ b/src/i18n/pt/chat.json
@@ -1172,5 +1172,8 @@
   },
   "scheduledTasks.run.reason.run_abandoned": {
     "message": "Estado da execução desconhecido"
+  },
+  "scheduledTasks.duplicate": {
+    "message": "Duplicate Task"
   }
 }

--- a/src/i18n/ru/chat.json
+++ b/src/i18n/ru/chat.json
@@ -1211,5 +1211,8 @@
   },
   "scheduledTasks.run.reason.run_abandoned": {
     "message": "Статус выполнения неизвестен"
+  },
+  "scheduledTasks.duplicate": {
+    "message": "Duplicate Task"
   }
 }

--- a/src/i18n/sr/chat.json
+++ b/src/i18n/sr/chat.json
@@ -1172,5 +1172,8 @@
   },
   "scheduledTasks.run.reason.run_abandoned": {
     "message": "Непознат статус извршавања"
+  },
+  "scheduledTasks.duplicate": {
+    "message": "Duplicate Task"
   }
 }

--- a/src/i18n/sv/chat.json
+++ b/src/i18n/sv/chat.json
@@ -1172,5 +1172,8 @@
   },
   "scheduledTasks.run.reason.run_abandoned": {
     "message": "Okänd körningsstatus"
+  },
+  "scheduledTasks.duplicate": {
+    "message": "Duplicate Task"
   }
 }

--- a/src/i18n/uk/chat.json
+++ b/src/i18n/uk/chat.json
@@ -1172,5 +1172,8 @@
   },
   "scheduledTasks.run.reason.run_abandoned": {
     "message": "Статус виконання невідомий"
+  },
+  "scheduledTasks.duplicate": {
+    "message": "Duplicate Task"
   }
 }

--- a/src/i18n/zh-CN/chat.json
+++ b/src/i18n/zh-CN/chat.json
@@ -689,6 +689,10 @@
     "message": "编辑任务",
     "description": "编辑对话框标题"
   },
+  "scheduledTasks.duplicate": {
+    "message": "复制任务",
+    "description": "复制任务按钮，基于已有任务预填新建表单"
+  },
   "scheduledTasks.empty": {
     "message": "还没有定时任务，点击「新建」创建一个",
     "description": "空状态提示"

--- a/src/i18n/zh-TW/chat.json
+++ b/src/i18n/zh-TW/chat.json
@@ -1172,5 +1172,8 @@
   },
   "scheduledTasks.run.reason.run_abandoned": {
     "message": "執行狀態未知"
+  },
+  "scheduledTasks.duplicate": {
+    "message": "Duplicate Task"
   }
 }

--- a/src/pages/chat/ScheduledTasks.test.ts
+++ b/src/pages/chat/ScheduledTasks.test.ts
@@ -195,9 +195,10 @@ describe('chat/ScheduledTasks', () => {
     vm.openDuplicate(editedTask);
     expect(vm.form.name).toBe('Existing task 3');
 
-    // Duplicating a copy re-uses the base name rather than stacking suffixes.
+    // Duplicating a copy appends rather than reusing the base: any rule that
+    // strips a trailing number eventually eats a real one (see the year test).
     vm.openDuplicate({ ...editedTask, id: 'task-2', name: 'Existing task 2' });
-    expect(vm.form.name).toBe('Existing task 3');
+    expect(vm.form.name).toBe('Existing task 2 2');
   });
 
   it('keeps the duplicated name within the 80-char input cap, without repeating it', async () => {
@@ -228,36 +229,57 @@ describe('chat/ScheduledTasks', () => {
     expect(vm.form.name.length).toBeLessThanOrEqual(80);
   });
 
-  it('does not split an emoji when truncating a long name', async () => {
+  it('does not split an emoji, and stays within the cap the browser enforces', async () => {
     const wrapper = mountComponent();
     const vm = wrapper.vm as unknown as {
       openDuplicate: (task: IScheduledTask) => void;
       form: { name: string };
     };
-    // 90 code points (180 UTF-16 units) so truncation actually fires, and the
-    // 78-code-point cut lands mid-emoji.
-    const emojiName = `a${'😀'.repeat(90)}`;
+    // Exactly 80 UTF-16 units — the input is already full, so the suffix has to
+    // displace something. Budgeting in code points here would return 82 units,
+    // the browser's maxlength would clip the " 2" back off, and every copy would
+    // come out identical.
+    const emojiName = '😀'.repeat(40);
     await wrapper.setData({ tasks: [{ ...editedTask, name: emojiName }] });
 
     vm.openDuplicate({ ...editedTask, name: emojiName });
+    const first = vm.form.name;
 
+    // maxlength counts UTF-16 units, so that is the unit that must be asserted.
+    expect(first.length).toBeLessThanOrEqual(80);
     // A lone high surrogate renders as the replacement character.
-    expect(vm.form.name).not.toMatch(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/);
-    expect([...vm.form.name].length).toBeLessThanOrEqual(80);
-    expect(vm.form.name.endsWith(' 2')).toBe(true);
+    expect(first).not.toMatch(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/);
+    expect(first.endsWith(' 2')).toBe(true);
+
+    // And the copy of the copy must still differ.
+    await wrapper.setData({
+      tasks: [
+        { ...editedTask, name: emojiName },
+        { ...editedTask, id: 'task-2', name: first }
+      ]
+    });
+    vm.openDuplicate({ ...editedTask, name: emojiName });
+    expect(vm.form.name).not.toBe(first);
+    expect(vm.form.name.length).toBeLessThanOrEqual(80);
   });
 
-  it('keeps a trailing number that is part of the name, not a copy suffix', async () => {
+  it('never eats a trailing number that is part of the name', async () => {
     const wrapper = mountComponent();
     const vm = wrapper.vm as unknown as {
       openDuplicate: (task: IScheduledTask) => void;
       form: { name: string };
     };
-    await wrapper.setData({ tasks: [{ ...editedTask, name: 'Weekly report 2026' }] });
+    // The generic prefix exists as its own task — the case where any
+    // "strip the trailing number" heuristic destroys the year.
+    await wrapper.setData({
+      tasks: [
+        { ...editedTask, name: 'Weekly report' },
+        { ...editedTask, id: 'task-2', name: 'Weekly report 2026' }
+      ]
+    });
 
     vm.openDuplicate({ ...editedTask, name: 'Weekly report 2026' });
 
-    // "Weekly report" is not an existing task, so 2026 is a year, not a suffix.
     expect(vm.form.name).toBe('Weekly report 2026 2');
   });
 

--- a/src/pages/chat/ScheduledTasks.test.ts
+++ b/src/pages/chat/ScheduledTasks.test.ts
@@ -154,6 +154,158 @@ describe('chat/ScheduledTasks', () => {
     });
   });
 
+  it('prefills the create form from an existing task, with a numbered name', async () => {
+    const wrapper = mountComponent();
+    const vm = wrapper.vm as unknown as {
+      openDuplicate: (task: IScheduledTask) => void;
+      editingTask: IScheduledTask | null;
+      form: Record<string, unknown>;
+      showCreateDialog: boolean;
+    };
+    await wrapper.setData({ tasks: [editedTask] });
+
+    vm.openDuplicate(editedTask);
+
+    // A copy is a CREATE, not an edit — otherwise saving would overwrite the original.
+    expect(vm.editingTask).toBeNull();
+    expect(vm.showCreateDialog).toBe(true);
+    expect(vm.form).toMatchObject({
+      name: 'Existing task 2',
+      question: 'Reuse the existing task prompt',
+      model: 'gpt-5.6-sol',
+      scheduleType: 'interval',
+      intervalValue: 6,
+      intervalUnit: 'hour',
+      authorizedSkills: ['hashnode'],
+      authorizedMcpServers: ['publishing'],
+      maxTurns: 12
+    });
+  });
+
+  it('skips names already taken when duplicating repeatedly', async () => {
+    const wrapper = mountComponent();
+    const vm = wrapper.vm as unknown as {
+      openDuplicate: (task: IScheduledTask) => void;
+      form: { name: string };
+    };
+    await wrapper.setData({
+      tasks: [editedTask, { ...editedTask, id: 'task-2', name: 'Existing task 2' }]
+    });
+
+    vm.openDuplicate(editedTask);
+    expect(vm.form.name).toBe('Existing task 3');
+
+    // Duplicating a copy re-uses the base name rather than stacking suffixes.
+    vm.openDuplicate({ ...editedTask, id: 'task-2', name: 'Existing task 2' });
+    expect(vm.form.name).toBe('Existing task 3');
+  });
+
+  it('keeps the duplicated name within the 80-char input cap, without repeating it', async () => {
+    const wrapper = mountComponent();
+    const vm = wrapper.vm as unknown as {
+      openDuplicate: (task: IScheduledTask) => void;
+      form: { name: string };
+    };
+    const longName = 'x'.repeat(80);
+    await wrapper.setData({ tasks: [{ ...editedTask, name: longName }] });
+
+    vm.openDuplicate({ ...editedTask, name: longName });
+    const first = vm.form.name;
+    expect(first.length).toBeLessThanOrEqual(80);
+    expect(first.endsWith(' 2')).toBe(true);
+
+    // Once that copy exists, duplicating again must not hand back the same
+    // truncated string — names are not unique server-side, so a repeat would
+    // leave two indistinguishable rows.
+    await wrapper.setData({
+      tasks: [
+        { ...editedTask, name: longName },
+        { ...editedTask, id: 'task-2', name: first }
+      ]
+    });
+    vm.openDuplicate({ ...editedTask, name: longName });
+    expect(vm.form.name).not.toBe(first);
+    expect(vm.form.name.length).toBeLessThanOrEqual(80);
+  });
+
+  it('does not split an emoji when truncating a long name', async () => {
+    const wrapper = mountComponent();
+    const vm = wrapper.vm as unknown as {
+      openDuplicate: (task: IScheduledTask) => void;
+      form: { name: string };
+    };
+    // 90 code points (180 UTF-16 units) so truncation actually fires, and the
+    // 78-code-point cut lands mid-emoji.
+    const emojiName = `a${'😀'.repeat(90)}`;
+    await wrapper.setData({ tasks: [{ ...editedTask, name: emojiName }] });
+
+    vm.openDuplicate({ ...editedTask, name: emojiName });
+
+    // A lone high surrogate renders as the replacement character.
+    expect(vm.form.name).not.toMatch(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/);
+    expect([...vm.form.name].length).toBeLessThanOrEqual(80);
+    expect(vm.form.name.endsWith(' 2')).toBe(true);
+  });
+
+  it('keeps a trailing number that is part of the name, not a copy suffix', async () => {
+    const wrapper = mountComponent();
+    const vm = wrapper.vm as unknown as {
+      openDuplicate: (task: IScheduledTask) => void;
+      form: { name: string };
+    };
+    await wrapper.setData({ tasks: [{ ...editedTask, name: 'Weekly report 2026' }] });
+
+    vm.openDuplicate({ ...editedTask, name: 'Weekly report 2026' });
+
+    // "Weekly report" is not an existing task, so 2026 is a year, not a suffix.
+    expect(vm.form.name).toBe('Weekly report 2026 2');
+  });
+
+  it('mints a fresh authorization expiry for the copy', async () => {
+    const wrapper = mountComponent();
+    const vm = wrapper.vm as unknown as {
+      openDuplicate: (task: IScheduledTask) => void;
+      openEdit: (task: IScheduledTask) => void;
+      form: { authorizationExpiresAt: number };
+    };
+    const expired = Math.floor(Date.now() / 1000) - 86400;
+    const stale = {
+      ...editedTask,
+      unattended_policy: { ...editedTask.unattended_policy!, expires_at: expired }
+    };
+    await wrapper.setData({ tasks: [stale] });
+
+    // Editing preserves the existing grant …
+    vm.openEdit(stale);
+    expect(vm.form.authorizationExpiresAt).toBe(expired);
+
+    // … but a copy must not inherit an already-expired one, or it would run
+    // with no skills and no error shown.
+    vm.openDuplicate(stale);
+    expect(vm.form.authorizationExpiresAt).toBeGreaterThan(Math.floor(Date.now() / 1000));
+  });
+
+  it('does not open a duplicate while a save is in progress', async () => {
+    const wrapper = mountComponent();
+    const vm = wrapper.vm as unknown as {
+      openDuplicate: (task: IScheduledTask) => void;
+      openEdit: (task: IScheduledTask) => void;
+      editingTask: IScheduledTask | null;
+      form: { name: string };
+    };
+    // Seed tasks so an unguarded openDuplicate would visibly rename the form.
+    await wrapper.setData({ tasks: [editedTask] });
+    vm.openEdit(editedTask);
+    await wrapper.setData({ saving: true });
+
+    vm.openDuplicate(editedTask);
+
+    // The in-flight edit must survive — swapping the form mid-save would submit
+    // the copy's fields as an update to the original.
+    expect(vm.editingTask).toMatchObject({ id: editedTask.id });
+    expect(vm.form.name).toBe('Existing task');
+  });
+
   it('prevents switching forms while a save is in progress', async () => {
     const wrapper = mountComponent();
     const vm = wrapper.vm as unknown as {

--- a/src/pages/chat/ScheduledTasks.vue
+++ b/src/pages/chat/ScheduledTasks.vue
@@ -922,25 +922,27 @@ export default defineComponent({
       this.showCreateDialog = true;
       void this.loadAuthorizableSkills();
     },
-    // "Report" → "Report 2"; "Report 2" → "Report 3". Skips names already taken
-    // so duplicating the same task twice doesn't produce two identical labels.
+    // "Report" → "Report 2", skipping names already taken so duplicating the
+    // same task twice doesn't produce two identical labels. The suffix is always
+    // appended to the full name: stripping a trailing number to avoid "X 2 2"
+    // needs a heuristic, and every version of it eventually eats a real number
+    // (a task literally named "Weekly report 2026" alongside "Weekly report").
+    // Names are not unique server-side, so never destroying one wins over pretty.
     nextCopyName(name: string): string {
-      const raw = (name || '').trim();
+      const base = (name || '').trim() || (this.$t('chat.scheduledTasks.title') as string);
       const taken = new Set(this.tasks.map((t) => t.name));
-      // Only treat a trailing number as a copy suffix when the stripped name is
-      // itself a real task — otherwise "Q3 2026" would become "Q3 2", destroying
-      // the year that distinguishes it.
-      const stripped = raw.replace(/\s+\d+$/, '').trim();
-      const base =
-        (stripped && stripped !== raw && taken.has(stripped) ? stripped : raw) ||
-        (this.$t('chat.scheduledTasks.title') as string);
-      // The name input caps at 80 chars; trim the base rather than the suffix so
-      // the copy stays distinguishable. Slice by code point so an emoji at the
-      // boundary isn't split into a lone surrogate.
+      // The name input's maxlength is 80 UTF-16 code units, so budget in units —
+      // going over would let the browser silently clip the suffix and hand back a
+      // duplicate name. Step by code point so an emoji is never split in half.
       const build = (n: number) => {
         const suffix = ` ${n}`;
-        const chars = [...base];
-        const head = chars.length + suffix.length <= 80 ? base : chars.slice(0, 80 - suffix.length).join('');
+        const budget = 80 - suffix.length;
+        if (base.length <= budget) return `${base}${suffix}`;
+        let head = '';
+        for (const ch of base) {
+          if (head.length + ch.length > budget) break;
+          head += ch;
+        }
         return `${head}${suffix}`;
       };
       // Collide-check the FINAL (already truncated) name — checking the untruncated

--- a/src/pages/chat/ScheduledTasks.vue
+++ b/src/pages/chat/ScheduledTasks.vue
@@ -67,6 +67,16 @@
                       <edit-icon :size="16" aria-hidden="true" focusable="false" />
                     </el-button>
                   </el-tooltip>
+                  <el-tooltip :content="$t('chat.scheduledTasks.duplicate')" placement="top">
+                    <el-button
+                      text
+                      class="icon-action"
+                      :aria-label="$t('chat.scheduledTasks.duplicate')"
+                      @click="openDuplicate(task)"
+                    >
+                      <copy-icon :size="16" aria-hidden="true" focusable="false" />
+                    </el-button>
+                  </el-tooltip>
                   <el-tooltip :content="$t('common.button.delete')" placement="top">
                     <el-button
                       text
@@ -520,6 +530,7 @@ import {
 } from 'element-plus';
 import { Pagination } from '@acedatacloud/core/components';
 import { AddIcon } from '@acedatacloud/core/icons/add';
+import { CopyIcon } from '@acedatacloud/core/icons/copy';
 import { DeleteIcon } from '@acedatacloud/core/icons/delete';
 import { EditIcon } from '@acedatacloud/core/icons/edit';
 import { RefreshIcon } from '@acedatacloud/core/icons/refresh';
@@ -582,6 +593,7 @@ export default defineComponent({
     PlayIcon,
     TimeIcon,
     AddIcon,
+    CopyIcon,
     DeleteIcon,
     EditIcon,
     RefreshIcon,
@@ -819,8 +831,9 @@ export default defineComponent({
       if (this.saving) return;
       this.showCreateDialog = false;
     },
-    openEdit(task: IScheduledTask) {
-      this.editingTask = task;
+    // Reverse of buildSchedule() + the policy hydration: turn a saved task back
+    // into an editable form. Shared by openEdit and openDuplicate.
+    taskToForm(task: IScheduledTask): TaskForm {
       const s = task.schedule;
       let scheduleType: TaskForm['scheduleType'] = 'cron';
       let intervalValue = 4;
@@ -859,7 +872,7 @@ export default defineComponent({
           intervalValue = Math.max(1, Math.round(sec / 60));
         }
       }
-      this.form = {
+      return {
         name: task.name,
         question: task.template.question,
         model: task.template.model,
@@ -883,8 +896,58 @@ export default defineComponent({
         authorizationExpiresAt: task.unattended_policy?.expires_at ?? Math.floor(Date.now() / 1000) + 30 * 24 * 60 * 60,
         maxTurns: task.template.max_turns ?? DEFAULT_SCHEDULED_MAX_TURNS
       };
+    },
+    openEdit(task: IScheduledTask) {
+      this.editingTask = task;
+      this.form = this.taskToForm(task);
       this.showCreateDialog = true;
       void this.loadAuthorizableSkills();
+    },
+    // Prefill the create form from an existing task. Deliberately opens the
+    // dialog instead of creating straight away: the backend forces new tasks to
+    // `enabled` and registers them with the scheduler before the response
+    // lands, so a silent copy could fire once before the user could review it.
+    openDuplicate(task: IScheduledTask) {
+      if (this.saving) return;
+      this.editingTask = null;
+      this.form = {
+        ...this.taskToForm(task),
+        name: this.nextCopyName(task.name),
+        // A copy is a fresh grant. Inheriting the original's expiry would let an
+        // old task produce a new one that is already expired — the backend only
+        // clamps expiry downward, and an expired policy drops all skills at run
+        // time with nothing surfaced to the user.
+        authorizationExpiresAt: Math.floor(Date.now() / 1000) + 30 * 24 * 60 * 60
+      };
+      this.showCreateDialog = true;
+      void this.loadAuthorizableSkills();
+    },
+    // "Report" → "Report 2"; "Report 2" → "Report 3". Skips names already taken
+    // so duplicating the same task twice doesn't produce two identical labels.
+    nextCopyName(name: string): string {
+      const raw = (name || '').trim();
+      const taken = new Set(this.tasks.map((t) => t.name));
+      // Only treat a trailing number as a copy suffix when the stripped name is
+      // itself a real task — otherwise "Q3 2026" would become "Q3 2", destroying
+      // the year that distinguishes it.
+      const stripped = raw.replace(/\s+\d+$/, '').trim();
+      const base =
+        (stripped && stripped !== raw && taken.has(stripped) ? stripped : raw) ||
+        (this.$t('chat.scheduledTasks.title') as string);
+      // The name input caps at 80 chars; trim the base rather than the suffix so
+      // the copy stays distinguishable. Slice by code point so an emoji at the
+      // boundary isn't split into a lone surrogate.
+      const build = (n: number) => {
+        const suffix = ` ${n}`;
+        const chars = [...base];
+        const head = chars.length + suffix.length <= 80 ? base : chars.slice(0, 80 - suffix.length).join('');
+        return `${head}${suffix}`;
+      };
+      // Collide-check the FINAL (already truncated) name — checking the untruncated
+      // one would let a capped name repeat forever.
+      let n = 2;
+      while (taken.has(build(n))) n += 1;
+      return build(n);
     },
     buildSchedule(): IScheduleSpec {
       const { scheduleType, intervalValue, intervalUnit, hourlyMinute, dailyTime, weekday, cronExpr } = this.form;


### PR DESCRIPTION
## 背景

创建定时任务要逐项填写 prompt、模型、调度、技能授权、账号绑定、maxTurns，做几个相似任务时非常繁琐。用户反馈希望能从已有任务「复制」一份。

## 改动

任务卡片操作区在「编辑」和「删除」之间新增**复制**按钮（`CopyIcon`）。点击后打开**新建**对话框，用原任务的全部字段预填，名称自动追加序号（`每日摘要` → `每日摘要 2`）。

**为什么是打开对话框，而不是静默创建副本：**后端 `action=create` 会忽略客户端传的 `state`，硬编码为 `enabled`，并且在落库前就注册到调度器。静默复制会让副本立刻按计划触发，用户来不及改内容。走「预填 → 用户确认 → 保存」，副本在点保存前根本不存在，从根上避免这个窗口。

实现上把 `openEdit` 中的 schedule 反解析 + 策略回填抽成共享的 `taskToForm()`，`openEdit` / `openDuplicate` 复用，行为保持一致。

### 命名规则

- 后缀**始终追加到完整名字**，不做「去掉尾部数字」的启发式。任何版本的剥离规则最终都会吃掉真实的数字（见评审第二轮），而名字在服务端不唯一，破坏用户数据比多一个后缀严重得多。代价是复制副本会得到 `X 2 2`
- 冲突跳号：已存在 `X 2` 时复制 `X` 得到 `X 3`
- 长度按 **UTF-16 码元**计预算（`maxlength=80` 透传给原生 input，原生按码元计），但**按码点步进**截断，既不会超出让浏览器把序号裁掉，也不会把 emoji 劈成孤立代理

### 授权有效期

副本重新签发 30 天授权，不继承原任务的 `expires_at`。否则复制一个 40 天前建的任务，会产出一个**授权已过期**的新任务——后端 `clampPolicyExpiry` 只向下取值不会兜底，运行时 `shipping.ts` 判定过期后直接不注入技能，且不向用户报错，属于静默失效。`openEdit` 仍保留原有效期不变。

## 验证

- 新增 6 个单测（预填 / 跳号 / 追加后缀 / 保留尾部数字 / emoji + 码元上限 / 新签发有效期 / saving 期间守卫），全量 731 个测试通过
- **变异测试**：逐个回退全部 6 处修复，确认每处都有测试转红（不是摆设）
- `vue-tsc`、`eslint`、`check_i18n_coverage.py` 全部通过
- **真实浏览器端到端验证**（Playwright 驱动，桩掉 API）：读取 input 在 `maxlength` **生效之后**的实际值，确认
  - `Weekly report 2026`（且 `Weekly report` 同时存在）→ `Weekly report 2026 2`，年份保住
  - 40 个 emoji（恰好顶满 80 码元）→ 输出正好 80 码元、序号完整、emoji 未劈开；再复制得到 ` 3`，两份确实不同
  - 对话框标题是「新建」而非「编辑」，prompt / 模型 / 调度 / 时间 / 技能 / maxTurns 全部正确继承

## i18n

`chat.scheduledTasks.duplicate` 手工维护 zh-CN + en，其余 16 个 locale 用 `i18n_backfill.py` 以 en 播种（每个文件仅 +3 行）。

## 🤖 对抗评审

Codex 额度用尽（`You've hit your usage limit`），按规程回退到 Claude `general-purpose` subagent 做跨上下文评审。**两轮，共 7 项 RISK，全部采纳修复。**

### 第一轮（5 项）

| # | 发现 | 处理 |
|---|---|---|
| 1 | 截断与查重顺序颠倒 —— 超长名字的副本**永远返回同一个字符串**（查重比对未截断名，返回却是截断名），产生两条无法区分的记录 | 已修：`build(n)` 先截断，循环对**最终名**查重 |
| 2 | 副本继承原任务 `expires_at`，复制旧任务会得到一个授权已过期、运行时静默丢技能的新任务 | 已修：副本重新签发 30 天 |
| 3 | `/\s+\d+$/` 无条件剥离尾数，`Q3 2026` → `Q3 2` | 已修（第二轮再次收紧，见下） |
| 4 | 按 UTF-16 码元截断会劈开 emoji 代理对 | 已修（第二轮再次修正单位，见下） |
| 5 | saving 守卫的测试没塞 `tasks`，删掉守卫也可能通过 | 已修：补种 `tasks` + 3 个针对性用例 |

### 第二轮（2 项，均为第一轮修复**引入的新缺陷**）

| # | 发现 | 处理 |
|---|---|---|
| 6 | 修 #4 时改成按**码点**计预算，但 `maxlength` 透传给原生 input 后按**码元**计。40 个 emoji（80 码元）的副本算出 82 码元，浏览器把 ` 2` 裁掉 → **第 1 题的重名 bug 复活**。我原来的 emoji 测试用码点断言，和 bug 同一个单位，抓不到 | 已修：按码元计预算、按码点步进；测试断言改为码元 |
| 7 | 修 #3 的条件剥离在「通用前缀恰好也是一个任务」时仍会吃掉年份（`Weekly report` + `Weekly report 2026` → `Weekly report 2`）。原测试只种了一个任务，没覆盖该分支 | 已修：**彻底去掉剥离启发式**，永远追加；测试补种前缀任务 |

第 6 题我独立复现确认：`element-plus` 的 `input2.mjs:306` 将 `maxlength` 原样绑定到原生 input，其 `textLength` 亦为 `nativeInputValue.value.length`（码元）；40 emoji 的副本实测 82 码元。第 7 题评审给的「加数字下限」备选方案它自己也承认解决不了该场景，故采用其推荐的稳妥方案。

评审同时**排除**了几项怀疑（已核实非缺陷）：`taskToForm` 对数组/对象均新建字面量、element-plus 的 select 不原地改数组，故无共享引用污染；`editingTask` 无法泄漏进副本提交路径（含 `submitTask` 的 force 重试递归与 `saveTask` 中会让出的 confirm await）；rebase 后 `run_accounts` / `accountTagText` 特性完好；i18n 17 locale × 45 namespace 覆盖完整；`CopyIcon` 在 `@acedatacloud/core@0.18.0` 中确实存在。第二轮另跑了 3000 例模糊测试，零字面重名。

一个已知的可接受残留：`taken` 取自客户端快照，若用户打开复制对话框后取消、再立刻复制一次，两轮会算出同一个候选名。仅在「取消后重做」这个窗口出现，且保存前用户可见可改。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
