### PR TITLE
fix(desktop): honest fs consent scope, working shell PATH, live session grants

### DIFF
--- a/change/@acedatacloud-nexior-15d72900-d576-4e68-89d6-9d28f7489583.json
+++ b/change/@acedatacloud-nexior-15d72900-d576-4e68-89d6-9d28f7489583.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "desktop local tools: folder-scoped fs consent stated in the dialog, working PATH for shell.run_command, session grants honored for every tool, macOS folder TCC strings, crash-safe write_file",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -85,13 +85,18 @@ mac:
   entitlements: build/entitlements.mac.plist
   entitlementsInherit: build/entitlements.mac.plist
   # TCC usage strings for the opt-in local-tool tiers (screen/mic/camera/
-  # automation). Without these macOS hard-crashes the app on first access.
+  # automation) and the three per-folder gates the file tools hit most
+  # (Desktop / Documents / Downloads). Without these macOS hard-crashes the app
+  # on first access, or shows a prompt with a blank reason.
   extendInfo:
     NSScreenCaptureUsageDescription: AceData lets the AI capture your screen only when you run a screen tool.
     NSAudioCaptureUsageDescription: AceData records system audio only when you run an audio-capture tool.
     NSMicrophoneUsageDescription: AceData uses the microphone only for voice tools you start.
     NSCameraUsageDescription: AceData uses the camera only for vision tools you start.
     NSAppleEventsUsageDescription: AceData controls other apps only when you run an automation tool.
+    NSDesktopFolderUsageDescription: AceData reads and writes files on your Desktop only in folders you approve when a file tool runs.
+    NSDocumentsFolderUsageDescription: AceData reads and writes files in Documents only in folders you approve when a file tool runs.
+    NSDownloadsFolderUsageDescription: AceData reads and writes files in Downloads only in folders you approve when a file tool runs.
   # electron-builder 26.x requires `notarize` to be a boolean. Credentials come
   # from env at sign time (any ONE of these sets):
   #   1) APPLE_API_KEY + APPLE_API_KEY_ID + APPLE_API_ISSUER   (App Store Connect API key — CI's choice)

--- a/electron/local/consent.ts
+++ b/electron/local/consent.ts
@@ -1,23 +1,29 @@
 import { dialog, BrowserWindow } from 'electron';
