### PR TITLE
feat(coding-bridge): 设备重命名，名字云端存储多端同步

### DIFF
--- a/change/@acedatacloud-nexior-7c4e91a2-3b6d-4f18-9a52-1e8d0c5b7a44.json
+++ b/change/@acedatacloud-nexior-7c4e91a2-3b6d-4f18-9a52-1e8d0c5b7a44.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "rename a Coding Bridge device; the name syncs to every signed-in client",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/codingBridge/NodeList.vue
+++ b/src/components/codingBridge/NodeList.vue
@@ -70,7 +70,18 @@
             </div>
           </div>
           <el-button
-            class="opacity-0 group-hover:opacity-100"
+            class="node-action"
+            text
+            circle
+            size="small"
+            :aria-label="$t('codingBridge.nodeList.rename')"
+            :title="$t('codingBridge.nodeList.rename')"
+            @click.stop="onRename(node)"
+          >
+            <edit-icon :size="'1em' as any" aria-hidden="true" focusable="false" />
+          </el-button>
+          <el-button
+            class="node-action"
             text
             circle
             size="small"
@@ -87,10 +98,18 @@
 </template>
 
 <script lang="ts">
-import { AddIcon, DeleteIcon, DesktopIcon, DeveloperIcon, RedoIcon } from '@acedatacloud/core/icons/components';
+import {
+  AddIcon,
+  DeleteIcon,
+  DesktopIcon,
+  DeveloperIcon,
+  EditIcon,
+  RedoIcon
+} from '@acedatacloud/core/icons/components';
 import { defineComponent } from 'vue';
 import { ElButton, ElMessage, ElMessageBox } from 'element-plus';
 import { ICodingBridgeConnectionStatus, ICodingBridgeNode } from '@/models';
