### PR TITLE
feat(openaiimage): 参考图上限从 5 张放开到 16 张

### DIFF
--- a/change/@acedatacloud-nexior-3f8b21c4-7d16-4a92-b5e3-9c40a1f7d882.json
+++ b/change/@acedatacloud-nexior-3f8b21c4-7d16-4a92-b5e3-9c40a1f7d882.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "openaiimage: raise the reference-image ceiling from 5 to 16 to match the upstream limit",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/openaiimage/config/ImageUrlsInput.vue
+++ b/src/components/openaiimage/config/ImageUrlsInput.vue
@@ -11,7 +11,7 @@
         accept=".png,.jpg,.jpeg,.gif,.bmp,.webp"
         name="file"
         class="value shrink-0"
-        :limit="5"
+        :limit="maxImages"
         :multiple="true"
         :show-file-list="false"
         :action="uploadUrl"
@@ -49,6 +49,7 @@ import { getBaseUrlPlatform, uploadTrackerMixin } from '@/utils';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import ImagePreview from '@/components/common/ImagePreview.vue';
 import { pasteUploadMixin, dropUploadMixin } from '@/utils';
+import { OPENAIIMAGE_MAX_REFERENCE_IMAGES } from '@/constants/openaiimage';
 
 interface IData {
   fileList: UploadFiles;
@@ -76,6 +77,9 @@ export default defineComponent({
     };
   },
   computed: {
+    maxImages(): number {
+      return OPENAIIMAGE_MAX_REFERENCE_IMAGES;
+    },
     headers() {
       return {
         Authorization: `Bearer ${this.$store.state.token.access}`
@@ -163,7 +167,7 @@ export default defineComponent({
       this.onSetImageUrls();
     },
     onExceed() {
-      ElMessage.warning(this.$t('openaiimage.message.uploadImageExceed'));
+      ElMessage.warning(this.$t('openaiimage.message.uploadImageExceed', { count: OPENAIIMAGE_MAX_REFERENCE_IMAGES }));
     },
     onError() {
       ElMessage.error(this.$t('openaiimage.message.uploadImageError'));

--- a/src/constants/openaiimage.ts
+++ b/src/constants/openaiimage.ts
@@ -12,6 +12,10 @@ export const OPENAIIMAGE_MODEL_GPT_IMAGE_2_OFFICIAL = 'gpt-image-2:official';
 
 export const OPENAIIMAGE_DEFAULT_MODEL = OPENAIIMAGE_MODEL_GPT_IMAGE_2;
 
+// Reference images accepted by /openai/images/edits. 16 is the upstream limit
+// (and what our OpenAPI documents), not a UI-side preference.
+export const OPENAIIMAGE_MAX_REFERENCE_IMAGES = 16;
+
 // Common 1K presets (shared across all models)
 export const OPENAIIMAGE_SIZE_1024 = '1024x1024';
 export const OPENAIIMAGE_SIZE_1536_1024 = '1536x1024';

--- a/src/i18n/ar/openaiimage.json
+++ b/src/i18n/ar/openaiimage.json
@@ -112,7 +112,7 @@
     "description": "وصف معلمة النموذج"
   },
   "description.imageUrls": {
-    "message": "قم بتحميل 1-5 صور مرجعية للدخول في وضع التحرير.",
+    "message": "قم بتحميل 1-16 صور مرجعية للدخول في وضع التحرير.",
     "description": "وصف معلمة image_urls"
   },
   "status.pending": {
@@ -156,7 +156,7 @@
     "description": "رسالة نفاد النقاط"
   },
   "message.uploadImageExceed": {
-    "message": "يمكنك تحميل ما يصل إلى 5 صور",
+    "message": "يمكنك تحميل ما يصل إلى {count} صور",
     "description": "تجاوز عدد الصور الحد المسموح به"
   },
   "message.uploadImageError": {

--- a/src/i18n/de/openaiimage.json
+++ b/src/i18n/de/openaiimage.json
@@ -112,7 +112,7 @@
     "description": "Beschreibung des model-Parameters"
   },
   "description.imageUrls": {
-    "message": "Laden Sie 1-5 Referenzbilder hoch, um in den Bearbeitungsmodus zu gelangen.",
+    "message": "Laden Sie 1-16 Referenzbilder hoch, um in den Bearbeitungsmodus zu gelangen.",
     "description": "Beschreibung des image_urls-Parameters"
   },
   "status.pending": {
@@ -156,7 +156,7 @@
     "description": "Hinweis, dass das Guthaben aufgebraucht ist"
   },
   "message.uploadImageExceed": {
-    "message": "Maximal 5 Bilder können hochgeladen werden",
+    "message": "Maximal {count} Bilder können hochgeladen werden",
     "description": "Bildanzahl überschreitet das Limit"
   },
   "message.uploadImageError": {

--- a/src/i18n/el/openaiimage.json
+++ b/src/i18n/el/openaiimage.json
@@ -112,7 +112,7 @@
     "description": "Περιγραφή παραμέτρου μοντέλου"
   },
   "description.imageUrls": {
-    "message": "Ανεβάστε 1-5 αναφορές εικόνας για να μπείτε σε λειτουργία επεξεργασίας.",
+    "message": "Ανεβάστε 1-16 αναφορές εικόνας για να μπείτε σε λειτουργία επεξεργασίας.",
     "description": "Περιγραφή παραμέτρου image_urls"
   },
   "status.pending": {
@@ -156,7 +156,7 @@
     "description": "Μήνυμα εξάντλησης"
   },
   "message.uploadImageExceed": {
-    "message": "Μπορείτε να ανεβάσετε έως 5 εικόνες",
+    "message": "Μπορείτε να ανεβάσετε έως {count} εικόνες",
     "description": "Περιορισμός αριθμού εικόνας"
   },
   "message.uploadImageError": {

--- a/src/i18n/en/openaiimage.json
+++ b/src/i18n/en/openaiimage.json
@@ -112,7 +112,7 @@
     "description": "Model parameter description"
   },
   "description.imageUrls": {
-    "message": "Upload 1-5 reference images to enter edit mode.",
+    "message": "Upload 1-16 reference images to enter edit mode.",
     "description": "Image URLs parameter description"
   },
   "status.pending": {
@@ -156,7 +156,7 @@
     "description": "Exhausted credits message"
   },
   "message.uploadImageExceed": {
-    "message": "You can upload a maximum of 5 images",
+    "message": "You can upload a maximum of {count} images",
     "description": "Image count exceeds limit"
   },
   "message.uploadImageError": {

--- a/src/i18n/es/openaiimage.json
+++ b/src/i18n/es/openaiimage.json
@@ -112,7 +112,7 @@
     "description": "Descripción del parámetro del modelo"
   },
   "description.imageUrls": {
-    "message": "Sube de 1 a 5 imágenes de referencia para entrar en modo de edición.",
+    "message": "Sube de 1 a 16 imágenes de referencia para entrar en modo de edición.",
     "description": "Descripción del parámetro image_urls"
   },
   "status.pending": {
@@ -156,7 +156,7 @@
     "description": "Mensaje de agotamiento"
   },
   "message.uploadImageExceed": {
-    "message": "Se pueden subir hasta 5 imágenes",
+    "message": "Se pueden subir hasta {count} imágenes",
     "description": "Número de imágenes excede el límite"
   },
   "message.uploadImageError": {

--- a/src/i18n/fi/openaiimage.json
+++ b/src/i18n/fi/openaiimage.json
@@ -112,7 +112,7 @@
     "description": "malli-parametrin kuvaus"
   },
   "description.imageUrls": {
-    "message": "Lataa 1-5 viittauskuvaa päästäksesi muokkaustilaan.",
+    "message": "Lataa 1-16 viittauskuvaa päästäksesi muokkaustilaan.",
     "description": "image_urls-parametrin kuvaus"
   },
   "status.pending": {
@@ -156,7 +156,7 @@
     "description": "Oikeudet käytetty loppuun -viesti"
   },
   "message.uploadImageExceed": {
-    "message": "Voit ladata enintään 5 kuvaa",
+    "message": "Voit ladata enintään {count} kuvaa",
     "description": "Kuvien määrä ylittää rajan"
   },
   "message.uploadImageError": {

--- a/src/i18n/fr/openaiimage.json
+++ b/src/i18n/fr/openaiimage.json
@@ -112,7 +112,7 @@
     "description": "Description du paramètre modèle"
   },
   "description.imageUrls": {
-    "message": "Téléchargez 1 à 5 images de référence pour passer en mode édition.",
+    "message": "Téléchargez 1 à 16 images de référence pour passer en mode édition.",
     "description": "Description du paramètre image_urls"
   },
   "status.pending": {
@@ -156,7 +156,7 @@
     "description": "Message d'épuisement des crédits"
   },
   "message.uploadImageExceed": {
-    "message": "Vous pouvez télécharger jusqu'à 5 images",
+    "message": "Vous pouvez télécharger jusqu'à {count} images",
     "description": "Nombre d'images dépassant la limite"
   },
   "message.uploadImageError": {

--- a/src/i18n/it/openaiimage.json
+++ b/src/i18n/it/openaiimage.json
@@ -112,7 +112,7 @@
     "description": "Descrizione del parametro model"
   },
   "description.imageUrls": {
-    "message": "Carica da 1 a 5 immagini di riferimento per entrare in modalità modifica.",
+    "message": "Carica da 1 a 16 immagini di riferimento per entrare in modalità modifica.",
     "description": "Descrizione del parametro image_urls"
   },
   "status.pending": {
@@ -156,7 +156,7 @@
     "description": "Messaggio di esaurimento"
   },
   "message.uploadImageExceed": {
-    "message": "Puoi caricare al massimo 5 immagini",
+    "message": "Puoi caricare al massimo {count} immagini",
     "description": "Numero di immagini oltre il limite"
   },
   "message.uploadImageError": {

--- a/src/i18n/ja/openaiimage.json
+++ b/src/i18n/ja/openaiimage.json
@@ -112,7 +112,7 @@
     "description": "model パラメータ説明"
   },
   "description.imageUrls": {
-    "message": "1〜5枚の参考画像をアップロードして編集モードに入ります。",
+    "message": "1〜16枚の参考画像をアップロードして編集モードに入ります。",
     "description": "image_urls パラメータ説明"
   },
   "status.pending": {
@@ -156,7 +156,7 @@
     "description": "使い切れたメッセージ"
   },
   "message.uploadImageExceed": {
-    "message": "最大5枚の画像をアップロードできます",
+    "message": "最大{count}枚の画像をアップロードできます",
     "description": "画像数が制限を超えています"
   },
   "message.uploadImageError": {

--- a/src/i18n/ko/openaiimage.json
+++ b/src/i18n/ko/openaiimage.json
@@ -112,7 +112,7 @@
     "description": "모델 매개변수 설명"
   },
   "description.imageUrls": {
-    "message": "1-5개의 참조 이미지를 업로드하여 편집 모드로 들어갈 수 있습니다.",
+    "message": "1-16개의 참조 이미지를 업로드하여 편집 모드로 들어갈 수 있습니다.",
     "description": "image_urls 매개변수 설명"
   },
   "status.pending": {
@@ -156,7 +156,7 @@
     "description": "소진 알림"
   },
   "message.uploadImageExceed": {
-    "message": "최대 5장의 이미지를 업로드할 수 있습니다.",
+    "message": "최대 {count}장의 이미지를 업로드할 수 있습니다.",
     "description": "이미지 수 초과 제한"
   },
   "message.uploadImageError": {

--- a/src/i18n/pl/openaiimage.json
+++ b/src/i18n/pl/openaiimage.json
@@ -112,7 +112,7 @@
     "description": "Opis parametru modelu"
   },
   "description.imageUrls": {
-    "message": "Prześlij 1-5 obrazów referencyjnych, aby przejść do trybu edycji.",
+    "message": "Prześlij 1-16 obrazów referencyjnych, aby przejść do trybu edycji.",
     "description": "Opis parametru image_urls"
   },
   "status.pending": {
@@ -156,7 +156,7 @@
     "description": "Komunikat o wyczerpaniu punktów"
   },
   "message.uploadImageExceed": {
-    "message": "Możesz przesłać maksymalnie 5 obrazów",
+    "message": "Możesz przesłać maksymalnie {count} obrazów",
     "description": "Przekroczono limit liczby obrazów"
   },
   "message.uploadImageError": {

--- a/src/i18n/pt/openaiimage.json
+++ b/src/i18n/pt/openaiimage.json
@@ -112,7 +112,7 @@
     "description": "Descrição do parâmetro model"
   },
   "description.imageUrls": {
-    "message": "Envie de 1 a 5 imagens de referência para entrar no modo de edição.",
+    "message": "Envie de 1 a 16 imagens de referência para entrar no modo de edição.",
     "description": "Descrição do parâmetro image_urls"
   },
   "status.pending": {
@@ -156,7 +156,7 @@
     "description": "Mensagem de créditos esgotados"
   },
   "message.uploadImageExceed": {
-    "message": "Máximo de 5 imagens permitidas",
+    "message": "Máximo de {count} imagens permitidas",
     "description": "Número de imagens excedeu o limite"
   },
   "message.uploadImageError": {

--- a/src/i18n/ru/openaiimage.json
+++ b/src/i18n/ru/openaiimage.json
@@ -112,7 +112,7 @@
     "description": "Описание параметра model"
   },
   "description.imageUrls": {
-    "message": "Загрузите 1-5 ссылок на изображения для перехода в режим редактирования.",
+    "message": "Загрузите 1-16 ссылок на изображения для перехода в режим редактирования.",
     "description": "Описание параметра image_urls"
   },
   "status.pending": {
@@ -156,7 +156,7 @@
     "description": "Сообщение об исчерпании"
   },
   "message.uploadImageExceed": {
-    "message": "Можно загрузить не более 5 изображений",
+    "message": "Можно загрузить не более {count} изображений",
     "description": "Количество изображений превышает лимит"
   },
   "message.uploadImageError": {

--- a/src/i18n/sr/openaiimage.json
+++ b/src/i18n/sr/openaiimage.json
@@ -112,7 +112,7 @@
     "description": "Objašnjenje parametra model"
   },
   "description.imageUrls": {
-    "message": "Otpremite 1-5 referentnih slika da biste ušli u režim uređivanja.",
+    "message": "Otpremite 1-16 referentnih slika da biste ušli u režim uređivanja.",
     "description": "Objašnjenje parametra image_urls"
   },
   "status.pending": {
@@ -156,7 +156,7 @@
     "description": "Poruka o potrošenim bodovima"
   },
   "message.uploadImageExceed": {
-    "message": "Maksimalno možete otpremiti 5 slika",
+    "message": "Maksimalno možete otpremiti {count} slika",
     "description": "Prekoračenje broja slika"
   },
   "message.uploadImageError": {

--- a/src/i18n/sv/openaiimage.json
+++ b/src/i18n/sv/openaiimage.json
@@ -112,7 +112,7 @@
     "description": "Beskrivning av model parameter"
   },
   "description.imageUrls": {
-    "message": "Ladda upp 1-5 referensbilder för att gå in i redigeringsläge.",
+    "message": "Ladda upp 1-16 referensbilder för att gå in i redigeringsläge.",
     "description": "Beskrivning av image_urls parameter"
   },
   "status.pending": {
@@ -156,7 +156,7 @@
     "description": "Meddelande om att poängen är slut"
   },
   "message.uploadImageExceed": {
-    "message": "Maximalt 5 bilder kan laddas upp",
+    "message": "Maximalt {count} bilder kan laddas upp",
     "description": "Antalet bilder överskrider gränsen"
   },
   "message.uploadImageError": {

--- a/src/i18n/uk/openaiimage.json
+++ b/src/i18n/uk/openaiimage.json
@@ -112,7 +112,7 @@
     "description": "Опис параметра model"
   },
   "description.imageUrls": {
-    "message": "Завантажте 1-5 зображень для переходу в режим редагування.",
+    "message": "Завантажте 1-16 зображень для переходу в режим редагування.",
     "description": "Опис параметра image_urls"
   },
   "status.pending": {
@@ -156,7 +156,7 @@
     "description": "Повідомлення про вичерпані бали"
   },
   "message.uploadImageExceed": {
-    "message": "Максимум можна завантажити 5 зображень",
+    "message": "Максимум можна завантажити {count} зображень",
     "description": "Кількість зображень перевищує ліміт"
   },
   "message.uploadImageError": {

--- a/src/i18n/zh-CN/openaiimage.json
+++ b/src/i18n/zh-CN/openaiimage.json
@@ -112,7 +112,7 @@
     "description": "model 参数说明"
   },
   "description.imageUrls": {
-    "message": "上传 1-5 张参考图即可进入编辑模式。",
+    "message": "上传 1-16 张参考图即可进入编辑模式。",
     "description": "image_urls 参数说明"
   },
   "status.pending": {
@@ -156,7 +156,7 @@
     "description": "已用完提示"
   },
   "message.uploadImageExceed": {
-    "message": "最多可上传 5 张图片",
+    "message": "最多可上传 {count} 张图片",
     "description": "图片数量超过限制"
   },
   "message.uploadImageError": {

--- a/src/i18n/zh-TW/openaiimage.json
+++ b/src/i18n/zh-TW/openaiimage.json
@@ -112,7 +112,7 @@
     "description": "model 引數說明"
   },
   "description.imageUrls": {
-    "message": "上傳 1-5 張參考圖即可進入編輯模式。",
+    "message": "上傳 1-16 張參考圖即可進入編輯模式。",
     "description": "image_urls 引數說明"
   },
   "status.pending": {
@@ -156,7 +156,7 @@
     "description": "已用完提示"
   },
   "message.uploadImageExceed": {
-    "message": "最多可上傳 5 張圖片",
+    "message": "最多可上傳 {count} 張圖片",
     "description": "圖片數量超過限制"
   },
   "message.uploadImageError": {


### PR DESCRIPTION
## 问题

`/openai/images/edits` 的实际上限是 **16 张**参考图：

- OpenAI 官方 spec 里 `maxItems: 16` 是硬约束
- 我们的 OpenAPI 也对外承诺 16 张
- 实测传 17 张才被上游以 413 拒绝

但 Nexior 的上传组件把它硬编码成了 **5**，用户被无谓地卡在 1/3 的能力上。

## 改动

| | |
|---|---|
| 新增常量 | `OPENAIIMAGE_MAX_REFERENCE_IMAGES = 16` |
| `ImageUrlsInput.vue` | `:limit="5"` → `:limit="maxImages"`，超限提示引用同一常量 |
| i18n | `message.uploadImageExceed` 改用 `{count}` 占位符；18 个 locale 的 `description.imageUrls` 文案 `1-5` → `1-16` |

`{count}` 参数化沿用了仓库既有写法（`kling.message.referenceImagesTotalLimit`），这样数字只存在于常量里，以后再调不用动 18 个 locale。

各语言的表记差异已逐条核对：`ja` 的 `1〜16枚`、`ko` 的 `1-16개`、`fr` 的 `1 à 16`、`es`/`pt` 的 `de 1 a 16` 等都保持了原本的本地化写法，没有被机械替换破坏。

## 与后端的关系

**本改动不依赖后端**。Nexior 走的是 multipart + 重复 `image` 字段传 **CDN URL 字符串**（`src/operators/openaiimage.ts`），不是二进制文件上传，因此不受 worker 侧 multer `files` 上限约束（那个限制只对文件计数生效）。

已按 Nexior 的确切请求形态实测：5 / 12 / 16 张均正常返回 200。

（顺带发现并单独修复了二进制上传路径的相关缺陷 —— 见 PlatformService#1758，两者互相独立。）

## 验证

- `python3 scripts/check_i18n_coverage.py` → `17 locale(s) × 47 namespace(s)` 全覆盖，无英文占位符残留
- `npx vue-tsc -b` → 通过
- `npx eslint` 改动文件 → 通过
- 18 个 locale JSON 均合法，且 range 与占位符逐一核对无遗漏

🤖 Generated with [Claude Code](https://claude.com/claude-code)