### PR TITLE
fix(coding-bridge): 打开会话直接停在最新消息，不再从最旧回放

### DIFF
--- a/change/@acedatacloud-nexior-5d1c8b34-9e27-4f60-a815-6b3d90fa27c4.json
+++ b/change/@acedatacloud-nexior-5d1c8b34-9e27-4f60-a815-6b3d90fa27c4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "coding bridge: open a conversation at its newest message instead of replaying the relay buffer oldest-first",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/codingBridge/SessionView.scroll.test.ts
+++ b/src/components/codingBridge/SessionView.scroll.test.ts
@@ -1,0 +1,224 @@
+// @vitest-environment jsdom
+//
+// The transcript must open — and stay — at the newest message. Two bugs made it
+// crawl in from the top instead: the watcher observed the events ARRAY (which
+// `appendEvent` mutates in place, so it never fired), and nothing scrolled on
+// mount for a transcript restored before the component existed.
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/assets/images/logos/claude.svg', () => ({ default: 'claude.svg' }));
+vi.mock('@/assets/images/logos/openai.svg', () => ({ default: 'openai.svg' }));
+vi.mock('@/assets/images/logos/github-copilot.svg', () => ({ default: 'copilot.svg' }));
+
+const SessionView = (await import('./SessionView.vue')).default as unknown as {
+  watch: Record<string, (this: Ctx) => void>;
+  methods: Record<string, (this: Ctx, ...args: unknown[]) => void>;
+  mounted: (this: Ctx) => void;
+  updated: (this: Ctx) => void;
+  beforeUnmount: (this: Ctx) => void;
+  data: () => Record<string, unknown>;
+};
+
+type Ctx = Record<string, unknown> & {
+  pinnedToBottom: boolean;
+  visibleCount: number;
+  scrolled: number;
+  scrollPending: boolean;
+  transcriptObserver?: { disconnect: () => void };
+  observedTranscript?: HTMLElement;
+  $refs: { transcript?: HTMLElement };
+  $nextTick: (fn: () => void) => void;
+  scrollToBottom: () => void;
+  scheduleScrollToBottom: () => void;
+  observeTranscript: () => void;
+};
+
+// A transcript element with real geometry: jsdom reports 0 for every layout
+// property, so the scroll maths needs explicit values.
+const transcriptEl = (geo: { scrollHeight: number; clientHeight: number; scrollTop: number }): HTMLElement => {
+  const el = document.createElement('div');
+  Object.defineProperty(el, 'scrollHeight', { get: () => geo.scrollHeight });
+  Object.defineProperty(el, 'clientHeight', { get: () => geo.clientHeight });
+  Object.defineProperty(el, 'scrollTop', {
+    get: () => geo.scrollTop,
+    set: (value: number) => {
+      geo.scrollTop = value;
+    }
+  });
+  return el;
+};
+
+const ctx = (overrides: Partial<Ctx> = {}): Ctx => {
+  const geo = { scrollHeight: 5000, clientHeight: 600, scrollTop: 0 };
+  const self = {
+    ...SessionView.data(),
+    geo,
+    $refs: { transcript: transcriptEl(geo) },
+    // Run synchronously so the assertions don't have to await the scheduler.
+    $nextTick: (fn: () => void) => fn(),
+    requestCapabilities: () => {},
+    syncSessionSettings: () => {},
+    ...overrides
+  } as unknown as Ctx;
+  self.scrollToBottom = SessionView.methods.scrollToBottom.bind(self) as () => void;
+  self.scheduleScrollToBottom = SessionView.methods.scheduleScrollToBottom.bind(self) as () => void;
+  self.observeTranscript = SessionView.methods.observeTranscript.bind(self) as () => void;
+  return self;
+};
+
+// rAF is the second pass of scrollToBottom; run it inline.
+vi.stubGlobal('requestAnimationFrame', (fn: FrameRequestCallback) => {
+  fn(0);
+  return 0;
+});
+
+describe('coding bridge transcript scroll pinning', () => {
+  it('watches the event COUNT, not the array instance', () => {
+    // `appendEvent` pushes into the same array, so a watcher on `events` sees
+    // oldValue === newValue and never fires. Watching the length is what makes
+    // live output keep the view at the bottom.
+    expect(SessionView.watch.eventCount).toBeDefined();
+    expect(SessionView.watch.events).toBeUndefined();
+  });
+
+  it('jumps to the bottom when the event count changes', () => {
+    const self = ctx();
+    SessionView.watch.eventCount.call(self);
+    expect((self as unknown as { geo: { scrollTop: number } }).geo.scrollTop).toBe(5000);
+  });
+
+  it('scrolls on mount so a restored transcript opens at its newest turn', () => {
+    // Deep link / reload: the events are already in the store before this
+    // component mounts, so no watcher ever fires for them.
+    const self = ctx();
+    SessionView.mounted.call(self);
+    expect((self as unknown as { geo: { scrollTop: number } }).geo.scrollTop).toBe(5000);
+  });
+
+  it('does not yank the user back down while they read earlier turns', () => {
+    const self = ctx({ pinnedToBottom: false });
+    SessionView.watch.eventCount.call(self);
+    expect((self as unknown as { geo: { scrollTop: number } }).geo.scrollTop).toBe(0);
+  });
+
+  it('detaches when scrolled up and re-attaches at the bottom', () => {
+    const self = ctx();
+    const geo = (self as unknown as { geo: { scrollTop: number } }).geo;
+    // Far from the bottom → following is off.
+    geo.scrollTop = 1000;
+    SessionView.methods.onTranscriptScroll.call(self);
+    expect(self.pinnedToBottom).toBe(false);
+    // Back within the threshold (5000 - 4390 - 600 = 10px) → following resumes.
+    geo.scrollTop = 4390;
+    SessionView.methods.onTranscriptScroll.call(self);
+    expect(self.pinnedToBottom).toBe(true);
+  });
+
+  it('re-pins and resets the render window when switching conversations', () => {
+    const self = ctx({ pinnedToBottom: false, visibleCount: 240 });
+    SessionView.watch.currentSessionId.call(self);
+    expect(self.pinnedToBottom).toBe(true);
+    expect(self.visibleCount).toBe(60);
+    expect((self as unknown as { geo: { scrollTop: number } }).geo.scrollTop).toBe(5000);
+  });
+
+  it('unpins when the user loads earlier turns', () => {
+    const self = ctx();
+    SessionView.methods.loadEarlier.call(self);
+    expect(self.pinnedToBottom).toBe(false);
+    expect(self.visibleCount).toBe(120);
+  });
+
+  // Streamed output arrives as `appendDelta`, which mutates the open bubble's
+  // text in place: the event COUNT never changes, so no watcher fires. Only a
+  // DOM observer keeps the view on the growing tail.
+  it('follows text that grows in place, where the event count never changes', async () => {
+    const self = ctx();
+    const el = self.$refs.transcript as HTMLElement;
+    const bubble = document.createElement('p');
+    bubble.textContent = 'hel';
+    el.appendChild(bubble);
+    document.body.appendChild(el);
+    SessionView.mounted.call(self);
+    const geo = (self as unknown as { geo: { scrollTop: number; scrollHeight: number } }).geo;
+    geo.scrollTop = 0;
+
+    // A delta lands: same event, longer text, taller transcript.
+    bubble.textContent = 'hello world';
+    geo.scrollHeight = 6000;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(geo.scrollTop).toBe(6000);
+  });
+
+  it('does not chase the tail once the user has scrolled up', async () => {
+    const self = ctx({ pinnedToBottom: false });
+    const el = self.$refs.transcript as HTMLElement;
+    document.body.appendChild(el);
+    SessionView.mounted.call(self);
+    const geo = (self as unknown as { geo: { scrollTop: number } }).geo;
+
+    el.appendChild(document.createElement('p'));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(geo.scrollTop).toBe(0);
+  });
+
+  it('attaches the observer once the transcript appears after mount', async () => {
+    // The transcript is behind `v-if="currentNode"`, so on a reload with a
+    // persisted node id the element does not exist yet at mount — the device
+    // list lands later. Without the `updated` hook the observer never attached
+    // and streamed output stopped following the tail.
+    const self = ctx({ $refs: {} });
+    SessionView.mounted.call(self);
+    expect(self.transcriptObserver).toBeUndefined();
+
+    const geo = (self as unknown as { geo: { scrollHeight: number; clientHeight: number; scrollTop: number } }).geo;
+    const el = transcriptEl(geo);
+    document.body.appendChild(el);
+    self.$refs.transcript = el;
+    SessionView.updated.call(self);
+    expect(self.transcriptObserver).toBeDefined();
+
+    geo.scrollTop = 0;
+    el.appendChild(document.createElement('p'));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(geo.scrollTop).toBe(5000);
+  });
+
+  it('re-attaching is a no-op while the element is unchanged', () => {
+    const self = ctx();
+    document.body.appendChild(self.$refs.transcript as HTMLElement);
+    SessionView.mounted.call(self);
+    const first = self.transcriptObserver;
+    SessionView.updated.call(self);
+    expect(self.transcriptObserver).toBe(first);
+  });
+
+  it('disconnects the old observer when the transcript element is replaced', () => {
+    const self = ctx();
+    document.body.appendChild(self.$refs.transcript as HTMLElement);
+    SessionView.mounted.call(self);
+    const first = self.transcriptObserver as { disconnect: () => void };
+    let disconnected = false;
+    first.disconnect = () => {
+      disconnected = true;
+    };
+
+    const geo = (self as unknown as { geo: { scrollHeight: number; clientHeight: number; scrollTop: number } }).geo;
+    self.$refs.transcript = transcriptEl(geo);
+    SessionView.updated.call(self);
+
+    expect(disconnected).toBe(true);
+    expect(self.transcriptObserver).not.toBe(first);
+  });
+
+  it('disconnects the observer on unmount', () => {
+    const self = ctx();
+    document.body.appendChild(self.$refs.transcript as HTMLElement);
+    SessionView.mounted.call(self);
+    expect(self.transcriptObserver).toBeDefined();
+    SessionView.beforeUnmount.call(self);
+    expect(self.transcriptObserver).toBeUndefined();
+  });
+});

