### PR TITLE
fix(coding-bridge): 补掉 seq 游标的三个洞（含 #1441 自身引入的两个）

### DIFF
--- a/change/@acedatacloud-nexior-coding-bridge-seq-guard-holes-2026-07-29.json
+++ b/change/@acedatacloud-nexior-coding-bridge-seq-guard-holes-2026-07-29.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "coding bridge: stop replaying the whole buffer on a re-keyed session, and clear the seq cursor when the relay renumbers it",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/store/codingBridge/actions.resume.test.ts
+++ b/src/store/codingBridge/actions.resume.test.ts
@@ -31,7 +31,7 @@ vi.mock('@/utils/codingBridgeSocket', () => ({
   }
 }));
 
-const { connect, reattachSession } = await import('./actions');
+const { connect, reattachSession, applyNodeEvent } = await import('./actions');
 
 const NODE = 'node-1';
 
@@ -55,6 +55,8 @@ const harness = () => {
   return {
     state,
     dispatched,
+    closed: (session_id: string) =>
+      applyNodeEvent(commit as never, dispatch as never, state, { event: 'session.closed', session_id } as never, NODE),
     open: (session_id: string) =>
       reattachSession(ctx as never, { node_id: NODE, provider: 'claude', session_id } as never)
   };
@@ -83,10 +85,12 @@ describe('coding bridge session resume cursor', () => {
     expect(resumeCalls).toEqual([{ seen: 42 }]);
   });
 
-  it('resumes from 0 for a session re-keyed mid-turn (its seq space restarts at 1)', () => {
-    // `renameSession` sets lastSeq[real] = 0 on purpose: the relay numbers seq
-    // per session_id, so the real id begins a FRESH space. That 0 is a real
-    // cursor over a buffer we are actively watching — a few events at most.
+  it('does NOT resume for a session re-keyed mid-turn (no cursor = nothing to catch up)', () => {
+    // `renameSession` leaves the real id with NO cursor: the relay numbers seq
+    // per session_id, so the real id begins a FRESH space this tab has never
+    // followed. Handing `reattachSession` a 0 instead would make it ask the
+    // relay for everything from seq 0 — the very full-buffer replay this guard
+    // exists to prevent.
     const h = harness();
     h.state.sessions['prov'] = { session_id: 'prov', node_id: NODE, status: 'running' } as never;
     h.state.lastSeq['prov'] = 7;
@@ -94,7 +98,20 @@ describe('coding bridge session resume cursor', () => {
       from: 'prov',
       to: 'real-1'
     });
+    expect(h.state.lastSeq['real-1']).toBeUndefined();
     h.open('real-1');
-    expect(resumeCalls).toEqual([{ 'real-1': 0 }]);
+    expect(resumeCalls).toEqual([]);
+  });
+
+  it('still resumes a closed session after a reconnect (close must not erase the cursor)', () => {
+    // `session.closed` releases the relay-side log but the session can be written
+    // to again. If the close had dropped our cursor, this reconnect would ask for
+    // nothing and whatever arrived while we were away would be lost with no
+    // truncation notice — a silent hole in the transcript.
+    const h = harness();
+    h.state.lastSeq['closed-then-written'] = 350;
+    h.closed('closed-then-written');
+    h.open('closed-then-written');
+    expect(resumeCalls).toEqual([{ 'closed-then-written': 350 }]);
   });
 });

--- a/src/store/codingBridge/actions.seq.test.ts
+++ b/src/store/codingBridge/actions.seq.test.ts
@@ -50,6 +50,14 @@ const harness = () => {
     dispatched,
     // A (re)connect is what re-opens the window for detecting a renumbered space.
     reconnect: () => commit('clearSeqChecked'),
+    emit: (event: string, extra: Record<string, unknown> = {}) =>
+      applyNodeEvent(
+        commit as never,
+        dispatch as never,
+        state,
+        { event, session_id: SESSION, ...extra } as never,
+        NODE
+      ),
     text: (seq: number, text: string) =>
       applyNodeEvent(
         commit as never,
@@ -136,5 +144,37 @@ describe('coding bridge seq cursor', () => {
     h.text(1, 'after a restart mid-session');
     expect(texts(h.state)).toEqual(['a', 'b', 'after a restart mid-session']);
     expect(h.state.lastSeq[SESSION]).toBe(1);
+  });
+
+  it('re-opens the re-baseline window on session.closed without losing the cursor', () => {
+    // An older relay releases a closed session's log, so its next event starts
+    // over at seq 1 — WITHOUT dropping our socket. The per-connection validation
+    // must go, or the re-baseline never runs and the transcript freezes for good.
+    const h = harness();
+    h.text(1, 'a');
+    h.text(2, 'b');
+    h.emit('session.closed');
+    expect(h.state.seqChecked[SESSION]).toBeUndefined();
+    // The cursor SURVIVES: dropping it would leave a reconnect with nothing to
+    // resume from, silently skipping whatever the closed session emitted while
+    // we were disconnected.
+    expect(h.state.lastSeq[SESSION]).toBe(2);
+    h.text(1, 'reopened');
+    expect(texts(h.state)).toEqual(['a', 'b', 'reopened']);
+  });
+
+  it('clears the cursor on stream_truncated so the resynced session keeps streaming', () => {
+    // The relay tells us our cursor is unreachable. Refetching the transcript
+    // without dropping the cursor leaves it above the events that follow, so the
+    // session would re-freeze the moment the resync lands.
+    const h = harness();
+    h.state.lastSeq[SESSION] = 900;
+    h.state.seqChecked[SESSION] = true;
+    h.emit('session.stream_truncated', { reason: 'cursor_too_old' });
+    expect(h.dispatched).toContain('resyncSession');
+    expect(h.state.lastSeq[SESSION]).toBeUndefined();
+    expect(h.state.seqChecked[SESSION]).toBeUndefined();
+    h.text(3, 'post-resync');
+    expect(texts(h.state)).toEqual(['post-resync']);
   });
 });

--- a/src/store/codingBridge/actions.ts
+++ b/src/store/codingBridge/actions.ts
@@ -349,6 +349,14 @@ export const applyNodeEvent = (
     case CB_EVENT_SESSION_CLOSED:
       commit('finalizeAllStreams', { session_id: sessionId });
       commit('updateSession', { session_id: sessionId, status: 'closed' });
+      // A closed session's relay-side log is released, and an older relay
+      // renumbers its seq space from 1 on the next event — WITHOUT dropping our
+      // socket, so `seqChecked` would keep the re-baseline branch from ever
+      // running and every later event would look already-applied. Clear only the
+      // validation, never the cursor: the first event of a renumbered space then
+      // re-baselines (and resyncs) on its own, while a plain reconnect can still
+      // resume from here instead of silently skipping what it missed.
+      commit('clearSeqCheckedFor', sessionId);
       break;
     case CB_EVENT_SESSION_REWOUND:
       // A past prompt was edited: fold the fork into the transcript by rewinding
@@ -365,7 +373,13 @@ export const applyNodeEvent = (
     case CB_EVENT_SESSION_STREAM_TRUNCATED:
       // The live stream lost events neither relay nor node could retain (cursor
       // too old / outbox overflow). Resync the session from the device transcript
-      // rather than trust the cursor — never a silent gap.
+      // rather than trust the cursor — never a silent gap. Unlike `session.closed`
+      // the cursor really is dropped here, because the relay has just declared it
+      // unreachable: keeping it would re-trigger this same truncation on every
+      // reconnect. Clear the validation too, or a renumbered space arriving on
+      // this still-open connection is dropped before it can re-baseline.
+      commit('resetLastSeq', sessionId);
+      commit('clearSeqCheckedFor', sessionId);
       dispatch('resyncSession', sessionId);
       break;
     case CB_EVENT_SESSIONS_SNAPSHOT:

--- a/src/store/codingBridge/mutations.test.ts
+++ b/src/store/codingBridge/mutations.test.ts
@@ -146,9 +146,11 @@ describe('coding bridge session identity (renameSession)', () => {
     expect(state.sessions['real'].status).toBe('running');
     expect(state.events['prov']).toBeUndefined();
     expect(state.events['real'].map((e) => e.id)).toEqual(['a']);
-    // The real id starts a FRESH relay seq space, so its cursor resets to 0 (not
-    // the provisional id's 7) — otherwise the real id's first events get dropped.
-    expect(state.lastSeq['real']).toBe(0);
+    // The real id starts a FRESH relay seq space, so it carries NO cursor (not
+    // the provisional id's 7) — otherwise the real id's first events get
+    // dropped. Absent, not 0: `reattachSession` treats a 0 as a real cursor and
+    // would ask the relay to replay that session's entire buffer.
+    expect(state.lastSeq['real']).toBeUndefined();
     expect(state.lastSeq['prov']).toBeUndefined();
     expect(state.currentSessionId).toBe('real');
     expect(state.historyRef?.session_id).toBe('real');
@@ -166,6 +168,24 @@ describe('coding bridge session identity (renameSession)', () => {
 
     expect(state.sessions['real'].model).toBe('opus');
     expect(state.events['real'].map((e) => e.id)).toEqual(['live']);
+  });
+
+  it('re-opens the re-baseline window when the real id was already validated', () => {
+    // The real id can already carry a cursor AND a validation from an earlier
+    // life in this tab (reopened history entry whose relay log has since been
+    // LRU-evicted). Its seq space restarts here, so the validation must go —
+    // otherwise `applyNodeEvent` short-circuits on the first low-seq event and
+    // the session never recovers. The cursor stays: the re-baseline needs it to
+    // notice the restart at all.
+    const state = createState();
+    upsertSession(state, session({ session_id: 'prov' }));
+    state.lastSeq['real'] = 120;
+    state.seqChecked['real'] = true;
+
+    renameSession(state, { from: 'prov', to: 'real' });
+
+    expect(state.seqChecked['real']).toBeUndefined();
+    expect(state.lastSeq['real']).toBe(120);
   });
 
   it('is a no-op when ids match or the source is missing', () => {

--- a/src/store/codingBridge/mutations.ts
+++ b/src/store/codingBridge/mutations.ts
@@ -117,11 +117,18 @@ export const renameSession = (state: ICodingBridgeState, payload: { from: string
   // that id begins a FRESH seq space (1, 2, 3…). Inheriting the provisional
   // cursor made the dedup in `applyNodeEvent` drop the real id's first events as
   // "already seen" — e.g. a codex turn's first reply (low seq) silently vanished
-  // while a later turn (higher seq) showed. The real id is brand-new to this tab
-  // at re-key time, so reset its cursor to accept its whole stream.
+  // while a later turn (higher seq) showed. Leave the real id with NO cursor:
+  // it is brand-new to this tab, so it accepts its whole stream, and
+  // `reattachSession` reads absent-cursor as "never followed" and skips the
+  // resume (a cursor of 0 would instead ask the relay for the entire buffer).
   delete state.lastSeq[from];
   delete state.seqChecked[from];
-  state.lastSeq[to] = 0;
+  // `to` may already carry a cursor from an earlier life in this tab (reopened
+  // history entry, LRU-evicted relay log). Its space restarts under us here, so
+  // drop the validation that would otherwise short-circuit the re-baseline in
+  // `applyNodeEvent` and swallow the real id's first events. The cursor itself
+  // stays: the re-baseline needs it to notice the restart at all.
+  delete state.seqChecked[to];
   for (const request of state.permissions) {
     if (request.session_id === from) {
       request.session_id = to;
@@ -197,6 +204,13 @@ export const resetLastSeq = (state: ICodingBridgeState, sessionId: string): void
 // Mark a session's seq space as validated on this connection.
 export const markSeqChecked = (state: ICodingBridgeState, sessionId: string): void => {
   state.seqChecked[sessionId] = true;
+};
+
+// Forget ONE session's validation. Used where that session's seq space is known
+// to restart under us (session.closed) but the socket — and every other
+// session's cursor on it — stays valid.
+export const clearSeqCheckedFor = (state: ICodingBridgeState, sessionId: string): void => {
+  delete state.seqChecked[sessionId];
 };
 
 // Forget every validation. Called on each (re)connect: the relay is
@@ -349,6 +363,7 @@ export default {
   resetLastSeq,
   markSeqChecked,
   clearSeqChecked,
+  clearSeqCheckedFor,
   appendDelta,
   finalizeStream,
   finalizeAllStreams,


### PR DESCRIPTION
## 背景

PR #1441 修好了「打开会话时整段 buffer 从旧到新重放」。合并后我对它做了一轮对抗评审，结果发现**我自己的那版修复引入了两个新缺陷**，加上一个原有的漏网点，一共三个洞。这个 PR 全部补上。

## 三个洞

### 1. `renameSession` 把游标写成 `to: 0`（原有）

relay 的 `seq` 是**按 session_id** 编号的。临时 id 换成 provider 真实 id 时，真实 id 开启一个全新的 seq 空间。原代码写 `state.lastSeq[to] = 0`——**0 是一个真游标**，`reattachSession` 读到它会向 relay 请求「从 0 之后的全部」，正是 #1441 要防的全量重放。

改为**不留游标**。`reattachSession` 把「无游标」读作「本标签页从未跟过这个会话」，直接跳过 resume；实时广播照常送达。

同时清掉 `seqChecked[to]`：真实 id 有可能在本标签页里已有前世（重开的历史条目、被 LRU 淘汰的 relay 日志）并已在本连接被验证过，那么重编号后的第一条低 seq 事件会撞上 `if (state.seqChecked[sessionId]) return;` 被直接吞掉——正是我们要防的失败模式。但 `lastSeq[to]` 要留着：re-baseline 需要它才能察觉到「空间重启了」。

### 2. `session.closed` 清游标 = 静默丢事件（#1441 引入）

我在 #1441 里给 `session.closed` 加了 `resetLastSeq`。但 `onOpen` 是这么攒游标的：

```ts
const cursors = { ...state.lastSeq };
if (Object.keys(cursors).length) socket?.resume(cursors);
```

游标被删 = 下次重连**不为这个会话请求任何补发**。而配上 relay 侧的修复，已关闭的会话完全可以被继续写入（seq 351、352…），那些事件既不会被重放，也不会触发 `stream_truncated`——转录里出现一个**没有任何提示的空洞**。

正确做法：**只清验证标记，不清游标**。

### 3. `stream_truncated` 只清游标不够

这里两个都要清。relay 刚刚明确宣告「你的游标不可达」，留着它会在每次重连重复触发同一次 truncation；而验证标记不清，重编号后的空间在这条**仍然存活的连接**上到达时会被 dedup 吞掉，来不及 re-baseline。

## 关键区分

游标和验证标记职责不同，这是本次修复的中心不变量：

| 场景 | `lastSeq` | `seqChecked` |
|---|---|---|
| `session.closed`（socket 存活，空间可能重启） | **保留** | 清 |
| `stream_truncated`（relay 宣告游标不可达） | 清 | 清 |
| `renameSession`（真实 id 开新空间） | `from` 清 / `to` 保留 | `from`、`to` 都清 |

## 测试

新增 4 条，其中 3 条直接钉住上面三个洞：

- `still resumes a closed session after a reconnect (close must not erase the cursor)`
- `re-opens the re-baseline window on session.closed without losing the cursor`
- `clears the cursor on stream_truncated so the resynced session keeps streaming`
- `re-opens the re-baseline window when the real id was already validated`

`mutations.test.ts` 里那条 `expect(state.lastSeq['real']).toBe(0)` 是把缺陷写进了断言，已改为 `.toBeUndefined()`。

store 全套 **6 files / 54 tests 通过**，`vue-tsc --noEmit` 干净。

## 🤖 对抗评审

用 `codex exec`（gpt-5.5）独立评审 #1441 的已合代码，两条命中意见都逐条回源码核实过，没有照单全收：

| 评审意见 | 核实结果 |
|---|---|
| `session.closed` 的 `resetLastSeq` 造成重连后静默丢事件（HIGH） | **确认** — `onOpen` 的 `cursors = {...state.lastSeq}` 证实，本 PR 洞 2 |
| `renameSession` 没清 `seqChecked[to]`（MEDIUM） | **确认** — 本 PR 洞 1 后半 |
| `resumeCalls` 是模块级变量 → 测试顺序耦合 | **驳回** — `beforeEach` 已有 `resumeCalls.length = 0` |

**变异测试**（每个新守卫都验证过能抓到对应缺陷）：

| 变异 | 结果 |
|---|---|
| `stream_truncated` 不清游标 | 1 failed / 7 passed |
| 恢复 `lastSeq[to] = 0` | 2 failed / 16 passed |
| `session.closed` 不清 `seqChecked` | 1 failed / 53 passed |
| `session.closed` 恢复 `resetLastSeq`（即评审指出的缺陷） | 2 failed / 52 passed |
| 去掉 `delete seqChecked[to]` | 1 failed / 53 passed |

全部恢复后 → 54 passed。

## 关联

配套 relay 修复：https://github.com/AceDataCloud/PlatformService/pull/1729

两者可独立上线：relay 那侧从根上消除重编号；本 PR 是对**旧版 relay**的客户端兼容防护。建议一起合。