+import { CB_NODE_NAME_MAX_LENGTH } from '@/constants';
 import NotificationToggle from './NotificationToggle.vue';
 
 export default defineComponent({
@@ -100,6 +119,7 @@ export default defineComponent({
     DeleteIcon,
     DesktopIcon,
     DeveloperIcon,
+    EditIcon,
     RedoIcon,
     ElButton,
     NotificationToggle
@@ -138,6 +158,43 @@ export default defineComponent({
     onRefresh() {
       this.$store.dispatch('codingBridge/getNodes');
     },
+    async onRename(node: ICodingBridgeNode) {
+      let value: string;
+      try {
+        const result = await ElMessageBox.prompt(
+          this.$t('codingBridge.nodeList.renamePrompt') as string,
+          this.$t('codingBridge.nodeList.rename') as string,
+          {
+            confirmButtonText: this.$t('common.button.confirm') as string,
+            cancelButtonText: this.$t('common.button.cancel') as string,
+            inputValue: node.name,
+            inputValidator: (input: string) => {
+              const trimmed = (input ?? '').trim();
+              if (!trimmed) {
+                return this.$t('codingBridge.nodeList.renameEmpty') as string;
+              }
+              // Count code points, not UTF-16 units, to match the server's len().
+              if ([...trimmed].length > CB_NODE_NAME_MAX_LENGTH) {
+                return this.$t('codingBridge.nodeList.renameTooLong', { max: CB_NODE_NAME_MAX_LENGTH }) as string;
+              }
+              return true;
+            }
+          }
+        );
+        value = (result.value ?? '').trim();
+      } catch {
+        return;
+      }
+      if (!value || value === node.name) {
+        return;
+      }
+      try {
+        await this.$store.dispatch('codingBridge/renameNode', { nodeId: node.node_id, name: value });
+        ElMessage.success(this.$t('codingBridge.nodeList.renameSuccess') as string);
+      } catch {
+        ElMessage.error(this.$t('codingBridge.nodeList.renameFailed') as string);
+      }
+    },
     async onDelete(node: ICodingBridgeNode) {
       try {
         await ElMessageBox.confirm(
@@ -162,3 +219,23 @@ export default defineComponent({
   }
 });
 </script>
+
+<style lang="scss" scoped>
+// Row actions reveal on hover, but a touch device has no hover state — the
+// buttons would be unreachable there (the drawer mount is touch-only), so they
+// stay visible whenever the pointer can't hover.
+.node-action {
+  opacity: 1;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .node-action {
+    opacity: 0;
+  }
+
+  .group:hover .node-action,
+  .node-action:focus-visible {
+    opacity: 1;
+  }
+}
+</style>

--- a/src/constants/codingBridge.ts
+++ b/src/constants/codingBridge.ts
@@ -15,6 +15,12 @@ export const CB_BROWSER_RESUME = 'browser.resume';
 export const CB_NODE_TO_BROWSER = 'node.to_browser';
 export const CB_NODES_SNAPSHOT = 'nodes.snapshot';
 export const CB_NODE_STATUS = 'node.status';
+// Another client of the same user renamed a node; apply it live.
+export const CB_NODE_RENAMED = 'node.renamed';
+// Kept in step with the relay's CODING_BRIDGE_NODE_NAME_MAX_LENGTH, so an
+// over-long name is rejected in the dialog instead of by a 400.
+export const CB_NODE_NAME_MAX_LENGTH = 64;
+
 export const CB_ERROR = 'error';
 
 // --- Inner actions: browser -> node ----------------------------------------

--- a/src/i18n/ar/codingBridge.json
+++ b/src/i18n/ar/codingBridge.json
@@ -446,5 +446,29 @@
   "notify.failed": {
     "message": "تعذّر تحديث إعدادات الإشعارات.",
     "description": "Toast when enabling or disabling notifications errors"
+  },
+  "nodeList.rename": {
+    "message": "إعادة تسمية",
+    "description": "Rename a device"
+  },
+  "nodeList.renamePrompt": {
+    "message": "امنح هذا الجهاز اسمًا. تتم مزامنة الاسم مع جميع أجهزتك التي سجّلت الدخول منها.",
+    "description": "Rename device input prompt"
+  },
+  "nodeList.renameEmpty": {
+    "message": "لا يمكن أن يكون الاسم فارغًا.",
+    "description": "Rename device empty-name validation"
+  },
+  "nodeList.renameTooLong": {
+    "message": "يجب ألا يزيد الاسم عن {max} حرفًا.",
+    "description": "Rename device too-long validation"
+  },
+  "nodeList.renameSuccess": {
+    "message": "تمت إعادة تسمية الجهاز.",
+    "description": "Rename device success"
+  },
+  "nodeList.renameFailed": {
+    "message": "تعذّرت إعادة تسمية الجهاز.",
+    "description": "Rename device failure"
   }
 }

--- a/src/i18n/de/codingBridge.json
+++ b/src/i18n/de/codingBridge.json
@@ -446,5 +446,29 @@
   "notify.failed": {
     "message": "Benachrichtigungseinstellungen konnten nicht aktualisiert werden.",
     "description": "Toast when enabling or disabling notifications errors"
+  },
+  "nodeList.rename": {
+    "message": "Umbenennen",
+    "description": "Rename a device"
+  },
+  "nodeList.renamePrompt": {
+    "message": "Gib diesem Gerät einen Namen. Der Name wird mit all deinen angemeldeten Geräten synchronisiert.",
+    "description": "Rename device input prompt"
+  },
+  "nodeList.renameEmpty": {
+    "message": "Der Name darf nicht leer sein.",
+    "description": "Rename device empty-name validation"
+  },
+  "nodeList.renameTooLong": {
+    "message": "Der Name darf höchstens {max} Zeichen lang sein.",
+    "description": "Rename device too-long validation"
+  },
+  "nodeList.renameSuccess": {
+    "message": "Gerät umbenannt.",
+    "description": "Rename device success"
+  },
+  "nodeList.renameFailed": {
+    "message": "Gerät konnte nicht umbenannt werden.",
+    "description": "Rename device failure"
   }
 }

--- a/src/i18n/el/codingBridge.json
+++ b/src/i18n/el/codingBridge.json
@@ -446,5 +446,29 @@
   "notify.failed": {
     "message": "Δεν ήταν δυνατή η ενημέρωση των ρυθμίσεων ειδοποιήσεων.",
     "description": "Toast when enabling or disabling notifications errors"
+  },
+  "nodeList.rename": {
+    "message": "Μετονομασία",
+    "description": "Rename a device"
+  },
+  "nodeList.renamePrompt": {
+    "message": "Δώστε ένα όνομα σε αυτήν τη συσκευή. Το όνομα συγχρονίζεται με όλες τις συνδεδεμένες συσκευές σας.",
+    "description": "Rename device input prompt"
+  },
+  "nodeList.renameEmpty": {
+    "message": "Το όνομα δεν πρέπει να είναι κενό.",
+    "description": "Rename device empty-name validation"
+  },
+  "nodeList.renameTooLong": {
+    "message": "Το όνομα πρέπει να έχει το πολύ {max} χαρακτήρες.",
+    "description": "Rename device too-long validation"
+  },
+  "nodeList.renameSuccess": {
+    "message": "Η συσκευή μετονομάστηκε.",
+    "description": "Rename device success"
+  },
+  "nodeList.renameFailed": {
+    "message": "Απέτυχε η μετονομασία της συσκευής.",
+    "description": "Rename device failure"
   }
 }

--- a/src/i18n/en/codingBridge.json
+++ b/src/i18n/en/codingBridge.json
@@ -19,6 +19,30 @@
     "message": "Pair your first device",
     "description": "Empty-state pairing button"
   },
+  "nodeList.rename": {
+    "message": "Rename",
+    "description": "Rename a device"
+  },
+  "nodeList.renamePrompt": {
+    "message": "Name this device. The name is synced to all your signed-in devices.",
+    "description": "Rename device input prompt"
+  },
+  "nodeList.renameEmpty": {
+    "message": "Name must not be empty.",
+    "description": "Rename device empty-name validation"
+  },
+  "nodeList.renameTooLong": {
+    "message": "Name must be at most {max} characters.",
+    "description": "Rename device too-long validation"
+  },
+  "nodeList.renameSuccess": {
+    "message": "Device renamed.",
+    "description": "Rename device success"
+  },
+  "nodeList.renameFailed": {
+    "message": "Failed to rename the device.",
+    "description": "Rename device failure"
+  },
   "nodeList.remove": {
     "message": "Remove",
     "description": "Remove a device"

--- a/src/i18n/es/codingBridge.json
+++ b/src/i18n/es/codingBridge.json
@@ -446,5 +446,29 @@
   "notify.failed": {
     "message": "No se pudo actualizar la configuración de notificaciones.",
     "description": "Toast when enabling or disabling notifications errors"
+  },
+  "nodeList.rename": {
+    "message": "Cambiar nombre",
+    "description": "Rename a device"
+  },
+  "nodeList.renamePrompt": {
+    "message": "Ponle un nombre a este dispositivo. El nombre se sincroniza con todos tus dispositivos con sesión iniciada.",
+    "description": "Rename device input prompt"
+  },
+  "nodeList.renameEmpty": {
+    "message": "El nombre no puede estar vacío.",
+    "description": "Rename device empty-name validation"
+  },
+  "nodeList.renameTooLong": {
+    "message": "El nombre debe tener como máximo {max} caracteres.",
+    "description": "Rename device too-long validation"
+  },
+  "nodeList.renameSuccess": {
+    "message": "Dispositivo renombrado.",
+    "description": "Rename device success"
+  },
+  "nodeList.renameFailed": {
+    "message": "No se pudo cambiar el nombre del dispositivo.",
+    "description": "Rename device failure"
   }
 }

--- a/src/i18n/fi/codingBridge.json
+++ b/src/i18n/fi/codingBridge.json
@@ -446,5 +446,29 @@
   "notify.failed": {
     "message": "Ilmoitusasetusten päivittäminen epäonnistui.",
     "description": "Ilmoitus, kun ilmoitusten käyttöönotto tai poistaminen epäonnistuu"
+  },
+  "nodeList.rename": {
+    "message": "Nimeä uudelleen",
+    "description": "Rename a device"
+  },
+  "nodeList.renamePrompt": {
+    "message": "Anna tälle laitteelle nimi. Nimi synkronoidaan kaikkiin laitteisiin, joilla olet kirjautuneena.",
+    "description": "Rename device input prompt"
+  },
+  "nodeList.renameEmpty": {
+    "message": "Nimi ei saa olla tyhjä.",
+    "description": "Rename device empty-name validation"
+  },
+  "nodeList.renameTooLong": {
+    "message": "Nimen enimmäispituus on {max} merkkiä.",
+    "description": "Rename device too-long validation"
+  },
+  "nodeList.renameSuccess": {
+    "message": "Laite nimettiin uudelleen.",
+    "description": "Rename device success"
+  },
+  "nodeList.renameFailed": {
+    "message": "Laitteen uudelleennimeäminen epäonnistui.",
+    "description": "Rename device failure"
   }
 }

--- a/src/i18n/fr/codingBridge.json
+++ b/src/i18n/fr/codingBridge.json
@@ -446,5 +446,29 @@
   "notify.failed": {
     "message": "Impossible de mettre à jour les paramètres de notification.",
     "description": "Toast when enabling or disabling notifications errors"
+  },
+  "nodeList.rename": {
+    "message": "Renommer",
+    "description": "Rename a device"
+  },
+  "nodeList.renamePrompt": {
+    "message": "Donnez un nom à cet appareil. Le nom est synchronisé avec tous vos appareils connectés.",
+    "description": "Rename device input prompt"
+  },
+  "nodeList.renameEmpty": {
+    "message": "Le nom ne peut pas être vide.",
+    "description": "Rename device empty-name validation"
+  },
+  "nodeList.renameTooLong": {
+    "message": "Le nom doit comporter au maximum {max} caractères.",
+    "description": "Rename device too-long validation"
+  },
+  "nodeList.renameSuccess": {
+    "message": "Appareil renommé.",
+    "description": "Rename device success"
+  },
+  "nodeList.renameFailed": {
+    "message": "Échec du renommage de l’appareil.",
+    "description": "Rename device failure"
   }
 }

--- a/src/i18n/it/codingBridge.json
+++ b/src/i18n/it/codingBridge.json
@@ -446,5 +446,29 @@
   "notify.failed": {
     "message": "Impossibile aggiornare le impostazioni delle notifiche.",
     "description": "Toast when enabling or disabling notifications errors"
+  },
+  "nodeList.rename": {
+    "message": "Rinomina",
+    "description": "Rename a device"
+  },
+  "nodeList.renamePrompt": {
+    "message": "Assegna un nome a questo dispositivo. Il nome viene sincronizzato su tutti i dispositivi in cui hai effettuato l’accesso.",
+    "description": "Rename device input prompt"
+  },
+  "nodeList.renameEmpty": {
+    "message": "Il nome non può essere vuoto.",
+    "description": "Rename device empty-name validation"
+  },
+  "nodeList.renameTooLong": {
+    "message": "Il nome deve contenere al massimo {max} caratteri.",
+    "description": "Rename device too-long validation"
+  },
+  "nodeList.renameSuccess": {
+    "message": "Dispositivo rinominato.",
+    "description": "Rename device success"
+  },
+  "nodeList.renameFailed": {
+    "message": "Impossibile rinominare il dispositivo.",
+    "description": "Rename device failure"
   }
 }

--- a/src/i18n/ja/codingBridge.json
+++ b/src/i18n/ja/codingBridge.json
@@ -446,5 +446,29 @@
   "notify.failed": {
     "message": "通知設定を更新できませんでした。",
     "description": "通知の有効化または無効化でエラーが発生した場合のトースト"
+  },
+  "nodeList.rename": {
+    "message": "名前を変更",
+    "description": "Rename a device"
+  },
+  "nodeList.renamePrompt": {
+    "message": "このデバイスに名前を付けます。名前はログイン中のすべてのデバイスに同期されます。",
+    "description": "Rename device input prompt"
+  },
+  "nodeList.renameEmpty": {
+    "message": "名前を空にすることはできません。",
+    "description": "Rename device empty-name validation"
+  },
+  "nodeList.renameTooLong": {
+    "message": "名前は最大 {max} 文字までです。",
+    "description": "Rename device too-long validation"
+  },
+  "nodeList.renameSuccess": {
+    "message": "デバイスの名前を変更しました。",
+    "description": "Rename device success"
+  },
+  "nodeList.renameFailed": {
+    "message": "デバイスの名前を変更できませんでした。",
+    "description": "Rename device failure"
   }
 }

