### PR TITLE
feat(local-tools): 持久 shell + 会话工作目录 + 项目约定加载

### DIFF
--- a/change/@acedatacloud-nexior-12c8d1fa-e9b2-43c0-b0fb-372ce95ce599.json
+++ b/change/@acedatacloud-nexior-12c8d1fa-e9b2-43c0-b0fb-372ce95ce599.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(local-tools): 持久 shell、会话工作目录与项目约定加载",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/electron/local/context.test.ts
+++ b/electron/local/context.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, realpathSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { setRoots, _resetRootsForTesting } from './fs';
+import { load_project_context } from './context';
+
+function repo() {
+  const base = realpathSync(mkdtempSync(path.join(os.tmpdir(), 'nx-ctx-')));
+  mkdirSync(path.join(base, 'pkg'));
+  setRoots([base]);
+  return base;
+}
+
+describe('project.load_context', () => {
+  afterEach(() => _resetRootsForTesting());
+
+  it('loads AGENTS.md from the root', async () => {
+    const base = repo();
+    writeFileSync(path.join(base, 'AGENTS.md'), '# Rules\nUse tabs.\n');
+    const res = await load_project_context({ path: base });
+    expect(res.output).toContain('Use tabs.');
+    expect(res.output).toContain('AUTHORITATIVE');
+  });
+
+  it('prefers AGENTS.md over CLAUDE.md in the same dir (no double-loading)', async () => {
+    const base = repo();
+    writeFileSync(path.join(base, 'AGENTS.md'), 'AGENTS rules\n');
+    writeFileSync(path.join(base, 'CLAUDE.md'), 'CLAUDE rules\n');
+    const res = await load_project_context({ path: base });
+    expect(res.output).toContain('AGENTS rules');
+    expect(res.output).not.toContain('CLAUDE rules');
+  });
+
+  it('cascades from the root down to a nested dir', async () => {
+    const base = repo();
+    writeFileSync(path.join(base, 'AGENTS.md'), 'root rules\n');
+    writeFileSync(path.join(base, 'pkg', 'AGENTS.md'), 'pkg rules\n');
+    const res = await load_project_context({ path: path.join(base, 'pkg') });
+    expect(res.output).toContain('root rules');
+    expect(res.output).toContain('pkg rules');
+    // Outermost first, so the nearer file appends last and effectively wins.
+    expect(res.output.indexOf('root rules')).toBeLessThan(res.output.indexOf('pkg rules'));
+  });
+
+  it('inlines an @-import (the CLAUDE.md → AGENTS.md convention)', async () => {
+    const base = repo();
+    writeFileSync(path.join(base, 'CLAUDE.md'), 'Preamble\n@AGENTS.md\n');
+    writeFileSync(path.join(base, 'AGENTS.md'), 'IMPORTED BODY\n');
+    // Only CLAUDE.md exists as a chosen file if AGENTS.md is absent; here both
+    // exist so AGENTS.md wins directly — assert the import path via a subdir.
+    mkdirSync(path.join(base, 'sub'));
+    writeFileSync(path.join(base, 'sub', 'CLAUDE.md'), 'Sub preamble\n@../AGENTS.md\n');
+    const res = await load_project_context({ path: path.join(base, 'sub') });
+    expect(res.output).toContain('IMPORTED BODY');
+  });
+
+  it('does not follow an @-import outside the authorized roots', async () => {
+    const base = repo();
+    const outside = realpathSync(mkdtempSync(path.join(os.tmpdir(), 'nx-out-')));
+    writeFileSync(path.join(outside, 'secret.md'), 'LEAKED');
+    writeFileSync(path.join(base, 'AGENTS.md'), `@${path.join(outside, 'secret.md')}\n`);
+    const res = await load_project_context({ path: base });
+    expect(res.output).not.toContain('LEAKED');
+  });
+
+  it('survives a circular import instead of recursing forever', async () => {
+    const base = repo();
+    mkdirSync(path.join(base, 'sub'));
+    writeFileSync(path.join(base, 'sub', 'CLAUDE.md'), '@../a.md\n');
+    writeFileSync(path.join(base, 'a.md'), 'A body\n@b.md\n');
+    writeFileSync(path.join(base, 'b.md'), 'B body\n@a.md\n');
+    const res = await load_project_context({ path: path.join(base, 'sub') });
+    expect(res.output).toContain('A body');
+    expect(res.output).toContain('B body');
+    expect(res.output).toContain('circular import');
+  });
+
+  it('lists project slash commands with descriptions', async () => {
+    const base = repo();
+    mkdirSync(path.join(base, '.claude', 'commands'), { recursive: true });
+    writeFileSync(path.join(base, '.claude', 'commands', 'deploy.md'), '# Deploy\nShip to production.\n');
+    const res = await load_project_context({ path: base });
+    expect(res.output).toContain('/deploy');
+    expect(res.output).toContain('Ship to production.');
+  });
+
+  it('finds root-level commands from a nested dir', async () => {
+    const base = repo();
+    mkdirSync(path.join(base, '.claude', 'commands'), { recursive: true });
+    writeFileSync(path.join(base, '.claude', 'commands', 'deploy.md'), 'Ship it.\n');
+    writeFileSync(path.join(base, 'AGENTS.md'), 'rules\n');
+    const res = await load_project_context({ path: path.join(base, 'pkg') });
+    expect(res.output).toContain('/deploy');
+  });
+
+  it('accepts a file path and resolves it to its directory', async () => {
+    const base = repo();
+    writeFileSync(path.join(base, 'AGENTS.md'), 'rules here\n');
+    const f = path.join(base, 'pkg', 'x.ts');
+    writeFileSync(f, 'x');
+    const res = await load_project_context({ path: f });
+    expect(res.output).toContain('rules here');
+  });
+
+  it('reports plainly when a project has no conventions', async () => {
+    const base = repo();
+    const res = await load_project_context({ path: base });
+    expect(res.output).toContain('no project context found');
+  });
+
+  it('rejects a path outside the authorized roots', async () => {
+    repo();
+    const outside = realpathSync(mkdtempSync(path.join(os.tmpdir(), 'nx-out-')));
+    await expect(load_project_context({ path: outside })).rejects.toThrow('path outside allowed roots');
+  });
+
+  it('errors clearly when no roots are authorized', async () => {
+    _resetRootsForTesting();
+    await expect(load_project_context({})).rejects.toThrow('no authorized roots');
+  });
+
+  it('does not walk above the authorized root', async () => {
+    const base = realpathSync(mkdtempSync(path.join(os.tmpdir(), 'nx-ctx-')));
+    const inner = path.join(base, 'inner');
+    mkdirSync(inner);
+    // A convention file ABOVE the root must not be picked up.
+    writeFileSync(path.join(base, 'AGENTS.md'), 'ABOVE ROOT');
+    writeFileSync(path.join(inner, 'AGENTS.md'), 'inner rules');
+    setRoots([inner]);
+    const res = await load_project_context({ path: inner });
+    expect(res.output).toContain('inner rules');
+    expect(res.output).not.toContain('ABOVE ROOT');
+  });
+});

