### PR TITLE
feat(chat): 定时任务卡片展示任务 ID，点击可复制

### DIFF
--- a/change/@acedatacloud-nexior-scheduled-task-id-2026-07-29.json
+++ b/change/@acedatacloud-nexior-scheduled-task-id-2026-07-29.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "show the scheduled task id under its name, click to copy",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/pages/chat/ScheduledTasks.test.ts
+++ b/src/pages/chat/ScheduledTasks.test.ts
@@ -15,6 +15,9 @@ import {
 import type { IAuthorizableSkill, IScheduledRun, IScheduledTask } from '@/operators/scheduledTasks';
 import ScheduledTasks from './ScheduledTasks.vue';
 
+const copyToClipboard = vi.hoisted(() => vi.fn());
+vi.mock('copy-to-clipboard', () => ({ default: copyToClipboard }));
+
 const editedTask: IScheduledTask = {
   id: 'task-1',
   name: 'Existing task',
@@ -118,6 +121,20 @@ describe('chat/ScheduledTasks', () => {
 
     expect(wrapper.find('.error-hint').text()).toBe(expected);
     expect(wrapper.text()).not.toContain(errorCode);
+  });
+
+  it('shows the task id on the card and copies it without opening the run drawer', async () => {
+    const wrapper = mountComponent();
+
+    await wrapper.setData({ tasks: [editedTask] });
+
+    const id = wrapper.find('.task-id');
+    expect(id.text()).toBe('task-1');
+
+    await id.trigger('click');
+
+    expect(copyToClipboard).toHaveBeenCalledWith('task-1');
+    expect((wrapper.vm as unknown as { showRunHistory: boolean }).showRunHistory).toBe(false);
   });
 
   it('opens a fresh form when New is clicked after editing a task', async () => {

--- a/src/pages/chat/ScheduledTasks.test.ts
+++ b/src/pages/chat/ScheduledTasks.test.ts
@@ -50,13 +50,14 @@ const errorMessages: Record<string, string> = {
   'chat.scheduledTasks.run.reason.billing_gate_failed': 'Billing authorization failed'
 };
 
-const mountComponent = (credential: { token: string } | null = null) =>
+const mountComponent = (credential: { token: string } | null = null, extraStubs: Record<string, unknown> = {}) =>
   shallowMount(ScheduledTasks, {
     global: {
       stubs: {
         ElCard: { template: '<div><slot /></div>' },
         ElDrawer: { template: '<div><slot /></div>' },
-        ElTag: { template: '<span><slot /></span>' }
+        ElTag: { template: '<span><slot /></span>' },
+        ...extraStubs
       },
       mocks: {
         $t: (key: string) => errorMessages[key] ?? key,
@@ -123,17 +124,22 @@ describe('chat/ScheduledTasks', () => {
     expect(wrapper.text()).not.toContain(errorCode);
   });
 
-  it('shows the task id on the card and copies it without opening the run drawer', async () => {
-    const wrapper = mountComponent();
+  it('labels the task id and copies it without opening the run drawer', async () => {
+    // Render the real CopyToClipboard rather than a stub — the click guard that
+    // keeps the copy from opening the drawer lives inside it. Its button sits in
+    // an ElTooltip slot, so that has to pass its children through too.
+    const wrapper = mountComponent(null, {
+      CopyToClipboard: false,
+      ElTooltip: { template: '<span><slot /></span>' }
+    });
 
     await wrapper.setData({ tasks: [editedTask] });
 
-    const id = wrapper.find('.task-id');
-    expect(id.text()).toBe('task-1');
+    expect(wrapper.find('.task-id-text').text()).toBe('common.entity.id: task-1');
 
-    await id.trigger('click');
+    await wrapper.find('.task-id .icon-copy').trigger('click');
 
-    expect(copyToClipboard).toHaveBeenCalledWith('task-1');
+    expect(copyToClipboard).toHaveBeenCalledWith('task-1', expect.anything());
     expect((wrapper.vm as unknown as { showRunHistory: boolean }).showRunHistory).toBe(false);
   });
 

--- a/src/pages/chat/ScheduledTasks.vue
+++ b/src/pages/chat/ScheduledTasks.vue
@@ -41,15 +41,10 @@
               <div class="task-top">
                 <div class="task-heading">
                   <div class="task-name">{{ task.name }}</div>
-                  <button
-                    type="button"
-                    class="task-id"
-                    :title="$t('common.button.copy')"
-                    :aria-label="$t('common.button.copy')"
-                    @click.stop="copyId(task.id)"
-                  >
-                    {{ task.id }}
-                  </button>
+                  <div class="task-id">
+                    <span class="task-id-text">{{ $t('common.entity.id') }}: {{ task.id }}</span>
+                    <copy-to-clipboard :content="task.id" class="inline-block shrink-0" />
+                  </div>
                 </div>
                 <div class="task-actions" @click.stop>
                   <el-switch
@@ -236,15 +231,10 @@
       class="run-history-drawer"
     >
       <div v-if="selectedTask" class="run-context">
-        <button
-          type="button"
-          class="task-id run-context-id"
-          :title="$t('common.button.copy')"
-          :aria-label="$t('common.button.copy')"
-          @click="copyId(selectedTask.id)"
-        >
-          {{ selectedTask.id }}
-        </button>
+        <div class="task-id run-context-id">
+          <span class="task-id-text">{{ $t('common.entity.id') }}: {{ selectedTask.id }}</span>
+          <copy-to-clipboard :content="selectedTask.id" class="inline-block shrink-0" />
+        </div>
         <div class="run-context-meta">
           <span>{{ scheduleLabel(selectedTask.schedule) }}</span>
           <span>{{ selectedTask.template.model }}</span>
@@ -524,7 +514,7 @@
 
 <script lang="ts">
 import { AiIcon, ExpandRightIcon, PlayIcon, TimeIcon } from '@acedatacloud/core/icons/components';
-import copyToClipboard from 'copy-to-clipboard';
+import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 import { defineComponent } from 'vue';
 import {
   ElButton,
@@ -648,7 +638,8 @@ export default defineComponent({
     ElRadio,
     ElTimePicker,
     ElInputNumber,
-    Pagination
+    Pagination,
+    CopyToClipboard
   },
   data() {
     return {
@@ -1383,10 +1374,6 @@ export default defineComponent({
         ElMessage.error(this.$t('chat.scheduledTasks.loadError') as string);
       }
     },
-    copyId(id: string) {
-      copyToClipboard(id);
-      ElMessage.success(this.$t('common.message.copied') as string);
-    },
     async triggerNow(task: IScheduledTask) {
       if (this.triggeringId) return;
       this.triggeringId = task.id;
@@ -1636,21 +1623,18 @@ export default defineComponent({
   word-break: break-word;
 }
 .task-id {
-  display: block;
+  display: flex;
+  align-items: center;
   margin-top: 3px;
-  padding: 0;
-  border: none;
-  background: none;
   font-family: var(--el-font-family-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
   font-size: 11px;
   line-height: 1.4;
   color: var(--el-text-color-placeholder);
-  word-break: break-all;
-  text-align: left;
-  cursor: pointer;
 }
-.task-id:hover {
-  color: var(--el-color-primary);
+.task-id-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .task-actions {
   display: flex;

--- a/src/pages/chat/ScheduledTasks.vue
+++ b/src/pages/chat/ScheduledTasks.vue
@@ -39,7 +39,18 @@
               @click="selectTask(task)"
             >
               <div class="task-top">
-                <div class="task-name">{{ task.name }}</div>
+                <div class="task-heading">
+                  <div class="task-name">{{ task.name }}</div>
+                  <button
+                    type="button"
+                    class="task-id"
+                    :title="$t('common.button.copy')"
+                    :aria-label="$t('common.button.copy')"
+                    @click.stop="copyId(task.id)"
+                  >
+                    {{ task.id }}
+                  </button>
+                </div>
                 <div class="task-actions" @click.stop>
                   <el-switch
                     :model-value="task.state === 'enabled'"
@@ -225,6 +236,15 @@
       class="run-history-drawer"
     >
       <div v-if="selectedTask" class="run-context">
+        <button
+          type="button"
+          class="task-id run-context-id"
+          :title="$t('common.button.copy')"
+          :aria-label="$t('common.button.copy')"
+          @click="copyId(selectedTask.id)"
+        >
+          {{ selectedTask.id }}
+        </button>
         <div class="run-context-meta">
           <span>{{ scheduleLabel(selectedTask.schedule) }}</span>
           <span>{{ selectedTask.template.model }}</span>
@@ -504,6 +524,7 @@
 
 <script lang="ts">
 import { AiIcon, ExpandRightIcon, PlayIcon, TimeIcon } from '@acedatacloud/core/icons/components';
+import copyToClipboard from 'copy-to-clipboard';
 import { defineComponent } from 'vue';
 import {
   ElButton,
@@ -1362,6 +1383,10 @@ export default defineComponent({
         ElMessage.error(this.$t('chat.scheduledTasks.loadError') as string);
       }
     },
+    copyId(id: string) {
+      copyToClipboard(id);
+      ElMessage.success(this.$t('common.message.copied') as string);
+    },
     async triggerNow(task: IScheduledTask) {
       if (this.triggeringId) return;
       this.triggeringId = task.id;
@@ -1600,12 +1625,32 @@ export default defineComponent({
   gap: 12px;
   margin-bottom: 10px;
 }
+.task-heading {
+  min-width: 0;
+}
 .task-name {
   font-weight: 600;
   font-size: 16px;
   line-height: 1.4;
   color: var(--el-text-color-primary);
   word-break: break-word;
+}
+.task-id {
+  display: block;
+  margin-top: 3px;
+  padding: 0;
+  border: none;
+  background: none;
+  font-family: var(--el-font-family-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 11px;
+  line-height: 1.4;
+  color: var(--el-text-color-placeholder);
+  word-break: break-all;
+  text-align: left;
+  cursor: pointer;
+}
+.task-id:hover {
+  color: var(--el-color-primary);
 }
 .task-actions {
   display: flex;
@@ -1720,6 +1765,9 @@ export default defineComponent({
   gap: 8px;
   font-size: 12px;
   color: var(--el-text-color-secondary);
+}
+.run-context-id {
+  margin: 0 0 6px;
 }
 .run-context-meta span + span::before {
   content: '·';


### PR DESCRIPTION
## 背景

定时任务列表里只显示任务名。排查问题、查 CLS 日志、调 API 时都需要任务 ID，但页面上拿不到，只能去后台翻。

## 改动

- 任务卡片标题下方新增一行小号等宽灰字显示 `task.id`
- 运行记录抽屉的上下文区同样展示 ID
- 点击 ID 复制到剪贴板（`copy-to-clipboard`，与代码块复制同一实现），弹 `common.message.copied`
- `@click.stop` 阻止冒泡，避免点复制时误开运行记录抽屉

复用了已有的 `common.button.copy` / `common.message.copied` 文案，17 个语言均已存在，无需新增 i18n key。

## 验证

- `vitest run src/pages/chat/ScheduledTasks.test.ts` — 56 passed（新增 1 条：断言 ID 渲染 + 复制被调用 + 抽屉未打开）
- 变异测试：去掉 `.stop` 后新测试失败，确认这条护栏有效
- `eslint` + `vue-tsc --noEmit` 均干净
- 静态样式预览截图确认 ID 不抢视觉、长 UUID 换行正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)