### PR TITLE
fix(console): 弹窗收口视口、断点对齐 767px、搜索框换 el-input

### DIFF
--- a/change/@acedatacloud-nexior-8cd9a4eb-ab74-4726-8250-6d8af63b7eb1.json
+++ b/change/@acedatacloud-nexior-8cd9a4eb-ab74-4726-8250-6d8af63b7eb1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(console): 弹窗收口视口、断点对齐、搜索框换 el-input",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/browser/BrowserPairingDialog.vue
+++ b/src/components/browser/BrowserPairingDialog.vue
@@ -2,7 +2,7 @@
   <el-dialog
     v-model="visible"
     :title="$t('user.browserDevice.pairTitle')"
-    width="620px"
+    width="min(620px, 94vw)"
     append-to-body
     destroy-on-close
     :close-on-click-modal="false"

--- a/src/components/connections/BrowseConnectors.vue
+++ b/src/components/connections/BrowseConnectors.vue
@@ -2,7 +2,7 @@
   <el-dialog
     v-model="visible"
     :title="$t('connection.title.browse')"
-    width="900px"
+    width="min(900px, 94vw)"
     top="5vh"
     :close-on-click-modal="false"
     @open="onOpen"
@@ -10,10 +10,17 @@
     <p class="browse-intro">{{ $t('connection.message.browseHint') }}</p>
 
     <div class="browse-toolbar">
-      <div class="search-wrapper">
-        <search-icon class="search-icon" :size="16" aria-hidden="true" focusable="false" />
-        <input v-model="query" type="text" class="search-input" :placeholder="$t('connection.placeholder.search')" />
-      </div>
+      <el-input
+        v-model="query"
+        class="search-input"
+        size="default"
+        clearable
+        :placeholder="$t('connection.placeholder.search')"
+      >
+        <template #prefix>
+          <search-icon :size="14" aria-hidden="true" focusable="false" />
+        </template>
+      </el-input>
       <el-select v-model="sort" size="default" class="sort-select" @change="fetchItems">
         <el-option :label="$t('connection.label.featured')" value="popular" />
         <el-option :label="$t('connection.label.new')" value="new" />
