### PR TITLE
feat(desktop): 本地定时任务 daemon — 常驻、调度、无窗口跑客户端工具

### DIFF
--- a/change/@acedatacloud-nexior-b67d5b2c-7f40-438a-b422-4fabe0b27d90.json
+++ b/change/@acedatacloud-nexior-b67d5b2c-7f40-438a-b422-4fabe0b27d90.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "desktop: run locally-executed scheduled tasks from the main process — tray residency, start-at-login, and the client-tool loop without a window",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,5 +1,6 @@
 import { app, BrowserWindow, ipcMain, shell, Menu, Notification, globalShortcut } from 'electron';
 import path from 'node:path';
+import os from 'node:os';
 import { registerAppProtocol, APP_ORIGIN } from './protocol';
 import { issueState, consumeState } from './auth-state';
 import { initUpdater } from './updater';
@@ -7,6 +8,15 @@ import { registerLocalExec, disableComputerUse } from './local/ipc';
 import { registry } from './local/registry';
 import { setRoots } from './local/fs';
 import { load as loadLocalConfig } from './local/config';
+import { daemon } from './scheduler/daemon';
+import { initTray, refreshTray, setOpenAtLogin, isOpenAtLogin } from './scheduler/tray';
+import {
+  getDeviceId,
+  getDeviceName,
+  setDeviceName,
+  setCredentials,
+  clearCredentials
+} from './scheduler/credentials';
 
 const DESKTOP_SCHEME = 'acedata-desktop';
 
