### PR TITLE
fix(chat): 修复聊天引用块间距被懒加载 CSS 覆盖

### DIFF
--- a/change/@acedatacloud-nexior-7163a863-7f77-452d-861e-18ac8a4b85c4.json
+++ b/change/@acedatacloud-nexior-7163a863-7f77-452d-861e-18ac8a4b85c4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(chat): restore blockquote spacing overridden by lazy-loaded github-markdown-css",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/assets/scss/_markdown.scss
+++ b/src/assets/scss/_markdown.scss
@@ -86,9 +86,11 @@
     font-size: 14px !important;
     border-left: 3px solid var(--el-color-primary) !important;
     background-color: var(--el-color-primary-light-9);
-    padding: 12px 16px !important;
+    // github-markdown-css ships in a lazily-loaded chunk that lands AFTER
+    // this file, so its `blockquote { margin: 0 }` wins without !important.
+    margin: 16px 0 !important;
+    padding: 16px 20px !important;
     border-radius: 0 8px 8px 0;
-    margin: 16px 0;
   }
 
   a {


### PR DESCRIPTION
## 问题

用户反馈聊天里 markdown 引用块（`>` blockquote）上下间距过小、内边距偏挤。

## 根因

`github-markdown-css` 是在 `MarkdownRenderer.vue` 的 `<style>` 里 `@import` 的，Vite 因此把它打进**懒加载的 `Message` chunk**，加载顺序晚于入口 `app.css`。两者选择器权重相同（`.markdown-body blockquote`，0,0,1,1），**后加载者胜出**：

| 声明 | 来源 | 是否生效 |
|---|---|---|
| `margin: 16px 0` | `_markdown.scss`（先加载） | ❌ 被覆盖 |
| `margin: 0` | `github-markdown-css`（后加载） | ✅ 实际生效 |
| `padding: 12px 16px !important` | `_markdown.scss` | ✅ 靠 `!important` 存活 |

同文件里 `padding` / `border-left` / `color` 都带 `!important` 所以没事，**唯独 `margin` 没写**，于是被静默吃掉。

线上实测（Chrome 加载生产 `app-B96mS-VB.css` + `Message-CfavcneZ.css`）：

```
blockquote.marginTop  = 0px      ← 源码写的是 16px
blockquote.marginBottom = 16px   ← 来自 github-markdown-css 自己的 --base-size-16
```

`margin-bottom` 恰好也是 16px 纯属巧合（GitHub 的默认值），所以只有**顶部**看起来紧贴，视觉上非常割裂。

## 修复

```scss
margin: 16px 0 !important;   // 补回被覆盖的 margin
padding: 16px 20px !important;  // 12px 16px → 16px 20px
```

## 验证

用**真实构建产物**验证（本地 build 出的 `Message` chunk hash `CfavcneZ` 与生产完全一致，确认复现环境无偏差），markdown 由 Nexior 自己的 markdown-it 管线渲染：

| 指标 | 修复前 | 修复后 |
|---|---|---|
| `margin-top` | `0px` | `16px` |
| `padding` | `12px 16px` | `16px 20px` |
| 与上一段间距 | 16px（仅靠 `p` 的 margin） | 16px + 16px |

已确认 `.think` 块无同类冲突（`github-markdown-css` 不含该选择器），无需改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)