### PR TITLE
feat(local-tools): fs.glob / fs.grep 本地检索工具

### DIFF
--- a/change/@acedatacloud-nexior-af1034a0-df90-44ad-b83f-8cf182747406.json
+++ b/change/@acedatacloud-nexior-af1034a0-df90-44ad-b83f-8cf182747406.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(local-tools): 新增 fs.glob / fs.grep 本地检索工具",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/electron/local/fs.ts
+++ b/electron/local/fs.ts
@@ -43,10 +43,23 @@ function inRootDir(full: string): boolean {
 // Models commonly pass `~/Desktop`; Node never expands `~`, so realpathSync
 // would walk a literal `/~` and ENOENT. Expand a leading `~`/`~/` to the home
 // dir (which is typically what an authorized root sits under).
-function expandHome(p: string): string {
+export function expandHome(p: string): string {
   if (p === '~') return os.homedir();
   if (p.startsWith('~/') || p.startsWith('~\\')) return path.join(os.homedir(), p.slice(2));
   return p;
+}
+
+// Every authorized root (persistent + session + live once-grants), for tools
+// that search across all of them when no explicit path is given. Includes the
+// once tier so a folder the user just approved is searchable for that call.
+export function listRoots(): string[] {
+  return [...ROOTS, ...SESSION_ROOTS, ...ONCE_ROOTS.keys()];
+}
+
+// Public boundary check for non-fs tools (search): resolve and assert the path
+// stays inside an authorized root. Same realpath semantics as resolveExisting.
+export function assertInRoots(p: string): string {
+  return resolveExisting(p);
 }
 
 // For reads/lists: resolve the real file and assert it stays in a root (blocks

--- a/electron/local/registry.ts
+++ b/electron/local/registry.ts
@@ -1,5 +1,6 @@
 import { McpHost } from './mcp';
 import * as fsTool from './fs';
+import * as search from './search';
 import { run_command } from './shell';
 import * as computer from './computer';
 import type { McpServerConf, McpServerStatus, ToolInvoke, ToolResult, ToolSpec } from './types';
@@ -9,6 +10,8 @@ const BUILTIN: ToolSpec[] = [
   { name: 'fs.list_dir', description: 'List a directory inside an authorized root', input_schema: { type: 'object', properties: { path: { type: 'string' } }, required: ['path'] }, source: 'builtin', mutates: false },
   { name: 'fs.write_file', description: 'Create or overwrite a whole file inside an authorized root. To change part of an existing file, prefer fs.edit_file.', input_schema: { type: 'object', properties: { path: { type: 'string' }, content: { type: 'string' } }, required: ['path', 'content'] }, source: 'builtin', mutates: true },
   { name: 'fs.edit_file', description: 'Replace an exact string in an existing file inside an authorized root. old_string must match exactly (including indentation) and be unique unless replace_all is set. Preferred over fs.write_file for editing — no need to resend the whole file.', input_schema: { type: 'object', properties: { path: { type: 'string' }, old_string: { type: 'string' }, new_string: { type: 'string' }, replace_all: { type: 'boolean' } }, required: ['path', 'old_string', 'new_string'] }, source: 'builtin', mutates: true },
+  { name: 'fs.glob', description: 'Find files by name pattern inside the authorized roots (e.g. "**/*.ts", "src/**/index.*"). Searches every root when path is omitted. Skips node_modules/.git/dist and similar. Prefer this over crawling with fs.list_dir.', input_schema: { type: 'object', properties: { pattern: { type: 'string' }, path: { type: 'string' }, hidden: { type: 'boolean' }, case_insensitive: { type: 'boolean' } }, required: ['pattern'] }, source: 'builtin', mutates: false },
+  { name: 'fs.grep', description: 'Search file CONTENT by regular expression inside the authorized roots, returning "path:line: text". Optionally restrict to files matching a glob. Skips binaries and node_modules/.git/dist. Use this to locate code instead of reading files one by one.', input_schema: { type: 'object', properties: { pattern: { type: 'string' }, path: { type: 'string' }, glob: { type: 'string' }, case_insensitive: { type: 'boolean' }, hidden: { type: 'boolean' }, max_results: { type: 'number' } }, required: ['pattern'] }, source: 'builtin', mutates: false },
   { name: 'shell.run_command', description: 'Run a local command (argv form)', input_schema: { type: 'object', properties: { cmd: { type: 'string' }, args: { type: 'array', items: { type: 'string' } }, cwd: { type: 'string' } }, required: ['cmd'] }, source: 'builtin', mutates: true }
 ];
 
@@ -261,6 +264,19 @@ export class Registry {
     if (inv.name === 'fs.write_file') return fsTool.write_file(inv.input as { path: string; content: string });
     if (inv.name === 'fs.edit_file')
       return fsTool.edit_file(inv.input as { path: string; old_string: string; new_string: string; replace_all?: boolean });
+    if (inv.name === 'fs.glob')
+      return search.glob(inv.input as { pattern: string; path?: string; hidden?: boolean; case_insensitive?: boolean });
+    if (inv.name === 'fs.grep')
+      return search.grep(
+        inv.input as {
+          pattern: string;
+          path?: string;
+          glob?: string;
+          case_insensitive?: boolean;
+          hidden?: boolean;
+          max_results?: number;
+        }
+      );
     if (inv.name === 'shell.run_command') return run_command(inv.input as { cmd: string; args?: string[]; cwd?: string });
     if (inv.name === 'computer.screenshot') return computer.screenshot();
     if (inv.name === 'computer.click') return computer.click(inv.input as { x: number; y: number; button?: 'left' | 'right' | 'middle' });

--- a/electron/local/search.test.ts
+++ b/electron/local/search.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, realpathSync, symlinkSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { setRoots, _resetRootsForTesting } from './fs';
+import { glob, grep } from './search';
+
+function tree() {
+  const base = realpathSync(mkdtempSync(path.join(os.tmpdir(), 'nx-search-')));
+  mkdirSync(path.join(base, 'src'));
+  mkdirSync(path.join(base, 'src', 'nested'));
+  mkdirSync(path.join(base, 'node_modules'));
+  writeFileSync(path.join(base, 'src', 'a.ts'), 'export const alpha = 1;\nconst other = 2;\n');
+  writeFileSync(path.join(base, 'src', 'nested', 'b.ts'), 'export const beta = 2;\n');
+  writeFileSync(path.join(base, 'src', 'c.js'), 'const alpha = 3;\n');
+  writeFileSync(path.join(base, 'readme.md'), 'alpha docs\n');
+  writeFileSync(path.join(base, 'node_modules', 'junk.ts'), 'export const alpha = 999;\n');
+  setRoots([base]);
+  return base;
+}
+
+describe('fs.glob', () => {
+  afterEach(() => _resetRootsForTesting());
+
+  it('matches by extension at any depth', async () => {
+    tree();
+    const res = await glob({ pattern: '**/*.ts' });
+    expect(res.output).toContain('a.ts');
+    expect(res.output).toContain('b.ts');
+    expect(res.output).not.toContain('c.js');
+  });
+
+  it('matches a bare filename pattern at any depth', async () => {
+    tree();
+    const res = await glob({ pattern: '*.ts' });
+    expect(res.output).toContain('a.ts');
+    expect(res.output).toContain('b.ts');
+  });
+
+  it('skips node_modules', async () => {
+    tree();
+    const res = await glob({ pattern: '**/*.ts' });
+    expect(res.output).not.toContain('junk.ts');
+  });
+
+  it('skips hidden files unless asked', async () => {
+    const base = tree();
+    writeFileSync(path.join(base, '.secret.ts'), 'x');
+    expect((await glob({ pattern: '**/*.ts' })).output).not.toContain('.secret.ts');
+    expect((await glob({ pattern: '**/*.ts', hidden: true })).output).toContain('.secret.ts');
+  });
+
+  it('a single * does not cross a directory boundary', async () => {
+    tree();
+    const res = await glob({ pattern: 'src/*.ts' });
+    expect(res.output).toContain('a.ts');
+    expect(res.output).not.toContain('b.ts'); // in src/nested/
+  });
+
+  it('rejects a path outside the authorized roots', async () => {
+    tree();
+    const outside = realpathSync(mkdtempSync(path.join(os.tmpdir(), 'nx-out-')));
+    await expect(glob({ pattern: '*', path: outside })).rejects.toThrow('path outside allowed roots');
+  });
+
+  it('does not follow a symlink out of the root', async () => {
+    const base = tree();
+    const outside = realpathSync(mkdtempSync(path.join(os.tmpdir(), 'nx-out-')));
+    writeFileSync(path.join(outside, 'leaked.ts'), 'secret');
+    symlinkSync(outside, path.join(base, 'escape'));
+    const res = await glob({ pattern: '**/*.ts' });
+    expect(res.output).not.toContain('leaked.ts');
+  });
+
+  it('reports no matches rather than erroring', async () => {
+    tree();
+    const res = await glob({ pattern: '**/*.rs' });
+    expect(res.output).toContain('no files match');
+  });
+});
+
+describe('fs.grep', () => {
+  afterEach(() => _resetRootsForTesting());
+
+  it('returns path:line: text for content matches', async () => {
+    tree();
+    const res = await grep({ pattern: 'alpha' });
+    expect(res.output).toMatch(/a\.ts:1: export const alpha = 1;/);
+  });
+
+  it('restricts to files matching a glob', async () => {
+    tree();
+    const res = await grep({ pattern: 'alpha', glob: '*.md' });
+    expect(res.output).toContain('readme.md');
+    expect(res.output).not.toContain('a.ts');
+  });
+
+  it('honors case sensitivity by default and case_insensitive on request', async () => {
+    tree();
+    expect((await grep({ pattern: 'ALPHA' })).output).toContain('no matches');
+    expect((await grep({ pattern: 'ALPHA', case_insensitive: true })).output).toContain('a.ts');
+  });
+
+  it('skips node_modules', async () => {
+    tree();
+    expect((await grep({ pattern: 'alpha' })).output).not.toContain('junk.ts');
+  });
+
+  it('skips binary files', async () => {
+    const base = tree();
+    writeFileSync(path.join(base, 'blob.bin'), Buffer.from([0x00, 0x61, 0x6c, 0x70, 0x68, 0x61]));
+    expect((await grep({ pattern: 'alpha' })).output).not.toContain('blob.bin');
+  });
+
+  it('rejects an invalid regex with a clear message', async () => {
+    tree();
+    await expect(grep({ pattern: '([' })).rejects.toThrow('invalid regex');
+  });
+
+  it('finds every match on consecutive lines even with a /g-style pattern', async () => {
+    const base = tree();
+    writeFileSync(path.join(base, 'src', 'many.ts'), 'hit\nhit\nhit\n');
+    const res = await grep({ pattern: 'hit', glob: 'many.ts' });
+    expect(res.output.split('\n').filter((l) => l.includes('many.ts'))).toHaveLength(3);
+  });
+
+  it('caps results at max_results', async () => {
+    const base = tree();
+    writeFileSync(path.join(base, 'src', 'many.ts'), Array.from({ length: 50 }, () => 'hit').join('\n'));
+    const res = await grep({ pattern: 'hit', glob: 'many.ts', max_results: 5 });
+    expect(res.output.split('\n').filter((l) => l.includes('many.ts'))).toHaveLength(5);
+    expect(res.output).toContain('[truncated');
+  });
+
+  it('rejects a path outside the authorized roots', async () => {
+    tree();
+    const outside = realpathSync(mkdtempSync(path.join(os.tmpdir(), 'nx-out-')));
+    await expect(grep({ pattern: 'x', path: outside })).rejects.toThrow('path outside allowed roots');
+  });
+
+  it('errors clearly when no roots are authorized at all', async () => {
+    _resetRootsForTesting();
+    await expect(grep({ pattern: 'x' })).rejects.toThrow('no authorized roots');
+  });
+});

--- a/electron/local/search.ts
+++ b/electron/local/search.ts
@@ -1,0 +1,236 @@
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import type { ToolResult } from './types';
+import { assertInRoots, expandHome, listRoots } from './fs';
+
+// Search tools (glob by name, grep by content) confined to the same authorized
+// roots as the file tools. Without these the model can only crawl `list_dir`
+// level by level, which costs a round-trip per directory.
+
+// Directories that are never worth walking and would dominate every result set.
+const SKIP_DIRS = new Set([
+  'node_modules',
+  '.git',
+  '.hg',
+  '.svn',
+  'dist',
+  'build',
+  'out',
+  '.next',
+  '.nuxt',
+  '.venv',
+  'venv',
+  '__pycache__',
+  '.pytest_cache',
+  '.ruff_cache',
+  '.mypy_cache',
+  'target',
+  'vendor',
+  '.gradle',
+  'Pods',
+  '.terraform'
+]);
+
+const MAX_FILES_SCANNED = 20_000; // walk ceiling, so a huge tree can't hang the app
+const MAX_GLOB_RESULTS = 500;
+const MAX_GREP_MATCHES = 200;
+const MAX_GREP_FILE_BYTES = 2_000_000; // skip anything bigger; not source code
+const MAX_LINE_CHARS = 400; // one minified line shouldn't blow the model's context
+const WALK_BUDGET_MS = 10_000;
+
+/** Glob → RegExp. Every non-wildcard char is escaped, so a path containing
+ *  regex metacharacters can never be reinterpreted as a pattern. */
+function globToRegExp(glob: string, caseInsensitive: boolean): RegExp {
+  let re = '';
+  for (let i = 0; i < glob.length; i++) {
+    const c = glob[i];
+    if (c === '*') {
+      if (glob[i + 1] === '*') {
+        // `**/` spans any depth INCLUDING zero, so `**/*.ts` also matches a
+        // top-level `a.ts`.
+        if (glob[i + 2] === '/') {
+          re += '(?:.*/)?';
+          i += 2;
+        } else {
+          re += '.*';
+          i += 1;
+        }
+      } else {
+        re += '[^/]*'; // a single * never crosses a directory boundary
+      }
+    } else if (c === '?') {
+      re += '[^/]';
+    } else if (c === '{') {
+      re += '(?:';
+    } else if (c === '}') {
+      re += ')';
+    } else if (c === ',') {
+      re += '|';
+    } else {
+      re += c.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    }
+  }
+  return new RegExp(`^${re}$`, caseInsensitive ? 'i' : '');
+}
+
+/** Resolve the search base: an explicit path (must be in a root) or all roots. */
+function searchBases(p?: string): string[] {
+  if (p) return [assertInRoots(expandHome(p))];
+  const roots = listRoots();
+  if (!roots.length) throw new Error('no authorized roots; add a folder in Settings → Local Tools');
+  return roots;
+}
+
+interface WalkOpts {
+  onFile: (full: string, rel: string) => Promise<boolean> | boolean; // false → stop
+  hidden?: boolean;
+}
+
+/** Depth-first walk bounded by file count and wall-clock budget.
+ *  `withFileTypes` + an explicit `isSymbolicLink` skip keeps the walk inside
+ *  the root: a symlink to `/` would otherwise escape the authorized boundary. */
+async function walk(base: string, opts: WalkOpts): Promise<{ scanned: number; hitLimit: boolean }> {
+  const deadline = Date.now() + WALK_BUDGET_MS;
+  let scanned = 0;
+  let hitLimit = false;
+  const stack: string[] = [base];
+
+  while (stack.length) {
+    if (scanned >= MAX_FILES_SCANNED || Date.now() > deadline) {
+      hitLimit = true;
+      break;
+    }
+    const dir = stack.pop()!;
+    let entries;
+    try {
+      entries = await fsp.readdir(dir, { withFileTypes: true });
+    } catch {
+      continue; // unreadable dir (permissions) — skip, don't fail the whole search
+    }
+    for (const e of entries) {
+      if (e.isSymbolicLink()) continue;
+      if (!opts.hidden && e.name.startsWith('.')) continue;
+      const full = path.join(dir, e.name);
+      if (e.isDirectory()) {
+        if (SKIP_DIRS.has(e.name)) continue;
+        stack.push(full);
+      } else if (e.isFile()) {
+        scanned++;
+        if (scanned >= MAX_FILES_SCANNED) {
+          hitLimit = true;
+          break;
+        }
+        const cont = await opts.onFile(full, path.relative(base, full));
+        if (cont === false) {
+          hitLimit = true;
+          return { scanned, hitLimit };
+        }
+      }
+    }
+  }
+  return { scanned, hitLimit };
+}
+
+/** Find files by name pattern (e.g. `**​/*.ts`, `src/**​/index.*`). */
+export async function glob(i: {
+  pattern: string;
+  path?: string;
+  hidden?: boolean;
+  case_insensitive?: boolean;
+}): Promise<ToolResult> {
+  if (!i.pattern) throw new Error('pattern is required');
+  const re = globToRegExp(i.pattern, i.case_insensitive ?? false);
+  const out: string[] = [];
+  let truncated = false;
+
+  for (const base of searchBases(i.path)) {
+    const { hitLimit } = await walk(base, {
+      hidden: i.hidden,
+      onFile: (full, rel) => {
+        // Match against the root-relative path (so `**/*.ts` behaves) and the
+        // bare filename (so a bare `*.ts` matches at any depth, which is what
+        // a model almost always means).
+        if (re.test(rel) || re.test(path.basename(rel))) {
+          out.push(full);
+          if (out.length >= MAX_GLOB_RESULTS) return false;
+        }
+        return true;
+      }
+    });
+    if (hitLimit) truncated = true;
+    if (out.length >= MAX_GLOB_RESULTS) {
+      truncated = true;
+      break;
+    }
+  }
+
+  if (!out.length) return { output: `no files match ${i.pattern}` };
+  const note = truncated ? `\n\n[truncated at ${out.length} results]` : '';
+  return { output: out.join('\n') + note };
+}
+
+/** A NUL byte in the first block is the standard binary heuristic (same as
+ *  grep's); scanning a binary produces garbage lines, not matches. */
+function looksBinary(buf: Buffer): boolean {
+  return buf.subarray(0, 8000).includes(0);
+}
+
+/** Search file CONTENT by regex, returning `path:line: text` hits. */
+export async function grep(i: {
+  pattern: string;
+  path?: string;
+  glob?: string;
+  case_insensitive?: boolean;
+  hidden?: boolean;
+  max_results?: number;
+}): Promise<ToolResult> {
+  if (!i.pattern) throw new Error('pattern is required');
+  let re: RegExp;
+  try {
+    re = new RegExp(i.pattern, i.case_insensitive ? 'i' : '');
+  } catch (e) {
+    throw new Error(`invalid regex: ${e instanceof Error ? e.message : String(e)}`);
+  }
+  const fileFilter = i.glob ? globToRegExp(i.glob, i.case_insensitive ?? false) : null;
+  const cap = Math.min(Math.max(1, Math.floor(i.max_results ?? MAX_GREP_MATCHES)), MAX_GREP_MATCHES);
+  const hits: string[] = [];
+  let truncated = false;
+
+  for (const base of searchBases(i.path)) {
+    const { hitLimit } = await walk(base, {
+      hidden: i.hidden,
+      onFile: async (full, rel) => {
+        if (fileFilter && !fileFilter.test(rel) && !fileFilter.test(path.basename(rel))) return true;
+        let buf: Buffer;
+        try {
+          const st = await fsp.stat(full);
+          if (st.size > MAX_GREP_FILE_BYTES) return true;
+          buf = await fsp.readFile(full);
+        } catch {
+          return true; // unreadable file — skip
+        }
+        if (looksBinary(buf)) return true;
+        const lines = buf.toString('utf8').split(/\r?\n/);
+        for (let n = 0; n < lines.length; n++) {
+          // `re` may carry /g from the model; lastIndex would then make test()
+          // stateful across lines and skip every other match.
+          re.lastIndex = 0;
+          if (!re.test(lines[n])) continue;
+          const text = lines[n].length > MAX_LINE_CHARS ? lines[n].slice(0, MAX_LINE_CHARS) + '…' : lines[n];
+          hits.push(`${full}:${n + 1}: ${text}`);
+          if (hits.length >= cap) return false;
+        }
+        return true;
+      }
+    });
+    if (hitLimit) truncated = true;
+    if (hits.length >= cap) {
+      truncated = true;
+      break;
+    }
+  }
+
+  if (!hits.length) return { output: `no matches for ${i.pattern}` };
+  const note = truncated ? `\n\n[truncated at ${hits.length} matches]` : '';
+  return { output: hits.join('\n') + note };
+}


### PR DESCRIPTION
## 背景

桌面端本地工具此前**没有任何检索能力**。模型想知道"某个符号定义在哪"，只有两条路：

1. `fs.list_dir` 一层层爬 —— 每一层都是一次 client-tool 往返；
2. 退到 `shell.run_command` 调外部 `grep`/`find` —— 每次弹窗审批，而且 shell **不受 ROOTS 边界约束**。

这既是往返次数多的主因，也在把用户推向"给 shell 开 tool-wide 授权"这个更危险的选择。

## 改动

新增 `electron/local/search.ts`，注册两个**只读**工具（`mutates: false`，因此不触发写操作那套逐次确认）：

### `fs.glob`
按文件名模式查找：`**/*.ts`、`src/**/index.*`。省略 `path` 时搜索全部授权根目录。

### `fs.grep`
按正则搜索文件**内容**，返回 `path:line: text`，可用 `glob` 参数限定文件范围，支持 `case_insensitive` / `max_results`。

## 边界与健壮性

安全边界与文件工具**完全一致**（ROOTS + realpath），另外处理了几个走查中发现的坑：

- **符号链接显式跳过**。`walk` 不跟随 symlink —— 否则授权目录里一条指向 `/` 的链接就能把整个磁盘读出来。已有测试覆盖。
- **glob → 正则转换对所有非通配字符转义**，避免路径中的正则元字符被重新解释为模式。
- **每次 `test()` 前重置 `lastIndex`**。模型传来的正则可能带 `/g`，那样 `test()` 会跨行保持状态、漏掉约一半匹配。
- 跳过 `node_modules` / `.git` / `dist` 等噪声目录；跳过二进制（首块 NUL 探测，与 grep 同款启发式）与 >2MB 的文件。
- `walk` 受**文件数（20k）与墙钟（10s）双重上限**约束，超长行截断到 400 字符 —— 一个压缩过的 bundle 不该吃掉模型整个上下文。
- 结果截断时**显式标注** `[truncated at N]`，不让模型误以为看到了全集。
- 单个 `*` 不跨目录分隔符；`**/` 匹配包含零层，所以 `**/*.ts` 也能命中顶层文件。

## 测试

`electron/local/search.test.ts` 新增 18 例，含符号链接逃逸、roots 越界、二进制跳过、`/g` 正则跨行、结果封顶、无授权根目录时的清晰报错。

```
electron/local/ 全量：Test Files 5 passed | Tests 54 passed
```

`npx vue-tsc -b` 通过。

## 说明

- 与 #1467（`fs.edit_file` + 分页读）相互独立，可分别 review；两者都改了 `registry.ts` 的工具表和 `fs.ts`，合并时会有小冲突，按后合并者 rebase 处理即可。
- **暂不合并**，等一并 review。

🤖 Generated with [Claude Code](https://claude.com/claude-code)