--- a/src/i18n/ko/codingBridge.json
+++ b/src/i18n/ko/codingBridge.json
@@ -446,5 +446,29 @@
   "notify.failed": {
     "message": "알림 설정을 업데이트하지 못했습니다.",
     "description": "Toast when enabling or disabling notifications errors"
+  },
+  "nodeList.rename": {
+    "message": "이름 변경",
+    "description": "Rename a device"
+  },
+  "nodeList.renamePrompt": {
+    "message": "이 기기의 이름을 지정하세요. 이름은 로그인된 모든 기기에 동기화됩니다.",
+    "description": "Rename device input prompt"
+  },
+  "nodeList.renameEmpty": {
+    "message": "이름은 비워 둘 수 없습니다.",
+    "description": "Rename device empty-name validation"
+  },
+  "nodeList.renameTooLong": {
+    "message": "이름은 최대 {max}자까지 입력할 수 있습니다.",
+    "description": "Rename device too-long validation"
+  },
+  "nodeList.renameSuccess": {
+    "message": "기기 이름을 변경했습니다.",
+    "description": "Rename device success"
+  },
+  "nodeList.renameFailed": {
+    "message": "기기 이름을 변경하지 못했습니다.",
+    "description": "Rename device failure"
   }
 }

--- a/src/i18n/pl/codingBridge.json
+++ b/src/i18n/pl/codingBridge.json
@@ -446,5 +446,29 @@
   "notify.failed": {
     "message": "Nie udało się zaktualizować ustawień powiadomień.",
     "description": "Toast when enabling or disabling notifications errors"
+  },
+  "nodeList.rename": {
+    "message": "Zmień nazwę",
+    "description": "Rename a device"
+  },
+  "nodeList.renamePrompt": {
+    "message": "Nadaj temu urządzeniu nazwę. Nazwa jest synchronizowana ze wszystkimi zalogowanymi urządzeniami.",
+    "description": "Rename device input prompt"
+  },
+  "nodeList.renameEmpty": {
+    "message": "Nazwa nie może być pusta.",
+    "description": "Rename device empty-name validation"
+  },
+  "nodeList.renameTooLong": {
+    "message": "Nazwa może mieć maksymalnie {max} znaków.",
+    "description": "Rename device too-long validation"
+  },
+  "nodeList.renameSuccess": {
+    "message": "Zmieniono nazwę urządzenia.",
+    "description": "Rename device success"
+  },
+  "nodeList.renameFailed": {
+    "message": "Nie udało się zmienić nazwy urządzenia.",
+    "description": "Rename device failure"
   }
 }

--- a/src/i18n/pt/codingBridge.json
+++ b/src/i18n/pt/codingBridge.json
@@ -446,5 +446,29 @@
   "notify.failed": {
     "message": "Não foi possível atualizar as configurações de notificação.",
     "description": "Toast when enabling or disabling notifications errors"
+  },
+  "nodeList.rename": {
+    "message": "Renomear",
+    "description": "Rename a device"
+  },
+  "nodeList.renamePrompt": {
+    "message": "Dê um nome a este dispositivo. O nome é sincronizado com todos os seus dispositivos conectados.",
+    "description": "Rename device input prompt"
+  },
+  "nodeList.renameEmpty": {
+    "message": "O nome não pode ficar vazio.",
+    "description": "Rename device empty-name validation"
+  },
+  "nodeList.renameTooLong": {
+    "message": "O nome deve ter no máximo {max} caracteres.",
+    "description": "Rename device too-long validation"
+  },
+  "nodeList.renameSuccess": {
+    "message": "Dispositivo renomeado.",
+    "description": "Rename device success"
+  },
+  "nodeList.renameFailed": {
+    "message": "Falha ao renomear o dispositivo.",
+    "description": "Rename device failure"
   }
 }