@@ -104,13 +114,29 @@ if (!gotLock) {
     void registry.boot(localCfg.mcp);
     registerLocalExec(() => mainWindow);
     registerPanicStop();
+    // Scheduled-task daemon: holds the schedules for tasks bound to this
+    // device and fires them from THIS process. It lives in main, not the
+    // renderer, because Chromium throttles a hidden window's timers to about
+    // once a minute — a "every 5 minutes" task would fire whenever the user
+    // happened to look at it.
+    initTray(() => focusWindow());
+    daemon.start();
+    void daemon.reportMissedSinceLastRun();
     // Windows cold-start protocol activation: URL is in this instance's argv.
     const coldUrl = process.argv.find((a) => a.startsWith(`${DESKTOP_SCHEME}://`));
     if (coldUrl) handleDeepLink(coldUrl);
   });
 
   app.on('window-all-closed', () => {
-    if (process.platform !== 'darwin') app.quit();
+    // Staying resident is what makes a local scheduled task fire at 7am with
+    // no window open. Only do it when this device actually holds one —
+    // otherwise closing the last window still quits, as it always did.
+    if (process.platform === 'darwin') return;
+    if (daemon.hasTasks()) {
+      refreshTray(() => focusWindow());
+      return;
+    }
+    app.quit();
   });
   app.on('will-quit', () => globalShortcut.unregisterAll());
   app.on('activate', () => {
@@ -237,7 +263,14 @@ function handleDeepLink(rawUrl: string): void {
 }
 
 function focusWindow(): void {
-  if (!mainWindow) return;
+  // Once the app can outlive its window (tray residency), "focus" may have to
+  // recreate it — otherwise clicking the tray icon after closing the window
+  // would do nothing at all.
+  if (!mainWindow || mainWindow.isDestroyed()) {
+    createWindow();
+    return;
+  }
+  if (mainWindow.isMinimized()) mainWindow.restore();
   mainWindow.show();
   mainWindow.focus();
 }
@@ -293,8 +326,59 @@ ipcMain.handle('notify:show', (_e, { title, body }: { title: string; body: strin
   n.show();
 });
 
+// --- Scheduled-task daemon IPC ---
+//
+// The daemon needs a Bearer token that outlives the window, so the renderer
+// hands it over on sign-in and main persists it (OS-encrypted, 0600). Nothing
+// here reads the token back out to the renderer — it only ever goes inward.
+
+ipcMain.handle('scheduler:identity', () => ({
+  device_id: getDeviceId(),
+  device_name: getDeviceName() ?? defaultDeviceName(),
+  open_at_login: isOpenAtLogin()
+}));
+
+ipcMain.handle('scheduler:setCredentials', (_e, { token, siteOrigin }: { token: string; siteOrigin?: string }) => {
+  if (typeof token !== 'string' || !token) return false;
+  setCredentials(token, typeof siteOrigin === 'string' ? siteOrigin : undefined);
+  daemon.start();
+  refreshTray(() => focusWindow());
+  return true;
+});
+
+ipcMain.handle('scheduler:clearCredentials', () => {
+  clearCredentials();
+  refreshTray(() => focusWindow());
+  return true;
+});
+
+ipcMain.handle('scheduler:setDeviceName', (_e, name: string) => {
+  if (typeof name !== 'string' || !name.trim()) return false;
+  setDeviceName(name.trim());
+  refreshTray(() => focusWindow());
+  return true;
+});
+
+ipcMain.handle('scheduler:setOpenAtLogin', (_e, enabled: boolean) => {
+  setOpenAtLogin(enabled === true);
+  refreshTray(() => focusWindow());
+  return isOpenAtLogin();
+});
+
+ipcMain.handle('scheduler:status', () => ({ ...daemon.getState(), schedule: daemon.getSchedule() }));
+
+/** A name the user will recognize in a task list without being asked to invent
+ *  one: their machine's hostname, which is what other devices already show. */
+function defaultDeviceName(): string {
+  const platform = process.platform === 'darwin' ? 'Mac' : 'PC';
+  try {
+    return os.hostname().replace(/\.local$/, '') || platform;
+  } catch {
+    return platform;
+  }
+}
+
 // Cross-platform menu. The Edit role is REQUIRED for clipboard accelerators
-// (Cmd/Ctrl+C/V/X/A, undo/redo) to work in inputs; without it they are dead.
 function setupAppMenu(): void {
   const isMac = process.platform === 'darwin';
   const nav = (dir: 'back' | 'forward') => {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -55,7 +55,26 @@ contextBridge.exposeInMainWorld('desktop', {
 
   // Show an OS notification via the main process (reliable when the window is
   // hidden/minimized, unlike Web Notification). Resolves after dispatch.
-  notify: (title: string, body: string): Promise<void> => ipcRenderer.invoke('notify:show', { title, body })
+  notify: (title: string, body: string): Promise<void> => ipcRenderer.invoke('notify:show', { title, body }),
+
+  // Scheduled-task daemon. The token is handed INWARD only — main persists it
+  // (OS-encrypted, 0600) so tasks keep firing after the window closes, and
+  // never hands it back out.
+  scheduler: {
+    identity: (): Promise<{ device_id: string; device_name: string; open_at_login: boolean }> =>
+      ipcRenderer.invoke('scheduler:identity'),
+    setCredentials: (token: string, siteOrigin?: string): Promise<boolean> =>
+      ipcRenderer.invoke('scheduler:setCredentials', { token, siteOrigin }),
+    clearCredentials: (): Promise<boolean> => ipcRenderer.invoke('scheduler:clearCredentials'),
+    setDeviceName: (name: string): Promise<boolean> => ipcRenderer.invoke('scheduler:setDeviceName', name),
+    setOpenAtLogin: (enabled: boolean): Promise<boolean> => ipcRenderer.invoke('scheduler:setOpenAtLogin', enabled),
+    status: (): Promise<{
+      state: 'stopped' | 'running' | 'signed_out';
+      error?: string;
+      taskCount: number;
+      schedule: { id: string; name: string; nextAt: number | null }[];
+    }> => ipcRenderer.invoke('scheduler:status')
+  }
 });
 
 // Local tool execution (desktop only): list authorized local tools and invoke

--- a/electron/scheduler/api.ts
+++ b/electron/scheduler/api.ts
@@ -1,0 +1,152 @@
+import { getToken } from './credentials';
+
+/**
+ * The daemon's HTTP client.
+ *
+ * Deliberately not the renderer's axios stack: this runs in the main process
+ * with no window, so it cannot reach the Vuex store, the shared interceptors,
+ * or `src/operators`. It speaks the same public API through Kong, with the same
+ * Bearer token, and is billed the same way — which is exactly why no local
+ * pre-authorization is needed here.
+ */
+
+const API_BASE = process.env.ACEDATA_API_BASE || 'https://api.acedata.cloud';
+const SCHEDULED_TASKS_URL = `${API_BASE}/aichat2/scheduled-tasks`;
+const CONVERSATIONS_URL = `${API_BASE}/aichat2/conversations`;
+
+export class UnauthorizedError extends Error {
+  constructor() {
+    super('unauthorized');
+    this.name = 'UnauthorizedError';
+  }
+}
+
+async function post<T>(url: string, body: unknown, siteOrigin?: string, timeoutMs = 30_000): Promise<T> {
+  const token = getToken();
+  if (!token) throw new UnauthorizedError();
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+        ...(siteOrigin ? { 'x-site-origin': siteOrigin } : {})
+      },
+      body: JSON.stringify(body),
+      signal: controller.signal
+    });
+    // A dead token must be distinguishable from a network blip: the tray says
+    // "sign in again" for one and stays quiet for the other.
+    if (res.status === 401 || res.status === 403) throw new UnauthorizedError();
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      throw new Error(`${res.status} ${text.slice(0, 300)}`);
+    }
+    return (await res.json()) as T;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export interface LocalTaskSummary {
+  id: string;
+  name: string;
+  schedule: import('./schedule').ScheduleSpec;
+  jitter_seconds?: number;
+  ends_at?: number;
+  state: 'enabled' | 'disabled' | 'error';
+  updated_at: number;
+}
+
+export interface ClaimedRun {
+  run_id: string;
+  question: string;
+  model: string;
+  max_turns?: number;
+  memory_enabled?: boolean;
+  skills?: string[];
+  mcp_servers?: string[];
+  unattended_policy?: { allowed_skills: string[]; allowed_mcp_servers?: string[]; allowed_local_tools?: string[] };
+  site_origin?: string;
+  title?: string;
+  /** Present instead of the rest when this tick is already running elsewhere. */
+  already_running?: boolean;
+}
+
+export const api = {
+  listLocalTasks(deviceId: string, siteOrigin?: string): Promise<{ items: LocalTaskSummary[] }> {
+    return post(SCHEDULED_TASKS_URL, { action: 'retrieve_local_batch', device_id: deviceId }, siteOrigin);
+  },
+
+  claimRun(
+    taskId: string,
+    deviceId: string,
+    scheduledAt: number,
+    siteOrigin?: string,
+    manual = false
+  ): Promise<ClaimedRun> {
+    return post(
+      SCHEDULED_TASKS_URL,
+      { action: 'claim_local_run', task_id: taskId, device_id: deviceId, scheduled_at: scheduledAt, manual },
+      siteOrigin
+    );
+  },
+
+  finishRun(
+    payload: {
+      run_id: string;
+      device_id: string;
+      conversation_id?: string;
+      terminal_reason?: string;
+      usage?: { prompt_tokens?: number; completion_tokens?: number };
+      answer?: string;
+      error_code?: string;
+      trace_id?: string;
+    },
+    siteOrigin?: string
+  ): Promise<{ status: string; outcome_reason?: string }> {
+    return post(SCHEDULED_TASKS_URL, { action: 'finish_local_run', ...payload }, siteOrigin);
+  },
+
+  reportSkipped(
+    taskId: string,
+    deviceId: string,
+    missedAt: number[],
+    siteOrigin?: string
+  ): Promise<{ recorded: number }> {
+    return post(
+      SCHEDULED_TASKS_URL,
+      { action: 'report_local_skipped', task_id: taskId, device_id: deviceId, missed_at: missedAt },
+      siteOrigin
+    );
+  },
+
+  /**
+   * One turn of the agent loop.
+   *
+   * Non-streaming: the daemon has no UI to stream into, and it only needs the
+   * turn's terminal state to decide whether to run tools and resume. A run that
+   * calls three local tools is three of these calls.
+   *
+   * The 15-minute timeout matches the cloud path's loopback budget.
+   */
+  chat(body: Record<string, unknown>, siteOrigin?: string): Promise<ChatTurnResponse> {
+    return post(CONVERSATIONS_URL, body, siteOrigin, 15 * 60 * 1000);
+  }
+};
+
+export interface ChatTurnResponse {
+  id?: string;
+  conversation_id?: string;
+  answer?: string;
+  terminal_reason?: string;
+  trace_id?: string;
+  usage?: { prompt_tokens?: number; completion_tokens?: number };
+  /** Client-executed tool calls this turn paused on. Absent when it did not
+   *  pause. A streaming caller would learn these from `tool_use_start` events;
+   *  the daemon has no event channel, so the worker reports them here. */
+  pending_client_tools?: { tool_use_id: string; name: string; input: unknown }[];
+}

--- a/electron/scheduler/credentials.ts
+++ b/electron/scheduler/credentials.ts
@@ -1,0 +1,133 @@
+import { app, safeStorage } from 'electron';
+import fs from 'node:fs';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+
+/**
+ * Credentials and device identity for the scheduled-task daemon.
+ *
+ * The daemon runs with no window, so it cannot read the renderer's
+ * localStorage: the token has to live on disk. It is encrypted with
+ * `safeStorage` (Keychain on macOS, DPAPI on Windows) where available, and the
+ * file is 0600 either way — the mode is the floor, not the plan.
+ *
+ * Writes are atomic (tmp + rename) because a torn file here reads as "signed
+ * out" and would silently stop every local task.
+ */
+
+interface StoredCredentials {
+  /** Bearer token used for the three daemon calls AND the chat request. */
+  token?: string;
+  /** Set when `token` is base64 safeStorage ciphertext rather than plaintext. */
+  encrypted?: boolean;
+  /** Stable per-installation id. Tasks are bound to it. */
+  device_id?: string;
+  /** Human-facing name shown in the task list ("Qingcai 的 MacBook Pro"). */
+  device_name?: string;
+  /** Site the token belongs to; local runs must chat against the same origin. */
+  site_origin?: string;
+  /** Last time the daemon was alive, epoch seconds. Bounds the missed-tick
+   *  sweep on wake so a fresh install doesn't report a year of skips. */
+  last_seen_at?: number;
+}
+
+const FILE = (): string => path.join(app.getPath('userData'), 'scheduler-credentials.json');
+
+let cache: StoredCredentials | null = null;
+
+function read(): StoredCredentials {
+  if (cache) return cache;
+  try {
+    const raw = fs.readFileSync(FILE(), 'utf8').replace(/^﻿/, '');
+    cache = JSON.parse(raw) as StoredCredentials;
+  } catch {
+    cache = {};
+  }
+  return cache;
+}
+
+function write(next: StoredCredentials): void {
+  cache = next;
+  const target = FILE();
+  const tmp = `${target}.${process.pid}.tmp`;
+  // Atomic: a half-written credentials file reads as signed-out, which would
+  // stop every local task without telling anyone why.
+  fs.writeFileSync(tmp, JSON.stringify(next, null, 2), { mode: 0o600 });
+  fs.renameSync(tmp, target);
+}
+
+/** Best-effort OS-keyed encryption. Falls back to plaintext-in-0600 on a box
+ *  with no keyring (some Linux desktops), which is still better than refusing
+ *  to run — the alternative is no local tasks at all. */
+function seal(token: string): { token: string; encrypted: boolean } {
+  try {
+    if (safeStorage.isEncryptionAvailable()) {
+      return { token: safeStorage.encryptString(token).toString('base64'), encrypted: true };
+    }
+  } catch {
+    /* fall through to plaintext */
+  }
+  return { token, encrypted: false };
+}
+
+function unseal(stored: StoredCredentials): string | undefined {
+  if (!stored.token) return undefined;
+  if (!stored.encrypted) return stored.token;
+  try {
+    return safeStorage.decryptString(Buffer.from(stored.token, 'base64'));
+  } catch {
+    // Keychain entry gone (OS reinstall, profile copied to another machine).
+    // Treat as signed out rather than throwing on every tick.
+    return undefined;
+  }
+}
+
+export function getToken(): string | undefined {
+  return unseal(read());
+}
+
+export function getSiteOrigin(): string | undefined {
+  return read().site_origin;
+}
+
+export function setCredentials(token: string, siteOrigin?: string): void {
+  const current = read();
+  write({ ...current, ...seal(token), ...(siteOrigin ? { site_origin: siteOrigin } : {}) });
+}
+
+/** Sign-out. Keeps `device_id` so re-signing in doesn't orphan tasks already
+ *  bound to this machine. */
+export function clearCredentials(): void {
+  const { device_id, device_name } = read();
+  write({ device_id, device_name });
+}
+
+/** Stable installation id, minted on first use. */
+export function getDeviceId(): string {
+  const current = read();
+  if (current.device_id) return current.device_id;
+  const deviceId = randomUUID();
+  write({ ...current, device_id: deviceId });
+  return deviceId;
+}
+
+export function getDeviceName(): string | undefined {
+  return read().device_name;
+}
+
+export function setDeviceName(name: string): void {
+  write({ ...read(), device_name: name.slice(0, 120) });
+}
+
+export function getLastSeenAt(): number | undefined {
+  return read().last_seen_at;
+}
+
+export function setLastSeenAt(epoch: number): void {
+  write({ ...read(), last_seen_at: epoch });
+}
+
+/** Test seam: drop the in-memory copy so the next read hits disk. */
+export function resetCacheForTests(): void {
+  cache = null;
+}

--- a/electron/scheduler/daemon.ts
+++ b/electron/scheduler/daemon.ts
@@ -1,0 +1,209 @@
+import { api, UnauthorizedError, type LocalTaskSummary } from './api';
+import { getDeviceId, getSiteOrigin, getToken, getLastSeenAt, setLastSeenAt } from './credentials';
+import { missedTicks, nextTick } from './schedule';
+import { executeRun } from './runner';
+
+/**
+ * The local scheduled-task daemon.
+ *
+ * Holds the schedules for tasks bound to this device and fires them from the
+ * main process — NOT the renderer, whose timers Chromium throttles to roughly
+ * once a minute when the window is hidden, which would make a "every 5 minutes"
+ * task fire whenever the user happened to look at it.
+ *
+ * There is no cloud-side driver for these tasks and no heartbeat: if this
+ * process is not running, nothing fires, by design. What the machine missed
+ * while it was off is reported as skipped on the next start, never run late.
+ */
+
+const POLL_INTERVAL_MS = 60_000;
+/** How far back a fresh start looks for missed ticks. Bounds the "I was off for
+ *  a month" case to something a user would still recognize as relevant. */
+const MAX_MISSED_LOOKBACK_SEC = 7 * 24 * 60 * 60;
+
+function nowSec(): number {
+  return Math.floor(Date.now() / 1000);
+}
+
+interface Tracked {
+  task: LocalTaskSummary;
+  /** Next fire time, epoch seconds. null = never again (expired / bad cron). */
+  nextAt: number | null;
+}
+
+export type DaemonState = 'stopped' | 'running' | 'signed_out';
+
+export class SchedulerDaemon {
+  private timer: NodeJS.Timeout | null = null;
+  private tracked = new Map<string, Tracked>();
+  private inFlight = new Set<string>();
+  private state: DaemonState = 'stopped';
+  private lastError: string | undefined;
+  private onStateChange?: (state: DaemonState, error?: string) => void;
+
+  constructor(private pollIntervalMs = POLL_INTERVAL_MS) {}
+
+  setStateListener(cb: (state: DaemonState, error?: string) => void): void {
+    this.onStateChange = cb;
+  }
+
+  getState(): { state: DaemonState; error?: string; taskCount: number } {
+    return { state: this.state, error: this.lastError, taskCount: this.tracked.size };
+  }
+
+  /** Tasks and their next fire times, for the tray menu. */
+  getSchedule(): { id: string; name: string; nextAt: number | null }[] {
+    return [...this.tracked.values()].map((t) => ({ id: t.task.id, name: t.task.name, nextAt: t.nextAt }));
+  }
+
+  start(): void {
+    if (this.timer) return;
+    this.setState('running');
+    // Poll once immediately so a just-created task doesn't wait a full minute
+    // to be picked up.
+    void this.tick();
+    this.timer = setInterval(() => void this.tick(), this.pollIntervalMs);
+  }
+
+  stop(): void {
+    if (this.timer) clearInterval(this.timer);
+    this.timer = null;
+    this.setState('stopped');
+  }
+
+  private setState(state: DaemonState, error?: string): void {
+    this.state = state;
+    this.lastError = error;
+    this.onStateChange?.(state, error);
+  }
+
+  private async tick(): Promise<void> {
+    if (!getToken()) {
+      // Signed out is a state, not an error: the tray says "sign in", and the
+      // loop keeps running so signing back in resumes without a restart.
+      this.setState('signed_out');
+      this.tracked.clear();
+      return;
+    }
+
+    try {
+      await this.refreshTasks();
+      this.setState('running');
+    } catch (err) {
+      if (err instanceof UnauthorizedError) {
+        this.setState('signed_out');
+        this.tracked.clear();
+        return;
+      }
+      // A failed refresh must not clear what we already know: a laptop on a
+      // flaky connection should keep firing the schedule it last saw.
+      this.setState('running', err instanceof Error ? err.message : String(err));
+    }
+
+    setLastSeenAt(nowSec());
+    await this.fireDueTasks();
+  }
+
+  private async refreshTasks(): Promise<void> {
+    const deviceId = getDeviceId();
+    const siteOrigin = getSiteOrigin();
+    const { items } = await api.listLocalTasks(deviceId, siteOrigin);
+
+    const seen = new Set<string>();
+    const now = nowSec();
+    for (const task of items) {
+      seen.add(task.id);
+      const existing = this.tracked.get(task.id);
+      // Recompute only when the task actually changed; otherwise keep the
+      // pending tick so a poll can never push a due task past its own fire time.
+      if (existing && existing.task.updated_at === task.updated_at) {
+        existing.task = task;
+        continue;
+      }
+      this.tracked.set(task.id, { task, nextAt: nextTick(task.schedule, now) });
+    }
+    for (const id of [...this.tracked.keys()]) {
+      if (!seen.has(id)) this.tracked.delete(id);
+    }
+  }
+
+  /**
+   * Report ticks that passed while this process was not running.
+   *
+   * Called once at startup, before the first fire pass, so the run history
+   * shows "didn't run" for the gap instead of an unexplained hole that reads
+   * the same as "ran and said nothing".
+   */
+  async reportMissedSinceLastRun(): Promise<void> {
+    const lastSeen = getLastSeenAt();
+    if (!lastSeen) return; // first ever start — nothing to be missing
+    const now = nowSec();
+    const from = Math.max(lastSeen, now - MAX_MISSED_LOOKBACK_SEC);
+    if (from >= now) return;
+
+    const deviceId = getDeviceId();
+    const siteOrigin = getSiteOrigin();
+    for (const { task } of this.tracked.values()) {
+      const missed = missedTicks(task.schedule, from, now);
+      if (!missed.length) continue;
+      try {
+        await api.reportSkipped(task.id, deviceId, missed, siteOrigin);
+      } catch {
+        // Bookkeeping only — never let it stop the daemon from starting.
+      }
+    }
+  }
+
+  private async fireDueTasks(): Promise<void> {
+    const now = nowSec();
+    for (const entry of this.tracked.values()) {
+      if (entry.nextAt === null || entry.nextAt > now) continue;
+      const scheduledAt = entry.nextAt;
+      // Advance BEFORE awaiting: a run that outlives the poll interval must not
+      // be started twice by the next tick.
+      entry.nextAt = nextTick(entry.task.schedule, scheduledAt);
+      if (this.inFlight.has(entry.task.id)) continue;
+      void this.runOne(entry.task, scheduledAt);
+    }
+  }
+
+  /** Claim → execute → report. Public so "run now" from the tray reuses it. */
+  async runOne(task: LocalTaskSummary, scheduledAt: number, manual = false): Promise<void> {
+    if (this.inFlight.has(task.id)) return;
+    this.inFlight.add(task.id);
+    const deviceId = getDeviceId();
+    const siteOrigin = getSiteOrigin();
+    try {
+      const claim = await api.claimRun(task.id, deviceId, scheduledAt, siteOrigin, manual);
+      if (claim.already_running) return;
+
+      const outcome = await executeRun(claim, { siteOrigin: claim.site_origin ?? siteOrigin, scheduledTaskId: task.id });
+      await api.finishRun(
+        {
+          run_id: claim.run_id,
+          device_id: deviceId,
+          conversation_id: outcome.conversationId,
+          terminal_reason: outcome.terminalReason,
+          usage: outcome.usage,
+          answer: outcome.answer,
+          error_code: outcome.errorCode,
+          trace_id: outcome.traceId
+        },
+        siteOrigin
+      );
+    } catch (err) {
+      if (err instanceof UnauthorizedError) this.setState('signed_out');
+      else console.warn(`[scheduler] task ${task.id} failed:`, err instanceof Error ? err.message : err);
+    } finally {
+      this.inFlight.delete(task.id);
+    }
+  }
+
+  /** Does this device hold any local task? Drives whether the app stays
+   *  resident after the last window closes. */
+  hasTasks(): boolean {
+    return this.tracked.size > 0;
+  }
+}
+
+export const daemon = new SchedulerDaemon();

--- a/electron/scheduler/runner.test.ts
+++ b/electron/scheduler/runner.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { wireTools } from './runner';
+
+describe('wireTools', () => {
+  it('sanitizes dotted tool names for OpenAI function names', () => {
+    // Dots are legal in our tool names but not in OpenAI function names; an
+    // unsanitized name makes the upstream 400 the whole turn.
+    expect(wireTools(['fs.read_file'])).toEqual([{ real: 'fs.read_file', wire: 'fs_read_file' }]);
+  });
+
+  it('keeps the mapping injective when sanitizing collides', () => {
+    // `mcp.a.b` and `mcp_a_b` both sanitize to `mcp_a_b`. Without the suffix
+    // the reverse lookup would resolve one to the other and silently invoke
+    // the WRONG local tool — a shell command instead of a file read, say.
+    const wired = wireTools(['mcp.a.b', 'mcp_a_b']);
+    expect(wired[0].wire).toBe('mcp_a_b');
+    expect(wired[1].wire).toBe('mcp_a_b_2');
+    expect(new Set(wired.map((w) => w.wire)).size).toBe(2);
+  });
+
+  it('is stable for the same input order', () => {
+    // The daemon builds the map once per turn and reuses it on resume; an
+    // order-dependent wire name would break the resume lookup.
+    const names = ['fs.list_dir', 'shell.run_command', 'computer.screenshot'];
+    expect(wireTools(names)).toEqual(wireTools(names));
+  });
+
+  it('leaves already-valid names untouched', () => {
+    expect(wireTools(['memory'])).toEqual([{ real: 'memory', wire: 'memory' }]);
+  });
+
+  it('handles an empty list', () => {
+    expect(wireTools([])).toEqual([]);
+  });
+});

--- a/electron/scheduler/runner.ts
+++ b/electron/scheduler/runner.ts
@@ -1,0 +1,184 @@
+import { registry } from '../local/registry';
+import { api, type ChatTurnResponse, type ClaimedRun } from './api';
+
+/**
+ * Execute one scheduled run locally.
+ *
+ * This is the frontend's client-tool loop (`Conversation.vue`
+ * `_runClientTools` → `_resumeWithToolResults`) with the UI removed: the model
+ * runs in the cloud, pauses when it wants a tool on this machine, we run it
+ * here, and resume with the results. The only structural difference is that
+ * nobody is watching — so consent is pre-authorized (`allowed_local_tools`)
+ * rather than prompted, and a tool outside that list never reaches the model in
+ * the first place (the worker refuses to register it).
+ */
+
+/** Tool names are dotted (`fs.list_dir`); OpenAI function names are not
+ *  allowed to contain dots, so the wire name is sanitized and mapped back
+ *  before invoking. Same rule as the renderer's `_wiredTools`. */
+export function wireTools(names: string[]): { real: string; wire: string }[] {
+  const used = new Set<string>();
+  return names.map((real) => {
+    let wire = real.replace(/[^a-zA-Z0-9_-]/g, '_');
+    if (used.has(wire)) {
+      let i = 2;
+      while (used.has(`${wire}_${i}`)) i += 1;
+      wire = `${wire}_${i}`;
+    }
+    used.add(wire);
+    return { real, wire };
+  });
+}
+
+export interface RunOutcome {
+  conversationId?: string;
+  terminalReason?: string;
+  answer?: string;
+  usage?: { prompt_tokens?: number; completion_tokens?: number };
+  traceId?: string;
+  errorCode?: string;
+}
+
+/**
+ * A local run must terminate even if the model keeps asking for tools.
+ *
+ * The cloud path gets a wall-clock bound for free (one 15-minute loopback
+ * call); a local run is N independent calls, so nothing bounds it but this.
+ * Without it a looping task would hold its run row open until the reaper
+ * eventually failed it 45 minutes later.
+ */
+const MAX_TOOL_ROUNDS = 24;
+const MAX_RUN_MS = 20 * 60 * 1000;
+
+export async function executeRun(
+  claim: ClaimedRun,
+  opts: { siteOrigin?: string; scheduledTaskId: string; signal?: { aborted: boolean } } = {
+    scheduledTaskId: ''
+  }
+): Promise<RunOutcome> {
+  const startedAt = Date.now();
+  const allowed = claim.unattended_policy?.allowed_local_tools ?? [];
+  // Declare only what the task pre-authorized. The worker enforces the same
+  // list, so sending more would be pointless; sending exactly this keeps the
+  // model's tool schema honest about what it can actually reach.
+  const specs = registry.specs().filter((s) => allowed.includes(s.name));
+  const wired = wireTools(specs.map((s) => s.name));
+  const wireToReal = new Map(wired.map((w) => [w.wire, w.real]));
+  const clientTools = specs.map((spec, i) => ({
+    name: wired[i].wire,
+    displayName: spec.name,
+    description: spec.description,
+    inputSchema: spec.input_schema
+  }));
+
+  let response: ChatTurnResponse;
+  try {
+    response = await api.chat(
+      {
+        action: 'chat',
+        model: claim.model,
+        message: claim.question,
+        messages: [{ role: 'user', content: claim.question }],
+        max_turns: claim.max_turns,
+        memory_enabled: claim.memory_enabled,
+        skills: claim.skills,
+        mcp_servers: claim.mcp_servers,
+        unattended_policy: claim.unattended_policy,
+        stateful: true,
+        title: claim.title,
+        metadata: {
+          source: 'scheduled_task',
+          scheduled_task_id: opts.scheduledTaskId,
+          run_id: claim.run_id
+        },
+        ...(clientTools.length ? { client_tools: clientTools } : {})
+      },
+      opts.siteOrigin
+    );
+  } catch (err) {
+    return { errorCode: classifyError(err) };
+  }
+
+  let conversationId = response.conversation_id ?? response.id;
+
+  for (let round = 0; round < MAX_TOOL_ROUNDS; round += 1) {
+    const pending = response.pending_client_tools ?? [];
+    if (!pending.length) break;
+    if (opts.signal?.aborted) return { conversationId, errorCode: 'run_cancelled' };
+    if (Date.now() - startedAt > MAX_RUN_MS) {
+      return { conversationId, traceId: response.trace_id, errorCode: 'run_timeout' };
+    }
+
+    const toolResults = [];
+    for (const call of pending) {
+      const realName = wireToReal.get(call.name) ?? call.name;
+      let result: { output: string; is_error?: boolean; image?: string };
+      try {
+        result = await registry.invoke({
+          name: realName,
+          input: (call.input ?? {}) as Record<string, unknown>,
+          sessionId: conversationId ?? claim.run_id
+        });
+      } catch (err) {
+        // A thrown invoke (e.g. "path outside allowed roots") must come back as
+        // a tool ERROR so the model can react, not abort the whole run.
+        result = { output: err instanceof Error ? err.message : String(err), is_error: true };
+      }
+      toolResults.push({
+        tool_use_id: call.tool_use_id,
+        output: result.output,
+        ...(result.is_error ? { is_error: true } : {})
+        // Screenshots are deliberately dropped here: hosting them needs the
+        // renderer's upload path, and an unattended task has no one to look at
+        // one anyway. The model still gets the textual result.
+      });
+    }
+
+    if (!conversationId) {
+      // Cannot resume without one — the worker addresses the paused turn by
+      // conversation id. Report rather than silently truncating the run.
+      return { conversationId, terminalReason: response.terminal_reason, errorCode: 'missing_conversation_id' };
+    }
+
+    try {
+      response = await api.chat(
+        {
+          id: conversationId,
+          model: claim.model,
+          stateful: true,
+          tool_results: toolResults,
+          unattended_policy: claim.unattended_policy,
+          // Re-send: the worker registers client tools per request, so a resume
+          // that omits them leaves the model unable to call one on the NEXT
+          // turn of the same run.
+          ...(clientTools.length ? { client_tools: clientTools } : {})
+        },
+        opts.siteOrigin
+      );
+    } catch (err) {
+      return { conversationId, errorCode: classifyError(err) };
+    }
+    conversationId = response.conversation_id ?? response.id ?? conversationId;
+  }
+
+  // Still paused after the round cap: the loop is not converging.
+  if ((response.pending_client_tools ?? []).length) {
+    return { conversationId, traceId: response.trace_id, errorCode: 'tool_loop_limit' };
+  }
+
+  return {
+    conversationId,
+    terminalReason: response.terminal_reason,
+    answer: response.answer,
+    usage: response.usage,
+    traceId: response.trace_id
+  };
+}
+
+function classifyError(err: unknown): string {
+  const msg = err instanceof Error ? err.message : String(err);
+  if (err instanceof Error && err.name === 'UnauthorizedError') return 'unauthorized';
+  if (msg.includes('abort')) return 'timeout';
+  if (/balance|insufficient/i.test(msg)) return 'balance_insufficient';
+  return 'internal_error';
+}

--- a/electron/scheduler/schedule.test.ts
+++ b/electron/scheduler/schedule.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from 'vitest';
+import { nextTick, missedTicks, parseCron, type ScheduleSpec } from './schedule';
+
+// Fixed reference points, so no test depends on the wall clock.
+// 2026-03-10T08:30:00 local time.
+const BASE = Math.floor(new Date(2026, 2, 10, 8, 30, 0).getTime() / 1000);
+const at = (y: number, mo: number, d: number, h: number, mi: number): number =>
+  Math.floor(new Date(y, mo, d, h, mi, 0).getTime() / 1000);
+
+describe('parseCron', () => {
+  it('accepts the shapes the task form produces', () => {
+    expect(parseCron('0 9 * * *')).not.toBeNull();
+    expect(parseCron('*/15 * * * *')).not.toBeNull();
+    expect(parseCron('30 8 * * 1-5')).not.toBeNull();
+    expect(parseCron('0 0,12 * * *')).not.toBeNull();
+  });
+
+  it('rejects malformed expressions rather than guessing', () => {
+    // A misparsed cron that silently "works" would fire at the wrong time
+    // forever; null makes the task visibly never fire instead.
+    expect(parseCron('0 9 * *')).toBeNull();
+    expect(parseCron('61 9 * * *')).toBeNull();
+    expect(parseCron('0 25 * * *')).toBeNull();
+    expect(parseCron('a b c d e')).toBeNull();
+    expect(parseCron('*/0 * * * *')).toBeNull();
+  });
+
+  it('folds cron day-of-week 7 onto Sunday', () => {
+    expect(parseCron('0 9 * * 7')?.dayOfWeek.has(0)).toBe(true);
+  });
+});
+
+describe('nextTick — interval', () => {
+  const every5min: ScheduleSpec = { type: 'interval', interval_seconds: 300, starts_at: BASE };
+
+  it('fires one period after the anchor', () => {
+    expect(nextTick(every5min, BASE)).toBe(BASE + 300);
+  });
+
+  it('stays on the anchor grid after a long outage instead of drifting', () => {
+    // The point: a machine asleep for 3h07m resumes on the original phase.
+    // `after + period` would shift every task a little later after every
+    // outage until a "9:00 daily" task quietly became a 9:47 one.
+    const after = BASE + 3 * 3600 + 7 * 60;
+    const tick = nextTick(every5min, after)!;
+    expect((tick - BASE) % 300).toBe(0);
+    expect(tick).toBeGreaterThan(after);
+    expect(tick - after).toBeLessThanOrEqual(300);
+  });
+
+  it('waits for a start date in the future', () => {
+    const later: ScheduleSpec = { type: 'interval', interval_seconds: 300, starts_at: BASE + 86400 };
+    expect(nextTick(later, BASE)).toBe(BASE + 86400);
+  });
+
+  it('returns null past ends_at', () => {
+    const ending: ScheduleSpec = { type: 'interval', interval_seconds: 300, starts_at: BASE, ends_at: BASE + 600 };
+    // The last tick on or before the end still fires...
+    expect(nextTick(ending, BASE + 500)).toBe(BASE + 600);
+    // ...but nothing beyond it, and nothing once the end has passed.
+    expect(nextTick(ending, BASE + 600)).toBeNull();
+    expect(nextTick(ending, BASE + 700)).toBeNull();
+  });
+
+  it('returns null for a nonsense period instead of a hot loop', () => {
+    expect(nextTick({ type: 'interval', interval_seconds: 0 }, BASE)).toBeNull();
+    expect(nextTick({ type: 'interval', interval_seconds: -60 }, BASE)).toBeNull();
+  });
+});
+
+describe('nextTick — cron', () => {
+  it('finds the next daily tick', () => {
+    // 08:30 → today 09:00
+    expect(nextTick({ type: 'cron', cron: '0 9 * * *' }, BASE)).toBe(at(2026, 2, 10, 9, 0));
+  });
+
+  it('rolls to tomorrow once today is past', () => {
+    const afterNine = at(2026, 2, 10, 9, 30);
+    expect(nextTick({ type: 'cron', cron: '0 9 * * *' }, afterNine)).toBe(at(2026, 2, 11, 9, 0));
+  });
+
+  it('honours weekday restrictions', () => {
+    // 2026-03-10 is a Tuesday; a Fri-only task should land on the 13th.
+    expect(nextTick({ type: 'cron', cron: '0 9 * * 5' }, BASE)).toBe(at(2026, 2, 13, 9, 0));
+  });
+
+  it('ORs the two day fields when both are restricted (POSIX rule)', () => {
+    // "the 1st OR a Monday" — from Tue the 10th, next Monday is the 16th,
+    // which is sooner than the 1st of April.
+    expect(nextTick({ type: 'cron', cron: '0 9 1 * 1' }, BASE)).toBe(at(2026, 2, 16, 9, 0));
+  });
+
+  it('returns null for an unparseable cron instead of firing arbitrarily', () => {
+    expect(nextTick({ type: 'cron', cron: 'not a cron' }, BASE)).toBeNull();
+  });
+
+  it('returns null for a date that never occurs', () => {
+    // Feb 30th: the search runs its full year bound and gives up.
+    expect(nextTick({ type: 'cron', cron: '0 9 30 2 *' }, BASE)).toBeNull();
+  });
+});
+
+describe('nextTick — once', () => {
+  it('fires only while still in the future', () => {
+    expect(nextTick({ type: 'once', at: BASE + 60 }, BASE)).toBe(BASE + 60);
+    expect(nextTick({ type: 'once', at: BASE - 60 }, BASE)).toBeNull();
+    expect(nextTick({ type: 'once', at: BASE }, BASE)).toBeNull();
+  });
+});
+
+describe('missedTicks', () => {
+  const daily: ScheduleSpec = { type: 'cron', cron: '0 9 * * *' };
+
+  it('lists every tick in the gap, oldest first', () => {
+    const from = at(2026, 2, 10, 10, 0); // after the 10th's run
+    const until = at(2026, 2, 13, 10, 0);
+    expect(missedTicks(daily, from, until)).toEqual([
+      at(2026, 2, 11, 9, 0),
+      at(2026, 2, 12, 9, 0),
+      at(2026, 2, 13, 9, 0)
+    ]);
+  });
+
+  it('is empty when nothing was missed', () => {
+    const from = at(2026, 2, 10, 10, 0);
+    expect(missedTicks(daily, from, at(2026, 2, 10, 20, 0))).toEqual([]);
+  });
+
+  it('caps the batch so a long outage cannot write unbounded history', () => {
+    const from = BASE;
+    const until = BASE + 365 * 86400;
+    expect(missedTicks(daily, from, until, 10)).toHaveLength(10);
+  });
+
+  it('terminates on a one-shot schedule instead of looping', () => {
+    // A `once` inside the window IS a missed tick and gets reported...
+    expect(missedTicks({ type: 'once', at: BASE - 100 }, BASE - 200, BASE)).toEqual([BASE - 100]);
+    // ...but one already past the window start yields nothing, and the loop
+    // exits rather than spinning on a schedule with no next tick.
+    expect(missedTicks({ type: 'once', at: BASE - 300 }, BASE - 200, BASE)).toEqual([]);
+  });
+});

--- a/electron/scheduler/schedule.ts
+++ b/electron/scheduler/schedule.ts
@@ -1,0 +1,176 @@
+/**
+ * When a locally-executed scheduled task should next fire.
+ *
+ * Pure and dependency-free so the tick maths can be tested without a clock, a
+ * window, or a network. Mirrors platform-scheduler's `computeNext` semantics
+ * closely enough that a task behaves the same whichever side fires it — but
+ * deliberately does NOT reimplement its jitter: a cloud scheduler jitters to
+ * spread thousands of users' ticks across a fleet, while one desktop firing its
+ * owner's handful of tasks has no herd to spread.
+ */
+
+export type ScheduleSpec =
+  | { type: 'cron'; cron: string; tz?: string; starts_at?: number; ends_at?: number }
+  | { type: 'interval'; interval_seconds: number; tz?: string; starts_at?: number; ends_at?: number }
+  | { type: 'once'; at: number; tz?: string };
+
+/** Seconds, matching the wire format (the backend speaks epoch seconds). */
+export type Epoch = number;
+
+const MINUTE = 60;
+
+/**
+ * Parse one field of a 5-field cron expression into the set of values it
+ * matches. Supports `*`, `a-b`, `*\/n`, `a-b/n` and comma-separated lists —
+ * the subset the task form can produce. Returns null for anything else, which
+ * the caller treats as "never fires" rather than guessing.
+ */
+function parseField(field: string, min: number, max: number): Set<number> | null {
+  const values = new Set<number>();
+  for (const part of field.split(',')) {
+    const [rangePart, stepPart] = part.split('/');
+    const step = stepPart === undefined ? 1 : Number(stepPart);
+    if (!Number.isInteger(step) || step < 1) return null;
+
+    let lo: number;
+    let hi: number;
+    if (rangePart === '*') {
+      lo = min;
+      hi = max;
+    } else if (rangePart.includes('-')) {
+      const [a, b] = rangePart.split('-').map(Number);
+      if (!Number.isInteger(a) || !Number.isInteger(b)) return null;
+      lo = a;
+      hi = b;
+    } else {
+      const v = Number(rangePart);
+      if (!Number.isInteger(v)) return null;
+      lo = v;
+      hi = v;
+    }
+    if (lo < min || hi > max || lo > hi) return null;
+    for (let v = lo; v <= hi; v += step) values.add(v);
+  }
+  return values.size ? values : null;
+}
+
+interface CronFields {
+  minute: Set<number>;
+  hour: Set<number>;
+  dayOfMonth: Set<number>;
+  month: Set<number>;
+  dayOfWeek: Set<number>;
+  /** Cron's day fields are OR'd when both are restricted — the POSIX rule. */
+  dayOfMonthRestricted: boolean;
+  dayOfWeekRestricted: boolean;
+}
+
+export function parseCron(expr: string): CronFields | null {
+  const parts = expr.trim().split(/\s+/);
+  if (parts.length !== 5) return null;
+  const minute = parseField(parts[0], 0, 59);
+  const hour = parseField(parts[1], 0, 23);
+  const dayOfMonth = parseField(parts[2], 1, 31);
+  const month = parseField(parts[3], 1, 12);
+  // Accept 7 as Sunday (crontab convention) and fold it onto 0.
+  const dayOfWeekRaw = parseField(parts[4], 0, 7);
+  if (!minute || !hour || !dayOfMonth || !month || !dayOfWeekRaw) return null;
+  const dayOfWeek = new Set([...dayOfWeekRaw].map((d) => (d === 7 ? 0 : d)));
+  return {
+    minute,
+    hour,
+    dayOfMonth,
+    month,
+    dayOfWeek,
+    dayOfMonthRestricted: parts[2] !== '*',
+    dayOfWeekRestricted: parts[4] !== '*'
+  };
+}
+
+function matchesCron(fields: CronFields, date: Date): boolean {
+  if (!fields.minute.has(date.getMinutes())) return false;
+  if (!fields.hour.has(date.getHours())) return false;
+  if (!fields.month.has(date.getMonth() + 1)) return false;
+  const domMatch = fields.dayOfMonth.has(date.getDate());
+  const dowMatch = fields.dayOfWeek.has(date.getDay());
+  // POSIX: when BOTH day fields are restricted, a match on either one fires.
+  // When only one is, that one must match.
+  if (fields.dayOfMonthRestricted && fields.dayOfWeekRestricted) return domMatch || dowMatch;
+  if (fields.dayOfMonthRestricted) return domMatch;
+  if (fields.dayOfWeekRestricted) return dowMatch;
+  return true;
+}
+
+/** A year of minutes — the search bound for a cron that may never match (e.g.
+ *  Feb 30). Cheap: the loop is integer maths over at most ~525k steps, and only
+ *  a pathological expression ever runs it to completion. */
+const CRON_SEARCH_LIMIT_MINUTES = 366 * 24 * 60;
+
+/**
+ * The first tick strictly after `after`.
+ *
+ * Returns null when the schedule has no future tick (a `once` already past, an
+ * expired `ends_at`, an unparseable or impossible cron). Callers treat null as
+ * "this task is done", never as "fire now".
+ *
+ * All cron maths runs in the host's LOCAL time. The task's `tz` is deliberately
+ * ignored here: a local task fires on the machine the user is sitting at, and
+ * "9am" means 9am where that machine is. A cloud task keeps using the
+ * scheduler's tz handling.
+ */
+export function nextTick(schedule: ScheduleSpec, after: Epoch): Epoch | null {
+  const endsAt = schedule.type === 'once' ? undefined : schedule.ends_at;
+  if (endsAt !== undefined && after >= endsAt) return null;
+
+  const tick = computeRawNext(schedule, after);
+  if (tick === null) return null;
+  if (endsAt !== undefined && tick > endsAt) return null;
+  return tick;
+}
+
+function computeRawNext(schedule: ScheduleSpec, after: Epoch): Epoch | null {
+  if (schedule.type === 'once') return schedule.at > after ? schedule.at : null;
+
+  if (schedule.type === 'interval') {
+    const period = Math.floor(schedule.interval_seconds);
+    if (!Number.isFinite(period) || period < 1) return null;
+    const anchor = schedule.starts_at ?? 0;
+    if (anchor > after) return anchor;
+    // Land on the anchor's grid rather than `after + period`, so a task that
+    // misses ticks while the machine sleeps resumes on its original phase
+    // instead of drifting a little later after every outage.
+    const elapsed = after - anchor;
+    return anchor + (Math.floor(elapsed / period) + 1) * period;
+  }
+
+  const fields = parseCron(schedule.cron);
+  if (!fields) return null;
+  const start = schedule.starts_at !== undefined && schedule.starts_at > after ? schedule.starts_at : after;
+  // Cron has minute resolution: begin at the next whole minute after `start`.
+  const cursor = new Date((Math.floor(start / MINUTE) + 1) * MINUTE * 1000);
+  for (let i = 0; i < CRON_SEARCH_LIMIT_MINUTES; i += 1) {
+    if (matchesCron(fields, cursor)) return Math.floor(cursor.getTime() / 1000);
+    cursor.setMinutes(cursor.getMinutes() + 1);
+  }
+  return null;
+}
+
+/**
+ * Every tick in (`from`, `until`], oldest first, capped at `limit`.
+ *
+ * Used on wake to find what was missed while the machine was off. These are
+ * recorded as skipped, never run late: a 3am digest delivered at noon is worse
+ * than none, and running a backlog all at once would bill the user for a burst
+ * of work they did not ask for at that moment.
+ */
+export function missedTicks(schedule: ScheduleSpec, from: Epoch, until: Epoch, limit = 50): Epoch[] {
+  const ticks: Epoch[] = [];
+  let cursor = from;
+  while (ticks.length < limit) {
+    const tick = nextTick(schedule, cursor);
+    if (tick === null || tick > until) break;
+    ticks.push(tick);
+    cursor = tick;
+  }
+  return ticks;
+}

--- a/electron/scheduler/tray.ts
+++ b/electron/scheduler/tray.ts
@@ -1,0 +1,114 @@
+import { app, Menu, Tray, nativeImage, shell } from 'electron';
+import path from 'node:path';
+import { daemon, type DaemonState } from './daemon';
+import { getDeviceName } from './credentials';
+
+/**
+ * The tray icon: the app's only visible presence once its window is closed.
+ *
+ * Without it, staying resident to fire local tasks would be indistinguishable
+ * from failing to quit — the user closes the window, the process lives on, and
+ * nothing on screen explains why or offers a way out. Every resident state has
+ * a menu entry, including Quit.
+ */
+
+let tray: Tray | null = null;
+
+function trayIcon(): Electron.NativeImage {
+  // The template image is monochrome so macOS can invert it for dark menu bars;
+  // Windows/Linux take it as-is.
+  const file = process.platform === 'darwin' ? 'trayTemplate.png' : 'icon.png';
+  const img = nativeImage.createFromPath(path.join(__dirname, '..', '..', 'build', file));
+  if (process.platform === 'darwin') img.setTemplateImage(true);
+  return img.isEmpty() ? nativeImage.createEmpty() : img;
+}
+
+function formatNext(nextAt: number | null): string {
+  if (nextAt === null) return 'no further runs';
+  const deltaSec = nextAt - Math.floor(Date.now() / 1000);
+  if (deltaSec <= 0) return 'due now';
+  if (deltaSec < 3600) return `in ${Math.max(1, Math.round(deltaSec / 60))} min`;
+  if (deltaSec < 86400) return `in ${Math.round(deltaSec / 3600)} h`;
+  return new Date(nextAt * 1000).toLocaleString();
+}
+
+function stateLabel(state: DaemonState, error?: string): string {
+  if (state === 'signed_out') return 'Signed out — open AceData to sign in';
+  if (state === 'stopped') return 'Scheduled tasks paused';
+  if (error) return `Last sync failed: ${error.slice(0, 60)}`;
+  const name = getDeviceName();
+  return name ? `Running on ${name}` : 'Running on this device';
+}
+
+export function initTray(showWindow: () => void): void {
+  if (tray) return;
+  tray = new Tray(trayIcon());
+  tray.setToolTip('AceData');
+  tray.on('click', () => showWindow());
+  daemon.setStateListener(() => refreshTray(showWindow));
+  refreshTray(showWindow);
+}
+
+export function refreshTray(showWindow: () => void): void {
+  if (!tray) return;
+  const { state, error } = daemon.getState();
+  const schedule = daemon.getSchedule();
+
+  const taskItems: Electron.MenuItemConstructorOptions[] = schedule.length
+    ? schedule.slice(0, 10).map((t) => ({
+        label: `${t.name} — ${formatNext(t.nextAt)}`,
+        enabled: false
+      }))
+    : [{ label: 'No tasks on this device', enabled: false }];
+
+  tray.setContextMenu(
+    Menu.buildFromTemplate([
+      { label: stateLabel(state, error), enabled: false },
+      { type: 'separator' },
+      ...taskItems,
+      { type: 'separator' },
+      { label: 'Open AceData', click: () => showWindow() },
+      {
+        label: state === 'stopped' ? 'Resume scheduled tasks' : 'Pause scheduled tasks',
+        click: () => {
+          if (state === 'stopped') daemon.start();
+          else daemon.stop();
+          refreshTray(showWindow);
+        }
+      },
+      { type: 'separator' },
+      {
+        label: 'Start at login',
+        type: 'checkbox',
+        checked: app.getLoginItemSettings().openAtLogin,
+        click: (item) => setOpenAtLogin(item.checked)
+      },
+      {
+        label: 'Manage tasks…',
+        click: () => {
+          showWindow();
+          void shell.openExternal('https://studio.acedata.cloud/chatgpt/scheduled').catch(() => {});
+        }
+      },
+      { type: 'separator' },
+      // Without this the app would be genuinely unquittable once the window is
+      // closed on Windows.
+      { label: 'Quit AceData', click: () => app.quit() }
+    ])
+  );
+}
+
+export function destroyTray(): void {
+  tray?.destroy();
+  tray = null;
+}
+
+export function setOpenAtLogin(enabled: boolean): void {
+  // `openAsHidden` (macOS) starts without stealing a window on boot — the point
+  // is to be there for the schedule, not to greet the user.
+  app.setLoginItemSettings({ openAtLogin: enabled, openAsHidden: true });
+}
+
+export function isOpenAtLogin(): boolean {
+  return app.getLoginItemSettings().openAtLogin;
+}

--- a/src/App.vue
+++ b/src/App.vue
@@ -21,6 +21,7 @@ import { Browser } from '@capacitor/browser';
 import { ElMessage } from 'element-plus';
 import { isNative, isDesktop } from '@/utils/surface';
 import { desktopBridge } from '@/utils/desktop';
+import { currentSiteOrigin } from '@/utils';
 import { parseInviterFromDeepLink, writeInviterCookie } from '@/utils/attribution';
 import { exchangeSsoCode } from '@/utils/auth/exchangeSsoCode';
 
@@ -60,7 +61,8 @@ export default defineComponent({
       // Desktop IPC listener detach handles (set in mounted on desktop only).
       offAuthCb: null as null | (() => void),
       offAuthExpired: null as null | (() => void),
-      offSiteWatch: null as null | (() => void)
+      offSiteWatch: null as null | (() => void),
+      offCredentialWatch: null as null | (() => void)
     };
   },
   computed: {
@@ -132,6 +134,18 @@ export default defineComponent({
         },
         { immediate: true }
       );
+      // Keep the scheduled-task daemon's copy of the API credential current.
+      // It runs in the main process with no window, so it cannot read the
+      // store — without this handoff a local task stops firing the moment the
+      // window closes, which looks identical to the machine being asleep.
+      this.offCredentialWatch = this.$watch(
+        () => this.$store.state.chat?.credential?.token as string | undefined,
+        (token) => {
+          if (token) void bridge?.scheduler?.setCredentials(token, currentSiteOrigin());
+          else void bridge?.scheduler?.clearCredentials();
+        },
+        { immediate: true }
+      );
     }
 
     const authenticated = !!this.$store.state.token.access && !!this.$store.state.user?.id;
@@ -152,6 +166,7 @@ export default defineComponent({
     this.offAuthCb?.();
     this.offAuthExpired?.();
     this.offSiteWatch?.();
+    this.offCredentialWatch?.();
   },
   methods: {
     async loadElementPlusLocale() {

--- a/src/utils/desktop.ts
+++ b/src/utils/desktop.ts
@@ -27,6 +27,32 @@ export interface DesktopBridge {
   setSiteOrigin(origin: string): void;
   /** Show an OS notification via the main process (reliable when window hidden). */
   notify(title: string, body: string): Promise<void>;
+  /**
+   * Scheduled-task daemon controls.
+   *
+   * The daemon fires locally-executed scheduled tasks from the main process,
+   * which is why it needs its own copy of the token: it must keep running after
+   * the window closes. The token only ever travels INWARD — nothing here hands
+   * it back to the renderer.
+   */
+  scheduler?: SchedulerBridge;
+}
+
+export interface SchedulerBridge {
+  /** This installation's device id + display name + autostart state. */
+  identity(): Promise<{ device_id: string; device_name: string; open_at_login: boolean }>;
+  /** Hand main the Bearer token to persist (OS-encrypted, 0600). */
+  setCredentials(token: string, siteOrigin?: string): Promise<boolean>;
+  /** Sign-out. Keeps the device id so tasks bound to this machine survive. */
+  clearCredentials(): Promise<boolean>;
+  setDeviceName(name: string): Promise<boolean>;
+  setOpenAtLogin(enabled: boolean): Promise<boolean>;
+  status(): Promise<{
+    state: 'stopped' | 'running' | 'signed_out';
+    error?: string;
+    taskCount: number;
+    schedule: { id: string; name: string; nextAt: number | null }[];
+  }>;
 }
 
 declare global {


### PR DESCRIPTION
配套后端：[PlatformService#1766](https://github.com/AceDataCloud/PlatformService/pull/1766) · 设计文档：[Index#328](https://github.com/AceDataCloud/Index/pull/328)

本地模式的定时任务不注册 `platform-scheduler`，由这台桌面机自己到点发起。**大脑仍在云端** —— 只有触发者变了，这才让本机工具（`fs.*` / `shell.*` / `computer.*` / 本地 MCP）够得着。

## 为什么调度器必须放 main 进程

窗口不可见时 Chromium 把渲染进程的定时器节流到约**一分钟一次**（`webPreferences` 没设 `backgroundThrottling`，用的是默认值）。放渲染进程的话，「每 5 分钟」的任务会变成「用户什么时候看它就什么时候跑」。

## Electron 此前完全不具备常驻，本 PR 补齐

| 项 | 说明 |
|---|---|
| **托盘** | 唯一可见入口：状态、每个任务的下次运行时间、暂停/恢复、开机自启、**退出**。没有退出项的话，Windows 上关窗不退 = 用户根本关不掉这个 app |
| **`window-all-closed`** | 只在本机**确实持有本地任务**时才保留进程；否则维持原来的关窗即退，不改变没用这功能的用户的体验 |
| **开机自启** | `openAsHidden` —— 开机是为了守排程，不是为了抢一个窗口 |
| **`focusWindow()`** | 现在会在窗口已销毁时重建。否则关窗后点托盘图标毫无反应 |

## 凭据落盘

daemon 没有窗口，读不到 renderer 的 store。token 由 renderer 在登录时通过 IPC 交给 main：`safeStorage` 加密（Keychain / DPAPI）+ `0600` + **原子写**（半个文件读起来等于已登出，会静默停掉所有任务）。

**token 只向内传**，没有任何接口把它回传给渲染进程。

## runner = Conversation.vue 那个循环的无 UI 版

模型在云端跑 → 要用本机工具时暂停 → 我们执行 → 带 `tool_results` 续跑。区别只在于**没人看着**：

- 授权走 `allowed_local_tools` **预授权**而非弹窗（`local/consent.ts` 里那个写好但从没用过的「无窗口」分支，本 PR 是它第一个真实使用者）
- 未授权的工具根本不会被 worker 注册 → 模型看不见 → 不会挂起等一台没人在的机器

## 几个非显而易见的决定

**本地循环需要自己的超时。** 云端路径有单次 loopback 的 15 分钟兜底；本地是 N 个独立请求，什么都不约束它。所以设了轮数 + 墙钟上限，否则跑飞的任务会一直占着 run 行直到 45 分钟后被 reaper 收掉。

**interval 按 anchor 网格推进**，不是 `after + period`。后者每次休眠都让任务往后漂一点，「每天 9:00」会慢慢变成 9:47。

**wire 名映射必须是单射的。** `mcp.a.b` 和 `mcp_a_b` 都会 sanitize 成 `mcp_a_b`；没有后缀去重的话反查会解析到**另一个工具**上 —— 本该读文件的调用变成跑 shell 命令。有测试守着。

**cron 解析失败返回 null 而不是猜。** 一个「能跑但时间是错的」cron 会永远在错误的时间触发；null 让任务明确地不触发。

**排程用本机时区。** 本地任务跑在用户正在用的这台机器上，「9 点」就是这台机器所在地的 9 点。

## 离线

设备关机期间错过的 tick 只上报 `skipped`，**不补跑**。凌晨的摘要中午送达比不送更糟。

## 验证

- 897 tests pass（既有 873 + 新增 24：排程运算 + wire 名映射）
- `tsc -p electron/tsconfig.json` + `vue-tsc -b` 均干净
- `npm run lint` 干净（2 个既有 warning 在我没碰的文件里）

## 未覆盖

- 打包后的托盘图标资源（`build/trayTemplate.png`）—— 缺失时降级成空图标，不崩
- macOS 公证后的 `setLoginItemSettings` 行为需实机验证（`electron-builder.yml` 开了 hardened runtime）
- token 过期时目前只是把状态标成 `signed_out` 并在托盘显示；静默刷新是后续

🤖 Generated with [Claude Code](https://claude.com/claude-code)