### PR TITLE
fix(console): 连接器/技能页样式对齐 Studio 控制台

### DIFF
--- a/change/@acedatacloud-nexior-18f3eeb3-739b-4c0b-8bb1-fe29dcf8f9a0.json
+++ b/change/@acedatacloud-nexior-18f3eeb3-739b-4c0b-8bb1-fe29dcf8f9a0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(console): 连接器/技能页样式对齐 Studio 控制台",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/connections/BrowseConnectors.vue
+++ b/src/components/connections/BrowseConnectors.vue
@@ -778,16 +778,19 @@ export default defineComponent({
   flex-direction: column;
   gap: 8px;
   padding: 14px;
-  border: 1px solid var(--el-border-color-lighter);
-  border-radius: 10px;
-  background: var(--el-bg-color);
+  // Same tokens as <el-card>, which every console page uses.
+  border: 1px solid var(--el-card-border-color);
+  border-radius: var(--el-card-border-radius);
+  background: var(--el-card-bg-color);
   transition:
     border-color 0.1s,
     box-shadow 0.1s;
 
   &:hover {
     border-color: var(--el-border-color);
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
+    // A literal black shadow is invisible on the dark background; the token
+    // adapts.
+    box-shadow: var(--app-shadow-sm);
   }
 }
 

--- a/src/components/skill/BrowseSkillsDialog.vue
+++ b/src/components/skill/BrowseSkillsDialog.vue
@@ -550,19 +550,21 @@ export default defineComponent({
   grid-template-columns: repeat(2, 1fr);
   gap: 12px;
 }
+/* Same tokens as <el-card>, which every console page uses. */
 .directory-card {
-  border: 1px solid var(--el-border-color-lighter);
-  border-radius: 10px;
+  border: 1px solid var(--el-card-border-color);
+  border-radius: var(--el-card-border-radius);
   padding: 14px 16px;
-  background: var(--el-bg-color);
+  background: var(--el-card-bg-color);
   cursor: pointer;
   transition:
     border-color 0.15s,
     box-shadow 0.15s;
 }
+/* A literal black shadow is invisible on the dark background; the token adapts. */
 .directory-card:hover {
   border-color: var(--el-color-primary-light-5);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+  box-shadow: var(--app-shadow-sm);
 }
 .directory-card.is-installed {
   background: var(--el-color-primary-light-9);

--- a/src/components/skill/FileNode.vue
+++ b/src/components/skill/FileNode.vue
@@ -215,7 +215,8 @@ export default defineComponent({
   gap: 6px;
   padding: 4px 12px 4px 8px;
   margin: 1px 8px;
-  border-radius: 6px;
+  /* Match the sibling skill rows and the console sidebar. */
+  border-radius: 10px;
   cursor: pointer;
   font-size: 13px;
   color: var(--el-text-color-regular);
@@ -223,12 +224,12 @@ export default defineComponent({
 }
 
 .file-node:hover {
-  background: var(--el-fill-color);
+  background: var(--el-fill-color-extra-light);
 }
 
 .file-node.active {
-  background: var(--el-fill-color-darker);
-  color: var(--el-text-color-primary);
+  background: var(--el-color-primary-light-9);
+  color: var(--el-color-primary);
   font-weight: 500;
 }
 

--- a/src/components/skill/SkillRow.vue
+++ b/src/components/skill/SkillRow.vue
@@ -92,7 +92,9 @@ export default defineComponent({
   gap: 6px;
   padding: 6px 12px 6px 8px;
   margin: 1px 8px;
-  border-radius: 6px;
+  /* Match the console sidebar's nav rows (SidePanel.vue) and the connectors
+     list, which sit right next to this one. */
+  border-radius: 10px;
   cursor: pointer;
   font-size: 13px;
   color: var(--el-text-color-regular);
@@ -100,12 +102,14 @@ export default defineComponent({
 }
 
 .skill-row:hover {
-  background: var(--el-fill-color);
+  background: var(--el-fill-color-extra-light);
 }
 
+/* Selection used a grey fill, dropping the brand accent every other list in
+   the console uses. */
 .skill-row.active {
-  background: var(--el-fill-color-darker);
-  color: var(--el-text-color-primary);
+  background: var(--el-color-primary-light-9);
+  color: var(--el-color-primary);
   font-weight: 500;
 }
 

--- a/src/pages/console/connectors/Index.vue
+++ b/src/pages/console/connectors/Index.vue
@@ -2082,11 +2082,23 @@ export default defineComponent({
   display: grid;
   grid-template-columns: 300px 1fr;
   gap: 0;
-  border: 1px solid var(--el-border-color-lighter);
-  border-radius: var(--page-card-radius);
-  background: var(--el-bg-color);
+  // Match <el-card>, which every other console page uses: same border token,
+  // same 4px radius, same elevation. `--page-card-radius` used to be here —
+  // an AuthFrontend variable that doesn't exist in Nexior, so the frame
+  // silently rendered square.
+  border: 1px solid var(--el-card-border-color);
+  border-radius: var(--el-card-border-radius);
+  background: var(--el-card-bg-color);
   overflow: hidden;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.02);
+  box-shadow: var(--app-shadow-xs);
+}
+
+// el-card gets a glass treatment in dark mode (see _common.scss). This pane
+// isn't an el-card, so mirror it or the page reads flat next to Applications.
+html.dark .connectors-shell {
+  background: var(--app-glass-bg);
+  backdrop-filter: blur(var(--app-glass-blur));
+  border-color: var(--app-glass-border);
 }
 
 .connectors-list {
@@ -2257,7 +2269,9 @@ export default defineComponent({
   gap: 10px;
   padding: 8px 10px;
   margin: 1px 0;
-  border-radius: 8px;
+  // Match the console sidebar's nav rows (SidePanel.vue): same radius, same
+  // hover fill, so the two lists sitting side by side agree.
+  border-radius: 10px;
   cursor: pointer;
   transition:
     background 0.15s,
@@ -2265,7 +2279,7 @@ export default defineComponent({
   position: relative;
 
   &:hover {
-    background: var(--el-fill-color-light);
+    background: var(--el-fill-color-extra-light);
   }
 
   &.active {

--- a/src/pages/console/skills/Index.vue
+++ b/src/pages/console/skills/Index.vue
@@ -564,10 +564,22 @@ export default defineComponent({
   flex: 1 1 auto;
   min-height: 0;
   display: flex;
-  border: 1px solid var(--el-border-color-lighter);
-  border-radius: var(--page-card-radius);
-  background: var(--el-bg-color);
+  /* Match <el-card>, which every other console page uses. `--page-card-radius`
+     used to be here — an AuthFrontend variable that doesn't exist in Nexior,
+     so the frame silently rendered square. */
+  border: 1px solid var(--el-card-border-color);
+  border-radius: var(--el-card-border-radius);
+  background: var(--el-card-bg-color);
   overflow: hidden;
+  box-shadow: var(--app-shadow-xs);
+}
+
+/* el-card gets a glass treatment in dark mode (see _common.scss); mirror it
+   here or the page reads flat next to Applications / Orders. */
+html.dark .skills-shell {
+  background: var(--app-glass-bg);
+  backdrop-filter: blur(var(--app-glass-blur));
+  border-color: var(--app-glass-border);
 }
 
 /* ---- Left pane ---- */


### PR DESCRIPTION
两个页面是从 AuthFrontend 整体移植的，带着 AuthFrontend 的设计约定，跟 `/console` 里其他页面并排放明显不是一套。

## 最要紧的是个真 bug

外框写的是 `border-radius: var(--page-card-radius)` —— **`--page-card-radius` 是 AuthFrontend 的变量，Nexior 里根本没定义**。CSS 变量未定义会静默回退，于是整个两栏框渲染成**直角**。

`vue-tsc` 和 `eslint` 都发现不了这类问题，只有肉眼能看出来。

## 改了什么

| 问题 | 修法 |
|---|---|
| **外框直角** | 改用 `el-card` 那套 token：`--el-card-border-color` / `-border-radius` / `-bg-color` |
| **边框比别人浅一档** | `--el-border-color-lighter` → `--el-card-border-color`（= `-light`） |
| **暗色下发扁** | 补 `html.dark` 玻璃效果 |
| **硬编码阴影** | `rgba(0,0,0,0.02/0.04)` → `--app-shadow-xs` / `--app-shadow-sm` |
| **三套 hover 并存** | 统一到侧栏的 `--el-fill-color-extra-light` |
| **列表圆角 10/8/6px 三种** | 统一 10px（对齐 `SidePanel.vue` 导航行） |
| **技能列表选中是灰的** | 恢复品牌色 `--el-color-primary-light-9` + `--el-color-primary` |

两点值得单独说：

**暗色玻璃**：`_common.scss` 里 `html.dark .el-card` 有 `backdrop-filter`，但这两个页面是手写 div、不是 `el-card`，规则压根不生效 —— 所以暗色下比旁边的「申请列表」扁。

**硬编码阴影**：字面黑色阴影在深色背景上等于没有，token 会自适应。

## 验证

```
vue-tsc -b        零错误   ← CI 用的就是这个，不是 --noEmit
npm run build:web ✓ built
npm run lint      0 errors（2 个既有 warning）
grep page-card-radius → 仅剩注释里的提及，实际引用归零
```

## 没在这个 PR 里做

审计还发现几项，改动面更大、和视觉对齐不是一回事，留作后续：

- 原生 `<input>` / `<button>` 换成 `el-input` / `el-button`（控制台其他页面都用 EP 组件）
- 900–960px 的弹窗在平板会溢出（只有 `BrowserDevicePicker` 用了 `min(520px, 94vw)`）
- 768–800px 断点死区：移植页用 `max-width: 800px`，Nexior 用 767/768px
- 圆角值仍有 3/4/6/8/10px 混用（本 PR 只统一了列表行和卡片外框）

🤖 Generated with [Claude Code](https://claude.com/claude-code)