--- a/src/i18n/ru/codingBridge.json
+++ b/src/i18n/ru/codingBridge.json
@@ -446,5 +446,29 @@
   "notify.failed": {
     "message": "Не удалось обновить настройки уведомлений.",
     "description": "Уведомление об ошибке при изменении настроек уведомлений"
+  },
+  "nodeList.rename": {
+    "message": "Переименовать",
+    "description": "Rename a device"
+  },
+  "nodeList.renamePrompt": {
+    "message": "Задайте имя этому устройству. Имя синхронизируется со всеми устройствами, где выполнен вход.",
+    "description": "Rename device input prompt"
+  },
+  "nodeList.renameEmpty": {
+    "message": "Имя не может быть пустым.",
+    "description": "Rename device empty-name validation"
+  },
+  "nodeList.renameTooLong": {
+    "message": "Имя должно содержать не более {max} символов.",
+    "description": "Rename device too-long validation"
+  },
+  "nodeList.renameSuccess": {
+    "message": "Устройство переименовано.",
+    "description": "Rename device success"
+  },
+  "nodeList.renameFailed": {
+    "message": "Не удалось переименовать устройство.",
+    "description": "Rename device failure"
   }
 }

--- a/src/i18n/sr/codingBridge.json
+++ b/src/i18n/sr/codingBridge.json
@@ -446,5 +446,29 @@
   "notify.failed": {
     "message": "Ажурирање подешавања обавештења није успело.",
     "description": "Обавештење када укључивање или искључивање обавештења не успе"
+  },
+  "nodeList.rename": {
+    "message": "Преименуј",
+    "description": "Rename a device"
+  },
+  "nodeList.renamePrompt": {
+    "message": "Дајте назив овом уређају. Назив се синхронизује са свим уређајима на којима сте пријављени.",
+    "description": "Rename device input prompt"
+  },
+  "nodeList.renameEmpty": {
+    "message": "Назив не сме бити празан.",
+    "description": "Rename device empty-name validation"
+  },
+  "nodeList.renameTooLong": {
+    "message": "Назив може имати највише {max} знакова.",
+    "description": "Rename device too-long validation"
+  },
+  "nodeList.renameSuccess": {
+    "message": "Уређај је преименован.",
+    "description": "Rename device success"
+  },
+  "nodeList.renameFailed": {
+    "message": "Преименовање уређаја није успело.",
+    "description": "Rename device failure"
   }
 }

--- a/src/i18n/sv/codingBridge.json
+++ b/src/i18n/sv/codingBridge.json
@@ -446,5 +446,29 @@
   "notify.failed": {
     "message": "Det gick inte att uppdatera aviseringsinställningarna.",
     "description": "Toast when enabling or disabling notifications errors"
+  },
+  "nodeList.rename": {
+    "message": "Byt namn",
+    "description": "Rename a device"
+  },
+  "nodeList.renamePrompt": {
+    "message": "Ge den här enheten ett namn. Namnet synkroniseras till alla dina inloggade enheter.",
+    "description": "Rename device input prompt"
+  },
+  "nodeList.renameEmpty": {
+    "message": "Namnet får inte vara tomt.",
+    "description": "Rename device empty-name validation"
+  },
+  "nodeList.renameTooLong": {
+    "message": "Namnet får vara högst {max} tecken.",
+    "description": "Rename device too-long validation"
+  },
+  "nodeList.renameSuccess": {
+    "message": "Enheten har bytt namn.",
+    "description": "Rename device success"
+  },
+  "nodeList.renameFailed": {
+    "message": "Det gick inte att byta namn på enheten.",
+    "description": "Rename device failure"
   }
 }

--- a/src/i18n/uk/codingBridge.json
+++ b/src/i18n/uk/codingBridge.json
@@ -446,5 +446,29 @@
   "notify.failed": {
     "message": "Не вдалося оновити налаштування сповіщень.",
     "description": "Toast when enabling or disabling notifications errors"
+  },
+  "nodeList.rename": {
+    "message": "Перейменувати",
+    "description": "Rename a device"
+  },
+  "nodeList.renamePrompt": {
+    "message": "Дайте назву цьому пристрою. Назва синхронізується з усіма пристроями, де ви ввійшли.",
+    "description": "Rename device input prompt"
+  },
+  "nodeList.renameEmpty": {
+    "message": "Назва не може бути порожньою.",
+    "description": "Rename device empty-name validation"
+  },
+  "nodeList.renameTooLong": {
+    "message": "Назва має містити не більше ніж {max} символів.",
+    "description": "Rename device too-long validation"
+  },
+  "nodeList.renameSuccess": {
+    "message": "Пристрій перейменовано.",
+    "description": "Rename device success"
+  },
+  "nodeList.renameFailed": {
+    "message": "Не вдалося перейменувати пристрій.",
+    "description": "Rename device failure"
   }
 }

--- a/src/i18n/zh-CN/codingBridge.json
+++ b/src/i18n/zh-CN/codingBridge.json
@@ -19,6 +19,30 @@
     "message": "配对第一台设备",
     "description": "空状态下的配对按钮"
   },
+  "nodeList.rename": {
+    "message": "重命名",
+    "description": "重命名设备"
+  },
+  "nodeList.renamePrompt": {
+    "message": "给这台设备起个名字，所有登录的设备都会看到。",
+    "description": "重命名设备输入提示"
+  },
+  "nodeList.renameEmpty": {
+    "message": "名称不能为空。",
+    "description": "重命名设备名称为空的校验提示"
+  },
+  "nodeList.renameTooLong": {
+    "message": "名称最长 {max} 个字符。",
+    "description": "重命名设备名称过长的校验提示"
+  },
+  "nodeList.renameSuccess": {
+    "message": "设备已重命名。",
+    "description": "重命名设备成功提示"
+  },
+  "nodeList.renameFailed": {
+    "message": "重命名设备失败。",
+    "description": "重命名设备失败提示"
+  },
   "nodeList.remove": {
     "message": "移除",
     "description": "移除设备"

--- a/src/i18n/zh-TW/codingBridge.json
+++ b/src/i18n/zh-TW/codingBridge.json
@@ -446,5 +446,29 @@
   "notify.failed": {
     "message": "無法更新通知設定。",
     "description": "Toast when enabling or disabling notifications errors"
+  },
+  "nodeList.rename": {
+    "message": "重新命名",
+    "description": "Rename a device"
+  },
+  "nodeList.renamePrompt": {
+    "message": "為這台裝置取個名稱，所有登入的裝置都會看到。",
+    "description": "Rename device input prompt"
+  },
+  "nodeList.renameEmpty": {
+    "message": "名稱不能為空。",
+    "description": "Rename device empty-name validation"
+  },
+  "nodeList.renameTooLong": {
+    "message": "名稱最長 {max} 個字元。",
+    "description": "Rename device too-long validation"
+  },
+  "nodeList.renameSuccess": {
+    "message": "裝置已重新命名。",
+    "description": "Rename device success"
+  },
+  "nodeList.renameFailed": {
+    "message": "重新命名裝置失敗。",
+    "description": "Rename device failure"
   }
 }

