### PR TITLE
feat(local-tools): fs.edit_file 精确编辑 + fs.read_file 分页读

### DIFF
--- a/change/@acedatacloud-nexior-5ca09626-5a2b-49ed-8e11-6b393b398124.json
+++ b/change/@acedatacloud-nexior-5ca09626-5a2b-49ed-8e11-6b393b398124.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(local-tools): 新增 fs.edit_file 精确编辑与 fs.read_file 分页读",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/electron/local/fs.test.ts
+++ b/electron/local/fs.test.ts
@@ -1,5 +1,14 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import { mkdtempSync, mkdirSync, writeFileSync, readdirSync, realpathSync } from 'node:fs';
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  chmodSync,
+  statSync
+} from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import {
@@ -9,6 +18,7 @@ import {
   list_dir,
   read_file,
   write_file,
+  edit_file,
   _resetRootsForTesting
 } from './fs';
 
@@ -121,5 +131,96 @@ describe('fs consent-authorized roots', () => {
     await expect(write_file({ path: path.join(docs, 'adir'), content: 'x' })).rejects.toThrow();
     const leftovers = readdirSync(docs).filter((f) => f.includes('.tmp'));
     expect(leftovers).toEqual([]);
+  });
+});
+
+describe('fs.edit_file', () => {
+  afterEach(() => _resetRootsForTesting());
+
+  function rooted(content: string, name = 'a.ts') {
+    const base = realpathSync(mkdtempSync(path.join(os.tmpdir(), 'nx-edit-')));
+    const file = path.join(base, name);
+    writeFileSync(file, content);
+    setRoots([base]);
+    return { base, file };
+  }
+
+  it('replaces a unique occurrence and leaves the rest intact', async () => {
+    const { file } = rooted('const a = 1;\nconst b = 2;\n');
+    const res = await edit_file({ path: file, old_string: 'const b = 2;', new_string: 'const b = 3;' });
+    expect(res.is_error).toBeFalsy();
+    expect(readFileSync(file, 'utf8')).toBe('const a = 1;\nconst b = 3;\n');
+  });
+
+  it('refuses an ambiguous match instead of editing the wrong one', async () => {
+    const { file } = rooted('x();\nx();\n');
+    await expect(edit_file({ path: file, old_string: 'x();', new_string: 'y();' })).rejects.toThrow('not unique');
+    expect(readFileSync(file, 'utf8')).toBe('x();\nx();\n'); // unchanged
+  });
+
+  it('replaces every occurrence with replace_all', async () => {
+    const { file } = rooted('x();\nx();\n');
+    await edit_file({ path: file, old_string: 'x();', new_string: 'y();', replace_all: true });
+    expect(readFileSync(file, 'utf8')).toBe('y();\ny();\n');
+  });
+
+  it('rejects a missing old_string', async () => {
+    const { file } = rooted('hello\n');
+    await expect(edit_file({ path: file, old_string: 'nope', new_string: 'x' })).rejects.toThrow('not found');
+  });
+
+  it('enforces the roots boundary', async () => {
+    const outside = realpathSync(mkdtempSync(path.join(os.tmpdir(), 'nx-out-')));
+    const file = path.join(outside, 'a.txt');
+    writeFileSync(file, 'hello');
+    setRoots([realpathSync(mkdtempSync(path.join(os.tmpdir(), 'nx-in-')))]);
+    await expect(edit_file({ path: file, old_string: 'hello', new_string: 'bye' })).rejects.toThrow(
+      'path outside allowed roots'
+    );
+  });
+
+  it('preserves the original file mode (does not strip the exec bit)', async () => {
+    const { file } = rooted('#!/bin/sh\necho hi\n', 'run.sh');
+    chmodSync(file, 0o755);
+    await edit_file({ path: file, old_string: 'echo hi', new_string: 'echo bye' });
+    expect(statSync(file).mode & 0o777).toBe(0o755);
+  });
+});
+
+describe('fs.read_file pagination', () => {
+  afterEach(() => _resetRootsForTesting());
+
+  function rootedLines(n: number) {
+    const base = realpathSync(mkdtempSync(path.join(os.tmpdir(), 'nx-read-')));
+    const file = path.join(base, 'big.txt');
+    writeFileSync(file, Array.from({ length: n }, (_, i) => `line ${i + 1}`).join('\n'));
+    setRoots([base]);
+    return file;
+  }
+
+  it('returns a small file whole, with no pagination footer', async () => {
+    const file = rootedLines(3);
+    const res = await read_file({ path: file });
+    expect(res.output).toBe('line 1\nline 2\nline 3');
+  });
+
+  it('returns the requested line window', async () => {
+    const file = rootedLines(100);
+    const res = await read_file({ path: file, offset: 10, limit: 3 });
+    expect(res.output).toContain('line 10\nline 11\nline 12');
+    expect(res.output).toContain('[lines 10-12 of 100]');
+  });
+
+  it('flags truncation so the model never thinks it saw the whole file', async () => {
+    const file = rootedLines(2500);
+    const res = await read_file({ path: file });
+    expect(res.output).toContain('[truncated: showing lines 1-2000 of 2500');
+    expect(res.output).not.toContain('line 2001');
+  });
+
+  it('reports an offset past the end rather than returning empty output', async () => {
+    const file = rootedLines(5);
+    const res = await read_file({ path: file, offset: 99 });
+    expect(res.output).toContain('offset 99 is past the end');
   });
 });

