### PR TITLE
feat(desktop): defer local MCP tool schemas instead of re-sending every turn

### DIFF
--- a/change/@acedatacloud-nexior-2c98af17-bc58-449b-b2dc-5e6121b0c04e.json
+++ b/change/@acedatacloud-nexior-2c98af17-bc58-449b-b2dc-5e6121b0c04e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "desktop: defer local MCP tool schemas behind load_mcp_server instead of re-sending them every turn",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/models/chat.ts
+++ b/src/models/chat.ts
@@ -351,6 +351,17 @@ export interface IChatConversationRequest {
   // Names must be OpenAI-valid (^[a-zA-Z0-9_-]+$) — the desktop sends sanitized
   // wire names and maps them back locally.
   client_tools?: { name: string; displayName?: string; description: string; inputSchema: Record<string, unknown> }[];
+  // Desktop local MCP servers, sent as one summary each instead of inlining
+  // every tool schema into `client_tools`. The model calls
+  // `load_mcp_server({server: <id>})` to pull one server's tools into the
+  // registry for the rest of the conversation — the same deferral the cloud
+  // remote-MCP path uses. Without it a single server (e.g. Playwright: 24
+  // tools, ~16 KB) costs ~4k tokens on EVERY turn, relevant or not.
+  local_mcp_servers?: {
+    id: string;
+    displayName?: string;
+    tools: { name: string; displayName?: string; description: string; inputSchema: Record<string, unknown> }[];
+  }[];
   connectors?: string[];
   skills?: string[];
   // Resume payload for a paused conversation. When present, the conversation

--- a/src/pages/chat/Conversation.localMcp.test.ts
+++ b/src/pages/chat/Conversation.localMcp.test.ts
@@ -1,0 +1,206 @@
+// @vitest-environment jsdom
+import { shallowMount } from '@vue/test-utils';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+import Conversation from './Conversation.vue';
+import { Status } from '@/models';
+import type { LocalToolSpec } from '@/utils/desktop';
+
+// Desktop surface: `supportsClientTools()` gates the whole injection.
+vi.mock('@/utils/surface', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return { ...actual, supportsClientTools: () => true };
+});
+
+vi.mock('@/operators', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return { ...actual, chatOperator: { chatConversation: vi.fn(() => new Promise(() => undefined)) } };
+});
+
+const spec = (name: string, source: 'builtin' | 'mcp'): LocalToolSpec => ({
+  name,
+  description: `desc for ${name}`,
+  input_schema: { type: 'object', properties: { a: { type: 'string' } } },
+  source,
+  mutates: false
+});
+
+const mountComponent = () =>
+  shallowMount(Conversation, {
+    global: {
+      stubs: {
+        Layout: { template: '<main><slot name="chat" /></main>' },
+        ElSkeleton: { template: '<div><slot name="template" /></div>' },
+        ElSkeletonItem: { template: '<span />' }
+      },
+      mocks: {
+        $t: (key: string) => key,
+        $route: { matched: [{ path: '/chatgpt' }], params: { id: 'c1' }, path: '/chatgpt/conversations/c1', query: {} },
+        $router: { push: vi.fn(), replace: vi.fn() },
+        $store: {
+          commit: vi.fn(),
+          dispatch: vi.fn(() => Promise.resolve(undefined)),
+          getters: { authenticated: true },
+          state: {
+            chat: {
+              application: undefined,
+              applications: undefined,
+              conversations: [],
+              credential: { token: 't' },
+              memoryEnabled: true,
+              model: undefined,
+              modelGroup: undefined,
+              service: undefined,
+              status: { getApplications: Status.None }
+            }
+          }
+        }
+      }
+    }
+  });
+
+describe('Conversation._localToolInjection — local MCP is deferred', () => {
+  let wrapper: ReturnType<typeof mountComponent>;
+
+  beforeEach(() => {
+    wrapper = mountComponent();
+  });
+  afterEach(() => wrapper?.unmount());
+
+  // `supported` mirrors the /health probe: false until a worker confirms it
+  // understands `local_mcp_servers`.
+  const inject = (tools: LocalToolSpec[], supported = true) => {
+    const vm = wrapper.vm as unknown as {
+      localTools: LocalToolSpec[];
+      localMcpDeferSupported: boolean;
+      _localToolInjection(): {
+        client_tools?: { name: string }[];
+        local_mcp_servers?: { id: string; tools: { name: string }[] }[];
+      };
+    };
+    vm.localTools = tools;
+    vm.localMcpDeferSupported = supported;
+    return vm._localToolInjection();
+  };
+
+  it('returns nothing when there are no local tools', () => {
+    expect(inject([])).toEqual({});
+  });
+
+  it('sends builtin tools eagerly in client_tools', () => {
+    const out = inject([spec('fs.read_file', 'builtin'), spec('shell.run_command', 'builtin')]);
+    expect(out.client_tools?.map((t) => t.name)).toEqual(['fs_read_file', 'shell_run_command']);
+    expect(out.local_mcp_servers).toBeUndefined();
+  });
+
+  it('sends MCP tools as per-server summaries, NOT in client_tools', () => {
+    const out = inject([
+      spec('fs.read_file', 'builtin'),
+      spec('mcp.playwright.browser_click', 'mcp'),
+      spec('mcp.playwright.browser_type', 'mcp'),
+      spec('mcp.github.create_issue', 'mcp')
+    ]);
+    // The whole point: MCP schemas must not ride along on every turn.
+    expect(out.client_tools?.map((t) => t.name)).toEqual(['fs_read_file']);
+    expect(out.local_mcp_servers?.map((s) => s.id).sort()).toEqual(['github', 'playwright']);
+    const pw = out.local_mcp_servers?.find((s) => s.id === 'playwright');
+    expect(pw?.tools.map((t) => t.name)).toEqual(['mcp_playwright_browser_click', 'mcp_playwright_browser_type']);
+  });
+
+  it('omits client_tools entirely when only MCP tools exist', () => {
+    const out = inject([spec('mcp.srv.a', 'mcp')]);
+    expect(out.client_tools).toBeUndefined();
+    expect(out.local_mcp_servers).toHaveLength(1);
+  });
+
+  it('keeps wire names unique and injective across BOTH buckets', () => {
+    // A builtin and an MCP tool that sanitize to the same wire name must not
+    // collide — _runClientTools maps the echoed wire name back to the dotted
+    // one, so a duplicate would dispatch to the wrong tool.
+    const out = inject([spec('mcp.a.b', 'mcp'), spec('mcp.a:b', 'mcp')]);
+    const names = out.local_mcp_servers!.flatMap((s) => s.tools.map((t) => t.name));
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it('groups by server id even when the tool name itself contains dots', () => {
+    const out = inject([spec('mcp.srv.deep.nested.tool', 'mcp')]);
+    expect(out.local_mcp_servers?.[0].id).toBe('srv');
+  });
+
+  it('falls back to inlining MCP schemas when the worker has not confirmed support', () => {
+    // An older worker ignores `local_mcp_servers` silently, so deferring
+    // unconditionally would make local MCP tools disappear with no error.
+    const out = inject([spec('fs.read_file', 'builtin'), spec('mcp.playwright.click', 'mcp')], false);
+    expect(out.client_tools?.map((t) => t.name)).toEqual(['fs_read_file', 'mcp_playwright_click']);
+    // Summaries still ride along so a NEW worker can defer from the first turn.
+    expect(out.local_mcp_servers?.[0].id).toBe('playwright');
+  });
+});
+
+describe('Conversation.onProbeWorkerFeatures', () => {
+  let wrapper: ReturnType<typeof mountComponent>;
+  beforeEach(() => {
+    wrapper = mountComponent();
+  });
+  afterEach(() => {
+    wrapper?.unmount();
+    vi.unstubAllGlobals();
+  });
+
+  // The probe only runs when a local MCP tool exists to defer, so every case
+  // seeds one first.
+  const probe = async (tools: LocalToolSpec[] = [spec('mcp.srv.a', 'mcp')]) => {
+    const vm = wrapper.vm as unknown as {
+      localTools: LocalToolSpec[];
+      localMcpDeferSupported: boolean;
+      localMcpProbed: boolean;
+      onProbeWorkerFeatures(): Promise<void>;
+    };
+    vm.localTools = tools;
+    await vm.onProbeWorkerFeatures();
+    return vm.localMcpDeferSupported;
+  };
+
+  it('enables deferral when the worker advertises the feature', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: true, json: async () => ({ features: ['local_mcp_servers'] }) }))
+    );
+    expect(await probe()).toBe(true);
+  });
+
+  it('stays off for a worker that does not advertise it', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: true, json: async () => ({ status: 'ok' }) }))
+    );
+    expect(await probe()).toBe(false);
+  });
+
+  it('does not fire at all without a local MCP server to defer', async () => {
+    // A pointless request shows up as a console error wherever the endpoint
+    // isn't reachable — which broke the Local Tools E2E smoke test.
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+    expect(await probe([spec('fs.read_file', 'builtin')])).toBe(false);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('probes at most once per session', async () => {
+    const fetchSpy = vi.fn(async () => ({ ok: true, json: async () => ({ features: [] }) }));
+    vi.stubGlobal('fetch', fetchSpy);
+    await probe();
+    await probe();
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('stays off when the probe fails (offline / blocked)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('network down');
+      })
+    );
+    expect(await probe()).toBe(false);
+  });
+});

