### PR TITLE
feat(coding-bridge): 历史会话「未读」标记(加粗标题 + 红点)

### DIFF
--- a/change/@acedatacloud-nexior-8c1f4a20-6b2d-4e93-9a17-2d5f8c04e1b7.json
+++ b/change/@acedatacloud-nexior-8c1f4a20-6b2d-4e93-9a17-2d5f8c04e1b7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "mark finished, unopened coding bridge history sessions as unread (bold title + red dot)",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/codingBridge/HistoryDrawer.vue
+++ b/src/components/codingBridge/HistoryDrawer.vue
@@ -86,7 +86,12 @@
               aria-hidden="true"
               focusable="false"
             />
-            <span class="text-sm font-medium truncate flex-1">{{ item.title }}</span>
+            <span class="text-sm truncate flex-1" :class="item.unread ? 'font-bold' : 'font-medium'">{{
+              item.title
+            }}</span>
+            <!-- Finished since the user last opened it. The watermark lives on the
+                 node, so reading it here clears it on every other device too. -->
+            <span v-if="item.unread" class="unread-dot" :title="$t('codingBridge.history.unread')"></span>
             <!-- Live on the node right now: opening it reattaches to the running
                  session (Stop button + streaming) rather than replaying a copy. -->
             <span v-if="item.running" class="running-dot" :title="$t('codingBridge.history.running')"></span>
