### PR TITLE
feat(local-tools): project.load_context 加载项目约定与命令

### DIFF
--- a/change/@acedatacloud-nexior-6406377f-a8cf-4c77-966d-13fe125926d9.json
+++ b/change/@acedatacloud-nexior-6406377f-a8cf-4c77-966d-13fe125926d9.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(local-tools): 新增 project.load_context 加载项目约定与命令",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/electron/local/context.test.ts
+++ b/electron/local/context.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, realpathSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { setRoots, _resetRootsForTesting } from './fs';
+import { load_project_context } from './context';
+
+function repo() {
+  const base = realpathSync(mkdtempSync(path.join(os.tmpdir(), 'nx-ctx-')));
+  mkdirSync(path.join(base, 'pkg'));
+  setRoots([base]);
+  return base;
+}
+
+describe('project.load_context', () => {
+  afterEach(() => _resetRootsForTesting());
+
+  it('loads AGENTS.md from the root', async () => {
+    const base = repo();
+    writeFileSync(path.join(base, 'AGENTS.md'), '# Rules\nUse tabs.\n');
+    const res = await load_project_context({ path: base });
+    expect(res.output).toContain('Use tabs.');
+    expect(res.output).toContain('AUTHORITATIVE');
+  });
+
+  it('prefers AGENTS.md over CLAUDE.md in the same dir (no double-loading)', async () => {
+    const base = repo();
+    writeFileSync(path.join(base, 'AGENTS.md'), 'AGENTS rules\n');
+    writeFileSync(path.join(base, 'CLAUDE.md'), 'CLAUDE rules\n');
+    const res = await load_project_context({ path: base });
+    expect(res.output).toContain('AGENTS rules');
+    expect(res.output).not.toContain('CLAUDE rules');
+  });
+
+  it('cascades from the root down to a nested dir', async () => {
+    const base = repo();
+    writeFileSync(path.join(base, 'AGENTS.md'), 'root rules\n');
+    writeFileSync(path.join(base, 'pkg', 'AGENTS.md'), 'pkg rules\n');
+    const res = await load_project_context({ path: path.join(base, 'pkg') });
+    expect(res.output).toContain('root rules');
+    expect(res.output).toContain('pkg rules');
+    // Outermost first, so the nearer file appends last and effectively wins.
+    expect(res.output.indexOf('root rules')).toBeLessThan(res.output.indexOf('pkg rules'));
+  });
+
+  it('inlines an @-import (the CLAUDE.md → AGENTS.md convention)', async () => {
+    const base = repo();
+    writeFileSync(path.join(base, 'CLAUDE.md'), 'Preamble\n@AGENTS.md\n');
+    writeFileSync(path.join(base, 'AGENTS.md'), 'IMPORTED BODY\n');
+    // Only CLAUDE.md exists as a chosen file if AGENTS.md is absent; here both
+    // exist so AGENTS.md wins directly — assert the import path via a subdir.
+    mkdirSync(path.join(base, 'sub'));
+    writeFileSync(path.join(base, 'sub', 'CLAUDE.md'), 'Sub preamble\n@../AGENTS.md\n');
+    const res = await load_project_context({ path: path.join(base, 'sub') });
+    expect(res.output).toContain('IMPORTED BODY');
+  });
+
+  it('does not follow an @-import outside the authorized roots', async () => {
+    const base = repo();
+    const outside = realpathSync(mkdtempSync(path.join(os.tmpdir(), 'nx-out-')));
+    writeFileSync(path.join(outside, 'secret.md'), 'LEAKED');
+    writeFileSync(path.join(base, 'AGENTS.md'), `@${path.join(outside, 'secret.md')}\n`);
+    const res = await load_project_context({ path: base });
+    expect(res.output).not.toContain('LEAKED');
+  });
+
+  it('survives a circular import instead of recursing forever', async () => {
+    const base = repo();
+    mkdirSync(path.join(base, 'sub'));
+    writeFileSync(path.join(base, 'sub', 'CLAUDE.md'), '@../a.md\n');
+    writeFileSync(path.join(base, 'a.md'), 'A body\n@b.md\n');
+    writeFileSync(path.join(base, 'b.md'), 'B body\n@a.md\n');
+    const res = await load_project_context({ path: path.join(base, 'sub') });
+    expect(res.output).toContain('A body');
+    expect(res.output).toContain('B body');
+    expect(res.output).toContain('circular import');
+  });
+
+  it('lists project slash commands with descriptions', async () => {
+    const base = repo();
+    mkdirSync(path.join(base, '.claude', 'commands'), { recursive: true });
+    writeFileSync(path.join(base, '.claude', 'commands', 'deploy.md'), '# Deploy\nShip to production.\n');
+    const res = await load_project_context({ path: base });
+    expect(res.output).toContain('/deploy');
+    expect(res.output).toContain('Ship to production.');
+  });
+
+  it('finds root-level commands from a nested dir', async () => {
+    const base = repo();
+    mkdirSync(path.join(base, '.claude', 'commands'), { recursive: true });
+    writeFileSync(path.join(base, '.claude', 'commands', 'deploy.md'), 'Ship it.\n');
+    writeFileSync(path.join(base, 'AGENTS.md'), 'rules\n');
+    const res = await load_project_context({ path: path.join(base, 'pkg') });
+    expect(res.output).toContain('/deploy');
+  });
+
+  it('accepts a file path and resolves it to its directory', async () => {
+    const base = repo();
+    writeFileSync(path.join(base, 'AGENTS.md'), 'rules here\n');
+    const f = path.join(base, 'pkg', 'x.ts');
+    writeFileSync(f, 'x');
+    const res = await load_project_context({ path: f });
+    expect(res.output).toContain('rules here');
+  });
+
+  it('reports plainly when a project has no conventions', async () => {
+    const base = repo();
+    const res = await load_project_context({ path: base });
+    expect(res.output).toContain('no project context found');
+  });
+
+  it('rejects a path outside the authorized roots', async () => {
+    repo();
+    const outside = realpathSync(mkdtempSync(path.join(os.tmpdir(), 'nx-out-')));
+    await expect(load_project_context({ path: outside })).rejects.toThrow('path outside allowed roots');
+  });
+
+  it('errors clearly when no roots are authorized', async () => {
+    _resetRootsForTesting();
+    await expect(load_project_context({})).rejects.toThrow('no authorized roots');
+  });
+
+  it('does not walk above the authorized root', async () => {
+    const base = realpathSync(mkdtempSync(path.join(os.tmpdir(), 'nx-ctx-')));
+    const inner = path.join(base, 'inner');
+    mkdirSync(inner);
+    // A convention file ABOVE the root must not be picked up.
+    writeFileSync(path.join(base, 'AGENTS.md'), 'ABOVE ROOT');
+    writeFileSync(path.join(inner, 'AGENTS.md'), 'inner rules');
+    setRoots([inner]);
+    const res = await load_project_context({ path: inner });
+    expect(res.output).toContain('inner rules');
+    expect(res.output).not.toContain('ABOVE ROOT');
+  });
+});