--- a/src/pages/chat/Conversation.vue
+++ b/src/pages/chat/Conversation.vue
@@ -112,6 +112,7 @@ import { defineComponent } from 'vue';
 import Message from '@/components/chat/Message.vue';
 import { shouldExecuteWithLocalExec } from '@/utils/browserToolExecution';
 import { CHAT_MODEL_GROUPS, CHAT_MODELS, ROLE_ASSISTANT, ROLE_USER } from '@/constants';
+import { BASE_URL_API } from '@/constants/endpoint';
 import {
   IChatMessageState,
   IChatConversationResponse,
@@ -182,6 +183,13 @@ export interface IData {
   // worker as `client_tools` so the model can call them; the worker pauses with
   // execution:'client' and the desktop runs them. Empty on web/native.
   localTools: LocalToolSpec[];
+  // Whether the worker understands `local_mcp_servers` (deferred local MCP
+  // loading). Probed once from /health; until confirmed we ALSO inline the MCP
+  // schemas in `client_tools`, because an older worker ignores unknown body
+  // fields silently and the tools would just vanish.
+  localMcpDeferSupported: boolean;
+  // Whether the /health probe already ran this session.
+  localMcpProbed: boolean;
   // A desktop client tool the model called this turn, deferred until the paused
   // stream finalizes (so the conversation id + route are settled and the
   // `answering` flag isn't cleared mid-resume). At most one per turn — the
@@ -221,6 +229,8 @@ export default defineComponent({
       question: '',
       references: [],
       localTools: [],
+      localMcpDeferSupported: false,
+      localMcpProbed: false,
       pendingClientTools: [],
       clientToolRunId: 0,
       upload: false,
@@ -370,9 +380,34 @@ export default defineComponent({
     this.onApplyQueryFromUrl();
     if (supportsClientTools()) {
       this.localTools = (await localExec()?.listTools()) ?? [];
+      void this.onProbeWorkerFeatures();
     }
   },
   methods: {
+    /**
+     * Ask the worker which optional body fields it understands. Only gates the
+     * `local_mcp_servers` optimization: a worker without it silently ignores
+     * the field, so we keep inlining MCP schemas in `client_tools` until the
+     * probe succeeds. Any failure leaves the safe (eager) behaviour in place.
+     *
+     * Skipped entirely unless a local MCP server actually exists to defer —
+     * with only builtin tools the answer changes nothing, and a request nobody
+     * needs is a real cost (it also surfaces as a console error wherever the
+     * endpoint isn't reachable). Runs at most once per session.
+     */
+    async onProbeWorkerFeatures() {
+      if (this.localMcpProbed || this.localMcpDeferSupported) return;
+      if (!this.localTools.some((t) => t.source === 'mcp')) return;
+      this.localMcpProbed = true;
+      try {
+        const res = await fetch(`${BASE_URL_API}/aichat2/health`);
+        if (!res.ok) return;
+        const body = (await res.json()) as { features?: unknown };
+        this.localMcpDeferSupported = Array.isArray(body?.features) && body.features.includes('local_mcp_servers');
+      } catch {
+        /* offline / old worker / blocked — keep sending schemas eagerly */
+      }
+    },
     resetConversation() {
       this.restoringConversationId = undefined;
       this.messages = [];
@@ -775,6 +810,9 @@ export default defineComponent({
       // prompt tokens — until the chat remounts.
       if (supportsClientTools()) {
         this.localTools = (await localExec()?.listTools()) ?? [];
+        // Re-checked here, not just on mount: an MCP server added in Settings
+        // mid-session is the first moment a probe is worth making.
+        await this.onProbeWorkerFeatures();
       }
       console.debug('start to get answer', this.messages);
       const token = this.credential?.token;
@@ -937,6 +975,15 @@ export default defineComponent({
      * with execution:'client', and {@link _runClientTools} runs it via
      * `localExec().invoke` then resumes with `tool_results`.
      *
+     * Builtin tools (fs.*, shell.*, computer.*) ship their schemas eagerly in
+     * `client_tools` — there are at most ten and the model needs them for the
+     * "my machine" routing to work at all. Local MCP tools do NOT: they go out
+     * as one `local_mcp_servers` summary per server, and the worker pulls a
+     * server's schemas into the registry only when the model calls
+     * `load_mcp_server`. One real server is enough to justify this —
+     * `@playwright/mcp` exposes 24 tools whose specs are ~16 KB (~4k tokens),
+     * which used to be re-sent on every turn AND every tool-result resume.
+     *
      * Local tool names are dotted (`fs.list_dir`, `mcp.srv.tool`), but OpenAI
      * function names must match `^[a-zA-Z0-9_-]+$` (no dots) or the upstream
      * 400s. So we send a sanitized wire name to the model and map it back to
@@ -949,19 +996,56 @@ export default defineComponent({
         description: string;
         inputSchema: Record<string, unknown>;
       }[];
+      local_mcp_servers?: {
+        id: string;
+        displayName?: string;
+        tools: { name: string; displayName?: string; description: string; inputSchema: Record<string, unknown> }[];
+      }[];
       working_directory?: string;
     } {
       if (!supportsClientTools() || !this.localTools.length) return {};
       const workingDirectory = this.$store.state.chat?.workingDirectory;
+      const wired = this._wiredTools();
+      const asSpec = ({ spec, wire }: { spec: LocalToolSpec; wire: string }) => ({
+        name: wire,
+        displayName: spec.name,
+        description: spec.description,
+        inputSchema: spec.input_schema
+      });
+      const builtins = wired.filter((w) => w.spec.source !== 'mcp');
+      const mcp = wired.filter((w) => w.spec.source === 'mcp');
+      // Group MCP tools by their server id — the middle segment of
+      // `mcp.<serverId>.<tool>`. The server id is constrained to [A-Za-z0-9_-]
+      // by the Settings UI, so splitting at the first dot after `mcp.` is safe
+      // even when the tool name itself contains dots.
+      const byServer = new Map<string, typeof wired>();
+      for (const w of mcp) {
+        const rest = w.spec.name.slice('mcp.'.length);
+        const dot = rest.indexOf('.');
+        const id = dot < 0 ? rest : rest.slice(0, dot);
+        if (!id) continue;
+        const bucket = byServer.get(id);
+        if (bucket) bucket.push(w);
+        else byServer.set(id, [w]);
+      }
+      // A worker that predates `local_mcp_servers` ignores unknown body fields
+      // silently (no schema validation), so sending ONLY the summaries would
+      // make local MCP tools vanish with no error — the user would just see
+      // their MCP server stop working. Until `localMcpDeferSupported` is
+      // confirmed, keep the schemas in `client_tools` as well; the summaries
+      // are cheap, and a worker that understands them registers each tool
+      // exactly once either way (ToolRegistry is keyed by name).
+      const mcpSpecs = mcp.map(asSpec);
+      const eager = this.localMcpDeferSupported ? builtins.map(asSpec) : [...builtins.map(asSpec), ...mcpSpecs];
       return {
-        client_tools: this._wiredTools().map(({ spec, wire }) => ({
-          name: wire,
-          displayName: spec.name,
-          description: spec.description,
-          inputSchema: spec.input_schema
-        })),
+        ...(eager.length ? { client_tools: eager } : {}),
+        ...(byServer.size
+          ? {
+              local_mcp_servers: [...byServer].map(([id, tools]) => ({ id, tools: tools.map(asSpec) }))
+            }
+          : {}),
         // Tells the model which project it is in, so it stops guessing paths.
-        // Sent alongside client_tools (never on its own) because the worker
+        // Sent alongside the tool payload (never on its own) because the worker
         // renders it inside the <local_environment> block, which only exists
         // when local tools are present.
         ...(workingDirectory ? { working_directory: workingDirectory } : {})


### PR DESCRIPTION
桌面端的配套改动。worker 侧见 **https://github.com/AceDataCloud/PlatformService/pull/1769**。

本机跑的 MCP server，其 tool schema 一直被内联进 `client_tools` 随每轮下发，resume 时再发一遍。

## 实测

真实 `@playwright/mcp`：

| | 每轮 |
|---|---|
| 改前 24 个 schema | 16,245 chars ≈ **4,061 token** |
| 改后一行摘要 | 650 chars ≈ **163 token** |
| | **省 96%** |

## 改动

- **builtin 工具（fs / shell / computer）仍然 eager** —— 最多十个，而且"我的机器"这套路由必须靠它们在场才能工作。
- **MCP 工具改发 `local_mcp_servers`**（每 server 一条摘要），模型调 `load_mcp_server` 时 worker 才把 schema 拉进 registry。
- 按 `mcp.<serverId>.<tool>` 的 server id 分组，在 `mcp.` 后的**第一个点**切分——server id 被设置界面限制为 `[A-Za-z0-9_-]`，所以工具名自身含点也能正确分组。
- wire 名在两个 bucket 间保持全局唯一（`_runClientTools` 要靠它反查回带点的真名）。

## 向后兼容

老 worker 没有 schema 校验，会**静默丢弃**未知字段——无条件延迟会让本地 MCP 工具无错消失。所以：

1. `/health` 现在声明 `features: ['local_mcp_servers']`
2. 探测确认前，schema **同时**留在 `client_tools` 里（摘要也照发，新 worker 首轮就能延迟）
3. 探测失败（离线/被拦/老 worker）一律退回安全的 eager 路径

因此两个 PR 的合并顺序**不影响正确性**。

## 验证

- 893 tests passed（新增 10 条：分组、双发回退、探测三种结果、wire 名唯一性）
- `vue-tsc -b` 0 error，lint 0 error

## 🤖 对抗评审 (reviewer: codex, 3 rounds)

跨两仓一起评审，共 7 条 RISK 全部已修（含 2 条是我前一轮修复自己引入的）。完整博弈记录在 [PlatformService#1769](https://github.com/AceDataCloud/PlatformService/pull/1769) 的 PR body 里。本仓相关的一条：

- **新桌面端 + 老 worker 不兼容** → 已修，即上面的"向后兼容"三步。