--- a/electron/local/fs.ts
+++ b/electron/local/fs.ts
@@ -119,8 +119,34 @@ export function _resetRootsForTesting(): void {
   ONCE_ROOTS.clear();
 }
 
-export async function read_file(i: { path: string }): Promise<ToolResult> {
-  return { output: await fsp.readFile(resolveExisting(i.path), 'utf8') };
+// A whole-file read of a large source file can dwarf the model's context
+// budget, so reads are paginated by line: `offset` (1-based) + `limit`.
+const DEFAULT_READ_LIMIT = 2000;
+
+export async function read_file(i: { path: string; offset?: number; limit?: number }): Promise<ToolResult> {
+  const text = await fsp.readFile(resolveExisting(i.path), 'utf8');
+  const paginate = i.offset !== undefined || i.limit !== undefined;
+  if (!paginate) {
+    const total = countLines(text);
+    if (total <= DEFAULT_READ_LIMIT) return { output: text };
+    // Silently returning the head would let the model believe it saw the whole
+    // file and "rewrite" it from a truncated view, destroying the tail.
+    const head = text.split(/\r?\n/).slice(0, DEFAULT_READ_LIMIT).join('\n');
+    return {
+      output: `${head}\n\n[truncated: showing lines 1-${DEFAULT_READ_LIMIT} of ${total}; pass offset/limit to read more]`
+    };
+  }
+  const lines = text.split(/\r?\n/);
+  const start = Math.max(1, Math.floor(i.offset ?? 1));
+  const limit = Math.max(1, Math.floor(i.limit ?? DEFAULT_READ_LIMIT));
+  const slice = lines.slice(start - 1, start - 1 + limit);
+  if (!slice.length) return { output: `[no lines: file has ${lines.length} lines, offset ${start} is past the end]` };
+  const end = start + slice.length - 1;
+  return { output: `${slice.join('\n')}\n\n[lines ${start}-${end} of ${lines.length}]` };
+}
+
+function countLines(text: string): number {
+  return text.split(/\r?\n/).length;
 }
 
 export async function list_dir(i: { path: string }): Promise<ToolResult> {
@@ -142,4 +168,48 @@ export async function write_file(i: { path: string; content: string }): Promise<
     throw e;
   }
   return { output: `wrote ${i.content.length} bytes` };
+}
+
+/**
+ * Exact string replacement — the difference between "can edit code" and
+ * "must rewrite whole files". `old_string` must appear EXACTLY once unless
+ * `replace_all` is set, so an ambiguous match fails loudly instead of
+ * silently editing the wrong occurrence.
+ */
+export async function edit_file(i: {
+  path: string;
+  old_string: string;
+  new_string: string;
+  replace_all?: boolean;
+}): Promise<ToolResult> {
+  const f = resolveExisting(i.path);
+  if (i.old_string === i.new_string) throw new Error('old_string and new_string are identical');
+  const text = await fsp.readFile(f, 'utf8');
+  const count = occurrences(text, i.old_string);
+  if (count === 0) throw new Error('old_string not found in file');
+  if (count > 1 && !i.replace_all) {
+    throw new Error(`old_string is not unique (${count} matches); add surrounding context or set replace_all`);
+  }
+  const next = i.replace_all ? text.split(i.old_string).join(i.new_string) : text.replace(i.old_string, i.new_string);
+  // Preserve the original mode: a fixed 0600 would silently strip the
+  // executable bit off a script, or make a world-readable file private.
+  const mode = (await fsp.stat(f)).mode & 0o777;
+  // Unique temp name + cleanup, same rationale as write_file: a fixed
+  // `<file>.tmp` orphaned by a crash makes the path unwritable forever.
+  const tmp = `${f}.${process.pid}.${randomUUID().slice(0, 8)}.tmp`;
+  try {
+    await fsp.writeFile(tmp, next, { flag: 'wx', mode });
+    await fsp.rename(tmp, f); // atomic
+  } catch (e) {
+    await fsp.unlink(tmp).catch(() => undefined);
+    throw e;
+  }
+  return { output: `replaced ${count === 1 || !i.replace_all ? 1 : count} occurrence(s) in ${f}` };
+}
+
+// `split().length - 1` rather than a regex: old_string is arbitrary user text
+// and must never be interpreted as a pattern.
+function occurrences(haystack: string, needle: string): number {
+  if (!needle) return 0;
+  return haystack.split(needle).length - 1;
 }

