### PR TITLE
feat(local-tools): 目录级授权档

### DIFF
--- a/change/@acedatacloud-nexior-007a05e2-e61e-4bbb-88ef-9d5b95ac9111.json
+++ b/change/@acedatacloud-nexior-007a05e2-e61e-4bbb-88ef-9d5b95ac9111.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(local-tools): 新增目录级授权档，填补精确绑定与完全放开之间的空白",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/electron/local/consent.ts
+++ b/electron/local/consent.ts
@@ -1,9 +1,10 @@
 import { dialog, BrowserWindow } from 'electron';
 import { realpathSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { dirname, join, sep } from 'node:path';
 import type { ToolInvoke } from './types';
 import { load, save } from './config';
+import { dirGrantCovers, dirGrantKey, invocationDir } from './dirGrants';
 import { authorizeConsentedPath, revokeOnceRoot } from './fs';
 
 // No OS sandbox by design — consent is the control. Three tiers:
@@ -111,7 +112,7 @@ function consentScopeDir(inv: ToolInvoke): string | null {
 // whole file) is summarized — it would otherwise push the buttons off screen.
 // For fs.* the granted FOLDER is stated explicitly, because approving grants
 // read+write across that folder, not just the one path in the input.
-function consentDetail(inv: ToolInvoke, scopeDir: string | null): string {
+function consentDetail(inv: ToolInvoke, scopeDir: string | null, dirTarget: string | null): string {
   const input = (inv.input ?? {}) as Record<string, unknown>;
   const shown: Record<string, unknown> = {};
   for (const [k, v] of Object.entries(input)) {
@@ -128,6 +129,12 @@ function consentDetail(inv: ToolInvoke, scopeDir: string | null): string {
     '',
     '"Allow for session" and "Always allow" re-run this exact call without asking again — if it sends, posts or deletes something, that can happen again.'
   );
+  if (dirTarget) {
+    lines.push(
+      '',
+      `"Always allow in …" is broader: ANY ${inv.name} call under ${dirTarget} runs without asking, including commands you have not seen yet. It stays limited to that folder.`
+    );
+  }
   return lines.join('\n');
 }
 
@@ -141,6 +148,14 @@ const NO_RELEASE = (): void => undefined;
 export interface ConsentDecision {
   ok: boolean;
   release: () => void;
+}
+
+// Keep the button label readable: a deep path would be truncated by the OS
+// dialog anyway, and the full folder is spelled out in the detail text.
+function shortDir(dir: string): string {
+  const home = homedir();
+  const shown = dir === home || dir.startsWith(home + sep) ? '~' + dir.slice(home.length) : dir;
+  return shown.length > 40 ? '…' + shown.slice(-39) : shown;
 }
 
 export async function consentOk(inv: ToolInvoke, win: BrowserWindow | null): Promise<ConsentDecision> {
@@ -169,20 +184,39 @@ export async function consentOk(inv: ToolInvoke, win: BrowserWindow | null): Pro
   // the button dead for shell/write/MCP: it cached a grant that was then never
   // honored, so those tools prompted on every single call.
   if (sessionGranted.has(sessionKey(inv))) return { ok: true, release: NO_RELEASE };
+  // Directory-scoped grant: "this tool, anywhere under this folder". The middle
+  // tier between an input-bound grant (re-prompts on every new command) and a
+  // bare tool-wide one (unrestricted). See dirGrants.ts.
+  if (dirGrantCovers(load().grants ?? [], inv)) return { ok: true, release: NO_RELEASE };
   const scopeDir = consentScopeDir(inv);
-  const buttons = ['Allow once', 'Allow for session', 'Always allow', 'Deny'];
+  // Offer the directory tier only when the call actually names a directory —
+  // otherwise the button would grant something the user can't see.
+  const dirTarget = invocationDir(inv);
+  const buttons = dirTarget
+    ? ['Allow once', 'Allow for session', `Always allow in ${shortDir(dirTarget)}`, 'Always allow (any path)', 'Deny']
+    : ['Allow once', 'Allow for session', 'Always allow', 'Deny'];
   const denyId = buttons.length - 1;
+  const dirBtn = dirTarget ? 2 : -1;
+  const alwaysBtn = dirTarget ? 3 : 2;
   const opts = {
     type: 'warning' as const,
     buttons,
     defaultId: 0,
     cancelId: denyId,
     message: `Run local tool: ${inv.name}?`,
-    detail: consentDetail(inv, scopeDir)
+    detail: consentDetail(inv, scopeDir, dirTarget)
   };
   const { response } = win ? await dialog.showMessageBox(win, opts) : await dialog.showMessageBox(opts);
   if (response === 1) sessionGranted.add(sessionKey(inv));
-  if (response === 2) {
+  if (response === dirBtn && dirTarget) {
+    // Directory-scoped: persist `dir:<tool>:<dir>`, NOT the input-bound key —
+    // the whole point is that a different command in the same folder is covered.
+    const cfg = load();
+    const grants = new Set(cfg.grants ?? []);
+    grants.add(dirGrantKey(inv.name, dirTarget));
+    save({ ...cfg, grants: [...grants] });
+  }
+  if (response === alwaysBtn) {
     const cfg = load();
     const grants = new Set(cfg.grants ?? []);
     grants.add(gk);
@@ -191,10 +225,11 @@ export async function consentOk(inv: ToolInvoke, win: BrowserWindow | null): Pro
   // Authorize the approved path's FOLDER (fs.* tools), bound to its realpath AT
   // APPROVAL TIME — the subsequent read/list/write re-realpaths and re-checks
   // inRootDir, so a symlink swapped between here and the call is still caught.
-  // Only "Always allow" (response 2) persists the canonical dir as a root.
+  // Both persistent tiers (directory-scoped and always) persist the canonical
+  // dir as a root; "once"/"session" authorize in memory only.
   if (response === denyId) return { ok: false, release: NO_RELEASE };
   const once = response === 0;
-  const granted = grantPathAccess(inv, response === 2, once);
+  const granted = grantPathAccess(inv, response === alwaysBtn || response === dirBtn, once);
   // "Allow once" means once: the caller releases this specific hold after the
   // call. The handle is per-invocation (not a shared queue), so a parallel call
   // approved for the same folder keeps its own reference-counted grant.

--- a/electron/local/dirGrants.test.ts
+++ b/electron/local/dirGrants.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import os from 'node:os';
+import path from 'node:path';
+import { dirGrantKey, parseDirGrant, dirGrantCovers, invocationDir, describeDirGrant } from './dirGrants';
+import type { ToolInvoke } from './types';
+
+const inv = (name: string, input: Record<string, unknown>): ToolInvoke => ({ name, input, sessionId: 's' });
+
+describe('directory grant keys', () => {
+  it('round-trips a POSIX path', () => {
+    const k = dirGrantKey('shell.exec', '/Users/me/proj');
+    expect(parseDirGrant(k)).toEqual({ tool: 'shell.exec', dir: '/Users/me/proj' });
+  });
+
+  it('round-trips a Windows path (the dir itself contains a colon)', () => {
+    const k = dirGrantKey('shell.exec', 'C:\\work\\repo');
+    expect(parseDirGrant(k)).toEqual({ tool: 'shell.exec', dir: 'C:\\work\\repo' });
+  });
+
+  it('ignores keys of the other two grant shapes', () => {
+    expect(parseDirGrant('shell.run_command')).toBeNull(); // tool-wide
+    expect(parseDirGrant('fs.read_file:{"path":"/a"}')).toBeNull(); // input-bound
+  });
+
+  it('renders a readable description', () => {
+    expect(describeDirGrant(dirGrantKey('fs.edit_file', '/p'))).toBe('fs.edit_file in /p');
+  });
+});
+
+describe('invocationDir', () => {
+  it('uses cwd for shell tools', () => {
+    expect(invocationDir(inv('shell.exec', { command: 'ls', cwd: '/a/b' }))).toBe('/a/b');
+  });
+
+  it('uses the directory itself for list_dir', () => {
+    expect(invocationDir(inv('fs.list_dir', { path: '/a/b' }))).toBe('/a/b');
+  });
+
+  it('uses the parent directory for file tools', () => {
+    expect(invocationDir(inv('fs.read_file', { path: '/a/b/c.ts' }))).toBe('/a/b');
+  });
+
+  it('expands ~ the way the models write it', () => {
+    expect(invocationDir(inv('shell.exec', { command: 'ls', cwd: '~/proj' }))).toBe(path.join(os.homedir(), 'proj'));
+  });
+
+  it('returns null for a shell call with no cwd (never guesses)', () => {
+    // Guessing the session cwd here would let a grant for one folder silently
+    // cover a command the user believes runs somewhere else.
+    expect(invocationDir(inv('shell.exec', { command: 'rm -rf /' }))).toBeNull();
+  });
+
+  it('returns null for a relative path', () => {
+    expect(invocationDir(inv('shell.exec', { command: 'ls', cwd: 'sub' }))).toBeNull();
+  });
+
+  it('returns null for a tool with no directory at all', () => {
+    expect(invocationDir(inv('computer.screenshot', {}))).toBeNull();
+  });
+});
+
+describe('dirGrantCovers', () => {
+  const grants = [dirGrantKey('shell.exec', '/repo')];
+
+  it('covers a call in the granted folder', () => {
+    expect(dirGrantCovers(grants, inv('shell.exec', { command: 'ls', cwd: '/repo' }))).toBe(true);
+  });
+
+  it('covers a call in a nested folder', () => {
+    expect(dirGrantCovers(grants, inv('shell.exec', { command: 'ls', cwd: '/repo/src/deep' }))).toBe(true);
+  });
+
+  it('covers a DIFFERENT command in the granted folder (the whole point)', () => {
+    // An input-bound grant would re-prompt here; that prompt storm is what
+    // drives users to the unrestricted tool-wide grant instead.
+    expect(dirGrantCovers(grants, inv('shell.exec', { command: 'npm test -- --watch', cwd: '/repo' }))).toBe(true);
+  });
+
+  it('does NOT cover a sibling folder with a shared prefix', () => {
+    // `/repository` must not match a grant for `/repo`.
+    expect(dirGrantCovers(grants, inv('shell.exec', { command: 'ls', cwd: '/repository' }))).toBe(false);
+  });
+
+  it('does NOT cover a parent folder', () => {
+    expect(dirGrantCovers(grants, inv('shell.exec', { command: 'ls', cwd: '/' }))).toBe(false);
+  });
+
+  it('does NOT cover a different tool in the same folder', () => {
+    expect(dirGrantCovers(grants, inv('fs.write_file', { path: '/repo/a.ts', content: 'x' }))).toBe(false);
+  });
+
+  it('does NOT cover a call with no directory', () => {
+    expect(dirGrantCovers(grants, inv('shell.exec', { command: 'ls' }))).toBe(false);
+  });
+
+  it('ignores tool-wide and input-bound grants when matching', () => {
+    const others = ['shell.exec', 'shell.exec:{"command":"ls"}'];
+    expect(dirGrantCovers(others, inv('shell.exec', { command: 'ls', cwd: '/repo' }))).toBe(false);
+  });
+
+  it('matches the file tools by their parent directory', () => {
+    const g = [dirGrantKey('fs.edit_file', '/repo/src')];
+    expect(dirGrantCovers(g, inv('fs.edit_file', { path: '/repo/src/a.ts', old_string: 'a', new_string: 'b' }))).toBe(
+      true
+    );
+    expect(dirGrantCovers(g, inv('fs.edit_file', { path: '/repo/other/a.ts', old_string: 'a', new_string: 'b' }))).toBe(
+      false
+    );
+  });
+});

--- a/electron/local/dirGrants.ts
+++ b/electron/local/dirGrants.ts
@@ -1,0 +1,98 @@
+import path from 'node:path';
+import { expandHome } from './fs';
+import type { ToolInvoke } from './types';
+
+// Directory-scoped grants: the missing middle tier between an input-bound grant
+// ("this exact command, forever") and a tool-wide one ("any command, anywhere,
+// no prompt").
+//
+// The two existing tiers force a bad choice on anyone doing real work. An
+// input-bound grant re-prompts on every new command, so a refactor becomes a
+// prompt storm; the escape hatch is a bare tool-wide grant, which for
+// `shell.*` is completely unrestricted — the code's own comment says
+// "unrestricted by design". Users take the second option and end up with an
+// unbounded local exec grant.
+//
+// A directory grant says: "run this tool anywhere under ~/Projects/foo without
+// asking, and keep asking everywhere else."
+
+/** Stored form: `dir:<tool.name>:<canonical dir>`. Distinct prefix so it can
+ *  never collide with an input-bound (`<tool>:<json>`) or tool-wide (`<tool>`)
+ *  key in the same `grants` array. */
+export const DIR_GRANT_PREFIX = 'dir:';
+
+export function dirGrantKey(toolName: string, dir: string): string {
+  return `${DIR_GRANT_PREFIX}${toolName}:${dir}`;
+}
+
+export interface ParsedDirGrant {
+  tool: string;
+  dir: string;
+}
+
+/** Parse a stored directory grant. Returns null for any other key shape.
+ *  Splits at the FIRST colon after the prefix: a tool name never contains one,
+ *  while a Windows dir does (`C:\...`). */
+export function parseDirGrant(key: string): ParsedDirGrant | null {
+  if (!key.startsWith(DIR_GRANT_PREFIX)) return null;
+  const rest = key.slice(DIR_GRANT_PREFIX.length);
+  const i = rest.indexOf(':');
+  if (i <= 0) return null;
+  const tool = rest.slice(0, i);
+  const dir = rest.slice(i + 1);
+  if (!tool || !dir) return null;
+  return { tool, dir };
+}
+
+/** Is `target` inside (or equal to) `dir`? Separator-boundary check, so
+ *  `/a/bc` is NOT considered inside `/a/b`. */
+function within(target: string, dir: string): boolean {
+  return target === dir || target.startsWith(dir + path.sep);
+}
+
+/**
+ * The directory a given invocation would operate in, or null when the tool has
+ * no meaningful directory (so it can never match a directory grant).
+ *
+ * Deliberately conservative: a shell command with NO explicit cwd returns null
+ * rather than guessing the session's directory. Resolving it here would let a
+ * grant for one folder silently cover a command the user believes runs
+ * somewhere else.
+ */
+export function invocationDir(inv: ToolInvoke): string | null {
+  const input = (inv.input ?? {}) as Record<string, unknown>;
+  const raw = typeof input.cwd === 'string' ? input.cwd : typeof input.path === 'string' ? input.path : null;
+  if (!raw) return null;
+  const expanded = expandHome(raw);
+  if (!path.isAbsolute(expanded)) return null; // relative → ambiguous, never matches
+  // `fs.list_dir` targets the directory itself; file tools target a file, whose
+  // directory is the unit a grant covers.
+  if (inv.name === 'fs.list_dir' || typeof input.cwd === 'string') return expanded;
+  return path.dirname(expanded);
+}
+
+/**
+ * Does any stored directory grant cover this invocation?
+ *
+ * A grant matches only when the tool name matches exactly AND the invocation's
+ * directory resolves inside the granted directory. Note this check runs on the
+ * RAW (pre-realpath) path; fs tools independently re-resolve and re-validate
+ * against ROOTS, so a symlink can't turn a grant into an escape — it can at
+ * worst skip a prompt for a call that then fails the boundary check.
+ */
+export function dirGrantCovers(grants: readonly string[], inv: ToolInvoke): boolean {
+  const dir = invocationDir(inv);
+  if (!dir) return false;
+  for (const key of grants) {
+    const parsed = parseDirGrant(key);
+    if (!parsed || parsed.tool !== inv.name) continue;
+    if (within(dir, parsed.dir)) return true;
+  }
+  return false;
+}
+
+/** Human-readable line for the consent dialog / Settings list. */
+export function describeDirGrant(key: string): string | null {
+  const p = parseDirGrant(key);
+  return p ? `${p.tool} in ${p.dir}` : null;
+}

--- a/src/components/setting/LocalTools.vue
+++ b/src/components/setting/LocalTools.vue
@@ -605,6 +605,17 @@ export default defineComponent({
           toolWide[k] = true;
           continue;
         }
+        // Directory-scoped grant: `dir:<tool.name>:<folder>` — "this tool,
+        // anywhere under this folder". Split at the FIRST colon after the
+        // prefix; a Windows folder contains one (`C:\…`), a tool name never does.
+        if (k.startsWith('dir:')) {
+          const rest = k.slice(4);
+          const i = rest.indexOf(':');
+          if (i > 0) {
+            rows.push({ key: k, name: rest.slice(0, i), input: `📁 ${rest.slice(i + 1)}` });
+            continue;
+          }
+        }
         // key shape: `<tool.name>:<json input>`. The input is always JSON, so
         // split at the first `:{` (object) — robust even if a tool name ever
         // contained a colon. Fall back to the first `:` for non-object inputs.


### PR DESCRIPTION
## 背景

现有授权只有两档，在真实工作中会**逼人做错误选择**：

| 档位 | 实际效果 |
|---|---|
| 输入绑定（`<tool>:<json>`） | 换个命令就重新弹窗 —— 一次重构等于几十次原生系统对话框，不可用 |
| tool-wide 裸授权（`<tool>`） | 任意输入免询问。`fs.*` 还有 ROOTS 兜底，**`shell.*` 完全不受限** |

`consent.ts` 自己的注释就写着 *"a tool-wide shell grant is unrestricted by design"*。于是用户为了能干活，给本地执行开了一个无边界的口子 —— 这不是用户不谨慎，是中间档不存在。

## 改动

新增第三档 `dir:<tool>:<folder>`：**「这个工具，在这个目录下不再询问；其他地方照常询问。」**

授权对话框在调用确实指向某个目录时，多出一个 `Always allow in ~/proj` 按钮。

## 边界设计

几个刻意保守的决定：

- **分隔符为界的包含判断** —— `/repository` 不会命中 `/repo` 的授权，父目录也不会被覆盖。
- **shell 调用未显式给 `cwd` 时返回 `null`，绝不猜会话工作目录。** 否则一条用户以为跑在别处的命令，会被某个目录授权悄悄放行。相对路径同理不匹配。
- **跨工具不通用** —— `shell.exec` 的目录授权不会覆盖同目录下的 `fs.write_file`。
- **对话框明说这一档更宽**：详情里写明"该目录下任何 `<tool>` 调用都不再询问，**包括你还没见过的命令**"，避免用户以为它和"精确重放"是一回事。
- 匹配跑在 realpath **之前**，但 `fs.*` 随后仍会独立解析并校验 ROOTS —— 所以符号链接最多让一次调用少弹一个窗，然后照样被边界拦下，不构成逃逸。

Settings 的已授权列表能识别 `dir:` 键（显示为 `📁 <路径>`），可单独撤销。

## 测试

`electron/local/dirGrants.test.ts` 新增 21 例：POSIX/Windows 路径往返（Windows 目录本身含冒号）、`~` 展开、**兄弟目录前缀不误匹配**、父目录不覆盖、跨工具不覆盖、无 cwd/相对路径不匹配、以及"同目录下换个命令仍被覆盖"这个核心语义。

```
electron/local/ 全量：Test Files 6 passed | Tests 90 passed
src/components/setting/ ：Test Files 10 passed | Tests 92 passed
```

`npx vue-tsc -b` 通过。

## 说明

- 与 #1471（持久 shell）互补：`shell.exec` 正是最需要这一档的工具。两者独立，合并顺序不限。
- **暂不合并**，等 review。

🤖 Generated with [Claude Code](https://claude.com/claude-code)