### PR TITLE
fix(desktop): surface MCP tool image results to the model

### DIFF
--- a/change/@acedatacloud-nexior-eed4ae25-bb3a-4d8f-8469-157cfaf2f305.json
+++ b/change/@acedatacloud-nexior-eed4ae25-bb3a-4d8f-8469-157cfaf2f305.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "desktop: surface MCP tool image results to the model instead of burying them in JSON",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/electron/local/mcp.test.ts
+++ b/electron/local/mcp.test.ts
@@ -33,24 +33,43 @@ describe('windowsNodeDirs', () => {
 // it, and it then claims to have shown a picture that was never displayed.
 describe('mapCallResult', () => {
   const img = (over: Record<string, unknown> = {}) => ({ type: 'image', data: 'AAAA', mimeType: 'image/png', ...over });
+  const texts = (r: { output: string }) => (JSON.parse(r.output) as { text?: string }[]).map((b) => b.text);
 
   it('lifts an image block into `image` as a data URL', () => {
-    const r = mapCallResult({ content: [{ type: 'text', text: 'scan me' }, img()] });
-    expect(r.image).toBe('data:image/png;base64,AAAA');
+    expect(mapCallResult({ content: [{ type: 'text', text: 'scan me' }, img()] }).image).toBe('data:image/png;base64,AAAA');
   });
 
-  it('keeps the non-image blocks in output and drops the lifted image', () => {
+  it('keeps other blocks and replaces the lifted image with a short note', () => {
     const r = mapCallResult({ content: [{ type: 'text', text: 'scan me' }, img()] });
-    expect(JSON.parse(r.output)).toEqual([{ type: 'text', text: 'scan me' }]);
-    expect(r.output).not.toContain('AAAA'); // no base64 blob left in the text channel
+    expect(texts(r)).toEqual(['scan me', '[image returned separately and shown to you]']);
+    expect(r.output).not.toContain('AAAA'); // base64 not duplicated into the text channel
   });
 
   it('defaults a missing mimeType to image/png', () => {
     expect(mapCallResult({ content: [img({ mimeType: undefined })] }).image).toBe('data:image/png;base64,AAAA');
   });
 
-  it('honours a non-png mimeType', () => {
-    expect(mapCallResult({ content: [img({ mimeType: 'image/jpeg' })] }).image).toBe('data:image/jpeg;base64,AAAA');
+  it.each(['image/jpeg', 'image/jpg', 'image/webp'])('lifts %s (accepted by the worker)', (mime) => {
+    expect(mapCallResult({ content: [img({ mimeType: mime })] }).image).toBe(`data:${mime};base64,AAAA`);
+  });
+
+  // REGRESSION GUARD: the worker's isValidResultImage only accepts
+  // png/jpeg/webp. Lifting anything else means the worker silently drops it
+  // while we have already removed it from `output` — the image vanishes
+  // entirely, which is worse than not lifting at all.
+  it.each(['image/gif', 'image/svg+xml', 'image/bmp'])('does NOT lift %s the worker would reject', (mime) => {
+    const r = mapCallResult({ content: [img({ mimeType: mime })] });
+    expect(r.image).toBeUndefined();
+    expect(texts(r)).toEqual([`[image not shown: unsupported type ${mime} (expected png/jpeg/webp)]`]);
+  });
+
+  it('falls through to a later liftable image when the first is unsupported', () => {
+    const r = mapCallResult({ content: [img({ mimeType: 'image/gif' }), img({ data: 'BBBB' })] });
+    expect(r.image).toBe('data:image/png;base64,BBBB');
+    expect(texts(r)).toEqual([
+      '[image not shown: unsupported type image/gif (expected png/jpeg/webp)]',
+      '[image returned separately and shown to you]'
+    ]);
   });
 
   it('leaves text-only results untouched', () => {
@@ -59,15 +78,26 @@ describe('mapCallResult', () => {
     expect(JSON.parse(r.output)).toEqual([{ type: 'text', text: 'hi' }]);
   });
 
-  it('drops an over-budget image rather than blowing the turn budget', () => {
+  it('reports an over-budget image instead of silently dropping it', () => {
     const r = mapCallResult({ content: [img({ data: 'x'.repeat(5_400_001) })] });
     expect(r.image).toBeUndefined();
-    expect(JSON.parse(r.output)).toHaveLength(1); // still reported as text
+    expect(texts(r)).toEqual(['[image not shown: too large to send]']);
+    expect(r.output.length).toBeLessThan(200); // the blob is gone, not inlined
   });
 
   it('ignores an image block with no data', () => {
-    const r = mapCallResult({ content: [{ type: 'image', mimeType: 'image/png' }] });
-    expect(r.image).toBeUndefined();
+    expect(mapCallResult({ content: [{ type: 'image', mimeType: 'image/png' }] }).image).toBeUndefined();
+  });
+
+  // audio / resource / resource_link have no channel to the model today, so
+  // they must pass through untouched rather than be mangled.
+  it('passes non-image block types through unchanged', () => {
+    const blocks = [
+      { type: 'audio', data: 'ZZZZ', mimeType: 'audio/wav' },
+      { type: 'resource_link', uri: 'https://example.com/a.pdf' }
+    ];
+    const r = mapCallResult({ content: blocks });
+    expect(JSON.parse(r.output)).toEqual(blocks);
   });
 
   it('propagates isError and tolerates a non-array content', () => {

--- a/electron/local/mcp.test.ts
+++ b/electron/local/mcp.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { windowsNodeDirs } from './mcp';
+import { windowsNodeDirs, mapCallResult } from './mcp';
 
 // A GUI-launched Windows app can inherit a stale PATH without the Node dir;
 // resolveEnhancedPath() appends these standard install dirs so a bare `node` /
@@ -23,5 +23,56 @@ describe('windowsNodeDirs', () => {
   it('skips any env var that is unset', () => {
     expect(windowsNodeDirs({ ProgramFiles: 'C:\\Program Files' } as NodeJS.ProcessEnv)).toEqual(['C:\\Program Files\\nodejs']);
     expect(windowsNodeDirs({} as NodeJS.ProcessEnv)).toEqual([]);
+  });
+});
+
+// An MCP tool can return an image block (xiaohongshu-mcp's login QR code, a
+// browser screenshot). It has to reach the model through `image` — the same
+// channel computer.screenshot uses. Serialized into `output` it is just a
+// base64 blob inside a JSON string: nothing renders it, the model never sees
+// it, and it then claims to have shown a picture that was never displayed.
+describe('mapCallResult', () => {
+  const img = (over: Record<string, unknown> = {}) => ({ type: 'image', data: 'AAAA', mimeType: 'image/png', ...over });
+
+  it('lifts an image block into `image` as a data URL', () => {
+    const r = mapCallResult({ content: [{ type: 'text', text: 'scan me' }, img()] });
+    expect(r.image).toBe('data:image/png;base64,AAAA');
+  });
+
+  it('keeps the non-image blocks in output and drops the lifted image', () => {
+    const r = mapCallResult({ content: [{ type: 'text', text: 'scan me' }, img()] });
+    expect(JSON.parse(r.output)).toEqual([{ type: 'text', text: 'scan me' }]);
+    expect(r.output).not.toContain('AAAA'); // no base64 blob left in the text channel
+  });
+
+  it('defaults a missing mimeType to image/png', () => {
+    expect(mapCallResult({ content: [img({ mimeType: undefined })] }).image).toBe('data:image/png;base64,AAAA');
+  });
+
+  it('honours a non-png mimeType', () => {
+    expect(mapCallResult({ content: [img({ mimeType: 'image/jpeg' })] }).image).toBe('data:image/jpeg;base64,AAAA');
+  });
+
+  it('leaves text-only results untouched', () => {
+    const r = mapCallResult({ content: [{ type: 'text', text: 'hi' }] });
+    expect(r.image).toBeUndefined();
+    expect(JSON.parse(r.output)).toEqual([{ type: 'text', text: 'hi' }]);
+  });
+
+  it('drops an over-budget image rather than blowing the turn budget', () => {
+    const r = mapCallResult({ content: [img({ data: 'x'.repeat(5_400_001) })] });
+    expect(r.image).toBeUndefined();
+    expect(JSON.parse(r.output)).toHaveLength(1); // still reported as text
+  });
+
+  it('ignores an image block with no data', () => {
+    const r = mapCallResult({ content: [{ type: 'image', mimeType: 'image/png' }] });
+    expect(r.image).toBeUndefined();
+  });
+
+  it('propagates isError and tolerates a non-array content', () => {
+    expect(mapCallResult({ content: [img()], isError: true }).is_error).toBe(true);
+    expect(mapCallResult({}).output).toBe('""');
+    expect(mapCallResult({ content: 'plain' }).output).toBe('"plain"');
   });
 });

--- a/electron/local/mcp.ts
+++ b/electron/local/mcp.ts
@@ -13,11 +13,19 @@ const STARTUP_TIMEOUT_MS = 60_000;
 // image budget (~6 MB of base64). An MCP image over budget is dropped from the
 // `image` channel and left as text in `output` rather than blowing up the turn.
 const MAX_IMAGE_B64_CHARS = 5_400_000;
+// The aichat2 worker only accepts these in a tool result's `image`
+// (isValidResultImage in handlers/conversations.ts). Lifting anything else
+// would be WORSE than doing nothing: the worker drops it silently AND we would
+// have already removed it from `output` — the image vanishes with no trace.
+// Keep this in sync with the worker's regex.
+const LIFTABLE_IMAGE_MIME = /^image\/(png|jpe?g|webp)$/;
 
 interface Pending { resolve: (v: unknown) => void; reject: (e: Error) => void; timer: NodeJS.Timeout; }
 
 // One block of an MCP `tools/call` result. Only `image` needs special handling;
-// everything else is serialized into `output` as before.
+// everything else is serialized into `output` as before. MCP also defines
+// `audio`, `resource` and `resource_link` blocks — those have no channel to the
+// model today (ToolResult carries an image only), so they stay in `output`.
 interface McpContentBlock {
   type?: string;
   data?: string;
@@ -25,17 +33,35 @@ interface McpContentBlock {
   [k: string]: unknown;
 }
 
+// Why a block could not be lifted, so `output` can say so instead of the image
+// disappearing without explanation (which is what made the model claim it had
+// displayed a QR code that was never there).
+function liftBlocker(b: McpContentBlock): string | null {
+  const mime = b.mimeType || 'image/png';
+  if (!LIFTABLE_IMAGE_MIME.test(mime)) return `unsupported type ${mime} (expected png/jpeg/webp)`;
+  if ((b.data?.length ?? 0) > MAX_IMAGE_B64_CHARS) return 'too large to send';
+  return null;
+}
+
 // Map an MCP `tools/call` result to a ToolResult. Exported for tests.
-// Lifts the first image block into `image` (the same channel
+// Lifts the first liftable image block into `image` (the same channel
 // computer.screenshot uses) so the model actually SEES it. Left inside
 // `output` it was only a base64 blob in a JSON string: unrenderable, and the
 // model would claim to have shown a picture it never received.
 export function mapCallResult(r: { content?: unknown; isError?: boolean }): ToolResult {
   const blocks = Array.isArray(r.content) ? (r.content as McpContentBlock[]) : [];
-  const img = blocks.find((b) => b?.type === 'image' && typeof b.data === 'string');
-  const image =
-    img && img.data!.length <= MAX_IMAGE_B64_CHARS ? `data:${img.mimeType || 'image/png'};base64,${img.data}` : undefined;
-  const rest = image ? blocks.filter((b) => b !== img) : blocks;
+  const images = blocks.filter((b) => b?.type === 'image' && typeof b.data === 'string');
+  const img = images.find((b) => liftBlocker(b) === null);
+  const image = img ? `data:${img.mimeType || 'image/png'};base64,${img.data}` : undefined;
+  // Replace every image block with a short note: the lifted one is already in
+  // `image` (no need to repeat 5 MB of base64 in the text channel), and a
+  // non-liftable one must not silently vanish — the model should know an image
+  // exists that it cannot see, rather than assume it was shown.
+  const rest = blocks.map((b) => {
+    if (!images.includes(b)) return b;
+    if (b === img) return { type: 'text', text: '[image returned separately and shown to you]' };
+    return { type: 'text', text: `[image not shown: ${liftBlocker(b)}]` };
+  });
   return {
     output: JSON.stringify(Array.isArray(r.content) ? rest : (r.content ?? '')),
     is_error: !!r.isError,

--- a/electron/local/mcp.ts
+++ b/electron/local/mcp.ts
@@ -9,8 +9,39 @@ const RPC_TIMEOUT_MS = 30_000;
 // slow machine can take far longer than RPC_TIMEOUT_MS just to boot Node + its
 // deps before it answers — a first-boot timeout would strand it as `failed`.
 const STARTUP_TIMEOUT_MS = 60_000;
+// Mirrors the cap in computer.ts: stay under the aichat2 worker's tool-result
+// image budget (~6 MB of base64). An MCP image over budget is dropped from the
+// `image` channel and left as text in `output` rather than blowing up the turn.
+const MAX_IMAGE_B64_CHARS = 5_400_000;
 
 interface Pending { resolve: (v: unknown) => void; reject: (e: Error) => void; timer: NodeJS.Timeout; }
+
+// One block of an MCP `tools/call` result. Only `image` needs special handling;
+// everything else is serialized into `output` as before.
+interface McpContentBlock {
+  type?: string;
+  data?: string;
+  mimeType?: string;
+  [k: string]: unknown;
+}
+
+// Map an MCP `tools/call` result to a ToolResult. Exported for tests.
+// Lifts the first image block into `image` (the same channel
+// computer.screenshot uses) so the model actually SEES it. Left inside
+// `output` it was only a base64 blob in a JSON string: unrenderable, and the
+// model would claim to have shown a picture it never received.
+export function mapCallResult(r: { content?: unknown; isError?: boolean }): ToolResult {
+  const blocks = Array.isArray(r.content) ? (r.content as McpContentBlock[]) : [];
+  const img = blocks.find((b) => b?.type === 'image' && typeof b.data === 'string');
+  const image =
+    img && img.data!.length <= MAX_IMAGE_B64_CHARS ? `data:${img.mimeType || 'image/png'};base64,${img.data}` : undefined;
+  const rest = image ? blocks.filter((b) => b !== img) : blocks;
+  return {
+    output: JSON.stringify(Array.isArray(r.content) ? rest : (r.content ?? '')),
+    is_error: !!r.isError,
+    ...(image ? { image } : {})
+  };
+}
 
 // A GUI-launched Electron app (Finder / Dock / Start menu) inherits a stripped
 // PATH — it does NOT source the user's shell profile — so `npx` / `node` /
@@ -163,7 +194,7 @@ export class McpHost {
 
   async call(server: string, tool: string, input: Record<string, unknown>): Promise<ToolResult> {
     const r = (await this.rpc(server, 'tools/call', { name: tool, arguments: input })) as { content?: unknown; isError?: boolean };
-    return { output: JSON.stringify(r.content ?? ''), is_error: !!r.isError };
+    return mapCallResult(r);
   }
 
   stopAll(): void {


### PR DESCRIPTION
## Problem

`McpHost.call` serialized the **entire** `tools/call` content array into `output`:

```ts
return { output: JSON.stringify(r.content ?? ''), is_error: !!r.isError };
```

An MCP tool that returns an image (a QR code, a browser screenshot) therefore delivered it as a base64 blob inside a JSON string. Nothing renders that, and the model never receives the picture — so it confidently reports having shown one. `ToolResult` has had an `image` field all along; only the builtin `computer.screenshot` path was using it.

### Reproduced

With `xiaohongshu-mcp`'s `get_login_qrcode`, the server returns two blocks:

```
content 块数: 2
 - type=text  text=请用小红书 App 在 … 前扫码登录 👇
 - type=image mimeType=image/png data长度=5856
```

In the app the chat said **"二维码已显示在上方"** and there was no QR code anywhere — login was impossible through the client.

## Change

Lift the first **liftable** image block into `ToolResult.image` as a data URL (the same channel `computer.screenshot` uses).

**Liftable is gated on png/jpeg/webp — the exact set the aichat2 worker's `isValidResultImage` accepts.** This matters: passing the MCP-reported `mimeType` through verbatim meant an `image/gif` would be built into a data URL, silently dropped by the worker, and — since the block was already removed from `output` — vanish entirely. That is *worse* than the original bug, which at least left the base64 in the text channel. If the first image is not liftable we fall through to a later one.

Every image block is replaced in `output` by a short note: the lifted one says it was shown, a non-liftable one says why it was not (`[image not shown: unsupported type image/gif (expected png/jpeg/webp)]`). An image the model cannot see is now *stated* rather than absent — the same root cause that let it assert a QR code had been displayed.

`audio` / `resource` / `resource_link` have no channel to the model today (`ToolResult` carries an image only), so they pass through untouched, with a test pinning that so a future change is deliberate.

## Testing

- `electron/local/` — 36 tests pass (17 for this mapping).
- **Mutation-tested all three guards**: restoring the original one-liner fails 1; suppressing the `image` field fails 3; widening the mime whitelist to `^image/` fails 4; replacing the "not shown" note with an empty string fails 5.
- **Cross-checked the whitelist against the live worker** — extracted the regex from `PlatformService/aichat2/worker/src/handlers/conversations.ts` and compared mime sets programmatically: exact match.
- `tsc -p electron` clean.
- **Verified in the running app** against the real MCP server.

## Follow-up (not in this PR)

Only one image is lifted per call; a tool returning several still reports the extras as notes. Multi-image support needs a `ToolResult` shape change (`images[]`) plus worker support, so it is deliberately out of scope.