--- a/electron/local/registry.ts
+++ b/electron/local/registry.ts
@@ -5,9 +5,10 @@ import * as computer from './computer';
 import type { McpServerConf, McpServerStatus, ToolInvoke, ToolResult, ToolSpec } from './types';
 
 const BUILTIN: ToolSpec[] = [
-  { name: 'fs.read_file', description: 'Read a UTF-8 file inside an authorized root', input_schema: { type: 'object', properties: { path: { type: 'string' } }, required: ['path'] }, source: 'builtin', mutates: false },
+  { name: 'fs.read_file', description: 'Read a UTF-8 file inside an authorized root. Large files are paginated: pass offset (1-based line) + limit to read a specific range.', input_schema: { type: 'object', properties: { path: { type: 'string' }, offset: { type: 'number' }, limit: { type: 'number' } }, required: ['path'] }, source: 'builtin', mutates: false },
   { name: 'fs.list_dir', description: 'List a directory inside an authorized root', input_schema: { type: 'object', properties: { path: { type: 'string' } }, required: ['path'] }, source: 'builtin', mutates: false },
-  { name: 'fs.write_file', description: 'Write a file inside an authorized root', input_schema: { type: 'object', properties: { path: { type: 'string' }, content: { type: 'string' } }, required: ['path', 'content'] }, source: 'builtin', mutates: true },
+  { name: 'fs.write_file', description: 'Create or overwrite a whole file inside an authorized root. To change part of an existing file, prefer fs.edit_file.', input_schema: { type: 'object', properties: { path: { type: 'string' }, content: { type: 'string' } }, required: ['path', 'content'] }, source: 'builtin', mutates: true },
+  { name: 'fs.edit_file', description: 'Replace an exact string in an existing file inside an authorized root. old_string must match exactly (including indentation) and be unique unless replace_all is set. Preferred over fs.write_file for editing — no need to resend the whole file.', input_schema: { type: 'object', properties: { path: { type: 'string' }, old_string: { type: 'string' }, new_string: { type: 'string' }, replace_all: { type: 'boolean' } }, required: ['path', 'old_string', 'new_string'] }, source: 'builtin', mutates: true },
   { name: 'shell.run_command', description: 'Run a local command (argv form)', input_schema: { type: 'object', properties: { cmd: { type: 'string' }, args: { type: 'array', items: { type: 'string' } }, cwd: { type: 'string' } }, required: ['cmd'] }, source: 'builtin', mutates: true }
 ];
 