@@ -169,6 +176,7 @@
 import { defineComponent, PropType } from 'vue';
 import {
   ElDialog,
+  ElInput,
   ElSelect,
   ElOption,
   ElMessage,
@@ -278,6 +286,7 @@ export default defineComponent({
   name: 'BrowseConnectors',
   components: {
     ElDialog,
+    ElInput,
     ElSelect,
     ElOption,
     ElTooltip,
@@ -633,49 +642,10 @@ export default defineComponent({
   margin-bottom: 14px;
 }
 
-.search-wrapper {
-  flex: 1 1 auto;
-  position: relative;
-  display: flex;
-  align-items: center;
-}
-
-.search-icon {
-  position: absolute;
-  left: 10px;
-  font-size: 12px;
-  color: var(--el-text-color-placeholder);
-  pointer-events: none;
-}
-
+// Styling comes from the global `.el-input__wrapper` rules in _common.scss,
+// so the field matches every other input in the console.
 .search-input {
-  width: 100%;
-  height: 34px;
-  padding: 0 10px 0 30px;
-  font-size: 13px;
-  color: var(--el-text-color-primary);
-  background: var(--el-fill-color-light);
-  border: 1px solid transparent;
-  border-radius: 8px;
-  outline: none;
-  transition:
-    background 0.15s,
-    border-color 0.15s,
-    box-shadow 0.15s;
-
-  &::placeholder {
-    color: var(--el-text-color-placeholder);
-  }
-
-  &:hover {
-    background: var(--el-fill-color);
-  }
-
-  &:focus {
-    background: var(--el-bg-color);
-    border-color: var(--el-color-primary);
-    box-shadow: 0 0 0 3px var(--el-color-primary-light-9);
-  }
+  flex: 1 1 auto;
 }
 
 .sort-select {

--- a/src/components/connections/ByocCredentialsDialog.vue
+++ b/src/components/connections/ByocCredentialsDialog.vue
@@ -1,5 +1,12 @@
 <template>
-  <el-dialog v-model="visible" :title="dialogTitle" width="520px" append-to-body destroy-on-close @close="onClose">
+  <el-dialog
+    v-model="visible"
+    :title="dialogTitle"
+    width="min(520px, 94vw)"
+    append-to-body
+    destroy-on-close
+    @close="onClose"
+  >
     <!-- Extension cookie-capture path (metadata.credential_source === 'extension') -->
     <template v-if="isExtension">
       <!-- A) extension not detected → install guidance -->

--- a/src/components/connections/ConnectorMethodPicker.vue
+++ b/src/components/connections/ConnectorMethodPicker.vue
@@ -1,5 +1,12 @@
 <template>
-  <el-dialog v-model="visible" :title="dialogTitle" width="480px" append-to-body destroy-on-close @close="onClose">
+  <el-dialog
+    v-model="visible"
+    :title="dialogTitle"
+    width="min(480px, 94vw)"
+    append-to-body
+    destroy-on-close
+    @close="onClose"
+  >
     <p class="picker-intro">{{ $t('connection.method.heading') }}</p>
     <el-tabs v-model="selectedId" class="picker-tabs">
       <el-tab-pane v-for="method in methods" :key="method.id" :name="method.id">

--- a/src/components/skill/BrowseSkillsDialog.vue
+++ b/src/components/skill/BrowseSkillsDialog.vue
@@ -2,7 +2,7 @@
   <el-dialog
     :model-value="modelValue"
     :title="$t('skill.dialog.directoryTitle')"
-    width="960px"
+    width="min(960px, 94vw)"
     align-center
     class="directory-dialog"
     :close-on-click-modal="!installing"
@@ -15,15 +15,18 @@
       <main class="directory-main">
         <template v-if="!selectedItem">
           <header class="directory-header">
-            <div class="directory-search">
-              <search-icon class="directory-search-icon" :size="16" aria-hidden="true" focusable="false" />
-              <input
-                v-model="searchQuery"
-                class="directory-search-input"
-                :placeholder="$t('skill.directory.searchPlaceholder')"
-                @input="onSearchInput"
-              />
-            </div>
+            <el-input
+              v-model="searchQuery"
+              class="directory-search"
+              size="default"
+              clearable
+              :placeholder="$t('skill.directory.searchPlaceholder')"
+              @input="onSearchInput"
+            >
+              <template #prefix>
+                <search-icon :size="14" aria-hidden="true" focusable="false" />
+              </template>
+            </el-input>
             <div class="directory-controls">
               <el-select
                 v-model="namespaceFilter"
@@ -188,7 +191,7 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElDialog, ElButton, ElMessage, ElPagination, ElSelect, ElOption, vLoading } from 'element-plus';
+import { ElDialog, ElInput, ElButton, ElMessage, ElPagination, ElSelect, ElOption, vLoading } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import {
   AddIcon,
@@ -255,6 +258,7 @@ export default defineComponent({
   components: {
     VueMarkdown,
     ElDialog,
+    ElInput,
     ElButton,
     ElPagination,
     ElSelect,
@@ -492,31 +496,10 @@ export default defineComponent({
   padding: 16px 20px;
   border-bottom: 1px solid var(--el-border-color-lighter);
 }
+/* Styling comes from the global `.el-input__wrapper` rules in _common.scss,
+   so the field matches every other input in the console. */
 .directory-search {
   flex: 1;
-  position: relative;
-  display: flex;
-  align-items: center;
-}
-.directory-search-icon {
-  position: absolute;
-  left: 12px;
-  color: var(--el-text-color-placeholder);
-  pointer-events: none;
-}
-.directory-search-input {
-  width: 100%;
-  height: 36px;
-  padding: 0 12px 0 36px;
-  border: 1px solid var(--el-border-color);
-  border-radius: 8px;
-  font-size: 14px;
-  background: var(--el-bg-color);
-  color: var(--el-text-color-primary);
-  outline: none;
-}
-.directory-search-input:focus {
-  border-color: var(--el-color-primary);
 }
 .directory-controls {
   display: flex;

--- a/src/components/skill/UploadSkillDialog.vue
+++ b/src/components/skill/UploadSkillDialog.vue
@@ -2,7 +2,7 @@
   <el-dialog
     :model-value="modelValue"
     :title="$t('skill.dialog.uploadTitle')"
-    width="520px"
+    width="min(520px, 94vw)"
     align-center
     :close-on-click-modal="!uploading"
     :close-on-press-escape="!uploading"

--- a/src/components/skill/WriteSkillDialog.vue
+++ b/src/components/skill/WriteSkillDialog.vue
@@ -2,7 +2,7 @@
   <el-dialog
     :model-value="modelValue"
     :title="$t('skill.dialog.writeTitle')"
-    width="720px"
+    width="min(720px, 94vw)"
     align-center
     :close-on-click-modal="!saving"
     :close-on-press-escape="!saving"

--- a/src/pages/console/connectors/Index.vue
+++ b/src/pages/console/connectors/Index.vue
@@ -8,15 +8,17 @@
       <!-- Left pane -->
       <aside class="connectors-list">
         <div class="list-toolbar">
-          <div class="search-wrapper">
-            <search-icon class="search-icon" :size="16" aria-hidden="true" focusable="false" />
-            <input
-              v-model="searchQuery"
-              type="text"
-              class="search-input"
-              :placeholder="$t('connection.placeholder.search')"
-            />
-          </div>
+          <el-input
+            v-model="searchQuery"
+            class="search-input"
+            size="default"
+            clearable
+            :placeholder="$t('connection.placeholder.search')"
+          >
+            <template #prefix>
+              <search-icon :size="14" aria-hidden="true" focusable="false" />
+            </template>
+          </el-input>
           <el-dropdown trigger="click" placement="bottom-end" @command="onAddCommand">
             <button
               type="button"
@@ -2068,7 +2070,7 @@ export default defineComponent({
   color: var(--el-text-color-secondary);
 }
 
-@media (max-width: 800px) {
+@media screen and (max-width: 767px) {
   // On phones let the page grow and scroll instead of trapping content
   // inside a viewport-height flex column.
   .page-shell {
@@ -2116,49 +2118,10 @@ html.dark .connectors-shell {
   padding: 14px 14px 12px;
 }
 
-.search-wrapper {
-  flex: 1 1 auto;
-  position: relative;
-  display: flex;
-  align-items: center;
-}
-
-.search-icon {
-  position: absolute;
-  left: 10px;
-  font-size: 12px;
-  color: var(--el-text-color-placeholder);
-  pointer-events: none;
-}
-
+// Styling comes from the global `.el-input__wrapper` rules in
+// _common.scss, so the field matches every other input in the console.
 .search-input {
-  width: 100%;
-  height: 34px;
-  padding: 0 10px 0 30px;
-  font-size: 13px;
-  color: var(--el-text-color-primary);
-  background: var(--el-fill-color-light);
-  border: 1px solid transparent;
-  border-radius: 8px;
-  outline: none;
-  transition:
-    background 0.15s,
-    border-color 0.15s,
-    box-shadow 0.15s;
-
-  &::placeholder {
-    color: var(--el-text-color-placeholder);
-  }
-
-  &:hover {
-    background: var(--el-fill-color);
-  }
-
-  &:focus {
-    background: var(--el-bg-color);
-    border-color: var(--el-color-primary);
-    box-shadow: 0 0 0 3px var(--el-color-primary-light-9);
-  }
+  flex: 1 1 auto;
 }
 
 .add-button {
@@ -2911,7 +2874,7 @@ html.dark .connectors-shell {
   margin: 4px 0 0;
 }
 
-@media (max-width: 800px) {
+@media screen and (max-width: 767px) {
   .connectors-shell {
     grid-template-columns: 1fr;
   }

--- a/src/pages/console/skills/Index.vue
+++ b/src/pages/console/skills/Index.vue
@@ -63,14 +63,18 @@
 
         <!-- Inline search field -->
         <div v-if="searchOpen" class="search-row">
-          <search-icon class="search-icon" :size="13" aria-hidden="true" focusable="false" />
-          <input
+          <el-input
             ref="searchInput"
             v-model="searchQuery"
             class="search-input"
+            size="default"
             :placeholder="$t('skill.placeholder.search')"
             @keydown.escape="closeSearch"
-          />
+          >
+            <template #prefix>
+              <search-icon :size="13" aria-hidden="true" focusable="false" />
+            </template>
+          </el-input>
           <button
             class="icon-btn icon-btn-sm"
             :aria-label="$t('common.button.close')"
@@ -246,6 +250,7 @@
 <script lang="ts">
 import { defineComponent, nextTick } from 'vue';
 import {
+  ElInput,
   ElSwitch,
   ElTag,
   ElTooltip,
@@ -301,6 +306,7 @@ interface IData {
 export default defineComponent({
   name: 'UserSkills',
   components: {
+    ElInput,
     ElSwitch,
     ElTag,
     ElTooltip,
@@ -431,8 +437,8 @@ export default defineComponent({
     openSearch() {
       this.searchOpen = true;
       nextTick(() => {
-        const input = this.$refs.searchInput as HTMLInputElement | undefined;
-        input?.focus();
+        const input = this.$refs.searchInput as { focus?: () => void } | undefined;
+        input?.focus?.();
       });
     },
 
@@ -554,7 +560,7 @@ export default defineComponent({
   color: var(--el-text-color-secondary);
 }
 
-@media (max-width: 800px) {
+@media screen and (max-width: 767px) {
   .page-shell {
     height: auto;
   }
@@ -637,25 +643,10 @@ html.dark .skills-shell {
   padding: 0 12px 8px;
 }
 
-.search-icon {
-  color: var(--el-text-color-secondary);
-  font-size: 13px;
-}
-
+/* Styling comes from the global `.el-input__wrapper` rules in _common.scss,
+   so the field matches every other input in the console. */
 .search-input {
   flex: 1;
-  border: 1px solid var(--el-border-color);
-  border-radius: 6px;
-  padding: 6px 10px;
-  font-size: 13px;
-  outline: none;
-  background: var(--el-fill-color-lighter);
-  color: var(--el-text-color-primary);
-}
-
-.search-input:focus {
-  border-color: var(--el-color-primary);
-  background: var(--el-bg-color);
 }
 
 .left-body {
@@ -862,7 +853,7 @@ html.dark .skills-shell {
 }
 
 /* ---- Responsive ---- */
-@media (max-width: 800px) {
+@media screen and (max-width: 767px) {
   .skills-shell {
     flex-direction: column;
   }


### PR DESCRIPTION
接 [#1470](https://github.com/AceDataCloud/Nexior/pull/1470) 的剩余项。

## 弹窗宽度写死 px，平板上会溢出

`BrowseSkillsDialog` 960px、`BrowseConnectors` 900px、`WriteSkillDialog` 720px、`BrowserPairingDialog` 620px —— 在 768–1024px 的屏幕上都超出可视宽度。

七个弹窗统一成 `min(<px>, 94vw)`，跟 Nexior 自己的 `Setting.vue` 一致。`BrowserDevicePicker` 本来就是这么写的，现在其余六个跟上。

## 断点死区

移植页用 `max-width: 800px`，而 `Console.vue` / `SidePanel.vue` 用 **767/768px**。

结果是 768–800px 之间**页面内部已经切成移动布局，外层壳还是桌面的**，两者打架。四处断点统一到 767px。

## 搜索框换 el-input

四个搜索框是手写 `<input>`，自带 border / radius / focus ring，跟控制台其他输入框不一样 —— Nexior 在 `_common.scss` 里全局定义了 `.el-input__wrapper`（含 `--adc-color-border` 描边和 `--app-shadow-xs`）。

换成 `el-input` + `prefix` 插槽，删掉自定义样式让全局规则接管，顺带白拿 `clearable`。

| 位置 | |
|---|---|
| `console/connectors/Index.vue` | 侧栏搜索 |
| `console/skills/Index.vue` | 内联搜索（保留 `ref` focus 和 Esc 关闭） |
| `connections/BrowseConnectors.vue` | 目录搜索 |
| `skill/BrowseSkillsDialog.vue` | 目录搜索 |

## 原生 `<button>` 没动

那 17 个都是 **26–34px 的紧凑图标按钮和折叠箭头**，换 `el-button` 会撑破布局，视觉上也没有收益。这个我判断保持现状更好。

## 验证

```
vue-tsc -b        零错误
npm run build:web ✓ built
npm run lint      0 errors（2 个既有 warning）
vitest            901 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