--- a/src/components/codingBridge/SessionView.vue
+++ b/src/components/codingBridge/SessionView.vue
@@ -76,7 +76,11 @@
       </div>
 
       <!-- Transcript -->
-      <div ref="transcript" class="flex-1 min-h-0 overflow-y-auto px-5 py-4 flex flex-col gap-3">
+      <div
+        ref="transcript"
+        class="flex-1 min-h-0 overflow-y-auto px-5 py-4 flex flex-col gap-3"
+        @scroll="onTranscriptScroll"
+      >
         <!-- Restoring a conversation: show a skeleton until its transcript lands,
              but only when we don't already hold (live) events to render. -->
         <div v-if="historyLoading && !events.length" class="cb-skeleton">
@@ -599,6 +603,9 @@ const MAX_ATTACHMENTS = 10;
 // TranscriptItem, this bounds rendered memory regardless of conversation size.
 const RENDER_WINDOW = 60;
 const RENDER_PAGE = 60;
+// Px from the bottom still counted as "following the tail". Generous enough to
+// survive sub-pixel rounding and the composer's own resize.
+const SCROLL_PIN_THRESHOLD = 80;
 
 // Brand marks for each coding backend. `invertOnDark` flips the black OpenAI /
 // Copilot glyphs to white in dark mode; Claude's orange already reads on both.