--- a/electron/local/context.ts
+++ b/electron/local/context.ts
@@ -1,0 +1,210 @@
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import type { ToolResult } from './types';
+import { assertInRoots, expandHome, listRoots } from './fs';
+import { currentWorkingDir } from './shellSession';
+
+// Project context: the convention files a coding agent is expected to obey
+// (AGENTS.md / CLAUDE.md and friends) plus the project's own slash commands.
+// Without this the model has no idea a repo has house rules — it writes code
+// that passes tests but violates every convention the team agreed on.
+
+// Ordered by precedence: the first name found in a directory wins, so a repo
+// carrying both CLAUDE.md and AGENTS.md doesn't get the same rules twice.
+const CONTEXT_FILES = ['AGENTS.md', 'CLAUDE.md', 'CONVENTIONS.md', '.cursorrules', '.github/copilot-instructions.md'];
+
+const MAX_TOTAL_CHARS = 60_000; // a very large AGENTS.md shouldn't eat the whole window
+const MAX_COMMANDS = 100;
+const MAX_IMPORT_DEPTH = 3; // CLAUDE.md → @AGENTS.md → … ; deep chains are pathological
+
+/** Directories to probe, from the given dir UP to (and including) the
+ *  authorized root that contains it. Conventions cascade: a monorepo root
+ *  holds the shared rules, a package dir may add its own. */
+function chainToRoot(start: string): string[] {
+  const roots = listRoots();
+  const owning = roots.find((r) => start === r || start.startsWith(r + path.sep));
+  const stopAt = owning ?? start;
+  const out: string[] = [];
+  let cur = start;
+  // Bounded by the root, and by parent===cur at the filesystem root.
+  for (;;) {
+    out.push(cur);
+    if (cur === stopAt) break;
+    const parent = path.dirname(cur);
+    if (parent === cur) break;
+    cur = parent;
+  }
+  return out.reverse(); // outermost first, so nearer files override/append last
+}
+
+/** Resolve `@path/to/file.md` imports (the syntax CLAUDE.md uses to pull in a
+ *  shared AGENTS.md). Only single-line `@...` directives, only inside roots. */
+async function inlineImports(text: string, baseDir: string, depth: number, seen: Set<string>): Promise<string> {
+  if (depth >= MAX_IMPORT_DEPTH) return text;
+  const lines = text.split(/\r?\n/);
+  const out: string[] = [];
+  for (const line of lines) {
+    const m = /^@([^\s`]+\.(?:md|markdown))\s*$/.exec(line.trim());
+    if (!m) {
+      out.push(line);
+      continue;
+    }
+    let resolved: string;
+    try {
+      resolved = assertInRoots(path.resolve(baseDir, m[1]));
+    } catch {
+      out.push(line); // outside the authorized roots — leave the directive as text
+      continue;
+    }
+    if (seen.has(resolved)) {
+      out.push(`[skipped circular import: ${m[1]}]`);
+      continue;
+    }
+    seen.add(resolved);
+    try {
+      const imported = await fsp.readFile(resolved, 'utf8');
+      out.push(`<!-- imported from ${resolved} -->`);
+      out.push(await inlineImports(imported, path.dirname(resolved), depth + 1, seen));
+    } catch {
+      out.push(line);
+    }
+  }
+  return out.join('\n');
+}
+
+/** List the project's own slash commands (`.claude/commands/*.md`) by name +
+ *  first-line description. Names only — bodies are loaded on demand via
+ *  fs.read_file, so a repo with 40 commands costs ~40 lines, not 40 files. */
+async function listCommands(dir: string): Promise<string[]> {
+  const cmdDir = path.join(dir, '.claude', 'commands');
+  let entries;
+  try {
+    entries = await fsp.readdir(cmdDir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const out: string[] = [];
+  for (const e of entries) {
+    if (out.length >= MAX_COMMANDS) break;
+    if (!e.isFile() || !e.name.endsWith('.md')) continue;
+    const full = path.join(cmdDir, e.name);
+    let desc = '';
+    try {
+      const head = (await fsp.readFile(full, 'utf8')).slice(0, 500).split(/\r?\n/);
+      // Prefer a `description:` frontmatter line; else the first non-empty,
+      // non-heading line.
+      desc =
+        head.find((l) => /^description:/i.test(l.trim()))?.replace(/^description:\s*/i, '') ??
+        head.find((l) => l.trim() && !l.startsWith('#') && !l.startsWith('---'))?.trim() ??
+        '';
+    } catch {
+      /* unreadable command file — list it without a description */
+    }
+    out.push(`/${e.name.replace(/\.md$/, '')}${desc ? ` — ${desc.slice(0, 120)}` : ''} (${full})`);
+  }
+  return out;
+}
+
+/**
+ * Load the convention files that govern a project directory, walking from the
+ * authorized root down to the given path so nested rules append to shared ones.
+ */
+export async function load_project_context(i: { path?: string; sessionId?: string }): Promise<ToolResult> {
+  let start: string;
+  if (i.path) {
+    start = assertInRoots(expandHome(i.path));
+  } else {
+    // Default to the session's working directory — the conversation's "current
+    // project". Falling back to an arbitrary entry of the roots list (whichever
+    // the user happened to add first) would load the wrong project's rules, or
+    // none at all, without the model ever noticing.
+    const wd = currentWorkingDir(i.sessionId);
+    if (!wd) {
+      const roots = listRoots();
+      if (roots.length === 1) {
+        start = roots[0]; // unambiguous: exactly one authorized project
+      } else if (!roots.length) {
+        throw new Error('no authorized roots; add a folder in Settings → Local Tools');
+      } else {
+        throw new Error(
+          `no working directory set and ${roots.length} folders are authorized — ` +
+            `call shell.set_working_dir first, or pass an explicit path. Authorized: ${roots.join(', ')}`
+        );
+      }
+    } else {
+      start = assertInRoots(wd);
+    }
+  }
+  // A file path is a natural thing for a model to pass ("what rules apply to
+  // this file?"); resolve it to its directory rather than failing.
+  try {
+    if ((await fsp.stat(start)).isFile()) start = path.dirname(start);
+  } catch {
+    /* assertInRoots already proved it exists; a race here is not worth failing */
+  }
+
+  const sections: string[] = [];
+  const found: string[] = [];
+  const seen = new Set<string>();
+  let total = 0;
+  let truncated = false;
+
+  for (const dir of chainToRoot(start)) {
+    for (const name of CONTEXT_FILES) {
+      const full = path.join(dir, name);
+      let text: string;
+      try {
+        text = await fsp.readFile(full, 'utf8');
+      } catch {
+        continue;
+      }
+      seen.add(full);
+      const expanded = await inlineImports(text, dir, 0, seen);
+      const remaining = MAX_TOTAL_CHARS - total;
+      if (remaining <= 0) {
+        truncated = true;
+        break;
+      }
+      const body = expanded.length > remaining ? expanded.slice(0, remaining) + '\n[…truncated]' : expanded;
+      total += body.length;
+      if (expanded.length > remaining) truncated = true;
+      found.push(full);
+      sections.push(`===== ${full} =====\n${body}`);
+      break; // first match in this dir wins (see CONTEXT_FILES ordering)
+    }
+  }
+
+  const commands = await listCommands(start);
+  // Commands may live at the repo root while `start` is a subdirectory.
+  if (!commands.length) {
+    for (const dir of chainToRoot(start)) {
+      const c = await listCommands(dir);
+      if (c.length) {
+        commands.push(...c);
+        break;
+      }
+    }
+  }
+
+  if (!sections.length && !commands.length) {
+    return { output: `no project context found (looked for ${CONTEXT_FILES.join(', ')} from ${start} up to its root)` };
+  }
+
+  const parts: string[] = [];
+  if (sections.length) {
+    parts.push(
+      'Project conventions below are AUTHORITATIVE for work in this directory. Follow them over your defaults.\n'
+    );
+    parts.push(sections.join('\n\n'));
+  }
+  if (commands.length) {
+    parts.push(
+      `\n===== project commands (.claude/commands) =====\n` +
+        `Read one with fs.read_file to see its full procedure.\n` +
+        commands.join('\n')
+    );
+  }
+  if (truncated) parts.push('\n[context truncated at the size cap; read specific files with fs.read_file]');
+  if (found.length) parts.push(`\n[loaded: ${found.join(', ')}]`);
+  return { output: parts.join('\n') };
+}

--- a/electron/local/registry.ts
+++ b/electron/local/registry.ts
@@ -2,6 +2,8 @@ import { McpHost } from './mcp';
 import * as fsTool from './fs';
 import * as search from './search';
 import { run_command } from './shell';
+import * as shellSession from './shellSession';
+import * as projectContext from './context';
 import * as computer from './computer';
 import type { McpServerConf, McpServerStatus, ToolInvoke, ToolResult, ToolSpec } from './types';
 
@@ -12,7 +14,10 @@ const BUILTIN: ToolSpec[] = [
   { name: 'fs.edit_file', description: 'Replace an exact string in an existing file inside an authorized root. old_string must match exactly (including indentation) and be unique unless replace_all is set. Preferred over fs.write_file for editing — no need to resend the whole file.', input_schema: { type: 'object', properties: { path: { type: 'string' }, old_string: { type: 'string' }, new_string: { type: 'string' }, replace_all: { type: 'boolean' } }, required: ['path', 'old_string', 'new_string'] }, source: 'builtin', mutates: true },
   { name: 'fs.glob', description: 'Find files by name pattern inside the authorized roots (e.g. "**/*.ts", "src/**/index.*"). Searches every root when path is omitted. Skips node_modules/.git/dist and similar. Prefer this over crawling with fs.list_dir.', input_schema: { type: 'object', properties: { pattern: { type: 'string' }, path: { type: 'string' }, hidden: { type: 'boolean' }, case_insensitive: { type: 'boolean' } }, required: ['pattern'] }, source: 'builtin', mutates: false },
   { name: 'fs.grep', description: 'Search file CONTENT by regular expression inside the authorized roots, returning "path:line: text". Optionally restrict to files matching a glob. Skips binaries and node_modules/.git/dist. Use this to locate code instead of reading files one by one.', input_schema: { type: 'object', properties: { pattern: { type: 'string' }, path: { type: 'string' }, glob: { type: 'string' }, case_insensitive: { type: 'boolean' }, hidden: { type: 'boolean' }, max_results: { type: 'number' } }, required: ['pattern'] }, source: 'builtin', mutates: false },
-  { name: 'shell.run_command', description: 'Run a local command (argv form)', input_schema: { type: 'object', properties: { cmd: { type: 'string' }, args: { type: 'array', items: { type: 'string' } }, cwd: { type: 'string' } }, required: ['cmd'] }, source: 'builtin', mutates: true }
+  { name: 'shell.run_command', description: 'Run a single local command (argv form) in a throwaway process. For anything stateful — cd, activating a venv, exporting vars, starting a dev server — use shell.exec instead.', input_schema: { type: 'object', properties: { cmd: { type: 'string' }, args: { type: 'array', items: { type: 'string' } }, cwd: { type: 'string' } }, required: ['cmd'] }, source: 'builtin', mutates: true },
+  { name: 'shell.exec', description: "Run a shell command in this conversation's PERSISTENT shell. State survives between calls: cd, exported vars, activated virtualenvs and background processes all persist. The working directory is also the session's current project. Prefer this over shell.run_command for multi-step work.", input_schema: { type: 'object', properties: { command: { type: 'string' }, cwd: { type: 'string' }, timeout_ms: { type: 'number' } }, required: ['command'] }, source: 'builtin', mutates: true },
+  { name: 'shell.set_working_dir', description: "Set (or read, when path is omitted) the conversation's working directory — the current project. Other tools default to it, notably project.load_context. Must be inside an authorized root.", input_schema: { type: 'object', properties: { path: { type: 'string' } } }, source: 'builtin', mutates: false },
+  { name: 'project.load_context', description: "Load the current project's convention files (AGENTS.md / CLAUDE.md / CONVENTIONS.md / .cursorrules) and its slash commands (.claude/commands). ALWAYS call this before writing or modifying code — these conventions override your defaults. Defaults to the session working directory; pass path to target another project.", input_schema: { type: 'object', properties: { path: { type: 'string' } } }, source: 'builtin', mutates: false }
 ];
 
 // Computer-use POC: see + control the GUI on the user's own machine. Kept in a
@@ -278,6 +283,15 @@ export class Registry {
         }
       );
     if (inv.name === 'shell.run_command') return run_command(inv.input as { cmd: string; args?: string[]; cwd?: string });
+    if (inv.name === 'shell.exec')
+      return shellSession.shell_exec({
+        ...(inv.input as { command: string; cwd?: string; timeout_ms?: number }),
+        sessionId: inv.sessionId
+      });
+    if (inv.name === 'shell.set_working_dir')
+      return shellSession.set_working_dir({ ...(inv.input as { path?: string }), sessionId: inv.sessionId });
+    if (inv.name === 'project.load_context')
+      return projectContext.load_project_context({ ...(inv.input as { path?: string }), sessionId: inv.sessionId });
     if (inv.name === 'computer.screenshot') return computer.screenshot();
     if (inv.name === 'computer.click') return computer.click(inv.input as { x: number; y: number; button?: 'left' | 'right' | 'middle' });
     if (inv.name === 'computer.move') return computer.move(inv.input as { x: number; y: number });

--- a/electron/local/shellSession.test.ts
+++ b/electron/local/shellSession.test.ts
@@ -1,0 +1,187 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, realpathSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { setRoots, _resetRootsForTesting } from './fs';
+import { shell_exec, set_working_dir, currentWorkingDir, endSession, _resetSessionsForTesting } from './shellSession';
+
+const WIN = process.platform === 'win32';
+
+function rooted() {
+  const base = realpathSync(mkdtempSync(path.join(os.tmpdir(), 'nx-sh-')));
+  mkdirSync(path.join(base, 'sub'));
+  setRoots([base]);
+  return base;
+}
+
+describe.skipIf(WIN)('shell.exec persistent session', () => {
+  afterEach(() => {
+    _resetSessionsForTesting();
+    _resetRootsForTesting();
+  });
+
+  it('keeps the working directory across calls (cd persists)', async () => {
+    const base = rooted();
+    await shell_exec({ command: `cd ${base}`, sessionId: 's1' });
+    await shell_exec({ command: 'cd sub', sessionId: 's1' });
+    const res = await shell_exec({ command: 'pwd', sessionId: 's1' });
+    expect(res.output).toContain(path.join(base, 'sub'));
+  });
+
+  it('keeps exported variables across calls', async () => {
+    const base = rooted();
+    await shell_exec({ command: 'export ACE_TEST=hello', cwd: base, sessionId: 's2' });
+    const res = await shell_exec({ command: 'echo "$ACE_TEST"', sessionId: 's2' });
+    expect(res.output).toContain('hello');
+  });
+
+  it('isolates sessions from each other', async () => {
+    const base = rooted();
+    await shell_exec({ command: 'export ACE_ONLY_A=1', cwd: base, sessionId: 'a' });
+    const res = await shell_exec({ command: 'echo "[${ACE_ONLY_A:-unset}]"', cwd: base, sessionId: 'b' });
+    expect(res.output).toContain('[unset]');
+  });
+
+  it('reports a non-zero exit as a tool error', async () => {
+    const base = rooted();
+    // NOT `exit 3` — that would terminate the persistent shell itself. A failing
+    // command is the realistic case (a build that breaks, a missing file).
+    const res = await shell_exec({ command: 'ls /definitely/not/here', cwd: base, sessionId: 's3' });
+    expect(res.is_error).toBe(true);
+  });
+
+  it('a failing command does not kill the session', async () => {
+    const base = rooted();
+    await shell_exec({ command: 'export ACE_ALIVE=1', cwd: base, sessionId: 's3b' });
+    await shell_exec({ command: 'false', sessionId: 's3b' });
+    const res = await shell_exec({ command: 'echo "$ACE_ALIVE"', sessionId: 's3b' });
+    expect(res.output).toContain('1');
+  });
+
+  it('surfaces the cwd in the footer so the model always knows where it is', async () => {
+    const base = rooted();
+    const res = await shell_exec({ command: 'echo hi', cwd: base, sessionId: 's4' });
+    expect(res.output).toContain('hi');
+    expect(res.output).toContain(`[cwd: ${base}`);
+  });
+
+  it('rejects a working directory outside the authorized roots', async () => {
+    rooted();
+    const outside = realpathSync(mkdtempSync(path.join(os.tmpdir(), 'nx-out-')));
+    await expect(shell_exec({ command: 'echo x', cwd: outside, sessionId: 's5' })).rejects.toThrow(
+      'path outside allowed roots'
+    );
+  });
+
+  it('survives a command timeout with the session state intact', async () => {
+    const base = rooted();
+    await shell_exec({ command: 'export ACE_KEEP=yes', cwd: base, sessionId: 's6' });
+    const slow = await shell_exec({ command: 'sleep 5', timeout_ms: 1000, sessionId: 's6' });
+    expect(slow.output).toContain('timed out');
+    // The shell must NOT have been killed — the exported var is still there.
+    const after = await shell_exec({ command: 'echo "$ACE_KEEP"', sessionId: 's6' });
+    expect(after.output).toContain('yes');
+  });
+
+  it('handles a directory containing spaces and quotes', async () => {
+    const base = rooted();
+    const odd = path.join(base, "we'ird dir");
+    mkdirSync(odd);
+    const res = await shell_exec({ command: 'pwd', cwd: odd, sessionId: 's7' });
+    expect(res.output).toContain(odd);
+  });
+
+  it('endSession terminates the shell so state does not leak to a new one', async () => {
+    const base = rooted();
+    await shell_exec({ command: 'export ACE_GONE=1', cwd: base, sessionId: 's8' });
+    endSession('s8');
+    const res = await shell_exec({ command: 'echo "[${ACE_GONE:-unset}]"', cwd: base, sessionId: 's8' });
+    expect(res.output).toContain('[unset]');
+  });
+});
+
+describe.skipIf(WIN)('shell.set_working_dir', () => {
+  afterEach(() => {
+    _resetSessionsForTesting();
+    _resetRootsForTesting();
+  });
+
+  it('sets the directory and makes it readable by currentWorkingDir', async () => {
+    const base = rooted();
+    const res = await set_working_dir({ path: base, sessionId: 'w1' });
+    expect(res.output).toContain(base);
+    expect(currentWorkingDir('w1')).toBe(base);
+  });
+
+  it('reads back the current directory when path is omitted', async () => {
+    const base = rooted();
+    await set_working_dir({ path: base, sessionId: 'w2' });
+    const res = await set_working_dir({ sessionId: 'w2' });
+    expect(res.output).toBe(base);
+  });
+
+  it('rejects a directory outside the authorized roots', async () => {
+    rooted();
+    const outside = realpathSync(mkdtempSync(path.join(os.tmpdir(), 'nx-out-')));
+    await expect(set_working_dir({ path: outside, sessionId: 'w3' })).rejects.toThrow('path outside allowed roots');
+  });
+
+  it('a subsequent shell.exec runs in the directory that was set', async () => {
+    const base = rooted();
+    await set_working_dir({ path: path.join(base, 'sub'), sessionId: 'w4' });
+    const res = await shell_exec({ command: 'pwd', sessionId: 'w4' });
+    expect(res.output).toContain(path.join(base, 'sub'));
+  });
+
+  it('currentWorkingDir is null before any directory is set', () => {
+    rooted();
+    expect(currentWorkingDir('never-used')).toBeNull();
+  });
+});
+
+// project.load_context defaulting to the session working directory is the whole
+// point of pairing it with this PR — verify the wiring, not just the tool.
+describe.skipIf(WIN)('project.load_context defaults to the working directory', () => {
+  afterEach(() => {
+    _resetSessionsForTesting();
+    _resetRootsForTesting();
+  });
+
+  it('loads the conventions of the project the session is working in', async () => {
+    const base = realpathSync(mkdtempSync(path.join(os.tmpdir(), 'nx-multi-')));
+    const projA = path.join(base, 'projA');
+    const projB = path.join(base, 'projB');
+    mkdirSync(projA);
+    mkdirSync(projB);
+    writeFileSync(path.join(projA, 'AGENTS.md'), 'RULES OF A\n');
+    writeFileSync(path.join(projB, 'AGENTS.md'), 'RULES OF B\n');
+    setRoots([projA, projB]);
+
+    const { load_project_context } = await import('./context');
+    // Working in B must load B's rules, not whichever root was added first.
+    await set_working_dir({ path: projB, sessionId: 'ctx1' });
+    const res = await load_project_context({ sessionId: 'ctx1' });
+    expect(res.output).toContain('RULES OF B');
+    expect(res.output).not.toContain('RULES OF A');
+  });
+
+  it('refuses to guess when several projects are authorized and no cwd is set', async () => {
+    const base = realpathSync(mkdtempSync(path.join(os.tmpdir(), 'nx-multi-')));
+    const a = path.join(base, 'a');
+    const b = path.join(base, 'b');
+    mkdirSync(a);
+    mkdirSync(b);
+    setRoots([a, b]);
+    const { load_project_context } = await import('./context');
+    await expect(load_project_context({ sessionId: 'ctx2' })).rejects.toThrow('no working directory set');
+  });
+
+  it('uses the single authorized root when there is no ambiguity', async () => {
+    const base = realpathSync(mkdtempSync(path.join(os.tmpdir(), 'nx-one-')));
+    writeFileSync(path.join(base, 'AGENTS.md'), 'ONLY RULES\n');
+    setRoots([base]);
+    const { load_project_context } = await import('./context');
+    const res = await load_project_context({ sessionId: 'ctx3' });
+    expect(res.output).toContain('ONLY RULES');
+  });
+});

--- a/electron/local/shellSession.ts
+++ b/electron/local/shellSession.ts
@@ -1,0 +1,292 @@
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import os from 'node:os';
+import path from 'node:path';
+import { resolveEnhancedPath } from './env';
+import { assertInRoots, expandHome } from './fs';
+import type { ToolResult } from './types';
+
+// A persistent shell per conversation, so `cd`, activated virtualenvs, exported
+// vars and started background processes SURVIVE between tool calls. `execFile`
+// (shell.run_command) spawns a fresh process every time, which makes the most
+// ordinary coding sequence — cd into the repo, install, run the dev server —
+// impossible to express.
+//
+// The working directory doubles as the session's "current project": it is what
+// project.load_context defaults to, and what a relative path resolves against.
+
+const IDLE_TIMEOUT_MS = 30 * 60 * 1000; // reap a shell nobody has used
+const DEFAULT_COMMAND_TIMEOUT_MS = 120_000;
+const MAX_OUTPUT_CHARS = 200_000;
+
+interface Session {
+  proc: ChildProcessWithoutNullStreams;
+  cwd: string;
+  buffer: string;
+  busy: boolean;
+  lastUsed: number;
+  timer: NodeJS.Timeout | null;
+  // Set after a timeout: the killed command's sentinel echo may still be queued
+  // in the shell, so the next run must drain stale output before trusting it.
+  needsResync: boolean;
+}
+
+const sessions = new Map<string, Session>();
+
+/** A marker the shell echoes after each command so we know where output ends
+ *  and can read back the exit code + the (possibly changed) cwd. Includes a
+ *  random token so command output that happens to contain the word can't be
+ *  mistaken for the real sentinel. */
+function makeSentinel(): string {
+  return `__ACE_DONE_${Math.random().toString(36).slice(2, 10)}__`;
+}
+
+function shellPath(): { cmd: string; args: string[] } {
+  if (process.platform === 'win32') {
+    return { cmd: process.env.COMSPEC || 'cmd.exe', args: ['/Q', '/K'] };
+  }
+  // A LOGIN shell would source the user's rc files and could hang on an
+  // interactive prompt; a plain interactive-less bash keeps startup predictable.
+  return { cmd: process.env.SHELL || '/bin/bash', args: [] };
+}
+
+async function spawnSession(cwd: string): Promise<Session> {
+  const enhancedPath = await resolveEnhancedPath();
+  const { cmd, args } = shellPath();
+  const proc = spawn(cmd, args, {
+    cwd,
+    env: {
+      // Same allowlist rationale as shell.run_command: never hand the model's
+      // commands the app's own tokens. PATH is the enhanced one so node/npm/uv
+      // resolve under a Dock launch.
+      PATH: enhancedPath,
+      HOME: process.env.HOME,
+      LANG: process.env.LANG,
+      TERM: 'dumb', // no ANSI escapes to strip out of the transcript
+      SystemRoot: process.env.SystemRoot
+    },
+    stdio: ['pipe', 'pipe', 'pipe']
+  }) as ChildProcessWithoutNullStreams;
+
+  const s: Session = {
+    proc,
+    cwd,
+    buffer: '',
+    busy: false,
+    lastUsed: Date.now(),
+    timer: null,
+    needsResync: false
+  };
+  proc.stdout.on('data', (d: Buffer) => {
+    s.buffer += d.toString('utf8');
+  });
+  proc.stderr.on('data', (d: Buffer) => {
+    s.buffer += d.toString('utf8');
+  });
+  // A shell that dies (user killed it, OOM) must not leave a stale entry that
+  // every later call writes into a closed pipe.
+  proc.on('exit', () => {
+    for (const [k, v] of sessions) if (v === s) sessions.delete(k);
+  });
+  return s;
+}
+
+function touch(key: string, s: Session): void {
+  s.lastUsed = Date.now();
+  if (s.timer) clearTimeout(s.timer);
+  s.timer = setTimeout(() => {
+    sessions.delete(key);
+    s.proc.kill();
+  }, IDLE_TIMEOUT_MS);
+  s.timer.unref?.();
+}
+
+/** Resolve + authorize a working directory. Must be inside an authorized root:
+ *  a persistent shell in an unauthorized folder would be a hole straight
+ *  through the fs boundary. */
+function resolveCwd(dir: string): string {
+  return assertInRoots(expandHome(dir));
+}
+
+async function getSession(key: string, cwd?: string): Promise<Session> {
+  const existing = sessions.get(key);
+  if (existing && !existing.proc.killed) {
+    if (cwd) {
+      const target = resolveCwd(cwd);
+      if (target !== existing.cwd) {
+        await runIn(existing, `cd ${quote(target)}`, DEFAULT_COMMAND_TIMEOUT_MS);
+        existing.cwd = target;
+      }
+    }
+    touch(key, existing);
+    return existing;
+  }
+  // No explicit cwd and no session yet: start in the user's home rather than
+  // wherever Electron happened to be launched from (a Dock launch gives `/`).
+  const start = cwd ? resolveCwd(cwd) : os.homedir();
+  const s = await spawnSession(start);
+  sessions.set(key, s);
+  touch(key, s);
+  return s;
+}
+
+function quote(s: string): string {
+  if (process.platform === 'win32') return `"${s.replace(/"/g, '""')}"`;
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+/** Kill the shell's child processes (the command that is currently running)
+ *  WITHOUT killing the shell itself. `pkill -P <pid>` targets children by
+ *  parent pid; on Windows `taskkill /T` without `/F` on the child list is not
+ *  available, so we fall back to killing the whole tree there (Windows has no
+ *  persistent-shell state guarantee to protect in that path). */
+function killChildren(pid: number | undefined): void {
+  if (!pid) return;
+  try {
+    if (process.platform === 'win32') {
+      spawn('taskkill', ['/PID', String(pid), '/T', '/F'], { stdio: 'ignore' });
+      return;
+    }
+    // SIGTERM first (lets a well-behaved child clean up); a stubborn child is
+    // then removed with SIGKILL a moment later.
+    spawn('pkill', ['-TERM', '-P', String(pid)], { stdio: 'ignore' });
+    setTimeout(() => {
+      try {
+        spawn('pkill', ['-KILL', '-P', String(pid)], { stdio: 'ignore' });
+      } catch {
+        /* the child already exited */
+      }
+    }, 500).unref?.();
+  } catch {
+    /* best effort: a timeout that can't kill the child still returns to caller */
+  }
+}
+
+/** Write one command to the shell and read until its sentinel appears. */
+function runIn(s: Session, command: string, timeoutMs: number): Promise<{ output: string; code: number | null }> {
+  if (s.busy) return Promise.resolve({ output: '[shell busy with another command]', code: null });
+  s.busy = true;
+  // Drop anything the previous (killed) command left in flight. Sentinels are
+  // per-call random, so a stale one can never be mistaken for this call's — but
+  // its raw output would still be prepended to ours.
+  s.buffer = '';
+  s.needsResync = false;
+  const sentinel = makeSentinel();
+  // `echo <sentinel> <exit code> <pwd>` after the command: one line that tells
+  // us the command finished, whether it succeeded, and where the shell now is.
+  const line =
+    process.platform === 'win32'
+      ? `${command}\r\necho ${sentinel} %ERRORLEVEL% %CD%\r\n`
+      : `${command}\necho ${sentinel} $? "$PWD"\n`;
+
+  return new Promise((resolve) => {
+    let done = false;
+    const finish = (output: string, code: number | null) => {
+      if (done) return;
+      done = true;
+      clearInterval(poll);
+      clearTimeout(timer);
+      s.busy = false;
+      resolve({ output, code });
+    };
+    const timer = setTimeout(() => {
+      // Kill the RUNNING COMMAND, not the shell. Signalling the shell directly
+      // would terminate it (a non-interactive bash exits on SIGINT), throwing
+      // away the cwd and every exported var the session accumulated — exactly
+      // the state this whole module exists to preserve. `detached: true` put
+      // the shell in its own process group, so a negative pid signals the group
+      // (shell + its children); we instead enumerate and kill only the
+      // children, leaving the shell itself untouched.
+      killChildren(s.proc.pid);
+      // The interrupted command's `echo <sentinel>` line is still queued in the
+      // shell; without draining it, the NEXT command would read that stale
+      // sentinel and return immediately with the wrong output. Mark the session
+      // so the next run resynchronises.
+      s.needsResync = true;
+      finish(s.buffer + `\n[timed out after ${Math.round(timeoutMs / 1000)}s; shell kept alive]`, null);
+    }, timeoutMs);
+    timer.unref?.();
+
+    const poll = setInterval(() => {
+      const idx = s.buffer.indexOf(sentinel);
+      if (idx < 0) {
+        if (s.buffer.length > MAX_OUTPUT_CHARS) {
+          s.proc.kill('SIGINT');
+          finish(s.buffer.slice(0, MAX_OUTPUT_CHARS) + '\n[output truncated]', null);
+        }
+        return;
+      }
+      const before = s.buffer.slice(0, idx);
+      const rest = s.buffer.slice(idx + sentinel.length);
+      const eol = rest.indexOf('\n');
+      if (eol < 0) return; // sentinel line not fully arrived yet
+      const tail = rest.slice(0, eol).trim();
+      const [codeStr, ...pwdParts] = tail.split(/\s+/);
+      const pwd = pwdParts.join(' ').replace(/^"|"$/g, '');
+      if (pwd) s.cwd = pwd;
+      finish(before, Number.isFinite(Number(codeStr)) ? Number(codeStr) : null);
+    }, 25);
+
+    s.proc.stdin.write(line);
+  });
+}
+
+/**
+ * Run a command in the conversation's persistent shell. State (cwd, env,
+ * background jobs) survives across calls.
+ */
+export async function shell_exec(i: {
+  command: string;
+  cwd?: string;
+  timeout_ms?: number;
+  sessionId?: string;
+}): Promise<ToolResult> {
+  if (!i.command || !i.command.trim()) throw new Error('command is required');
+  const key = i.sessionId || 'default';
+  const s = await getSession(key, i.cwd);
+  const timeoutMs = Math.min(Math.max(1000, i.timeout_ms ?? DEFAULT_COMMAND_TIMEOUT_MS), 600_000);
+  const { output, code } = await runIn(s, i.command, timeoutMs);
+  touch(key, s);
+  const trimmed = output.replace(/\s+$/, '');
+  const footer = `\n[cwd: ${s.cwd}${code === null ? '' : ` | exit ${code}`}]`;
+  return { output: (trimmed || '(no output)') + footer, is_error: code !== null && code !== 0 };
+}
+
+/** Read or set the session's working directory (the "current project"). */
+export async function set_working_dir(i: { path?: string; sessionId?: string }): Promise<ToolResult> {
+  const key = i.sessionId || 'default';
+  if (!i.path) {
+    const s = sessions.get(key);
+    return { output: s ? s.cwd : os.homedir() };
+  }
+  const target = resolveCwd(i.path);
+  const s = await getSession(key, target);
+  return { output: `working directory: ${s.cwd}` };
+}
+
+/** The session's current working directory, for other tools that default to
+ *  "the project I'm working in" (e.g. project.load_context). Null when the
+ *  conversation has not started a shell / set a directory yet. */
+export function currentWorkingDir(sessionId?: string): string | null {
+  const s = sessions.get(sessionId || 'default');
+  return s ? s.cwd : null;
+}
+
+/** Terminate a conversation's shell (called when its window/session ends). */
+export function endSession(sessionId: string): void {
+  const s = sessions.get(sessionId);
+  if (!s) return;
+  if (s.timer) clearTimeout(s.timer);
+  sessions.delete(sessionId);
+  s.proc.kill();
+}
+
+export function _resetSessionsForTesting(): void {
+  for (const [k, s] of sessions) {
+    if (s.timer) clearTimeout(s.timer);
+    s.proc.kill();
+    sessions.delete(k);
+  }
+}
+
+// Exposed for tests that need a deterministic path helper.
+export const _internal = { quote, resolveCwd, sessionsSize: () => sessions.size, pathSep: path.sep };


### PR DESCRIPTION
## 背景

这三件事看起来是三个功能，实际是**同一个缺失概念**的三个面：aichat2 没有"当前项目"。

- `shell.run_command` 走 `execFile`，每次全新进程 —— `cd` 不留、venv 激活不了、`npm run dev` 起不来。
- #1469 想加 `project.load_context`，但**不知道默认该去哪找 `AGENTS.md`** —— 它当时回落到 `listRoots()[0]`，即用户在 Settings 里最先添加的那个目录，纯属偶然。这就是那个 PR 被关掉的原因。

补上工作目录这个概念，两个问题一起解决。

## 改动

### `shell.exec` — 每个会话一个常驻 shell

`cd`、导出的变量、激活的 virtualenv、启动的后台进程，都在多次调用间存活。会话按 `sessionId`（consent 已在用的那个）隔离，30 分钟空闲回收。

**超时只杀子进程，不杀 shell。** 最初实现用 `SIGINT` 发给 shell 本身 —— 测试直接抓到：非交互式 bash 收到 SIGINT 会**退出**，cwd 和所有导出变量一起丢掉，正是这个模块存在的意义被反噬。改成 `pkill -P <shell pid>`（先 TERM 后 KILL）只清理当前命令。

被中断的命令可能残留 sentinel 回显，故标记 `needsResync`，下次调用先清空缓冲区 —— 否则下一条命令会读到上一条的输出。

### `shell.set_working_dir` — 会话的当前项目

设置/读取工作目录。**必须落在授权根目录内**：一个不受 ROOTS 约束的常驻 shell 等于在整个 fs 边界上开洞。

### `project.load_context` — 项目约定（原 #1469，已修正）

收集 `AGENTS.md` / `CLAUDE.md` / `CONVENTIONS.md` / `.cursorrules` 与 `.claude/commands`，支持 `@path.md` 内联导入。

**默认解析规则（#1469 的修正点）**：
1. 显式 `path` → 用它
2. 会话已设工作目录 → 用它
3. 只有一个授权根 → 无歧义，用它
4. 多个根且未设工作目录 → **报错并列出候选**，要求先 `set_working_dir`

第 4 条是关键：宁可让模型看到一句明确的错误，也不能悄悄加载错项目的规则。

## 测试

`electron/local/shellSession.test.ts` 新增 18 例：`cd` 与变量跨调用存活、会话间隔离、失败命令不杀会话、**超时后会话状态完好**、含空格与引号的目录、越界拒绝、`endSession` 清理；以及 `load_context` 的默认解析三分支（跟随工作目录 / 单根回落 / 多根拒绝猜测）。

```
electron/local/ 全量：Test Files 7 passed | Tests 101 passed
```

`npx vue-tsc -b` 通过。

## 说明

- Windows 下持久 shell 走 `cmd.exe`，相关测试 `skipIf(win32)`；`killChildren` 在 Windows 回落到 `taskkill /T`。
- 接续已合并的 #1467（edit_file）、#1468（glob/grep）。**暂不合并**，等 review。

🤖 Generated with [Claude Code](https://claude.com/claude-code)