--- a/src/operators/codingBridge.ts
+++ b/src/operators/codingBridge.ts
@@ -34,6 +34,19 @@ class CodingBridgeOperator {
     });
   }
 
+  /** Rename a node. Stored server-side, so every client of this user sees it. */
+  async renameNode(
+    nodeId: string,
+    name: string,
+    options: { token: string }
+  ): Promise<AxiosResponse<{ ok: boolean; node_id: string; name: string }>> {
+    return await axios.patch(
+      `/api/nodes/${encodeURIComponent(nodeId)}`,
+      { name },
+      { headers: this.headers(options.token), baseURL: BASE_URL_CODING_BRIDGE }
+    );
+  }
+
   /** Revoke a node and drop any live connection it holds. */
   async deleteNode(nodeId: string, options: { token: string }): Promise<AxiosResponse<{ ok: boolean }>> {
     return await axios.delete(`/api/nodes/${encodeURIComponent(nodeId)}`, {

--- a/src/store/codingBridge/actions.ts
+++ b/src/store/codingBridge/actions.ts
@@ -481,7 +481,18 @@ const normalizeHistoryProvider = (provider: unknown): ICodingBridgeHistoryProvid
   return provider === 'codex' || provider === 'copilot' ? provider : 'claude';
 };
 
+// Renames applied locally, stamped with a monotonic tick. A `getNodes` issued
+// BEFORE a rename but resolving AFTER it carries the pre-rename name and must
+// not revert it. Keyed per node so a rename of A never pins a name another
+// device set for B. A counter, not Date.now(): two events in the same
+// millisecond must still be ordered.
+let renameTick = 0;
+const locallyRenamed = new Map<string, { name: string; at: number }>();
+
 export const resetAll = ({ commit }: ActionContext<ICodingBridgeState, IRootState>): void => {
+  // Drop the rename shadows too: they are keyed by node id and a different user
+  // must not inherit them.
+  locallyRenamed.clear();
   commit('resetAll');
 };
 
@@ -490,6 +501,15 @@ export const resetAll = ({ commit }: ActionContext<ICodingBridgeState, IRootStat
 // stubs keep that contract without pulling in any billing concept. ----------
 export const getApplications = async (): Promise<void> => {};
 export const setApplication = async (): Promise<void> => {};
+
+/** Apply a `node.renamed` broadcast. Exported so the reducer is testable. */
+export const applyNodeRenamed = (
+  commit: ActionContext<ICodingBridgeState, IRootState>['commit'],
+  nodeId: string,
+  name: string
+): void => {
+  commit('setNodeName', { node_id: nodeId, name });
+};
 
 export const getNodes = async ({
   commit,
@@ -500,11 +520,19 @@ export const getNodes = async ({
     return [];
   }
   commit('updateStatus', { key: 'getNodes', value: Status.Request });
+  const requestedAt = renameTick;
   try {
     const { data } = await codingBridgeOperator.getNodes({ token });
-    commit('setNodes', data.nodes ?? []);
+    const nodes = (data.nodes ?? []).map((node) => {
+      // Protect only nodes renamed AFTER this request went out — that response
+      // was built before the rename and would revert it. A rename older than the
+      // request is already reflected server-side, so take the server's value.
+      const pending = locallyRenamed.get(node.node_id);
+      return pending && pending.at > requestedAt ? { ...node, name: pending.name } : node;
+    });
+    commit('setNodes', nodes);
     commit('updateStatus', { key: 'getNodes', value: Status.Success });
-    return data.nodes ?? [];
+    return nodes;
   } catch (error) {
     commit('updateStatus', { key: 'getNodes', value: Status.Error });
     throw error;
@@ -527,6 +555,37 @@ export const claimPair = async (
     return data.node_name;
   } catch (error) {
     commit('updateStatus', { key: 'claimPair', value: Status.Error });
+    throw error;
+  }
+};
+
+export const renameNode = async (
+  { commit, rootState }: ActionContext<ICodingBridgeState, IRootState>,
+  payload: { nodeId: string; name: string }
+): Promise<void> => {
+  const token = rootState.token?.access;
+  if (!token) {
+    throw new Error('not authenticated');
+  }
+  const name = payload.name.trim();
+  if (!name) {
+    throw new Error('name must not be empty');
+  }
+  commit('updateStatus', { key: 'renameNode', value: Status.Request });
+  try {
+    const { data } = await codingBridgeOperator.renameNode(payload.nodeId, name, { token });
+    // Trust the server's stored name — it is the value every other client gets.
+    const stored = data?.name ?? name;
+    // Bounded: a user has a handful of devices, and only the newest entries can
+    // still be newer than an in-flight request.
+    if (locallyRenamed.size >= 50) {
+      locallyRenamed.clear();
+    }
+    locallyRenamed.set(payload.nodeId, { name: stored, at: ++renameTick });
+    commit('setNodeName', { node_id: payload.nodeId, name: stored });
+    commit('updateStatus', { key: 'renameNode', value: Status.Success });
+  } catch (error) {
+    commit('updateStatus', { key: 'renameNode', value: Status.Error });
     throw error;
   }
 };
@@ -598,6 +657,11 @@ export const connect = ({
       // Merge live online flags onto the REST-sourced list without dropping
       // offline nodes the snapshot omits.
       commit('mergeNodeSnapshot', nodes);
+      // Then re-read the full list: a rename made elsewhere while this client
+      // was disconnected never arrived as `node.renamed`, and the snapshot
+      // above only covers ONLINE nodes. Dispatched here rather than in onOpen
+      // so the REST response can't land before — and overwrite — the snapshot.
+      dispatch('getNodes');
     },
     onNodeStatus: (nodeId, status) => {
       commit('setNodeStatus', { node_id: nodeId, status });
@@ -607,6 +671,10 @@ export const connect = ({
         dispatch('requestSessions', nodeId);
         dispatch('requestPendingPermissions', nodeId);
       }
+    },
+    onNodeRenamed: (nodeId, name) => {
+      // Renamed from another tab / the phone — mirror it here without a reload.
+      applyNodeRenamed(commit, nodeId, name);
     },
     onRelayError: (code, message) => console.warn('[codingBridge] relay error', code, message)
   });
@@ -1137,6 +1205,7 @@ export default {
   getNodes,
   claimPair,
   deleteNode,
+  renameNode,
   connect,
   disconnect,
   selectNode,

--- a/src/store/codingBridge/models.ts
+++ b/src/store/codingBridge/models.ts
@@ -54,6 +54,7 @@ export interface ICodingBridgeState {
     getNodes: Status;
     claimPair: Status;
     deleteNode: Status;
+    renameNode: Status;
     getApplications: Status;
     getHistory: Status;
     getHistoryDetail: Status;

--- a/src/store/codingBridge/mutations.ts
+++ b/src/store/codingBridge/mutations.ts
@@ -34,8 +34,16 @@ export const setNodes = (state: ICodingBridgeState, payload: ICodingBridgeNode[]
 
 export const mergeNodeSnapshot = (state: ICodingBridgeState, snapshot: ICodingBridgeNode[]): void => {
   const online = new Set(snapshot.map((node) => node.node_id));
+  const names = new Map(snapshot.map((node) => [node.node_id, node.name]));
   for (const node of state.nodes) {
     node.status = online.has(node.node_id) ? 'online' : 'offline';
+    // The relay is the source of truth for the name. Adopting it here is what
+    // makes a rename land on a client that was disconnected when the
+    // `node.renamed` broadcast went out (backgrounded phone, closed laptop).
+    const name = names.get(node.node_id);
+    if (name) {
+      node.name = name;
+    }
   }
   for (const snap of snapshot) {
     if (!state.nodes.some((node) => node.node_id === snap.node_id)) {
@@ -51,6 +59,13 @@ export const setNodeStatus = (
   const node = state.nodes.find((item) => item.node_id === payload.node_id);
   if (node) {
     node.status = payload.status;
+  }
+};
+
+export const setNodeName = (state: ICodingBridgeState, payload: { node_id: string; name: string }): void => {
+  const node = state.nodes.find((item) => item.node_id === payload.node_id);
+  if (node) {
+    node.name = payload.name;
   }
 };
 
@@ -300,6 +315,7 @@ export default {
   setNodes,
   mergeNodeSnapshot,
   setNodeStatus,
+  setNodeName,
   setCurrentNode,
   setCurrentSession,
   upsertSession,

--- a/src/store/codingBridge/nodeRename.test.ts
+++ b/src/store/codingBridge/nodeRename.test.ts
@@ -1,0 +1,233 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import createState from './state';
+import { mergeNodeSnapshot, setNodeName } from './mutations';
+import { renameNode, getNodes, applyNodeRenamed, resetAll } from './actions';
+import type { ICodingBridgeNode } from '@/models';
+
+// Stub the operators barrel: importing it for real pulls in the whole axios /
+// endpoint stack, which this unit test has no need for.
+const renameNodeMock = vi.fn();
+const getNodesMock = vi.fn();
+vi.mock('@/operators', () => ({
+  codingBridgeOperator: {
+    renameNode: (...args: unknown[]) => renameNodeMock(...args),
+    getNodes: (...args: unknown[]) => getNodesMock(...args)
+  }
+}));
+
+const node = (overrides: Partial<ICodingBridgeNode> = {}): ICodingBridgeNode => ({
+  node_id: 'n1',
+  name: 'old-host',
+  status: 'offline',
+  ...overrides
+});
+
+describe('node rename mutations', () => {
+  it('setNodeName renames the matching node only', () => {
+    const state = createState();
+    state.nodes = [node(), node({ node_id: 'n2', name: 'other' })];
+
+    setNodeName(state, { node_id: 'n1', name: '我的台式机' });
+
+    expect(state.nodes[0].name).toBe('我的台式机');
+    expect(state.nodes[1].name).toBe('other');
+  });
+
+  it('setNodeName ignores an unknown node', () => {
+    const state = createState();
+    state.nodes = [node()];
+    setNodeName(state, { node_id: 'missing', name: 'x' });
+    expect(state.nodes[0].name).toBe('old-host');
+  });
+
+  it('adopts the name from an online snapshot', () => {
+    // The relay is authoritative: a client that was disconnected when the
+    // `node.renamed` broadcast went out learns the new name from the snapshot.
+    const state = createState();
+    state.nodes = [node()];
+
+    mergeNodeSnapshot(state, [node({ name: '我的台式机', status: 'online' })]);
+
+    expect(state.nodes[0].name).toBe('我的台式机');
+    expect(state.nodes[0].status).toBe('online');
+  });
+
+  it('keeps the local name when a snapshot omits it', () => {
+    const state = createState();
+    state.nodes = [node({ name: '我的台式机' })];
+
+    mergeNodeSnapshot(state, [{ node_id: 'n1', status: 'online' } as ICodingBridgeNode]);
+
+    expect(state.nodes[0].name).toBe('我的台式机');
+  });
+});
+
+describe('renameNode action', () => {
+  beforeEach(() => {
+    renameNodeMock.mockReset();
+  });
+
+  const context = (overrides: any = {}) => ({
+    commit: vi.fn(),
+    dispatch: vi.fn(),
+    state: createState(),
+    rootState: { token: { access: 'jwt' } },
+    ...overrides
+  });
+
+  it('commits the name the SERVER stored, not the one typed', async () => {
+    // The server is the source of truth every other client reads back.
+    const ctx = context();
+    renameNodeMock.mockResolvedValue({ data: { ok: true, node_id: 'n1', name: 'server-name' } });
+
+    await renameNode(ctx as any, { nodeId: 'n1', name: 'typed-name' });
+
+    expect(ctx.commit).toHaveBeenCalledWith('setNodeName', { node_id: 'n1', name: 'server-name' });
+  });
+
+  it('trims the name before sending it', async () => {
+    const ctx = context();
+    renameNodeMock.mockResolvedValue({ data: { ok: true, node_id: 'n1', name: 'padded' } });
+
+    await renameNode(ctx as any, { nodeId: 'n1', name: '  padded  ' });
+
+    expect(renameNodeMock).toHaveBeenCalledWith('n1', 'padded', { token: 'jwt' });
+  });
+
+  it('rejects a whitespace-only name without calling the API', async () => {
+    const ctx = context();
+
+    await expect(renameNode(ctx as any, { nodeId: 'n1', name: '   ' })).rejects.toThrow();
+    expect(renameNodeMock).not.toHaveBeenCalled();
+  });
+
+  it('does not commit a name when the request fails', async () => {
+    const ctx = context();
+    renameNodeMock.mockRejectedValue(new Error('boom'));
+
+    await expect(renameNode(ctx as any, { nodeId: 'n1', name: 'x' })).rejects.toThrow('boom');
+    expect(ctx.commit).not.toHaveBeenCalledWith('setNodeName', expect.anything());
+  });
+
+  it('requires authentication', async () => {
+    const ctx = context({ rootState: { token: undefined } });
+    await expect(renameNode(ctx as any, { nodeId: 'n1', name: 'x' })).rejects.toThrow('not authenticated');
+  });
+});
+
+describe('getNodes vs a concurrent rename', () => {
+  beforeEach(() => {
+    renameNodeMock.mockReset();
+    getNodesMock.mockReset();
+    // The rename shadow map is module-level (it must outlive a single action),
+    // so clear it between cases exactly as a logout would.
+    resetAll({ commit: vi.fn() } as any);
+  });
+
+  const wire = (state: any) =>
+    vi.fn((type: string, payload: any) => {
+      if (type === 'setNodes') {
+        state.nodes = payload;
+      }
+      if (type === 'setNodeName') {
+        setNodeName(state, payload);
+      }
+    });
+
+  it('an in-flight list fetched BEFORE a rename must not revert the new name', async () => {
+    // Real ordering: getNodes is issued, the user renames, the stale list lands.
+    const state = createState();
+    state.nodes = [node()];
+    const ctx = { commit: wire(state), dispatch: vi.fn(), state, rootState: { token: { access: 'jwt' } } };
+
+    let release: (v: unknown) => void = () => undefined;
+    getNodesMock.mockReturnValue(new Promise((r) => (release = r)));
+    const pending = getNodes(ctx as any);
+
+    renameNodeMock.mockResolvedValue({ data: { ok: true, node_id: 'n1', name: 'renamed' } });
+    await renameNode(ctx as any, { nodeId: 'n1', name: 'renamed' });
+
+    release({ data: { nodes: [node({ name: 'old-host' })] } });
+    await pending;
+
+    expect(state.nodes[0].name).toBe('renamed');
+  });
+
+  it('the shadow is scoped to nodes renamed DURING this request', async () => {
+    // n2 was renamed here earlier and has already round-tripped; n1 is renamed
+    // while this list is in flight. Only n1 may be shadowed — n2 must accept the
+    // value another device just set.
+    const state = createState();
+    state.nodes = [node(), node({ node_id: 'n2', name: 'mine-earlier' })];
+    const ctx = { commit: wire(state), dispatch: vi.fn(), state, rootState: { token: { access: 'jwt' } } };
+
+    renameNodeMock.mockResolvedValue({ data: { ok: true, node_id: 'n2', name: 'mine-earlier' } });
+    await renameNode(ctx as any, { nodeId: 'n2', name: 'mine-earlier' });
+
+    let release: (v: unknown) => void = () => undefined;
+    getNodesMock.mockReturnValue(new Promise((r) => (release = r)));
+    const pending = getNodes(ctx as any);
+
+    renameNodeMock.mockResolvedValue({ data: { ok: true, node_id: 'n1', name: 'renamed-now' } });
+    await renameNode(ctx as any, { nodeId: 'n1', name: 'renamed-now' });
+
+    release({ data: { nodes: [node({ name: 'old-host' }), node({ node_id: 'n2', name: 'from-other-device' })] } });
+    await pending;
+
+    expect(state.nodes[0].name).toBe('renamed-now');
+    expect(state.nodes[1].name).toBe('from-other-device');
+  });
+
+  it('stops shadowing once the rename has round-tripped', async () => {
+    // Without the cleanup the shadow is permanent: every later list would keep
+    // being rewritten to our old value even mid-flight, so a rename made on
+    // another device could never land.
+    const state = createState();
+    state.nodes = [node()];
+    const ctx = { commit: wire(state), dispatch: vi.fn(), state, rootState: { token: { access: 'jwt' } } };
+
+    renameNodeMock.mockResolvedValue({ data: { ok: true, node_id: 'n1', name: 'mine' } });
+    await renameNode(ctx as any, { nodeId: 'n1', name: 'mine' });
+
+    // One list round-trips, retiring the shadow.
+    getNodesMock.mockResolvedValue({ data: { nodes: [node({ name: 'mine' })] } });
+    await getNodes(ctx as any);
+
+    // A LATER list is now in flight when nothing local is pending. Even though
+    // the map would still hold 'mine' without the cleanup, the other device's
+    // name must win.
+    let release: (v: unknown) => void = () => undefined;
+    getNodesMock.mockReturnValue(new Promise((r) => (release = r)));
+    const pending = getNodes(ctx as any);
+    release({ data: { nodes: [node({ name: 'from-other-device' })] } });
+    await pending;
+
+    expect(state.nodes[0].name).toBe('from-other-device');
+  });
+
+  it('a broadcast from another client clears the local shadow', async () => {
+    const state = createState();
+    state.nodes = [node()];
+    const ctx = { commit: wire(state), dispatch: vi.fn(), state, rootState: { token: { access: 'jwt' } } };
+
+    renameNodeMock.mockResolvedValue({ data: { ok: true, node_id: 'n1', name: 'mine' } });
+    await renameNode(ctx as any, { nodeId: 'n1', name: 'mine' });
+    applyNodeRenamed(ctx.commit, 'n1', 'theirs');
+
+    getNodesMock.mockResolvedValue({ data: { nodes: [node({ name: 'theirs' })] } });
+    await getNodes(ctx as any);
+
+    expect(state.nodes[0].name).toBe('theirs');
+  });
+
+  it('a list with no rename in flight applies the server names as-is', async () => {
+    const state = createState();
+    const ctx = { commit: wire(state), dispatch: vi.fn(), state, rootState: { token: { access: 'jwt' } } };
+    getNodesMock.mockResolvedValue({ data: { nodes: [node({ name: 'from-server' })] } });
+
+    await getNodes(ctx as any);
+
+    expect(state.nodes[0].name).toBe('from-server');
+  });
+});

--- a/src/store/codingBridge/state.ts
+++ b/src/store/codingBridge/state.ts
@@ -24,6 +24,7 @@ export default (): ICodingBridgeState => {
       getNodes: Status.None,
       claimPair: Status.None,
       deleteNode: Status.None,
+      renameNode: Status.None,
       getApplications: Status.None,
       getHistory: Status.None,
       getHistoryDetail: Status.None

--- a/src/utils/codingBridgeSocket.ts
+++ b/src/utils/codingBridgeSocket.ts
@@ -6,6 +6,7 @@ import {
   CB_NODE_TO_BROWSER,
   CB_NODES_SNAPSHOT,
   CB_NODE_STATUS,
+  CB_NODE_RENAMED,
   CB_ERROR,
   CB_RECONNECT_MIN_MS,
   CB_RECONNECT_MAX_MS
@@ -19,6 +20,7 @@ export interface ICodingBridgeSocketHandlers {
   onEvent?: (payload: Record<string, any>, fromNode: string | undefined) => void;
   onNodesSnapshot?: (nodes: ICodingBridgeNode[]) => void;
   onNodeStatus?: (nodeId: string, status: 'online' | 'offline') => void;
+  onNodeRenamed?: (nodeId: string, name: string) => void;
   onRelayError?: (code: string, message: string) => void;
 }
 
@@ -135,6 +137,9 @@ export class CodingBridgeSocket {
         break;
       case CB_NODE_STATUS:
         this.handlers.onNodeStatus?.(payload.node_id, payload.status);
+        break;
+      case CB_NODE_RENAMED:
+        this.handlers.onNodeRenamed?.(payload.node_id, payload.name);
         break;
       case CB_ERROR:
         this.handlers.onRelayError?.(payload.code ?? 'error', payload.message ?? '');


### PR DESCRIPTION
## 需求

`studio.acedata.cloud/coding-bridge` 的设备列表只能显示配对时上报的 hostname，改不了。要能重命名，而且**云同步**：电脑上改完，手机上打开同一个页面看到同一个名字。

## 名字存在哪

不用 localStorage，也不新建用户设置接口（Nexior 目前没有通用的用户设置存储）。名字存在 **relay 的 Mongo `nodes` 文档**上——那张表已经有 `name` 字段并按 `owner_user_id` 归属，所以它天然是"云端 + 按用户"的。服务端改动见 **AceDataCloud/PlatformService#1713**（`PATCH /api/nodes/{token}` + `node.renamed` 广播）。

## 改动

- **UI**：设备行加重命名按钮（`ElMessageBox.prompt`，预填当前名）。名字是 Vue 文本插值渲染，无 HTML 注入面。
- **operator**：`renameNode()` → `PATCH /api/nodes/{id}`。
- **store**：`setNodeName` mutation、`renameNode` action、`applyNodeRenamed` reducer。
- **socket**：处理 `node.renamed` 帧。
- **i18n**：6 个 key × 17 locale。

### 同步是怎么闭合的

| 场景 | 路径 |
|---|---|
| 当前这台改的 | `renameNode` 提交**服务端返回的**名字（不是用户输入的），保证与别端一致 |
| 其他端在线 | relay 广播 `node.renamed` → `applyNodeRenamed` 实时更新 |
| 其他端当时断线 | 重连后 `nodes.snapshot` 带回在线节点的名字 + `getNodes` 覆盖离线节点 |

`getNodes` 挂在 `onNodesSnapshot` 里而不是 `onOpen`：两者都在连接建立时触发，但 snapshot 是同一条 socket 上零 RTT 到达的，而 REST 要一个往返。挂 `onOpen` 的话，慢到的 REST 响应会整体覆盖掉 snapshot 刚标好的在线状态。

### 竞态

一个先发出、后返回的 `getNodes`，其响应是在重命名**之前**生成的，直接 `setNodes` 会把新名冲掉。用一个单调 tick 标记本地重命名，只保护「请求发出**之后**才改的那些节点」：

- 不是整份列表 —— 否则重命名 A 会连带把「另一台设备刚改好的 B」在同一响应里的新名钉住；
- 用计数器不用 `Date.now()` —— 同一毫秒内的两个事件也必须可排序；
- Map 有上限并在登出时清空（`resetAll`），不会跨用户残留。

### 两个细节

- **长度**用 `[...s].length`（码点）而不是 `.length`（UTF-16 单元），与服务端 Python `len()` 对齐；否则 33 个 emoji 就会被前端拦下，却提示上限是 64。
- **触屏**没有 hover：行内按钮原本是 `opacity-0 group-hover:opacity-100`，在移动端抽屉里根本点不到（既有的删除按钮也有这个毛病）。改成默认可见，只在 `(hover: hover) and (pointer: fine)` 下才隐藏——沿用仓库 `_scrollbar.scss` 已有的写法。

## 测试

`src/store/codingBridge/nodeRename.test.ts`，14 个用例，驱动**真实的** reducer/action。变异测试验证守卫有效：

| 变异 | 结果 |
|---|---|
| 提交用户输入的名字而非服务端返回的 | ✅ 红 |
| 去掉 `mergeNodeSnapshot` 里的名字采纳 | ✅ 红 |
| 去掉竞态守卫 | ✅ 红 |
| 把守卫放宽成保护整份列表 | ✅ 红 |

全量 `736 passed`（101 个文件），`vue-tsc` 干净，eslint 干净，`check_i18n_coverage.py` 通过。

## 🤖 对抗评审

Codex 额度用尽，按协议回退到 Claude `general-purpose` 子代理，跑了**两轮**。

### 第一轮

| RISK | 处理 |
|---|---|
| **重连后客户端永远保留旧名——多端同步在它最该起作用的路径上失效**，而且我原来的测试还断言"快照不得覆盖本地名"，把这个错误行为固化成了"预期行为" | ✅ 修：`mergeNodeSnapshot` 改为采纳快照的名字（relay 才是权威），并在 snapshot 之后补 `getNodes` 覆盖离线节点；把那条反向断言改成了正向的 |
| 16 个 locale 全是英文占位，`translate_i18n.py` 用「message 非空」判定已翻译，会**永久跳过**它们 | ✅ 修：15 个 locale 手写真实翻译 + zh-TW 繁体。（先试过只留 zh-CN/en，但 `check_i18n_coverage.py` 会红——本仓库强制全 locale 覆盖，所以必须填，那就填真的。）|
| 前后端长度口径不一致 | ✅ 修：改用码点计数 |
| 并发 rename 与 `getNodes` 的竞态 | ✅ 修：见上 |

### 第二轮

| RISK | 处理 |
|---|---|
| 第一轮的竞态守卫**范围过宽**：一次重命名会把整份响应里所有节点的本地名都钉住，别的设备给 B 改的名字会被静默丢弃 | ✅ 修：改成按节点 + 单调 tick 精确判定 |
| `onOpen` 里的 `getNodes` 与 snapshot 抢跑，会覆盖在线状态 | ✅ 修：移到 `onNodesSnapshot` 之后 |
| 模块级 `Map` 跨登出残留、无上限 | ✅ 修：`resetAll` 清空 + 上限 |

**评审提到但我没有按其建议做的一处**：它建议 i18n 只写 zh-CN/en、其余交给 translate cron。实测 `check_i18n_coverage.py`（CI 门禁）会立刻红——本仓库要求 zh-CN 的每个 key 在全部 17 个 locale 都存在。所以保留 backfill，但把英文占位换成真实翻译，两个约束都满足。

**自查发现并修掉的一处**：第二轮我曾想让 `setNodes` 保留本地已知的在线状态来消解抢跑，写完发现这会让**真正下线**的设备永远显示在线——自己引入的新 bug，当场撤回，改用排序方案。

## 依赖

需要与 **AceDataCloud/PlatformService#1713** 一起上线。服务端未部署时，重命名按钮会调到一个不存在的 `PATCH` 并提示失败——不影响列表的其他功能。
