### PR TITLE
fix(types): 数字参数 setter 的类型标注改回 number

### DIFF
--- a/change/@acedatacloud-nexior-09dd859d-e2b8-4c4f-88c3-f8d6aa671580.json
+++ b/change/@acedatacloud-nexior-09dd859d-e2b8-4c4f-88c3-f8d6aa671580.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "kling/flux/pixverse: 数字参数 setter 的类型标注改回 number",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/flux/config/QualitySelector.vue
+++ b/src/components/flux/config/QualitySelector.vue
@@ -33,7 +33,7 @@ export default defineComponent({
       get() {
         return this.$store.state.flux.config?.quality;
       },
-      set(val: string) {
+      set(val: number) {
         console.debug('set quality', val);
         this.$store.commit('flux/setConfig', {
           ...this.$store.state.flux.config,

--- a/src/components/kling/config/CfgScaleSelector.vue
+++ b/src/components/kling/config/CfgScaleSelector.vue
@@ -33,7 +33,7 @@ export default defineComponent({
       get() {
         return this.$store.state?.kling?.config?.cfg_scale;
       },
-      set(val: string) {
+      set(val: number) {
         console.debug('set cfg_scale', val);
         this.$store.commit('kling/setConfig', {
           ...this.$store.state?.kling?.config,

--- a/src/components/pixverse/config/DurationSelector.vue
+++ b/src/components/pixverse/config/DurationSelector.vue
@@ -44,7 +44,7 @@ export default defineComponent({
       get() {
         return this.$store.state.pixverse?.config?.duration;
       },
-      set(val: string) {
+      set(val: number) {
         this.$store.commit('pixverse/setConfig', {
           ...this.$store.state.pixverse.config,
           duration: val

--- a/src/components/pixverse/config/SeedSelector.vue
+++ b/src/components/pixverse/config/SeedSelector.vue
@@ -32,7 +32,7 @@ export default defineComponent({
       get() {
         return this.$store.state?.pixverse?.config?.seed;
       },
-      set(val: string) {
+      set(val: number) {
         console.debug('set seed', val);
         this.$store.commit('pixverse/setConfig', {
           ...this.$store.state?.pixverse?.config,


### PR DESCRIPTION
## 背景

排查 [PlatformFrontend #989](https://github.com/AceDataCloud/PlatformFrontend/pull/989)（调试表单把 `integer` 参数当字符串发出去）时，顺带全量审计了 Nexior 有没有同类问题。

**结论：Nexior 没有这个 bug。** 但审计过程中发现四处误导性的类型标注，本 PR 修掉它们。

## 审计结论（供参考）

Nexior 免疫，而且是**结构性**的，不是运气：

- 全仓 `<el-input type="number">` **零occurrence** —— 这是 Element Plus 的经典陷阱（它仍然发出字符串）
- 89 处 `<el-input>` 全部喂真字符串字段（prompt / title / style / url / lyric / negative_prompt …）
- 数字参数一律走 `el-input-number`（+ 可选 `el-slider`），枚举型数字走 `el-select` 且选项是**未加引号的数字字面量**
- 唯一用 `<el-input>` 喂数字参数的地方（qrart `seed`）显式 `parseInt` 了
- 各服务 `persist.ts` 只持久化 `credential`/`application`，**不持久化 `config`** —— 数字参数每次都从数字常量重建，不经过 localStorage 的 JSON 往返

## 本 PR 改什么

四个 setter 标注成 `set(val: string)`，但绑定的控件发出的是 `number`：

| 组件 | 参数 | 实际控件 |
|---|---|---|
| kling `CfgScaleSelector` | `cfg_scale` | `el-input-number` + `el-slider` |
| flux `QualitySelector` | `quality` | `el-input-number` + `el-slider` |
| pixverse `SeedSelector` | `seed` | `el-input-number` + `el-slider` |
| pixverse `DurationSelector` | `duration` | 数字 `el-option`（`5` / `8`） |

值流进无类型的 `$store.commit` 载荷，所以 TS 一直没报错 —— 是个不会触发的谎。

**为什么值得修**：

1. 它误导审计。排查「数字参数被当成字符串」这类问题时，得逐个打开控件才能排除 —— 这次正是被这四处拖慢的。
2. 它削弱防线。`pages/pixverse/Index.vue` 是 `{ ...this.config, async: true }` 裸 spread 进请求体，`baseTaskOperator.generate()` 也是 `axios.post(path, data)` 无转换层 —— **store 与网络之间没有任何归一化**，setter 就是唯一的把关处。标注错了等于把关失效：将来谁把控件换成 `el-input`，TS 不会拦。

## 复核范围

除审计点名的四处，我另外筛出 8 个「含 `el-input-number`/`el-slider` 且写了 `set(val: string)`」的组件逐个确认，它们对应的都是**真字符串**字段（`styleNegative`、`lyricPrompt`、`waitForSelector`、camera type、`prompt`、`langs`、`"1024x1024"`）或 `el-input` + `parseInt`（`continue_at`），标注正确，**未改动**。

## 验证

- `npx vue-tsc --noEmit` 通过 —— 这本身就是证据：若这四处实际收到的是 `string`，改标注后必然报错
- `npx eslint` 通过

纯类型标注修正，无运行时行为变化。

🤖 Generated with [Claude Code](https://claude.com/claude-code)