@@ -671,7 +678,15 @@ export default defineComponent({
       maxAttachments: MAX_ATTACHMENTS,
       // How many of the most recent events to render; grows by RENDER_PAGE when
       // the user loads earlier turns. Reset on session switch.
-      visibleCount: RENDER_WINDOW
+      visibleCount: RENDER_WINDOW,
+      // Whether the transcript is following the tail. Cleared when the user
+      // scrolls up (so incoming events don't yank them back down), restored the
+      // moment they scroll back to the bottom or switch conversations.
+      pinnedToBottom: true,
+      // One tail-jump per frame, however many mutations the burst produced.
+      scrollPending: false,
+      transcriptObserver: undefined as MutationObserver | undefined,
+      observedTranscript: undefined as HTMLElement | undefined
     };
   },
   computed: {
@@ -704,6 +719,10 @@ export default defineComponent({
     events(): ICodingBridgeEvent[] {
       const id = this.currentSessionId;
       return id ? (this.$store.state.codingBridge?.events?.[id] ?? []) : [];
+    },
+    // A primitive the watcher can actually compare — see the `eventCount` watch.
+    eventCount(): number {
+      return this.events.length;
     },
     // Only the most recent `visibleCount` events are rendered; the rest stay
     // behind the "load earlier" control so a huge transcript never mounts at once.
@@ -963,7 +982,10 @@ export default defineComponent({
     }
   },
   watch: {
-    events() {
+    // Watch the COUNT, not the array: `appendEvent` pushes into the same array
+    // instance, so a watcher on `events` sees oldValue === newValue and never
+    // fires — the transcript then stopped following live output.
+    eventCount() {
       this.scrollToBottom();
     },
     pendingQuestion() {
@@ -973,6 +995,8 @@ export default defineComponent({
       this.scrollToBottom();
     },
     currentSessionId() {
+      // A different conversation always opens pinned to its newest message.
+      this.pinnedToBottom = true;
       this.scrollToBottom();
       // A different conversation starts capped to the most recent window again.
       this.visibleCount = RENDER_WINDOW;
@@ -1027,6 +1051,20 @@ export default defineComponent({
   mounted() {
     this.requestCapabilities();
     this.syncSessionSettings();
+    // A transcript restored before mount (deep link / page reload) already has
+    // its events in the store, so no watcher fires — open it at the newest turn.
+    this.scrollToBottom();
+    this.observeTranscript();
+  },
+  updated() {
+    // The transcript is behind `v-if="currentNode"`, so on a reload it appears
+    // only once the device list lands — after mount. Cheap no-op once attached.
+    this.observeTranscript();
+  },
+  beforeUnmount() {
+    this.transcriptObserver?.disconnect();
+    this.transcriptObserver = undefined;
+    this.observedTranscript = undefined;
   },
   methods: {
     requestCapabilities() {
@@ -1393,17 +1431,73 @@ export default defineComponent({
       });
     },
     scrollToBottom() {
-      this.$nextTick(() => {
+      if (!this.pinnedToBottom) {
+        return;
+      }
+      const jump = () => {
         const el = this.$refs.transcript as HTMLElement | undefined;
         if (el) {
           el.scrollTop = el.scrollHeight;
         }
+      };
+      // Two passes: $nextTick lands after the patch, the rAF after the browser
+      // has laid out (images, code blocks and markdown grow the content AFTER
+      // the DOM patch, which left the old single-pass jump short of the bottom).
+      this.$nextTick(() => {
+        jump();
+        requestAnimationFrame(jump);
       });
+    },
+    // Streamed output grows via `appendDelta`, which mutates the open bubble's
+    // text in place — the event COUNT never changes, so no watcher fires and the
+    // tail would grow below the viewport. Watch the rendered DOM instead, which
+    // covers every way the transcript gets taller (deltas, markdown, images).
+    // Re-runs on every patch because the transcript sits behind `v-if`: on a
+    // reload the device list arrives after mount, so the element the observer
+    // needs does not exist yet at mount time.
+    observeTranscript() {
+      const el = this.$refs.transcript as HTMLElement | undefined;
+      if (el === this.observedTranscript) {
+        return;
+      }
+      this.transcriptObserver?.disconnect();
+      this.transcriptObserver = undefined;
+      this.observedTranscript = el;
+      if (!el || typeof MutationObserver === 'undefined') {
+        return;
+      }
+      this.transcriptObserver = new MutationObserver(() => this.scheduleScrollToBottom());
+      this.transcriptObserver.observe(el, { childList: true, subtree: true, characterData: true });
+    },
+    // Coalesce a delta burst into one jump per frame.
+    scheduleScrollToBottom() {
+      if (!this.pinnedToBottom || this.scrollPending) {
+        return;
+      }
+      this.scrollPending = true;
+      requestAnimationFrame(() => {
+        this.scrollPending = false;
+        const el = this.$refs.transcript as HTMLElement | undefined;
+        if (el && this.pinnedToBottom) {
+          el.scrollTop = el.scrollHeight;
+        }
+      });
+    },
+    // Following the tail is the user's to break: scrolling up detaches, coming
+    // back within a threshold of the bottom re-attaches.
+    onTranscriptScroll() {
+      const el = this.$refs.transcript as HTMLElement | undefined;
+      if (!el) {
+        return;
+      }
+      this.pinnedToBottom = el.scrollHeight - el.scrollTop - el.clientHeight <= SCROLL_PIN_THRESHOLD;
     },
     // Reveal an older page of the transcript, keeping the current scroll anchor.
     loadEarlier() {
       const el = this.$refs.transcript as HTMLElement | undefined;
       const prevHeight = el?.scrollHeight ?? 0;
+      // Reading earlier turns means we are no longer following the tail.
+      this.pinnedToBottom = false;
       this.visibleCount += RENDER_PAGE;
       this.$nextTick(() => {
         if (el) {

--- a/src/store/codingBridge/actions.resume.test.ts
+++ b/src/store/codingBridge/actions.resume.test.ts
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+//
+// Opening a conversation must NOT replay the relay's whole retained buffer.
+// `resume` is pure catch-up on top of the live broadcast the relay already sends
+// to every browser socket, so asking for it without a cursor made the relay
+// stream up to 5000 buffered events oldest-first — the transcript then painted
+// in from the beginning while the user waited for the newest message.
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import createState from './state';
+import mutations from './mutations';
+import type { ICodingBridgeState } from './models';
+
+const resumeCalls: Array<Record<string, number>> = [];
+
+vi.mock('@/utils/codingBridgeNotify', () => ({
+  notifyPermissionLocally: () => {},
+  subscribeWebPush: async () => null,
+  unsubscribeWebPush: async () => null,
+  registerNativePush: async () => null,
+  requestWebPermission: async () => 'granted'
+}));
+
+vi.mock('@/utils/codingBridgeSocket', () => ({
+  CodingBridgeSocket: class {
+    isOpen = true;
+    connect(): void {}
+    close(): void {}
+    resume(cursors: Record<string, number>): void {
+      resumeCalls.push(cursors);
+    }
+  }
+}));
+
+const { connect, reattachSession } = await import('./actions');
+
+const NODE = 'node-1';
+
+// Harness over the real mutations, with the module-level socket singleton
+// installed via the real `connect` action (that is the only way in).
+const harness = () => {
+  const state: ICodingBridgeState = createState();
+  const dispatched: Array<{ type: string; payload: unknown }> = [];
+  const commit = (type: string, payload?: unknown): void => {
+    const fn = (mutations as Record<string, (s: ICodingBridgeState, p: unknown) => void>)[type];
+    if (!fn) {
+      throw new Error(`unknown mutation: ${type}`);
+    }
+    fn(state, payload);
+  };
+  const dispatch = (type: string, payload?: unknown): void => {
+    dispatched.push({ type, payload });
+  };
+  const ctx = { state, commit, dispatch, rootState: { token: { access: 'tok' } } };
+  connect(ctx as never);
+  return {
+    state,
+    dispatched,
+    open: (session_id: string) =>
+      reattachSession(ctx as never, { node_id: NODE, provider: 'claude', session_id } as never)
+  };
+};
+
+describe('coding bridge session resume cursor', () => {
+  beforeEach(() => {
+    resumeCalls.length = 0;
+  });
+
+  it('does not resume a session this tab has never followed', () => {
+    const h = harness();
+    h.open('never-seen');
+    // No cursor → no replay. The transcript comes from history.detail and any
+    // further output arrives on the relay's unconditional live broadcast.
+    expect(resumeCalls).toEqual([]);
+    // The conversation is still opened and its transcript still requested.
+    expect(h.state.currentSessionId).toBe('never-seen');
+    expect(h.dispatched.some((d) => d.type === 'getHistoryDetail')).toBe(true);
+  });
+
+  it('resumes from the stored cursor for a session it was already following', () => {
+    const h = harness();
+    h.state.lastSeq['seen'] = 42;
+    h.open('seen');
+    expect(resumeCalls).toEqual([{ seen: 42 }]);
+  });
+
+  it('resumes from 0 for a session re-keyed mid-turn (its seq space restarts at 1)', () => {
+    // `renameSession` sets lastSeq[real] = 0 on purpose: the relay numbers seq
+    // per session_id, so the real id begins a FRESH space. That 0 is a real
+    // cursor over a buffer we are actively watching — a few events at most.
+    const h = harness();
+    h.state.sessions['prov'] = { session_id: 'prov', node_id: NODE, status: 'running' } as never;
+    h.state.lastSeq['prov'] = 7;
+    (mutations as never as Record<string, (s: ICodingBridgeState, p: unknown) => void>).renameSession(h.state, {
+      from: 'prov',
+      to: 'real-1'
+    });
+    h.open('real-1');
+    expect(resumeCalls).toEqual([{ 'real-1': 0 }]);
+  });
+});

--- a/src/store/codingBridge/actions.seq.test.ts
+++ b/src/store/codingBridge/actions.seq.test.ts
@@ -1,0 +1,140 @@
+// @vitest-environment jsdom
+//
+// `seq` is assigned by the relay from an IN-MEMORY log, but the browser
+// persists its cursor across reloads. When the relay restarts, the session's
+// seq space begins again at 1 while the stored cursor still holds the old
+// high-water mark — every live event then looks like one already applied and
+// the conversation goes silent for good.
+import { describe, expect, it, vi } from 'vitest';
+import createState from './state';
+import mutations from './mutations';
+import type { ICodingBridgeState } from './models';
+
+vi.mock('@/utils/codingBridgeNotify', () => ({
+  notifyPermissionLocally: () => {},
+  subscribeWebPush: async () => null,
+  unsubscribeWebPush: async () => null,
+  registerNativePush: async () => null,
+  requestWebPermission: async () => 'granted'
+}));
+
+vi.mock('@/utils/codingBridgeSocket', () => ({
+  CodingBridgeSocket: class {
+    isOpen = true;
+    connect(): void {}
+    close(): void {}
+    resume(): void {}
+  }
+}));
+
+const { applyNodeEvent } = await import('./actions');
+
+const NODE = 'node-1';
+const SESSION = 'sess-1';
+
+const harness = () => {
+  const state: ICodingBridgeState = createState();
+  const dispatched: string[] = [];
+  const commit = (type: string, payload?: unknown): void => {
+    const fn = (mutations as Record<string, (s: ICodingBridgeState, p: unknown) => void>)[type];
+    if (!fn) {
+      throw new Error(`unknown mutation: ${type}`);
+    }
+    fn(state, payload);
+  };
+  const dispatch = (type: string): void => {
+    dispatched.push(type);
+  };
+  return {
+    state,
+    dispatched,
+    // A (re)connect is what re-opens the window for detecting a renumbered space.
+    reconnect: () => commit('clearSeqChecked'),
+    text: (seq: number, text: string) =>
+      applyNodeEvent(
+        commit as never,
+        dispatch as never,
+        state,
+        { event: 'session.text', session_id: SESSION, seq, text } as never,
+        NODE
+      )
+  };
+};
+
+const texts = (state: ICodingBridgeState): (string | undefined)[] =>
+  (state.events[SESSION] ?? []).map((event) => event.text);
+
+describe('coding bridge seq cursor', () => {
+  it('drops events already applied', () => {
+    const h = harness();
+    h.text(1, 'a');
+    h.text(2, 'b');
+    h.text(2, 'b again');
+    expect(texts(h.state)).toEqual(['a', 'b']);
+  });
+
+  it('re-baselines when the relay restarts its seq space', () => {
+    // Persisted cursor from before the restart.
+    const h = harness();
+    h.state.lastSeq[SESSION] = 200;
+    h.text(1, 'after restart');
+    h.text(2, 'still live');
+    // Without the re-baseline both are silently discarded and the session looks
+    // frozen until the user reloads the page.
+    expect(texts(h.state)).toEqual(['after restart', 'still live']);
+    expect(h.state.lastSeq[SESSION]).toBe(2);
+  });
+
+  it('re-baselines even when the first events of the new space were missed', () => {
+    // The tab was backgrounded across the restart, so seq 1..5 went out while it
+    // was disconnected. `resume` at cursor 200 finds nothing above 200 and the
+    // relay emits no `stream_truncated` (its log exists and starts at 1), so the
+    // only recovery signal is this first event — which a `seq === 1` test misses.
+    const h = harness();
+    h.state.lastSeq[SESSION] = 200;
+    h.text(6, 'first one we see');
+    h.text(7, 'and the next');
+    expect(texts(h.state)).toEqual(['first one we see', 'and the next']);
+    expect(h.state.lastSeq[SESSION]).toBe(7);
+    // seq 1..5 are unreachable by any resume, so the live stream alone leaves a
+    // hole. The transcript resync is what actually fills it.
+    expect(h.dispatched).toContain('resyncSession');
+  });
+
+  it('does not re-baseline on a mid-space replay overlap', () => {
+    // Replay only sends seq > cursor, so after the space has been validated on
+    // this connection any seq <= cursor is a genuine duplicate. Re-baselining
+    // there would re-apply the whole retained buffer.
+    const h = harness();
+    h.text(1, 'a');
+    h.text(2, 'b');
+    h.text(3, 'c');
+    h.text(2, 'duplicate');
+    expect(texts(h.state)).toEqual(['a', 'b', 'c']);
+    expect(h.state.lastSeq[SESSION]).toBe(3);
+    // A duplicate must not trigger a transcript refetch on every replay overlap.
+    expect(h.dispatched).not.toContain('resyncSession');
+  });
+
+  it('does not re-baseline when seq 1 is itself the duplicate', () => {
+    const h = harness();
+    h.text(1, 'a');
+    h.text(1, 'a duplicate');
+    expect(texts(h.state)).toEqual(['a']);
+  });
+
+  it('re-validates the space on every reconnect', () => {
+    // A reconnect is the only moment a restarted relay can be detected, so the
+    // per-connection validation has to be dropped there — otherwise the very
+    // first session opened in a tab would be the only one that can recover.
+    const h = harness();
+    h.text(1, 'a');
+    h.text(2, 'b');
+    h.reconnect();
+    // Post-restart space: seq 1 is below the cursor (2) but is the first event we
+    // see on this connection, so it re-baselines instead of being dropped.
+    h.text(1, 'after a restart mid-session');
+    expect(texts(h.state)).toEqual(['a', 'b', 'after a restart mid-session']);
+    expect(h.state.lastSeq[SESSION]).toBe(1);
+  });
+});

--- a/src/store/codingBridge/actions.ts
+++ b/src/store/codingBridge/actions.ts
@@ -143,8 +143,29 @@ export const applyNodeEvent = (
   if (typeof seq === 'number' && sessionId) {
     const last = state.lastSeq[sessionId];
     if (last !== undefined && seq <= last) {
-      return;
+      // seq comes from the relay's IN-MEMORY log, so a relay restart (deploy,
+      // crash) begins the session's seq space again at 1 while our cursor — which
+      // outlives it, persisted — still holds the pre-restart high-water mark.
+      // Every live event then looks already-applied and the session goes silent
+      // for good. The relay is single-replica, so a restart always drops our
+      // socket: within ONE connection the first event of a healthy space is
+      // necessarily above the cursor (replay only sends seq > cursor, live only
+      // grows). So a first-since-connect event at or below it means the space
+      // restarted — re-baseline onto the new one. Afterwards, seq <= cursor is a
+      // genuine replay/live overlap and stays dropped.
+      if (state.seqChecked[sessionId]) {
+        return;
+      }
+      commit('resetLastSeq', sessionId);
+      // Re-baselining only rescues the stream from here on. Anything the new
+      // space emitted while we were disconnected sits BELOW this event and no
+      // resume can reach it (we asked from the old, far higher cursor and the
+      // relay saw a valid log, so it sent nothing and raised no truncation).
+      // Pull the device transcript to close that gap — the same recovery the
+      // relay asks for on `stream_truncated`.
+      dispatch('resyncSession', sessionId);
     }
+    commit('markSeqChecked', sessionId);
     commit('setLastSeq', { session_id: sessionId, seq });
   }
   // Keep the session's trace id current with whatever turn the node is on.
@@ -632,6 +653,10 @@ export const connect = ({
   socket = new CodingBridgeSocket(token, {
     onOpen: () => {
       commit('setConnection', 'connected');
+      // A dropped socket is the only way the relay can have restarted (it is
+      // single-replica), so this is where a renumbered seq space becomes
+      // detectable — see the cursor guard in `applyNodeEvent`.
+      commit('clearSeqChecked');
       // Reconnect: resume each session's live stream from the seq we last saw,
       // so in-flight output is replayed instead of lost. Empty after a full page
       // reload (lastSeq is in-memory) — there the history restore below rebuilds
@@ -1074,9 +1099,16 @@ export const reattachSession = (
   dispatch('getHistoryDetail', ref);
   dispatch('requestSessions', ref.node_id);
   dispatch('requestPendingPermissions', ref.node_id);
-  // Replay the live stream from the last event we applied (0 = from the start of
-  // the relay's buffer). The relay and the browser both dedupe by seq.
-  socket?.resume({ [ref.session_id]: state.lastSeq[ref.session_id] ?? 0 });
+  // Resume the live stream ONLY for a session this tab already followed. The
+  // relay broadcasts new events to every browser unconditionally, so `resume` is
+  // pure backfill — and with no cursor it replayed the relay's ENTIRE retained
+  // buffer for that session (up to 5000 events, oldest first, one message each)
+  // on top of the transcript we just asked for. That is what made an opened
+  // conversation crawl in from the oldest message instead of showing the newest.
+  const cursor = state.lastSeq[ref.session_id];
+  if (cursor !== undefined) {
+    socket?.resume({ [ref.session_id]: cursor });
+  }
 };
 
 // Resync a live session from the device transcript after the live stream lost

--- a/src/store/codingBridge/models.ts
+++ b/src/store/codingBridge/models.ts
@@ -26,9 +26,13 @@ export interface ICodingBridgeState {
   sessions: Record<string, ICodingBridgeSession>;
   events: Record<string, ICodingBridgeEvent[]>;
   // Highest relay-assigned event `seq` applied per session. Drives reconnect
-  // replay (resume_from) and dedups overlapping events. In-memory only: a full
-  // reload rebuilds the transcript from history instead of a seq cursor.
+  // replay (resume_from) and dedups overlapping events. Persisted, so it can
+  // outlive the relay's in-memory seq space — see `seqChecked`.
   lastSeq: Record<string, number>;
+  // Sessions whose seq space has already been validated against `lastSeq` on
+  // the CURRENT connection. Never persisted: the flag is what distinguishes a
+  // duplicate from a relay that restarted and renumbered from 1.
+  seqChecked: Record<string, boolean>;
   // Past on-device sessions per node, sourced live from `history.list`.
   history: Record<string, ICodingBridgeHistorySummary[]>;
   // What each node can do (providers/models/efforts), from `capabilities.get`.

--- a/src/store/codingBridge/mutations.ts
+++ b/src/store/codingBridge/mutations.ts
@@ -120,6 +120,7 @@ export const renameSession = (state: ICodingBridgeState, payload: { from: string
   // while a later turn (higher seq) showed. The real id is brand-new to this tab
   // at re-key time, so reset its cursor to accept its whole stream.
   delete state.lastSeq[from];
+  delete state.seqChecked[from];
   state.lastSeq[to] = 0;
   for (const request of state.permissions) {
     if (request.session_id === from) {
@@ -184,6 +185,25 @@ export const setLastSeq = (state: ICodingBridgeState, payload: { session_id: str
   if (payload.seq > current) {
     state.lastSeq[payload.session_id] = payload.seq;
   }
+};
+
+// Drop a session's cursor. Used when the relay's seq space restarts under us
+// (see `applyNodeEvent`), where keeping the old high-water mark would make every
+// live event look like one we had already applied.
+export const resetLastSeq = (state: ICodingBridgeState, sessionId: string): void => {
+  delete state.lastSeq[sessionId];
+};
+
+// Mark a session's seq space as validated on this connection.
+export const markSeqChecked = (state: ICodingBridgeState, sessionId: string): void => {
+  state.seqChecked[sessionId] = true;
+};
+
+// Forget every validation. Called on each (re)connect: the relay is
+// single-replica, so a restart always drops our socket — the first event of a
+// session after one is where a renumbered seq space can be detected.
+export const clearSeqChecked = (state: ICodingBridgeState): void => {
+  state.seqChecked = {};
 };
 
 // Streaming: append an incremental text chunk onto the open bubble matching
@@ -301,6 +321,7 @@ export const removeNodeData = (state: ICodingBridgeState, nodeId: string): void 
       delete state.sessions[session.session_id];
       delete state.events[session.session_id];
       delete state.lastSeq[session.session_id];
+      delete state.seqChecked[session.session_id];
       if (state.currentSessionId === session.session_id) {
         state.currentSessionId = undefined;
       }
@@ -325,6 +346,9 @@ export default {
   truncateEventsBefore,
   rewindToCut,
   setLastSeq,
+  resetLastSeq,
+  markSeqChecked,
+  clearSeqChecked,
   appendDelta,
   finalizeStream,
   finalizeAllStreams,

--- a/src/store/codingBridge/persist.ts
+++ b/src/store/codingBridge/persist.ts
@@ -7,9 +7,11 @@
 // `lastSeq` is persisted so that after a full page reload the reconnect can ask
 // the relay to `resume` each session's stream from the last event we applied —
 // otherwise the cursor is empty, no replay is requested, and an actively
-// streaming session looks frozen until the user sends something. A stale cursor
-// (relay buffer trimmed) is self-healing: the relay replies `stream_truncated`
-// and the session resyncs from the device transcript.
+// streaming session looks frozen until the user sends something. A cursor left
+// past the relay's retained window heals via `stream_truncated` → resync from
+// the device transcript; a cursor left past a RESTARTED relay's seq space does
+// not (the relay sees a valid log starting at 1) and is caught client-side by
+// the `seqChecked` re-baseline in `applyNodeEvent`.
 export default [
   'codingBridge.currentNodeId',
   'codingBridge.historyRef',

--- a/src/store/codingBridge/state.ts
+++ b/src/store/codingBridge/state.ts
@@ -9,6 +9,7 @@ export default (): ICodingBridgeState => {
     sessions: {},
     events: {},
     lastSeq: {},
+    seqChecked: {},
     history: {},
     capabilities: {},
     historyRef: undefined,


### PR DESCRIPTION
## 问题

`https://studio.acedata.cloud/coding-bridge` 上打开一个会话时，页面会**从最旧的消息开始**灌一大批内容，右侧滚动条一路变短，用户要等很久才能看到最新一条。

## 根因（两处，wire 两端都已核实）

**主因 — `reattachSession` 用 cursor 0 请求了全量回放。**

打开一个本标签页从未跟过的会话时，`state.lastSeq[session_id]` 是 undefined，旧代码 `?? 0` 兜底后调 `socket.resume({sid: 0})`。relay 侧 `read_since(sid, 0)`（`app/main.py:561`）返回该会话保留环里**全部**事件（上限 5000 条），`_replay_session` 按 seq 从旧到新**一条一个 WS 消息**推下来，逐条 `appendEvent` 叠在刚请求的 `history.detail` 之上 —— 正是用户看到的"从旧到新、滚动条越缩越短"。

修复是跳过无 cursor 时的 `resume`。**安全前提**：relay 的 `_forward_event_to_browsers` 对该用户的每个 browser socket 无条件下发，`hub.browsers_for_user` 只按 `user_id` 过滤、**没有按会话订阅**，所以 `resume` 纯粹是补历史、从来不是实时订阅的开关。跳过它不会丢任何实时事件。

**次因 — 转录区并不可靠地贴在底部。**

- `watch` 观察的是 events **数组本身**，而 `appendEvent` 是原地 `push`，新旧引用相同 → watch 永不触发。改为 watch 原始值 `eventCount`。
- 深链/刷新时 events 早于组件存在，任何 watch 都不会为它们触发 → `mounted()` 补一次滚动。
- 流式输出走 `appendDelta`，**原地**改 `target.text`，长度不变，连 `eventCount` 都不动 → 加 `MutationObserver`（`characterData: true`），按帧合并成一次跳转。
- 转录区在 `v-if` 之后，所以 observer 必须在 `updated()` 里（重新）挂载，不能只在 `mounted()`。
- `pinnedToBottom` 记录用户意图：往上翻阅历史时不会被拽回底部。

## 顺带修掉的 seq 游标跨 relay 重启漏洞

`seq` 来自 relay 的**内存**日志（`eventlog.py`，MongoDB 持久层在文档里明确标注为 deferred），而浏览器把游标持久化了。relay 一重启（发版/崩溃），会话 seq 空间从 1 重新编号，持久化游标还停在旧高水位 → 每条实时事件都 `seq <= last` 被当成重复丢弃，**会话永久静默**。`stream_truncated` 救不了它：relay 看到的是一个从 1 开始的合法日志，不满足任何截断条件。

修法：新增**不持久化**的 `seqChecked`，每次 `onOpen` 清空。relay 是单副本，重启必然断开我们的 socket；因此在**同一条连接内**，健康 seq 空间的首个事件必然高于游标（replay 只发 `seq > cursor`，实时只增长）。所以"本连接首个事件却 ≤ 游标"就是空间已重启的判据 —— 重新基线；之后的 `seq <= cursor` 仍是正常的 replay/实时重叠，照常丢弃。

再叠一层：重新基线只救得回从此刻往后的流。断连期间新空间已发出、落在这条事件**之下**的低位事件，任何 resume 都够不到（我们是拿旧的高游标去问的，relay 什么都没返回也没报截断）。所以重新基线时同时 `dispatch('resyncSession')`，拉一次设备转录把这个洞补上 —— 复用 relay 在 `stream_truncated` 时要求的同一条恢复路径。

## 验证

- `npx vitest run src/store/codingBridge src/components/codingBridge` → **7 files / 68 tests 全绿**
- `npx eslint`（全部改动文件）→ 0
- `npx vue-tsc --noEmit` → 0
- **突变测试**（每条新测试都先还原被测修复、确认测试转红）：6 个突变体全部被杀死 —— seq 判据退回 `seq === 1` 启发式、`clearSeqChecked` 改空实现、`reattachSession` 恢复无条件 resume、删掉 `updated()` 钩子、去掉 observer 幂等早退、去掉 `resyncSession` 派发。

> 一个真实的测试弱点就是这样抓到的：`clearSeqChecked` 改空实现时 6 条 seq 测试仍全绿，因为重连用例用的 seq 高于游标、根本没进 `seq <= last` 分支。改成低于游标的 seq 后突变体才被杀死。

## 🤖 对抗评审

**第 1 轮**（Claude 子代理）3 条：A、B 已修并补回归测试；**C 判为既有的协议层限制不在本 PR 修**——`history.detail` 不携带 `seq`（见 `CodingBridgeAgent/coding_bridge/connection.py:530`，它从**磁盘**转录读取），要让它与 relay 的 seq 空间对齐需要改 node 侧协议。

**第 2 轮**（codex）2 条，均已修 + 回归测试：
- **High** — 原先用 `seq === 1` 判断空间重启，靠运气：断连期间错过前几条时首见 seq 是 6 而非 1。已换成上文的 `seqChecked` 按连接校验。
- **Medium** — observer 只在 `mounted()` 挂载，而转录区在 `v-if` 之后，刷新场景下挂载时元素还不存在。已加 `updated()` + 幂等的 `observeTranscript()`。

**第 3 轮**（codex）3 条：
- **High（已修）** — 重启后落在新空间低位的事件会被永久跳过。核实属实：`read_since` 只返回 `seq > cursor`、relay 无重启存活层、`stream_truncated` 不会触发。已加 `resyncSession` 派发，并用突变测试确认新断言有效。
- **Medium（记录，不在本 PR 修）** — 会话正在另一浏览器跑、本标签页无 cursor 时，`reattachSession` 只拿 `history.detail`，relay 缓冲中尚未落盘到 node 转录的事件可能取不到。**没有干净的纯客户端修法**：relay 的 `resume_from` 收的是绝对游标，浏览器不知道 `latest_seq`。正确的修法在 relay 侧（`resume_from: "latest-N"` 或回传 `latest_seq`），且它比本 PR 修掉的"全量回放"严重性低一个量级。
- **Low（已修）** — 那条测试把数据丢失当成了预期行为。现在它同时断言 `resyncSession` 被派发。

## 后续（另开 PR，PlatformService）

给 relay 的 `read_since` 加尾部上限，并加一个重启纪元信号（或持久化 `EventLog`），这样客户端就不必靠启发式推断 seq 空间重启。