@@ -236,6 +241,16 @@ export default defineComponent({
       if (!this.currentNodeId) {
         return;
       }
+      if (item.unread) {
+        // Watermark what this browser rendered, so anything appended after the
+        // listing stays unread. The node replies with a refreshed snapshot.
+        this.$store.dispatch('codingBridge/markHistoryRead', {
+          node_id: this.currentNodeId,
+          provider: item.provider,
+          session_id: item.session_id,
+          updated_at: item.updated_at
+        });
+      }
       // Reattach (not just fetch the transcript): if this conversation is still
       // running on the node, this re-pulls its live stream, running state and any
       // blocked permission/AskUserQuestion prompt instead of showing it idle.
@@ -326,6 +341,14 @@ export default defineComponent({
   border-radius: 9999px;
   background: var(--el-color-success);
   box-shadow: 0 0 0 3px color-mix(in srgb, var(--el-color-success) 25%, transparent);
+}
+
+.unread-dot {
+  flex: none;
+  width: 8px;
+  height: 8px;
+  border-radius: 9999px;
+  background: var(--el-color-danger);
 }
 
 // The OpenAI glyph ships black; flip it to white on dark backgrounds.

--- a/src/constants/codingBridge.ts
+++ b/src/constants/codingBridge.ts
@@ -36,6 +36,12 @@ export const CB_ACTION_PERMISSIONS_LIST = 'permissions.list';
 export const CB_ACTION_SESSIONS_LIST = 'sessions.list';
 export const CB_ACTION_HISTORY_LIST = 'history.list';
 export const CB_ACTION_HISTORY_GET = 'history.get';
+// Clear a session's unread dot. The node answers with a refreshed history
+// snapshot, so no dedicated reply event is needed.
+export const CB_ACTION_HISTORY_MARK_READ = 'history.mark_read';
+// Page size for the history drawer. mark_read echoes it so its refreshed
+// listing covers the same rows the drawer is showing.
+export const CB_HISTORY_LIMIT = 200;
 export const CB_ACTION_FS_LIST = 'fs.list';
 export const CB_ACTION_CAPABILITIES_GET = 'capabilities.get';
 export const CB_ACTION_PING = 'ping';

--- a/src/i18n/ar/codingBridge.json
+++ b/src/i18n/ar/codingBridge.json
@@ -287,6 +287,10 @@
     "message": "قيد التشغيل",
     "description": "Marks a history conversation that is currently live on the device"
   },
+  "history.unread": {
+    "message": "Unread",
+    "description": "Marks a finished history conversation the user has not opened yet"
+  },
   "history.resumeHint": {
     "message": "سيؤدي إرسال رسالة إلى استئناف هذه المحادثة على الجهاز.",
     "description": "Resume composer hint"

--- a/src/i18n/de/codingBridge.json
+++ b/src/i18n/de/codingBridge.json
@@ -287,6 +287,10 @@
     "message": "Läuft",
     "description": "Marks a history conversation that is currently live on the device"
   },
+  "history.unread": {
+    "message": "Unread",
+    "description": "Marks a finished history conversation the user has not opened yet"
+  },
   "history.resumeHint": {
     "message": "Eine Nachricht setzt diese Konversation auf dem Gerät fort.",
     "description": "Resume composer hint"

--- a/src/i18n/el/codingBridge.json
+++ b/src/i18n/el/codingBridge.json
@@ -287,6 +287,10 @@
     "message": "Σε εκτέλεση",
     "description": "Marks a history conversation that is currently live on the device"
   },
+  "history.unread": {
+    "message": "Unread",
+    "description": "Marks a finished history conversation the user has not opened yet"
+  },
   "history.resumeHint": {
     "message": "Η αποστολή μηνύματος θα συνεχίσει αυτή τη συνομιλία στη συσκευή.",
     "description": "Resume composer hint"

--- a/src/i18n/en/codingBridge.json
+++ b/src/i18n/en/codingBridge.json
@@ -287,6 +287,10 @@
     "message": "Running",
     "description": "Marks a history conversation that is currently live on the device"
   },
+  "history.unread": {
+    "message": "Unread",
+    "description": "Marks a finished history conversation the user has not opened yet"
+  },
   "history.resumeHint": {
     "message": "Sending a message will resume this conversation on the device.",
     "description": "Resume composer hint"

--- a/src/i18n/es/codingBridge.json
+++ b/src/i18n/es/codingBridge.json
@@ -287,6 +287,10 @@
     "message": "En ejecución",
     "description": "Marks a history conversation that is currently live on the device"
   },
+  "history.unread": {
+    "message": "Unread",
+    "description": "Marks a finished history conversation the user has not opened yet"
+  },
   "history.resumeHint": {
     "message": "Enviar un mensaje reanudará esta conversación en el dispositivo.",
     "description": "Resume composer hint"

--- a/src/i18n/fi/codingBridge.json
+++ b/src/i18n/fi/codingBridge.json
@@ -287,6 +287,10 @@
     "message": "Käynnissä",
     "description": "Merkitsee historian keskustelun, joka on parhaillaan käynnissä laitteella"
   },
+  "history.unread": {
+    "message": "Unread",
+    "description": "Marks a finished history conversation the user has not opened yet"
+  },
   "history.resumeHint": {
     "message": "Viestin lähettäminen jatkaa tätä keskustelua laitteella.",
     "description": "Jatka-syöttökentän vihje"

--- a/src/i18n/fr/codingBridge.json
+++ b/src/i18n/fr/codingBridge.json
@@ -287,6 +287,10 @@
     "message": "En cours",
     "description": "Marks a history conversation that is currently live on the device"
   },
+  "history.unread": {
+    "message": "Unread",
+    "description": "Marks a finished history conversation the user has not opened yet"
+  },
   "history.resumeHint": {
     "message": "Envoyer un message reprendra cette conversation sur l’appareil.",
     "description": "Resume composer hint"

--- a/src/i18n/it/codingBridge.json
+++ b/src/i18n/it/codingBridge.json
@@ -287,6 +287,10 @@
     "message": "In esecuzione",
     "description": "Marks a history conversation that is currently live on the device"
   },
+  "history.unread": {
+    "message": "Unread",
+    "description": "Marks a finished history conversation the user has not opened yet"
+  },
   "history.resumeHint": {
     "message": "L’invio di un messaggio riprenderà questa conversazione sul dispositivo.",
     "description": "Resume composer hint"

--- a/src/i18n/ja/codingBridge.json
+++ b/src/i18n/ja/codingBridge.json
@@ -287,6 +287,10 @@
     "message": "実行中",
     "description": "デバイス上で現在ライブ実行中の会話を示す"
   },
+  "history.unread": {
+    "message": "Unread",
+    "description": "Marks a finished history conversation the user has not opened yet"
+  },
   "history.resumeHint": {
     "message": "メッセージを送信すると、デバイス上でこの会話が再開されます。",
     "description": "再開コンポーザーのヒント"

--- a/src/i18n/ko/codingBridge.json
+++ b/src/i18n/ko/codingBridge.json
@@ -287,6 +287,10 @@
     "message": "실행 중",
     "description": "Marks a history conversation that is currently live on the device"
   },
+  "history.unread": {
+    "message": "Unread",
+    "description": "Marks a finished history conversation the user has not opened yet"
+  },
   "history.resumeHint": {
     "message": "메시지를 보내면 기기에서 이 대화가 다시 시작됩니다.",
     "description": "Resume composer hint"

--- a/src/i18n/pl/codingBridge.json
+++ b/src/i18n/pl/codingBridge.json
@@ -287,6 +287,10 @@
     "message": "Działa",
     "description": "Marks a history conversation that is currently live on the device"
   },
+  "history.unread": {
+    "message": "Unread",
+    "description": "Marks a finished history conversation the user has not opened yet"
+  },
   "history.resumeHint": {
     "message": "Wysłanie wiadomości wznowi tę rozmowę na urządzeniu.",
     "description": "Resume composer hint"

--- a/src/i18n/pt/codingBridge.json
+++ b/src/i18n/pt/codingBridge.json
@@ -287,6 +287,10 @@
     "message": "Em execução",
     "description": "Marks a history conversation that is currently live on the device"
   },
+  "history.unread": {
+    "message": "Unread",
+    "description": "Marks a finished history conversation the user has not opened yet"
+  },
   "history.resumeHint": {
     "message": "Enviar uma mensagem retomará esta conversa no dispositivo.",
     "description": "Resume composer hint"

--- a/src/i18n/ru/codingBridge.json
+++ b/src/i18n/ru/codingBridge.json
@@ -287,6 +287,10 @@
     "message": "Выполняется",
     "description": "Пометка разговора из истории, который сейчас активен на устройстве"
   },
+  "history.unread": {
+    "message": "Unread",
+    "description": "Marks a finished history conversation the user has not opened yet"
+  },
   "history.resumeHint": {
     "message": "Отправка сообщения возобновит этот разговор на устройстве.",
     "description": "Подсказка о возобновлении разговора"

--- a/src/i18n/sr/codingBridge.json
+++ b/src/i18n/sr/codingBridge.json
@@ -287,6 +287,10 @@
     "message": "У току",
     "description": "Означава да је овај разговор из историје тренутно активан на уређају"
   },
+  "history.unread": {
+    "message": "Unread",
+    "description": "Marks a finished history conversation the user has not opened yet"
+  },
   "history.resumeHint": {
     "message": "Слање поруке ће наставити овај разговор на уређају.",
     "description": "Савет за наставак уноса"

--- a/src/i18n/sv/codingBridge.json
+++ b/src/i18n/sv/codingBridge.json
@@ -287,6 +287,10 @@
     "message": "Körs",
     "description": "Marks a history conversation that is currently live on the device"
   },
+  "history.unread": {
+    "message": "Unread",
+    "description": "Marks a finished history conversation the user has not opened yet"
+  },
   "history.resumeHint": {
     "message": "Att skicka ett meddelande återupptar konversationen på enheten.",
     "description": "Resume composer hint"

--- a/src/i18n/uk/codingBridge.json
+++ b/src/i18n/uk/codingBridge.json
@@ -287,6 +287,10 @@
     "message": "Виконується",
     "description": "Marks a history conversation that is currently live on the device"
   },
+  "history.unread": {
+    "message": "Unread",
+    "description": "Marks a finished history conversation the user has not opened yet"
+  },
   "history.resumeHint": {
     "message": "Надсилання повідомлення відновить цю розмову на пристрої.",
     "description": "Resume composer hint"

--- a/src/i18n/zh-CN/codingBridge.json
+++ b/src/i18n/zh-CN/codingBridge.json
@@ -287,6 +287,10 @@
     "message": "运行中",
     "description": "历史会话当前正在设备上运行的标记"
   },
+  "history.unread": {
+    "message": "未读",
+    "description": "历史会话已运行完但用户尚未查看的标记"
+  },
   "history.resumeHint": {
     "message": "发送消息将在设备上续接此会话。",
     "description": "续接输入框提示"

--- a/src/i18n/zh-TW/codingBridge.json
+++ b/src/i18n/zh-TW/codingBridge.json
@@ -287,6 +287,10 @@
     "message": "執行中",
     "description": "歷史會話當前正在裝置上執行的標記"
   },
+  "history.unread": {
+    "message": "Unread",
+    "description": "Marks a finished history conversation the user has not opened yet"
+  },
   "history.resumeHint": {
     "message": "傳送訊息將在裝置上接續此會話。",
     "description": "續接輸入框提示"

--- a/src/models/codingBridge.ts
+++ b/src/models/codingBridge.ts
@@ -115,6 +115,9 @@ export interface ICodingBridgeHistorySummary {
   // True when this transcript is a session live on the node right now, so the
   // drawer can flag it and opening it reattaches instead of replaying a copy.
   running?: boolean;
+  // Finished since the user last opened it. The read watermark lives on the node,
+  // so a session read on the phone is read on the desktop too.
+  unread?: boolean;
 }
 
 /** A normalised transcript returned by `history.get`. */

--- a/src/store/codingBridge/actions.markRead.test.ts
+++ b/src/store/codingBridge/actions.markRead.test.ts
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+//
+// The unread dot: the drawer must tell the node WHAT it rendered (so output
+// appended during the round trip stays unread) and must not fire at all for a
+// session that is already read.
+import { describe, expect, it, vi } from 'vitest';
+import createState from './state';
+import type { ICodingBridgeState } from './models';
+
+vi.mock('@/utils/codingBridgeNotify', () => ({
+  notifyPermissionLocally: () => {},
+  subscribeWebPush: async () => null,
+  unsubscribeWebPush: async () => null,
+  registerNativePush: async () => null,
+  requestWebPermission: async () => 'granted'
+}));
+
+const sent: Array<{ nodeId: string; payload: Record<string, unknown> }> = [];
+
+vi.mock('@/utils/codingBridgeSocket', () => ({
+  CodingBridgeSocket: class {
+    isOpen = true;
+    connect() {}
+    sendToNode(nodeId: string, payload: Record<string, unknown>) {
+      sent.push({ nodeId, payload });
+    }
+    resume() {}
+    close() {}
+  }
+}));
+
+const actions = await import('./actions');
+
+const NODE = 'node-1';
+
+const harness = () => {
+  const state: ICodingBridgeState = createState();
+  sent.length = 0;
+  const ctx = {
+    state,
+    commit: () => {},
+    dispatch: () => {},
+    rootState: { token: { access: 'tok' } }
+  };
+  actions.connect(ctx as never);
+  return { state, ctx };
+};
+
+describe('markHistoryRead', () => {
+  it('sends the rendered updated_at so a later append stays unread', () => {
+    const { ctx } = harness();
+    sent.length = 0;
+    actions.markHistoryRead(ctx as never, {
+      node_id: NODE,
+      provider: 'claude',
+      session_id: 's1',
+      updated_at: 1_700_000_000_000
+    });
+    expect(sent).toEqual([
+      {
+        nodeId: NODE,
+        payload: {
+          action: 'history.mark_read',
+          provider: 'claude',
+          session_id: 's1',
+          updated_at: 1_700_000_000_000,
+          limit: 200
+        }
+      }
+    ]);
+  });
+
+  it('is a no-op without a provider — the node keys watermarks by (provider, id)', () => {
+    const { ctx } = harness();
+    sent.length = 0;
+    actions.markHistoryRead(
+      ctx as never,
+      {
+        node_id: NODE,
+        session_id: 's1'
+      } as never
+    );
+    expect(sent).toEqual([]);
+  });
+});

--- a/src/store/codingBridge/actions.ts
+++ b/src/store/codingBridge/actions.ts
@@ -31,6 +31,8 @@ import {
   CB_ACTION_SESSIONS_LIST,
   CB_ACTION_HISTORY_LIST,
   CB_ACTION_HISTORY_GET,
+  CB_ACTION_HISTORY_MARK_READ,
+  CB_HISTORY_LIMIT,
   CB_ACTION_FS_LIST,
   CB_ACTION_CAPABILITIES_GET,
   CB_EVENT_SESSION_STARTED,
@@ -1023,7 +1025,7 @@ export const getHistory = ({ commit, state }: ActionContext<ICodingBridgeState, 
     return;
   }
   commit('updateStatus', { key: 'getHistory', value: Status.Request });
-  socket.sendToNode(target, { action: CB_ACTION_HISTORY_LIST, limit: 200 });
+  socket.sendToNode(target, { action: CB_ACTION_HISTORY_LIST, limit: CB_HISTORY_LIMIT });
 };
 
 // Ask a node to replay one past transcript so it can be viewed / resumed.
@@ -1045,6 +1047,26 @@ export const getHistoryDetail = (
   // Safety net: never leave the skeleton spinning if the reply is lost (node
   // went offline mid-request). The transcript falls back to its empty hint.
   setTimeout(() => commit('updateStatus', { key: 'getHistoryDetail', value: Status.Success }), 12000);
+};
+
+// Clear one session's unread dot. `updated_at` is what this browser actually
+// rendered — the node stores that as the watermark, so output appended during
+// the round trip stays unread. The reply is a refreshed history snapshot.
+export const markHistoryRead = (
+  _ctx: ActionContext<ICodingBridgeState, IRootState>,
+  payload: ICodingBridgeHistoryRef & { updated_at?: number }
+): void => {
+  if (!payload?.node_id || !payload?.session_id || !payload?.provider || !socket) {
+    return;
+  }
+  socket.sendToNode(payload.node_id, {
+    action: CB_ACTION_HISTORY_MARK_READ,
+    provider: payload.provider,
+    session_id: payload.session_id,
+    updated_at: payload.updated_at,
+    // Same page size as getHistory, so the refreshed listing isn't truncated.
+    limit: CB_HISTORY_LIMIT
+  });
 };
 
 // Re-establish a conversation as fully LIVE — used when restoring after a reload
@@ -1223,6 +1245,7 @@ export default {
   answerQuestion,
   getHistory,
   getHistoryDetail,
+  markHistoryRead,
   reattachSession,
   resyncSession,
   browseDir,


### PR DESCRIPTION
## 背景

Coding Bridge「历史会话」抽屉里,用户看不出哪些会话在自己没盯着时已经跑完并产出了新内容。本 PR 给「已跑完但用户尚未打开」的会话加一个未读标记:**标题加粗 + 红点**。

## 设计(与 Agent 端 PR 配套)

- 未读 = **已结束 且 未读**。运行中的会话永远不标未读(还没跑完不需要提醒)。
- 「读到哪」的水位线存在 **node 端 sidecar 文件**(`~/.ace-bridge/reads.json`),因此**跨设备**:手机上看过了,电脑上也算看过。浏览器只负责渲染 `unread` 布尔值和触发 mark。
- 打开一条会话时,上报**本浏览器实际渲染的 `updated_at`** 作为水位线(不是 "now"),这样列表拉取后又追加的输出仍会保持未读;node 回一份刷新后的快照。
- 未读判定、水位线逻辑全部在 node 端(见 Agent 仓 PR https://github.com/AceDataCloud/CodingBridgeAgent/pull/74)。relay 零改动。

## 本 PR(Nexior/UI)改动

- `HistoryDrawer.vue`:未读标题 `font-bold`,尾部 `.unread-dot`(`var(--el-color-danger)`);`open()` 时若 `item.unread` 则 dispatch `markHistoryRead`。
- `store/codingBridge/actions.ts`:新增 `markHistoryRead` action,向 node 发 `history.mark_read`。
- `constants/codingBridge.ts`:`CB_ACTION_HISTORY_MARK_READ`。
- `models/codingBridge.ts`:`ICodingBridgeHistorySummary.unread?: boolean`。
- i18n `history.unread`(zh-CN + en 手写,其余 locale 从 en backfill)。
- vitest:`actions.markRead.test.ts`(2 passed)。

## 验证

- `vue-tsc --noEmit` ✅ / `eslint` ✅
- `scripts/check_i18n_coverage.py` ✅(17 locale × 45 namespace)
- `vitest run actions.markRead.test.ts` ✅ 2 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)