--- a/electron/local/context.ts
+++ b/electron/local/context.ts
@@ -1,0 +1,192 @@
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import type { ToolResult } from './types';
+import { assertInRoots, expandHome, listRoots } from './fs';
+
+// Project context: the convention files a coding agent is expected to obey
+// (AGENTS.md / CLAUDE.md and friends) plus the project's own slash commands.
+// Without this the model has no idea a repo has house rules — it writes code
+// that passes tests but violates every convention the team agreed on.
+
+// Ordered by precedence: the first name found in a directory wins, so a repo
+// carrying both CLAUDE.md and AGENTS.md doesn't get the same rules twice.
+const CONTEXT_FILES = ['AGENTS.md', 'CLAUDE.md', 'CONVENTIONS.md', '.cursorrules', '.github/copilot-instructions.md'];
+
+const MAX_TOTAL_CHARS = 60_000; // a very large AGENTS.md shouldn't eat the whole window
+const MAX_COMMANDS = 100;
+const MAX_IMPORT_DEPTH = 3; // CLAUDE.md → @AGENTS.md → … ; deep chains are pathological
+
+/** Directories to probe, from the given dir UP to (and including) the
+ *  authorized root that contains it. Conventions cascade: a monorepo root
+ *  holds the shared rules, a package dir may add its own. */
+function chainToRoot(start: string): string[] {
+  const roots = listRoots();
+  const owning = roots.find((r) => start === r || start.startsWith(r + path.sep));
+  const stopAt = owning ?? start;
+  const out: string[] = [];
+  let cur = start;
+  // Bounded by the root, and by parent===cur at the filesystem root.
+  for (;;) {
+    out.push(cur);
+    if (cur === stopAt) break;
+    const parent = path.dirname(cur);
+    if (parent === cur) break;
+    cur = parent;
+  }
+  return out.reverse(); // outermost first, so nearer files override/append last
+}
+
+/** Resolve `@path/to/file.md` imports (the syntax CLAUDE.md uses to pull in a
+ *  shared AGENTS.md). Only single-line `@...` directives, only inside roots. */
+async function inlineImports(text: string, baseDir: string, depth: number, seen: Set<string>): Promise<string> {
+  if (depth >= MAX_IMPORT_DEPTH) return text;
+  const lines = text.split(/\r?\n/);
+  const out: string[] = [];
+  for (const line of lines) {
+    const m = /^@([^\s`]+\.(?:md|markdown))\s*$/.exec(line.trim());
+    if (!m) {
+      out.push(line);
+      continue;
+    }
+    let resolved: string;
+    try {
+      resolved = assertInRoots(path.resolve(baseDir, m[1]));
+    } catch {
+      out.push(line); // outside the authorized roots — leave the directive as text
+      continue;
+    }
+    if (seen.has(resolved)) {
+      out.push(`[skipped circular import: ${m[1]}]`);
+      continue;
+    }
+    seen.add(resolved);
+    try {
+      const imported = await fsp.readFile(resolved, 'utf8');
+      out.push(`<!-- imported from ${resolved} -->`);
+      out.push(await inlineImports(imported, path.dirname(resolved), depth + 1, seen));
+    } catch {
+      out.push(line);
+    }
+  }
+  return out.join('\n');
+}
+
+/** List the project's own slash commands (`.claude/commands/*.md`) by name +
+ *  first-line description. Names only — bodies are loaded on demand via
+ *  fs.read_file, so a repo with 40 commands costs ~40 lines, not 40 files. */
+async function listCommands(dir: string): Promise<string[]> {
+  const cmdDir = path.join(dir, '.claude', 'commands');
+  let entries;
+  try {
+    entries = await fsp.readdir(cmdDir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const out: string[] = [];
+  for (const e of entries) {
+    if (out.length >= MAX_COMMANDS) break;
+    if (!e.isFile() || !e.name.endsWith('.md')) continue;
+    const full = path.join(cmdDir, e.name);
+    let desc = '';
+    try {
+      const head = (await fsp.readFile(full, 'utf8')).slice(0, 500).split(/\r?\n/);
+      // Prefer a `description:` frontmatter line; else the first non-empty,
+      // non-heading line.
+      desc =
+        head.find((l) => /^description:/i.test(l.trim()))?.replace(/^description:\s*/i, '') ??
+        head.find((l) => l.trim() && !l.startsWith('#') && !l.startsWith('---'))?.trim() ??
+        '';
+    } catch {
+      /* unreadable command file — list it without a description */
+    }
+    out.push(`/${e.name.replace(/\.md$/, '')}${desc ? ` — ${desc.slice(0, 120)}` : ''} (${full})`);
+  }
+  return out;
+}
+
+/**
+ * Load the convention files that govern a project directory, walking from the
+ * authorized root down to the given path so nested rules append to shared ones.
+ */
+export async function load_project_context(i: { path?: string }): Promise<ToolResult> {
+  let start: string;
+  if (i.path) {
+    start = assertInRoots(expandHome(i.path));
+  } else {
+    const roots = listRoots();
+    if (!roots.length) throw new Error('no authorized roots; add a folder in Settings → Local Tools');
+    start = roots[0];
+  }
+  // A file path is a natural thing for a model to pass ("what rules apply to
+  // this file?"); resolve it to its directory rather than failing.
+  try {
+    if ((await fsp.stat(start)).isFile()) start = path.dirname(start);
+  } catch {
+    /* assertInRoots already proved it exists; a race here is not worth failing */
+  }
+
+  const sections: string[] = [];
+  const found: string[] = [];
+  const seen = new Set<string>();
+  let total = 0;
+  let truncated = false;
+
+  for (const dir of chainToRoot(start)) {
+    for (const name of CONTEXT_FILES) {
+      const full = path.join(dir, name);
+      let text: string;
+      try {
+        text = await fsp.readFile(full, 'utf8');
+      } catch {
+        continue;
+      }
+      seen.add(full);
+      const expanded = await inlineImports(text, dir, 0, seen);
+      const remaining = MAX_TOTAL_CHARS - total;
+      if (remaining <= 0) {
+        truncated = true;
+        break;
+      }
+      const body = expanded.length > remaining ? expanded.slice(0, remaining) + '\n[…truncated]' : expanded;
+      total += body.length;
+      if (expanded.length > remaining) truncated = true;
+      found.push(full);
+      sections.push(`===== ${full} =====\n${body}`);
+      break; // first match in this dir wins (see CONTEXT_FILES ordering)
+    }
+  }
+
+  const commands = await listCommands(start);
+  // Commands may live at the repo root while `start` is a subdirectory.
+  if (!commands.length) {
+    for (const dir of chainToRoot(start)) {
+      const c = await listCommands(dir);
+      if (c.length) {
+        commands.push(...c);
+        break;
+      }
+    }
+  }
+
+  if (!sections.length && !commands.length) {
+    return { output: `no project context found (looked for ${CONTEXT_FILES.join(', ')} from ${start} up to its root)` };
+  }
+
+  const parts: string[] = [];
+  if (sections.length) {
+    parts.push(
+      'Project conventions below are AUTHORITATIVE for work in this directory. Follow them over your defaults.\n'
+    );
+    parts.push(sections.join('\n\n'));
+  }
+  if (commands.length) {
+    parts.push(
+      `\n===== project commands (.claude/commands) =====\n` +
+        `Read one with fs.read_file to see its full procedure.\n` +
+        commands.join('\n')
+    );
+  }
+  if (truncated) parts.push('\n[context truncated at the size cap; read specific files with fs.read_file]');
+  if (found.length) parts.push(`\n[loaded: ${found.join(', ')}]`);
+  return { output: parts.join('\n') };
+}

--- a/electron/local/fs.ts
+++ b/electron/local/fs.ts
@@ -35,10 +35,22 @@ function inRootDir(full: string): boolean {
 // Models commonly pass `~/Desktop`; Node never expands `~`, so realpathSync
 // would walk a literal `/~` and ENOENT. Expand a leading `~`/`~/` to the home
 // dir (which is typically what an authorized root sits under).
-function expandHome(p: string): string {
+export function expandHome(p: string): string {
   if (p === '~') return os.homedir();
   if (p.startsWith('~/') || p.startsWith('~\\')) return path.join(os.homedir(), p.slice(2));
   return p;
+}
+
+// Every authorized root (persistent + session), for tools that operate across
+// all of them when no explicit path is given.
+export function listRoots(): string[] {
+  return [...ROOTS, ...SESSION_ROOTS];
+}
+
+// Public boundary check for non-fs tools: resolve and assert the path stays
+// inside an authorized root. Same realpath semantics as resolveExisting.
+export function assertInRoots(p: string): string {
+  return resolveExisting(p);
 }
 
 // For reads/lists: resolve the real file and assert it stays in a root (blocks

--- a/electron/local/registry.ts
+++ b/electron/local/registry.ts
@@ -1,5 +1,6 @@
 import { McpHost } from './mcp';
 import * as fsTool from './fs';
+import * as projectContext from './context';
 import { run_command } from './shell';
 import * as computer from './computer';
 import type { McpServerConf, McpServerStatus, ToolInvoke, ToolResult, ToolSpec } from './types';
@@ -8,6 +9,7 @@ const BUILTIN: ToolSpec[] = [
   { name: 'fs.read_file', description: 'Read a UTF-8 file inside an authorized root', input_schema: { type: 'object', properties: { path: { type: 'string' } }, required: ['path'] }, source: 'builtin', mutates: false },
   { name: 'fs.list_dir', description: 'List a directory inside an authorized root', input_schema: { type: 'object', properties: { path: { type: 'string' } }, required: ['path'] }, source: 'builtin', mutates: false },
   { name: 'fs.write_file', description: 'Write a file inside an authorized root', input_schema: { type: 'object', properties: { path: { type: 'string' }, content: { type: 'string' } }, required: ['path', 'content'] }, source: 'builtin', mutates: true },
+  { name: 'project.load_context', description: "Load a project's convention files (AGENTS.md / CLAUDE.md / CONVENTIONS.md / .cursorrules) and its slash commands (.claude/commands). ALWAYS call this before writing or modifying code in a project directory — these conventions override your defaults. Walks from the authorized root down to the given path so shared and nested rules both apply.", input_schema: { type: 'object', properties: { path: { type: 'string' } } }, source: 'builtin', mutates: false },
   { name: 'shell.run_command', description: 'Run a local command (argv form)', input_schema: { type: 'object', properties: { cmd: { type: 'string' }, args: { type: 'array', items: { type: 'string' } }, cwd: { type: 'string' } }, required: ['cmd'] }, source: 'builtin', mutates: true }
 ];
 
@@ -258,6 +260,7 @@ export class Registry {
     if (inv.name === 'fs.read_file') return fsTool.read_file(inv.input as { path: string });
     if (inv.name === 'fs.list_dir') return fsTool.list_dir(inv.input as { path: string });
     if (inv.name === 'fs.write_file') return fsTool.write_file(inv.input as { path: string; content: string });
+    if (inv.name === 'project.load_context') return projectContext.load_project_context(inv.input as { path?: string });
     if (inv.name === 'shell.run_command') return run_command(inv.input as { cmd: string; args?: string[]; cwd?: string });
     if (inv.name === 'computer.screenshot') return computer.screenshot();
     if (inv.name === 'computer.click') return computer.click(inv.input as { x: number; y: number; button?: 'left' | 'right' | 'middle' });


### PR DESCRIPTION
## 背景

模型在用户机器上写代码时，**完全看不到项目自身的规范**：仓库根目录的 `AGENTS.md` / `CLAUDE.md`、`.claude/commands/` 下的既有流程，一个都读不到。

结果是写出来的代码能跑通测试，却违反团队约定的每一条 —— 包管理器用错、目录放错、提交规范不符。这是本地写代码能力与 Claude Code 差距里**最不显眼但影响最大**的一块：前两个 PR 让模型"能改文件、能找代码"，这个 PR 让它"改得符合这个项目的规矩"。

## 改动

新增 `project.load_context`（只读）。从授权根目录**向下走到**指定路径，逐级收集：

- 约定文件：`AGENTS.md` → `CLAUDE.md` → `CONVENTIONS.md` → `.cursorrules` → `.github/copilot-instructions.md`
- 项目斜杠命令：`.claude/commands/*.md`

工具描述里写明了 *"ALWAYS call this before writing or modifying code in a project directory"*，所以模型会在动手前自己拉取。

## 设计要点

- **同目录内按优先级取第一个命中**。仓库同时有 `AGENTS.md` 和 `CLAUDE.md`（本项目就是这种情况）时，不会把同一份规则灌两遍。
- **支持 `@path.md` 内联导入** —— 即 `CLAUDE.md` 引用共享 `AGENTS.md` 的写法。导入目标同样受 ROOTS 约束（根外的直接留作普通文本），循环引用被识别并标注跳过，深度上限 3 层。
- **命令只列名称 + 首行描述 + 路径**，正文按需用 `fs.read_file` 取。一个有 40 个命令的仓库因此只花约 40 行上下文，而不是 40 个文件。
- **向上遍历以授权根为界**。根之外的约定文件不会被读到（有测试专门覆盖）。
- 级联顺序是外层在前，所以更近的规则追加在后、自然覆盖。
- 总量上限 60k 字符，超出显式标注截断。
- 传文件路径（"这个文件适用什么规则？"）会自动解析到其所在目录，而不是报错。

## 测试

`electron/local/context.test.ts` 新增 13 例，含：优先级去重、多级级联顺序、`@`-import 内联、**import 越界拦截**、**循环引用**、**不越过授权根向上读**、命令列举与根级回退、无约定时的清晰提示。

```
electron/local/ 全量：Test Files 5 passed | Tests 49 passed
```

`npx vue-tsc -b` 通过。

## 说明

- 与 #1467、#1468 相互独立。三者都在 `registry.ts` 工具表与 `fs.ts` 导出上有小范围重叠（本 PR 与 #1468 都需要 `assertInRoots`/`listRoots`/`expandHome`，内容一致），合并时后者 rebase 即可。
- **暂不合并**，等一并 review。

🤖 Generated with [Claude Code](https://claude.com/claude-code)