+import { realpathSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
 import type { ToolInvoke } from './types';
 import { load, save } from './config';
-import { authorizeConsentedPath } from './fs';
+import { authorizeConsentedPath, revokeOnceRoot } from './fs';
 
 // No OS sandbox by design — consent is the control. Three tiers:
-//   • Allow once     — run this one time.
+//   • Allow once     — run this one time. An fs folder grant is revoked as soon
+//                      as the call finishes.
 //   • Allow for session — cache in-memory for this app run; cleared on restart.
-//                      Non-computer mutating tools still re-confirm; computer.*
-//                      honors it (mutation is the point) so a screenshot→act
-//                      loop isn't a per-step prompt storm.
+//                      Honored by EVERY tool, mutating included: the key is
+//                      input-bound (except computer.*), so it only skips the
+//                      prompt for a byte-identical repeat of what was approved.
 //   • Always allow   — persist a session-independent grant to disk so the call
-//                      never prompts again — even for mutating tools, because
-//                      the user explicitly opted in. Revocable from Settings.
+//                      never prompts again. Revocable from Settings.
 // fs/shell grants are bound to the EXACT input; computer.* grants are name-
 // scoped (their inputs — mouse coords, typed text — vary every call, so an
 // input-scoped grant would never match twice). A computer.* "Always allow" is
 // thus an explicit opt-in to prompt-less screen control; the panic hotkey still
 // hard-disables Computer Use regardless (the registry gate blocks every
 // computer.* call before consent runs).
+// For fs.* the approval authorizes the containing FOLDER (read + write), which
+// the dialog states outright — one file is rarely the useful unit of work, and
+// a file-scoped grant would re-prompt for every sibling.
 // The full argv/path is shown untruncated so the dangerous part can't hide.
 const sessionGranted = new Set<string>();
 
@@ -63,24 +69,81 @@ export function grantKey(inv: ToolInvoke): string {
 // Bridge consent → the fs allowlist. Approving the popup for a file tool used to
 // grant only the *right to run the call*; fs.ts then independently rejected any
 // path not separately added in Settings ("path outside allowed roots"). Here we
-// authorize the exact path the user approved so the call can actually proceed.
-// `persist` (Always allow) additionally writes the granted dir to config.roots
-// so it survives a restart; once/session authorize in-memory only.
-function grantPathAccess(inv: ToolInvoke, persist: boolean): void {
-  if (!inv.name.startsWith('fs.')) return;
+// authorize the FOLDER the approved path lives in so the call can proceed and
+// its siblings don't each re-prompt. `persist` (Always allow) additionally
+// writes the granted dir to config.roots so it survives a restart;
+// once/session authorize in-memory only. Returns the granted dir so the caller
+// can revoke it again after a one-shot ("Allow once") approval.
+function grantPathAccess(inv: ToolInvoke, persist: boolean, once: boolean): string | null {
+  if (!inv.name.startsWith('fs.')) return null;
   const p = (inv.input as Record<string, unknown> | undefined)?.path;
-  if (typeof p !== 'string' || !p) return;
-  const dir = authorizeConsentedPath(inv.name, p);
+  if (typeof p !== 'string' || !p) return null;
+  const dir = authorizeConsentedPath(inv.name, p, once);
   if (dir && persist) {
     const cfg = load();
     const roots = new Set(cfg.roots ?? []);
     roots.add(dir);
     save({ ...cfg, roots: [...roots] });
   }
+  return dir;
 }
 
-export async function consentOk(inv: ToolInvoke, win: BrowserWindow | null, mutates: boolean): Promise<boolean> {
-  const isComputer = inv.name.startsWith('computer.');
+// The folder an fs.* call would authorize, resolved WITHOUT granting anything —
+// so the dialog can name the real scope before the user decides. Mirrors
+// authorizeConsentedPath's dir choice; falls back to the lexical dirname when
+// the path can't be realpath'd (e.g. a write whose parent is a broken symlink),
+// which is still the honest scope to show.
+function consentScopeDir(inv: ToolInvoke): string | null {
+  if (!inv.name.startsWith('fs.')) return null;
+  const p = (inv.input as Record<string, unknown> | undefined)?.path;
+  if (typeof p !== 'string' || !p) return null;
+  const expanded = p === '~' ? homedir() : p.startsWith('~/') || p.startsWith('~\\') ? join(homedir(), p.slice(2)) : p;
+  const target = inv.name === 'fs.list_dir' ? expanded : dirname(expanded);
+  try {
+    return realpathSync(target);
+  } catch {
+    return target;
+  }
+}
+
+// Render the dialog's detail text. The full argv/path stays untruncated so the
+// dangerous part can't hide, but a big `content` (fs.write_file can carry a
+// whole file) is summarized — it would otherwise push the buttons off screen.
+// For fs.* the granted FOLDER is stated explicitly, because approving grants
+// read+write across that folder, not just the one path in the input.
+function consentDetail(inv: ToolInvoke, scopeDir: string | null): string {
+  const input = (inv.input ?? {}) as Record<string, unknown>;
+  const shown: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(input)) {
+    shown[k] = typeof v === 'string' && v.length > 400 ? `<${v.length} characters>` : v;
+  }
+  const lines = [JSON.stringify(shown)];
+  if (scopeDir) {
+    lines.push('', `Approving grants read + write access to this folder and everything inside it:\n${scopeDir}`);
+  }
+  // Spell out the repeat semantics: a session/always grant re-runs this exact
+  // call without asking again, which for a non-idempotent tool (sending,
+  // posting, deleting) means the side effect can happen more than once.
+  lines.push(
+    '',
+    '"Allow for session" and "Always allow" re-run this exact call without asking again — if it sends, posts or deletes something, that can happen again.'
+  );
+  return lines.join('\n');
+}
+
+// A no-op release, shared by every decision that grants nothing to undo.
+const NO_RELEASE = (): void => undefined;
+
+/** Outcome of a consent check. `release` undoes an "Allow once" folder grant and
+ *  MUST be called after the invocation (see ipc.ts's `finally`); it is a no-op
+ *  for every other decision. Per-invocation, so parallel calls can't revoke
+ *  each other's grant. */
+export interface ConsentDecision {
+  ok: boolean;
+  release: () => void;
+}
+
+export async function consentOk(inv: ToolInvoke, win: BrowserWindow | null): Promise<ConsentDecision> {
   const gk = grantKey(inv);
   // Cached grants must NOT re-authorize the path here. Re-running
   // authorizeConsentedPath() would realpath the CURRENT target, so a symlink
@@ -90,7 +153,7 @@ export async function consentOk(inv: ToolInvoke, win: BrowserWindow | null, muta
   // config.roots (loaded into ROOTS on launch); "Allow for session" keeps its
   // SESSION_ROOTS entry for the run. (Grants created before this change have no
   // persisted root, so they re-prompt once — which then persists it.)
-  if ((load().grants ?? []).includes(gk)) return true; // persistent always-allow
+  if ((load().grants ?? []).includes(gk)) return { ok: true, release: NO_RELEASE }; // persistent always-allow
   // Tool-wide always-allow: a grant stored as the BARE tool name (no `:input`)
   // means "run this tool for ANY input without asking" — opted in per-tool from
   // Settings → Local Tools. For computer.* the grant key already IS the bare
@@ -98,11 +161,15 @@ export async function consentOk(inv: ToolInvoke, win: BrowserWindow | null, muta
   // tools (shell.run_command, fs.*). fs.* still enforces its ROOTS boundary in
   // fs.ts, so a tool-wide fs grant can't escape the authorized folders; a
   // tool-wide shell grant is unrestricted by design (the Settings toggle warns).
-  if (inv.name !== gk && (load().grants ?? []).includes(inv.name)) return true;
-  // Non-computer mutating tools still re-confirm; computer.* honors its (name-
-  // scoped) session grant even though it mutates — that is the whole point of
-  // "Allow for session" for a screen-control loop.
-  if (sessionGranted.has(sessionKey(inv)) && (isComputer || !mutates)) return true;
+  if (inv.name !== gk && (load().grants ?? []).includes(inv.name)) return { ok: true, release: NO_RELEASE };
+  // "Allow for session" applies to EVERY tool, mutating included. The key is
+  // input-bound for fs/shell/mcp (sessionKey), so this only skips the prompt for
+  // a byte-identical repeat of what the user already approved — re-running the
+  // same command, not a new one. It used to be gated on `!mutates`, which made
+  // the button dead for shell/write/MCP: it cached a grant that was then never
+  // honored, so those tools prompted on every single call.
+  if (sessionGranted.has(sessionKey(inv))) return { ok: true, release: NO_RELEASE };
+  const scopeDir = consentScopeDir(inv);
   const buttons = ['Allow once', 'Allow for session', 'Always allow', 'Deny'];
   const denyId = buttons.length - 1;
   const opts = {
@@ -111,7 +178,7 @@ export async function consentOk(inv: ToolInvoke, win: BrowserWindow | null, muta
     defaultId: 0,
     cancelId: denyId,
     message: `Run local tool: ${inv.name}?`,
-    detail: JSON.stringify(inv.input)
+    detail: consentDetail(inv, scopeDir)
   };
   const { response } = win ? await dialog.showMessageBox(win, opts) : await dialog.showMessageBox(opts);
   if (response === 1) sessionGranted.add(sessionKey(inv));
@@ -121,12 +188,18 @@ export async function consentOk(inv: ToolInvoke, win: BrowserWindow | null, muta
     grants.add(gk);
     save({ ...cfg, grants: [...grants] });
   }
-  // Authorize the approved path (fs.* tools), bound to its realpath AT APPROVAL
-  // TIME — the subsequent read/list/write re-realpaths and re-checks inRootDir,
-  // so a symlink swapped between here and the call is still caught. Only
-  // "Always allow" (response 2) persists the canonical dir as a root.
-  if (response !== denyId) grantPathAccess(inv, response === 2);
-  return response !== denyId;
+  // Authorize the approved path's FOLDER (fs.* tools), bound to its realpath AT
+  // APPROVAL TIME — the subsequent read/list/write re-realpaths and re-checks
+  // inRootDir, so a symlink swapped between here and the call is still caught.
+  // Only "Always allow" (response 2) persists the canonical dir as a root.
+  if (response === denyId) return { ok: false, release: NO_RELEASE };
+  const once = response === 0;
+  const granted = grantPathAccess(inv, response === 2, once);
+  // "Allow once" means once: the caller releases this specific hold after the
+  // call. The handle is per-invocation (not a shared queue), so a parallel call
+  // approved for the same folder keeps its own reference-counted grant.
+  if (once && granted) return { ok: true, release: () => revokeOnceRoot(granted) };
+  return { ok: true, release: NO_RELEASE };
 }
 
 export function resetConsent(): void {

--- a/electron/local/env.ts
+++ b/electron/local/env.ts
@@ -1,0 +1,66 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+// A GUI-launched Electron app (Finder / Dock / Start menu) inherits a stripped
+// PATH — it does NOT source the user's shell profile — so `npx` / `node` /
+// `uvx` / `bunx` (in Homebrew, nvm, ~/.local, bun) resolve to `spawn ENOENT`.
+// On macOS `launchctl getenv PATH` is typically empty, leaving only
+// /usr/bin:/bin:/usr/sbin:/sbin — enough for `git`/`python3`, not for
+// node/npm/brew. Shared by the MCP host and `shell.run_command` so both resolve
+// commands the same way. Rebuilt once, cached (as a Promise) for the process
+// lifetime. ASYNC so the login-shell probe never blocks the main thread / UI.
+
+// Standard Node + global-npm install dirs on Windows, derived from STABLE env
+// vars (never the possibly-stale inherited PATH). Exported for tests.
+export function windowsNodeDirs(env: NodeJS.ProcessEnv = process.env): string[] {
+  return [
+    env.ProgramFiles && `${env.ProgramFiles}\\nodejs`,
+    env['ProgramFiles(x86)'] && `${env['ProgramFiles(x86)']}\\nodejs`,
+    env.APPDATA && `${env.APPDATA}\\npm`,
+    env.LOCALAPPDATA && `${env.LOCALAPPDATA}\\Programs\\nodejs`
+  ].filter((d): d is string => !!d);
+}
+
+let cachedPath: Promise<string> | null = null;
+
+export function resolveEnhancedPath(): Promise<string> {
+  if (cachedPath) return cachedPath;
+  cachedPath = (async (): Promise<string> => {
+    const sep = process.platform === 'win32' ? ';' : ':';
+    let parts = (process.env.PATH || '').split(sep);
+    if (process.platform !== 'win32') {
+      // Ask the user's login shell for its real PATH (covers nvm / asdf / brew /
+      // bun). Bounded by a short timeout + static fallback so a slow or noisy
+      // shell can't wedge startup; take the last non-empty line.
+      try {
+        const shell = process.env.SHELL || '/bin/zsh';
+        const { stdout } = await execFileAsync(shell, ['-lic', 'printf "%s" "$PATH"'], { timeout: 3000, encoding: 'utf8' });
+        const line = stdout.trim().split('\n').filter(Boolean).pop() || '';
+        if (line.includes('/')) parts = line.split(sep).concat(parts);
+      } catch {
+        /* login shell unavailable — fall back to the static dirs below */
+      }
+      const home = process.env.HOME || '';
+      parts = parts.concat(['/opt/homebrew/bin', '/usr/local/bin', '/usr/bin', '/bin', `${home}/.local/bin`, `${home}/.bun/bin`]);
+    } else {
+      // A GUI-launched Windows app can inherit a STALE PATH — e.g. an
+      // explorer.exe started before Node was installed (or before its installer
+      // updated the registry PATH) — so a bare `node` / `npx` resolves to
+      // `spawn ENOENT` even though Node IS installed and on the machine PATH.
+      // Append the standard Node + global-npm install dirs so the common install
+      // still resolves. Bare-command resolution tolerates the space in
+      // "Program Files".
+      parts = parts.concat(windowsNodeDirs());
+    }
+    const seen = new Set<string>();
+    return parts.filter((d) => d && !seen.has(d) && seen.add(d)).join(sep);
+  })();
+  return cachedPath;
+}
+
+// Test hook: drop the cached PATH so a case can re-probe with a different env.
+export function _resetPathCacheForTesting(): void {
+  cachedPath = null;
+}

--- a/electron/local/fs.test.ts
+++ b/electron/local/fs.test.ts
@@ -1,8 +1,16 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import { mkdtempSync, mkdirSync, writeFileSync, realpathSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, readdirSync, realpathSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { setRoots, authorizeConsentedPath, list_dir, read_file, _resetRootsForTesting } from './fs';
+import {
+  setRoots,
+  authorizeConsentedPath,
+  revokeOnceRoot,
+  list_dir,
+  read_file,
+  write_file,
+  _resetRootsForTesting
+} from './fs';
 
 // A consented path must become readable/listable even when it was never added
 // as a root in Settings — otherwise the consent popup grants nothing usable
@@ -31,13 +39,51 @@ describe('fs consent-authorized roots', () => {
     expect(res.output).toContain('a.txt');
   });
 
-  it('authorizes a file after consent so read_file succeeds (and only that file)', async () => {
+  it('authorizes the containing folder after consent on a file', async () => {
     const { docs } = tmpTree();
     const file = path.join(docs, 'a.txt');
-    authorizeConsentedPath('fs.read_file', file);
-    const res = await read_file({ path: file });
-    expect(res.output).toBe('hello');
-    // The sibling directory listing is still blocked (only the file was granted).
+    // Consent is folder-scoped by design: reading one file implies its siblings
+    // are in scope, and the dialog says so. See consent.ts's header.
+    const granted = authorizeConsentedPath('fs.read_file', file);
+    expect(granted).toBe(docs);
+    expect((await read_file({ path: file })).output).toBe('hello');
+    expect((await list_dir({ path: docs })).output).toContain('a.txt');
+  });
+
+  it('does not authorize the PARENT of the granted folder', async () => {
+    const { base, docs } = tmpTree();
+    authorizeConsentedPath('fs.read_file', path.join(docs, 'a.txt'));
+    // Escaping upward stays blocked — the grant is one folder, not the tree.
+    await expect(list_dir({ path: base })).rejects.toThrow('path outside allowed roots');
+  });
+
+  it('an Allow-once grant is released after the call', async () => {
+    const { docs } = tmpTree();
+    const granted = authorizeConsentedPath('fs.list_dir', docs, true);
+    expect((await list_dir({ path: docs })).output).toContain('a.txt');
+    revokeOnceRoot(granted);
+    await expect(list_dir({ path: docs })).rejects.toThrow('path outside allowed roots');
+  });
+
+  it('releasing an Allow-once grant leaves a session grant on the SAME folder intact', async () => {
+    const { docs } = tmpTree();
+    // "Allow for session" on a.txt, then "Allow once" on a sibling in the same
+    // folder. Releasing the once-grant must not revoke the session one.
+    authorizeConsentedPath('fs.read_file', path.join(docs, 'a.txt'));
+    const once = authorizeConsentedPath('fs.read_file', path.join(docs, 'a.txt'), true);
+    revokeOnceRoot(once);
+    expect((await read_file({ path: path.join(docs, 'a.txt') })).output).toBe('hello');
+  });
+
+  it('parallel Allow-once grants on one folder are reference-counted', async () => {
+    const { docs } = tmpTree();
+    // Two parallel client tools each approved "Allow once" for the same folder.
+    const a = authorizeConsentedPath('fs.list_dir', docs, true);
+    const b = authorizeConsentedPath('fs.list_dir', docs, true);
+    // The first finishing must NOT strand the second.
+    revokeOnceRoot(a);
+    expect((await list_dir({ path: docs })).output).toContain('a.txt');
+    revokeOnceRoot(b);
     await expect(list_dir({ path: docs })).rejects.toThrow('path outside allowed roots');
   });
 
@@ -52,5 +98,28 @@ describe('fs consent-authorized roots', () => {
     // The home dir itself; authorizing "~" must add the real home as a root.
     const granted = authorizeConsentedPath('fs.list_dir', '~');
     expect(granted).toBe(realpathSync(os.homedir()));
+  });
+
+  it('write_file survives an orphaned temp file from an earlier crash', async () => {
+    const { docs } = tmpTree();
+    setRoots([docs]);
+    const target = path.join(docs, 'out.txt');
+    // A crash between writeFile(tmp) and rename() used to leave `<file>.tmp`,
+    // which made every later write to that path fail EEXIST forever.
+    writeFileSync(target + '.tmp', 'orphan from a previous run');
+    const res = await write_file({ path: target, content: 'fresh' });
+    expect(res.output).toBe('wrote 5 bytes');
+    expect((await read_file({ path: target })).output).toBe('fresh');
+  });
+
+  it('write_file leaves no temp file behind when the write fails', async () => {
+    const { docs } = tmpTree();
+    setRoots([docs]);
+    // A directory as the target makes rename() fail (EISDIR) after the temp
+    // was written — the temp must still be cleaned up.
+    mkdirSync(path.join(docs, 'adir'));
+    await expect(write_file({ path: path.join(docs, 'adir'), content: 'x' })).rejects.toThrow();
+    const leftovers = readdirSync(docs).filter((f) => f.includes('.tmp'));
+    expect(leftovers).toEqual([]);
   });
 });

--- a/electron/local/fs.ts
+++ b/electron/local/fs.ts
@@ -1,5 +1,6 @@
 import fsp from 'node:fs/promises';
 import { realpathSync } from 'node:fs';
+import { randomUUID } from 'node:crypto';
 import os from 'node:os';
 import path from 'node:path';
 import type { ToolResult } from './types';
@@ -13,7 +14,14 @@ let ROOTS: string[] = [];
 // persists the granted dir to config.roots (see consent.ts) so it survives a
 // restart via setRoots(). Kept separate from ROOTS so a one-shot/session grant
 // never silently becomes a permanent root.
+//
+// Two tiers, tracked separately BY DESIGN. A folder can be granted by both an
+// "Allow for session" approval and a later "Allow once" one; releasing the
+// once-grant must not revoke the session grant, so a single unowned set would
+// be wrong. Once-grants are additionally reference-counted because parallel
+// client tools can each hold one for the same folder — the last release wins.
 const SESSION_ROOTS = new Set<string>();
+const ONCE_ROOTS = new Map<string, number>();
 
 export function setRoots(roots: string[]): void {
   ROOTS = roots
@@ -29,7 +37,7 @@ export function setRoots(roots: string[]): void {
 
 function inRootDir(full: string): boolean {
   const ok = (r: string) => full === r || full.startsWith(r + path.sep);
-  return ROOTS.some(ok) || [...SESSION_ROOTS].some(ok);
+  return ROOTS.some(ok) || [...SESSION_ROOTS].some(ok) || [...ONCE_ROOTS.keys()].some(ok);
 }
 
 // Models commonly pass `~/Desktop`; Node never expands `~`, so realpathSync
@@ -62,28 +70,53 @@ function resolveForWrite(p: string): string {
   return full;
 }
 
-// Authorize a path the user just consented to via the tool popup, so the
-// matching read/list/write actually passes inRootDir. Without this, approving
-// the consent dialog would still fail with "path outside allowed roots" unless
-// the folder was separately added in Settings. Returns the canonical (realpath)
-// dir/file that was granted, or null if it can't be resolved. For writes the
-// target file may not exist yet, so authorize its parent directory.
-export function authorizeConsentedPath(name: string, p: string): string | null {
+// Authorize the FOLDER a consented path lives in, so the matching read/list/
+// write actually passes inRootDir. Without this, approving the consent dialog
+// would still fail with "path outside allowed roots" unless the folder was
+// separately added in Settings.
+//
+// Scope is deliberately the containing DIRECTORY for every fs tool — reading
+// one file almost always implies reading its siblings (that is the useful unit
+// of work), and a file-scoped grant would prompt again for every neighbour. The
+// consent dialog states the folder being granted, so the popup matches what is
+// actually authorized. Returns the canonical (realpath) directory, or null if
+// it can't be resolved.
+//
+// `fs.list_dir` already targets a directory; `read_file`/`write_file` target a
+// file, so we take its parent. A write target may not exist yet, hence the
+// dirname is resolved rather than the path itself.
+//
+// `once` routes the grant into the reference-counted ONCE_ROOTS tier so
+// releasing it later can't revoke a session grant that happens to name the same
+// folder, nor a sibling parallel call's grant.
+export function authorizeConsentedPath(name: string, p: string, once = false): string | null {
   try {
     const expanded = expandHome(p);
-    const target =
-      name === 'fs.write_file' ? realpathSync(path.dirname(expanded)) : realpathSync(expanded);
-    SESSION_ROOTS.add(target);
+    const target = name === 'fs.list_dir' ? realpathSync(expanded) : realpathSync(path.dirname(expanded));
+    if (once) ONCE_ROOTS.set(target, (ONCE_ROOTS.get(target) ?? 0) + 1);
+    else SESSION_ROOTS.add(target);
     return target;
   } catch {
     return null;
   }
 }
 
-// Test hook: clear all roots (persistent + session) between cases.
+// Release one "Allow once" hold on a folder. Reference-counted: the root stays
+// authorized until every parallel once-grant on it has been released, and the
+// session/persistent tiers are untouched either way.
+export function revokeOnceRoot(dir: string | null): void {
+  if (!dir) return;
+  const n = ONCE_ROOTS.get(dir);
+  if (n === undefined) return;
+  if (n <= 1) ONCE_ROOTS.delete(dir);
+  else ONCE_ROOTS.set(dir, n - 1);
+}
+
+// Test hook: clear all roots (persistent + session + once) between cases.
 export function _resetRootsForTesting(): void {
   ROOTS = [];
   SESSION_ROOTS.clear();
+  ONCE_ROOTS.clear();
 }
 
 export async function read_file(i: { path: string }): Promise<ToolResult> {
@@ -97,8 +130,16 @@ export async function list_dir(i: { path: string }): Promise<ToolResult> {
 
 export async function write_file(i: { path: string; content: string }): Promise<ToolResult> {
   const f = resolveForWrite(i.path);
-  const tmp = f + '.tmp';
-  await fsp.writeFile(tmp, i.content, { flag: 'wx', mode: 0o600 }); // no symlink follow, not world-readable
-  await fsp.rename(tmp, f); // atomic
+  // Unique temp name per call: a fixed `<file>.tmp` with flag 'wx' made the
+  // path permanently unwritable (EEXIST) once a crash or a concurrent write
+  // orphaned one, and the error named a file the user never knew existed.
+  const tmp = `${f}.${process.pid}.${randomUUID().slice(0, 8)}.tmp`;
+  try {
+    await fsp.writeFile(tmp, i.content, { flag: 'wx', mode: 0o600 }); // no symlink follow, not world-readable
+    await fsp.rename(tmp, f); // atomic
+  } catch (e) {
+    await fsp.unlink(tmp).catch(() => undefined); // never leave a partial temp behind
+    throw e;
+  }
   return { output: `wrote ${i.content.length} bytes` };
 }

--- a/electron/local/ipc.ts
+++ b/electron/local/ipc.ts
@@ -72,9 +72,16 @@ export function registerLocalExec(getWin: () => BrowserWindow | null): void {
   ipcMain.handle('local.tool.invoke', async (e, inv: ToolInvoke) => {
     gate(e);
     if (!registry.isKnown(inv.name)) return { output: `unknown tool ${inv.name}`, is_error: true };
-    const mutates = inv.name !== 'fs.read_file' && inv.name !== 'fs.list_dir';
-    if (!(await consentOk(inv, getWin(), mutates))) return { output: 'denied by user', is_error: true };
-    return registry.invoke(inv);
+    const decision = await consentOk(inv, getWin());
+    if (!decision.ok) return { output: 'denied by user', is_error: true };
+    try {
+      return await registry.invoke(inv);
+    } finally {
+      // An "Allow once" fs grant covers exactly this call — release this
+      // invocation's own hold even if the tool threw. Other calls' grants (and
+      // the session/persistent tiers) are unaffected.
+      decision.release();
+    }
   });
 
   ipcMain.handle('local.config.get', (e) => {

--- a/electron/local/mcp.ts
+++ b/electron/local/mcp.ts
@@ -1,8 +1,11 @@
-import { spawn, execFile, ChildProcess } from 'node:child_process';
-import { promisify } from 'node:util';
+import { spawn, ChildProcess } from 'node:child_process';
+import { resolveEnhancedPath, windowsNodeDirs } from './env';
 import type { McpServerConf, ToolSpec, ToolResult } from './types';
 
-const execFileAsync = promisify(execFile);
+// Re-exported so existing importers/tests keep resolving it from here; the
+// implementation now lives in env.ts, shared with shell.run_command.
+export { windowsNodeDirs };
+
 const RPC_TIMEOUT_MS = 30_000;
 // The initial `initialize` handshake gets a longer budget than a mid-turn call:
 // a cold MCP server (e.g. `node …/@playwright/mcp` loading playwright-core) on a
@@ -67,59 +70,6 @@ export function mapCallResult(r: { content?: unknown; isError?: boolean }): Tool
     is_error: !!r.isError,
     ...(image ? { image } : {})
   };
-}
-
-// A GUI-launched Electron app (Finder / Dock / Start menu) inherits a stripped
-// PATH — it does NOT source the user's shell profile — so `npx` / `node` /
-// `uvx` / `bunx` (in Homebrew, nvm, ~/.local, bun) resolve to `spawn ENOENT`
-// and every MCP server silently fails to connect. Rebuild a usable PATH once,
-// cached (as a Promise) for the process lifetime. ASYNC so the login-shell
-// probe never blocks the main thread / UI.
-// Standard Node + global-npm install dirs on Windows, derived from STABLE env
-// vars (never the possibly-stale inherited PATH). Exported for tests.
-export function windowsNodeDirs(env: NodeJS.ProcessEnv = process.env): string[] {
-  return [
-    env.ProgramFiles && `${env.ProgramFiles}\\nodejs`,
-    env['ProgramFiles(x86)'] && `${env['ProgramFiles(x86)']}\\nodejs`,
-    env.APPDATA && `${env.APPDATA}\\npm`,
-    env.LOCALAPPDATA && `${env.LOCALAPPDATA}\\Programs\\nodejs`
-  ].filter((d): d is string => !!d);
-}
-
-let cachedPath: Promise<string> | null = null;
-function resolveEnhancedPath(): Promise<string> {
-  if (cachedPath) return cachedPath;
-  cachedPath = (async (): Promise<string> => {
-    const sep = process.platform === 'win32' ? ';' : ':';
-    let parts = (process.env.PATH || '').split(sep);
-    if (process.platform !== 'win32') {
-      // Ask the user's login shell for its real PATH (covers nvm / asdf / brew /
-      // bun). Bounded by a short timeout + static fallback so a slow or noisy
-      // shell can't wedge startup; take the last non-empty line.
-      try {
-        const shell = process.env.SHELL || '/bin/zsh';
-        const { stdout } = await execFileAsync(shell, ['-lic', 'printf "%s" "$PATH"'], { timeout: 3000, encoding: 'utf8' });
-        const line = stdout.trim().split('\n').filter(Boolean).pop() || '';
-        if (line.includes('/')) parts = line.split(sep).concat(parts);
-      } catch {
-        /* login shell unavailable — fall back to the static dirs below */
-      }
-      const home = process.env.HOME || '';
-      parts = parts.concat(['/opt/homebrew/bin', '/usr/local/bin', '/usr/bin', '/bin', `${home}/.local/bin`, `${home}/.bun/bin`]);
-    } else {
-      // A GUI-launched Windows app can inherit a STALE PATH — e.g. an
-      // explorer.exe started before Node was installed (or before its installer
-      // updated the registry PATH) — so a bare `node` / `npx` resolves to
-      // `spawn ENOENT` even though Node IS installed and on the machine PATH.
-      // Append the standard Node + global-npm install dirs so the common install
-      // still resolves. Bare-command resolution tolerates the space in
-      // "Program Files".
-      parts = parts.concat(windowsNodeDirs());
-    }
-    const seen = new Set<string>();
-    return parts.filter((d) => d && !seen.has(d) && seen.add(d)).join(sep);
-  })();
-  return cachedPath;
 }
 
 // Spawns local stdio MCP servers and bridges tools/list + tools/call.

--- a/electron/local/shell.ts
+++ b/electron/local/shell.ts
@@ -1,10 +1,19 @@
 import { execFile } from 'node:child_process';
+import { resolveEnhancedPath } from './env';
 import type { ToolResult } from './types';
 
 // NO sandbox by design (user's own machine; gated by consent + visibility).
 // execFile with argv (never a shell string) avoids injection; env is an
 // explicit allowlist so local tokens/API keys never leak to AI-run commands.
-export function run_command(i: { cmd: string; args?: string[]; cwd?: string }, timeoutMs = 120_000): Promise<ToolResult> {
+// PATH comes from resolveEnhancedPath(), not the inherited one: a Dock/Finder
+// launch inherits a stripped PATH (launchctl's is empty on macOS), which left
+// `node`/`npm`/`brew`/`uv` at ENOENT while `git`/`python3` in /usr/bin worked.
+// Same resolution the MCP host uses.
+export async function run_command(
+  i: { cmd: string; args?: string[]; cwd?: string },
+  timeoutMs = 120_000
+): Promise<ToolResult> {
+  const path = await resolveEnhancedPath();
   return new Promise((resolve) => {
     execFile(
       i.cmd,
@@ -13,7 +22,7 @@ export function run_command(i: { cmd: string; args?: string[]; cwd?: string }, t
         cwd: i.cwd,
         timeout: timeoutMs,
         maxBuffer: 8_000_000,
-        env: { PATH: process.env.PATH, HOME: process.env.HOME, LANG: process.env.LANG, SystemRoot: process.env.SystemRoot }
+        env: { PATH: path, HOME: process.env.HOME, LANG: process.env.LANG, SystemRoot: process.env.SystemRoot }
       },
       (err, stdout, stderr) => resolve({ output: (stdout || '') + (stderr || ''), is_error: !!err })
     );


### PR DESCRIPTION
桌面端本地工具（Mac app 的 `fs.*` / `shell.*` / 本地 MCP）的 5 个缺陷。起因是审计「本地工具与云端 aichat2 工具如何配合」，逐条实测复现后修复。

## 问题与修复

### 1. fs 授权范围远大于对话框描述 — 安全

批准一次 `fs.write_file`，实际授权的是**整个父目录的读 + 写**（`SESSION_ROOTS` 是 `inRootDir()` 里所有 fs 操作的统一判据），而弹框只写了单个文件名。实测：

```
对话框: "Run local tool: fs.write_file? {path: .../Desktop/notes.txt}" → Always allow
→ 同级 secrets.txt      可读
→ 子目录 private/keys.txt 可读
→ 整个 Desktop 列目录     可读
```

而且权限方向是反的：`fs.read_file` 只授权那一个文件（既有测试有断言），`fs.write_file` 却授权父目录 —— 写本该更严。

**修复：** 统一为文件夹级读写授权（这是有用的工作单元，逐文件授权会让每个邻居都重新弹框），并让对话框**如实写出被授权的文件夹绝对路径**。同时让「Allow once」名副其实——调用结束即释放，三个档位才真的是三个语义。

### 2. `shell.run_command` 在 Dock/Finder 启动时基本残废 — 功能

用的是继承来的 PATH。macOS 上 `launchctl getenv PATH` 为空，GUI 启动的 app 只拿到 `/usr/bin:/bin:/usr/sbin:/sbin`。实测：

```
node FAIL ENOENT   npm FAIL ENOENT   brew FAIL ENOENT
git  ok            python3 ok         （因为在 /usr/bin）
```

症状取决于启动方式：终端启动一切正常，Dock 点开就挂。`mcp.ts` 早就解决了这个问题（探测 login shell + 补 homebrew/nvm/bun），但 shell.ts 完全没用。

**修复：** 解析器抽到 `local/env.ts`，两个调用方共用。

### 3.「Allow for session」对 shell / write / 全部 MCP 工具是死按钮 — 体验

`consentOk` 用 `!mutates` 做门禁，而 `ipc.ts` 把 `mutates` 算成「不是 read_file/list_dir 就算」（连 `ToolSpec.mutates` 字段都没读）。结果：按钮能点、写进了缓存、但永远不生效，每次调用还是弹框。档位实际只有「每次都问」和「永久不问」两档。

**修复：** session grant 对所有工具生效。它的 key 是**输入绑定**的，所以只会对「与已批准内容逐字节相同的重复调用」跳过弹框。

### 4. macOS 缺三个文件夹 TCC 用途说明 — 打包

`NSDesktopFolderUsageDescription` / `NSDocumentsFolderUsageDescription` / `NSDownloadsFolderUsageDescription` 全缺。这三个目录是独立 TCC 门，而「改我桌面上的文件」正是本功能最典型的用例，缺 usage string 时系统提示理由空白。

### 5. write_file 崩溃后该路径永久写不进去 — 健壮性

固定的 `<file>.tmp` + `flag:'wx'` + 无任何清理。崩在 write 和 rename 之间会残留 tmp，此后对该路径的所有写入永久 `EEXIST`，错误还指向一个用户根本不知道存在的文件。实测确认。

**修复：** 唯一 tmp 名 + 失败时 unlink。

## 验证

- `npm run test:run` — 873 passed（新增 7 条针对上述场景的测试）
- `tsc -p electron/tsconfig.json` — 0 error
- `npm run lint` / `npm run build` — 通过
- 每条修复前都先写了复现测试确认问题真实存在

## 不在本 PR 范围

本地 MCP 工具**无条数上限、无 lazy loading**，全量进每轮 prompt（云端 MCP 有 `load_mcp_server` 按需展开）。挂一个 Playwright MCP ≈ 每轮 +3~5k token。这条涉及 aichat2 worker，单开 PR。

## 🤖 对抗评审 (reviewer: codex, 2 rounds)

第 1 轮 — 2 RISK，均针对我新加的 Allow-once 释放逻辑，**都已实测复现并修复**：

- **RISK: 一个调用完成会撤销其他并行的 once 授权** → 已修。`releaseOnceGrants()` 排干的是全局队列，并行 fs 调用会互相撤销。改为 `consentOk` 返回**每次调用自己的** `release` 句柄。
- **RISK: once 清理会误删同一文件夹上已有的 session 授权** → 已修。`SESSION_ROOTS` 是无主集合，先 session 授权 `/dir/a`、再 once 授权 `/dir/b`，释放后 `/dir` 被整个删掉，session 授权成为附带损害（已写测试复现）。改为 session / once 两层分离，且 once 层**引用计数**。

第 2 轮 — 1 RISK，**驳回并缓解**：

- **RISK: session 授权现在会让非幂等工具静默重复执行** → 未采纳。旧的 `!mutates` 门提供的"保护"是意外产物而非设计：它把授权写进缓存却永不兑现，等于给用户一个点了没反应的按钮 —— 恢复它正好把本 PR 要修的 #3 重新变回 bug。session key 是 `conversationId + 工具名 + 逐字节输入`，用户对着精确输入点「Allow for session」本身就是在表达"这个会话里这条别再问"。**缓解：** 对话框现在明确写出重复语义 —— "会不再询问地重复执行这次调用，如果它会发送/发布/删除，那可能再次发生"。