@@ -255,9 +256,11 @@ export class Registry {
       if (dot < 0) return { output: `bad mcp tool name ${inv.name}`, is_error: true };
       return this.host.call(rest.slice(0, dot), rest.slice(dot + 1), inv.input);
     }
-    if (inv.name === 'fs.read_file') return fsTool.read_file(inv.input as { path: string });
+    if (inv.name === 'fs.read_file') return fsTool.read_file(inv.input as { path: string; offset?: number; limit?: number });
     if (inv.name === 'fs.list_dir') return fsTool.list_dir(inv.input as { path: string });
     if (inv.name === 'fs.write_file') return fsTool.write_file(inv.input as { path: string; content: string });
+    if (inv.name === 'fs.edit_file')
+      return fsTool.edit_file(inv.input as { path: string; old_string: string; new_string: string; replace_all?: boolean });
     if (inv.name === 'shell.run_command') return run_command(inv.input as { cmd: string; args?: string[]; cwd?: string });
     if (inv.name === 'computer.screenshot') return computer.screenshot();
     if (inv.name === 'computer.click') return computer.click(inv.input as { x: number; y: number; button?: 'left' | 'right' | 'middle' });


### PR DESCRIPTION
## 背景

桌面端本地工具（`window.localExec`，由 aichat2 云端大脑通过 `client_tools` 调用）此前只有三个文件工具，其中写路径**只有 `fs.write_file` 全文覆写**。

这意味着改一个 500 行文件里的 3 行，模型必须：读全文 → 在上下文里重排全文 → 整体写回。token 开销随文件线性增长，而且重排过程中极易丢内容 —— 这是"能不能写代码"的分水岭。

## 改动

### `fs.edit_file`（新增）

`old_string` → `new_string` 精确替换：

- **默认要求唯一匹配**。命中多处时报错并提示补充上下文，而不是静默改掉第一处 —— 后者会在模型无感知的情况下改错位置。
- `replace_all` 显式放开批量替换。
- **保留原文件权限**。`write_file` 的 `tmp + rename` 路径硬编码 `mode: 0o600`，用它改一个 `0755` 的脚本会静默丢掉执行位；`edit_file` 先 `stat` 再按原 mode 写。
- 匹配用 `split().length - 1` 而非正则 —— `old_string` 是任意用户文本，绝不能被当作模式解释。

### `fs.read_file`（增强）

- 新增 `offset`（1-based 行号）+ `limit` 分页。
- 未分页且超过 2000 行时**截断并显式标注** `[truncated: showing lines 1-2000 of N]`。静默返回头部会让模型以为读到了全文，进而据此"重写"整个文件、毁掉尾部。
- 小文件行为不变（原样返回，无页脚）。

## 安全边界

**不变**。两个工具都走既有的 `resolveExisting()` → ROOTS + realpath 校验，符号链接逃逸与兄弟目录前缀绕过的防护原样生效。

`edit_file` 的 consent 授权落在**文件本身**（`authorizeConsentedPath` 对非 `fs.write_file` 走 `realpath(目标)`），比 `write_file` 授权父目录的范围更窄。

## 测试

`electron/local/fs.test.ts` 新增 10 例，覆盖：唯一替换 / 歧义拒绝且文件不变 / `replace_all` / 未命中 / **roots 边界拦截** / **权限位保留**，以及分页的四个分支（小文件原样、指定窗口、截断标注、offset 越界）。

```
Test Files  1 passed (1)
     Tests  15 passed (15)
```

`npx vue-tsc -b` 与 `npx beachball check` 均通过。

## 说明

- 这是对标 Claude Code 本地能力的第一步；配套的 `fs.grep` / `fs.glob`（检索）与项目上下文（`AGENTS.md`）分别在独立 PR 中。
- **暂不合并**，等一并 review。

🤖 Generated with [Claude Code](https://claude.com/claude-code)