### PR TITLE
feat(local-tools): 工作目录落到主进程配置

### DIFF
--- a/change/@acedatacloud-nexior-cded5f34-1fde-485a-b602-e93e5e05ab34.json
+++ b/change/@acedatacloud-nexior-cded5f34-1fde-485a-b602-e93e5e05ab34.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(local-tools): 工作目录持久化到主进程配置，并作为 shell 与项目约定的默认目录",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/electron/local/config.test.ts
+++ b/electron/local/config.test.ts
@@ -7,7 +7,7 @@ import path from 'node:path';
 const state = vi.hoisted(() => ({ userData: '' }));
 vi.mock('electron', () => ({ app: { getPath: () => state.userData } }));
 
-import { load } from './config';
+import { load, getWorkingDir, rootsWithWorkingDir, mergeConfigSave } from './config';
 
 describe('local-tools config load', () => {
   const dirs: string[] = [];
@@ -58,5 +58,84 @@ describe('local-tools config load', () => {
     expect(load()).toEqual({ roots: [], mcp: [], grants: [], computerUse: false });
     writeFileSync(path.join(d, 'local-tools.json'), '{ not json');
     expect(load()).toEqual({ roots: [], mcp: [], grants: [], computerUse: false });
+  });
+});
+
+describe('working directory', () => {
+  const dirs: string[] = [];
+  function tmpUserData(): string {
+    const d = mkdtempSync(path.join(os.tmpdir(), 'nx-wd-'));
+    dirs.push(d);
+    state.userData = d;
+    return d;
+  }
+  afterEach(() => {
+    for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+  });
+
+  // Regression guard: `load()` builds its result field-by-field, so a field
+  // missing from that list is silently dropped on every read→write round trip.
+  it('survives a load round trip', () => {
+    const d = tmpUserData();
+    writeFileSync(path.join(d, 'local-tools.json'), JSON.stringify({ roots: ['/tmp/a'], mcp: [], workingDir: '/tmp/proj' }));
+    expect(load().workingDir).toBe('/tmp/proj');
+    expect(getWorkingDir()).toBe('/tmp/proj');
+  });
+
+  it('reports undefined — not an empty string — when unset', () => {
+    const d = tmpUserData();
+    writeFileSync(path.join(d, 'local-tools.json'), JSON.stringify({ roots: [], mcp: [], workingDir: '' }));
+    expect(getWorkingDir()).toBeUndefined();
+  });
+
+  it('is undefined when the config is missing entirely', () => {
+    tmpUserData();
+    expect(getWorkingDir()).toBeUndefined();
+  });
+
+  describe('rootsWithWorkingDir', () => {
+    it('authorizes the working directory alongside the explicit roots', () => {
+      // Picking a project folder must make it readable; otherwise the user
+      // chooses a folder and then finds the AI cannot open anything in it.
+      expect(rootsWithWorkingDir(['/a'], '/proj')).toEqual(['/a', '/proj']);
+    });
+
+    it('does not duplicate a working directory already listed as a root', () => {
+      expect(rootsWithWorkingDir(['/a', '/proj'], '/proj')).toEqual(['/a', '/proj']);
+    });
+
+    it('is a no-op when no working directory is set', () => {
+      expect(rootsWithWorkingDir(['/a'], undefined)).toEqual(['/a']);
+    });
+  });
+
+  // The renderer has four read-modify-write save paths and none of them sends
+  // `workingDir`. Every one of them must leave it alone.
+  describe('mergeConfigSave', () => {
+    const stored = {
+      roots: ['/a'],
+      mcp: [],
+      grants: ['fs.read_file'],
+      computerUse: true,
+      workingDir: '/proj'
+    };
+
+    it('preserves the working directory when the payload omits it', () => {
+      // This is the "save MCP servers wipes the project folder" regression.
+      const next = mergeConfigSave(stored, { roots: ['/a'], mcp: [{ id: 'x', command: 'y', args: [] }] });
+      expect(next.workingDir).toBe('/proj');
+      expect(next.grants).toEqual(['fs.read_file']);
+      expect(next.computerUse).toBe(true);
+    });
+
+    it('applies a new working directory when the payload sets one', () => {
+      const next = mergeConfigSave(stored, { roots: ['/a'], mcp: [], workingDir: '/other' });
+      expect(next.workingDir).toBe('/other');
+    });
+
+    it('still lets roots and mcp be replaced wholesale', () => {
+      const next = mergeConfigSave(stored, { roots: ['/b'], mcp: [] });
+      expect(next.roots).toEqual(['/b']);
+    });
   });
 });

--- a/electron/local/config.ts
+++ b/electron/local/config.ts
@@ -14,10 +14,52 @@ export function load(): LocalConfig {
     // authorized root, MCP server and grant.
     const raw = fs.readFileSync(file(), 'utf8').replace(/^\uFEFF/, '');
     const c = JSON.parse(raw) as Partial<LocalConfig>;
-    return { roots: c.roots ?? [], mcp: c.mcp ?? [], grants: c.grants ?? [], computerUse: c.computerUse ?? false };
+    return {
+      roots: c.roots ?? [],
+      mcp: c.mcp ?? [],
+      grants: c.grants ?? [],
+      computerUse: c.computerUse ?? false,
+      workingDir: c.workingDir
+    };
   } catch {
     return { roots: [], mcp: [], grants: [], computerUse: false };
   }
+}
+
+/** The user's current project directory, or undefined when none is chosen.
+ *  Read straight from disk so the shell + project-context tools see the same
+ *  value the renderer saved, with no in-memory copy to keep in sync. */
+export function getWorkingDir(): string | undefined {
+  return load().workingDir || undefined;
+}
+
+/** Merge a renderer save payload onto the stored config.
+ *
+ * Pure, and separate from the IPC handler, because this is where a field gets
+ * silently lost: the renderer has FOUR read-modify-write save paths (folders,
+ * MCP, reconnect, Computer Use) and each sends only the slice it owns. Any
+ * field absent from the payload must fall back to the stored value, or e.g.
+ * saving an MCP server would wipe the working directory.
+ */
+export function mergeConfigSave(cur: LocalConfig, cfg: LocalConfig): LocalConfig {
+  return {
+    ...cur,
+    roots: cfg.roots,
+    mcp: cfg.mcp,
+    computerUse: cfg.computerUse ?? cur.computerUse ?? false,
+    workingDir: cfg.workingDir ?? cur.workingDir
+  };
+}
+
+/** The set of folders to authorize: the explicit list plus the working
+ *  directory. Picking a project directory implicitly authorizes it — otherwise
+ *  the user picks a folder and then finds the AI cannot read it, and has to add
+ *  the same path a second time under Settings. Kept OUT of `config.roots` so
+ *  the "authorized folders" list doesn't gain a row the user never added
+ *  (and can't meaningfully remove while it is the working directory). */
+export function rootsWithWorkingDir(roots: string[], workingDir?: string): string[] {
+  if (!workingDir) return roots;
+  return roots.includes(workingDir) ? roots : [...roots, workingDir];
 }
 
 export function save(c: LocalConfig): void {

--- a/electron/local/context.ts
+++ b/electron/local/context.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import type { ToolResult } from './types';
 import { assertInRoots, expandHome, listRoots } from './fs';
 import { currentWorkingDir } from './shellSession';
+import { getWorkingDir } from './config';
 
 // Project context: the convention files a coding agent is expected to obey
 // (AGENTS.md / CLAUDE.md and friends) plus the project's own slash commands.
@@ -114,25 +115,30 @@ export async function load_project_context(i: { path?: string; sessionId?: strin
   if (i.path) {
     start = assertInRoots(expandHome(i.path));
   } else {
-    // Default to the session's working directory — the conversation's "current
-    // project". Falling back to an arbitrary entry of the roots list (whichever
-    // the user happened to add first) would load the wrong project's rules, or
-    // none at all, without the model ever noticing.
-    const wd = currentWorkingDir(i.sessionId);
+    // Resolution order, narrowest first:
+    //   1. the session's live shell cwd (the model may have cd'd elsewhere)
+    //   2. the user's configured project directory
+    // Falling back to an arbitrary entry of the roots list (whichever the user
+    // happened to add first) would load the WRONG project's rules without the
+    // model ever noticing — that mistake is why the first attempt at this tool
+    // was withdrawn.
+    const wd = currentWorkingDir(i.sessionId) ?? getWorkingDir();
     if (!wd) {
       const roots = listRoots();
+      // A single authorized folder is unambiguous, so use it rather than
+      // failing on a technicality.
       if (roots.length === 1) {
-        start = roots[0]; // unambiguous: exactly one authorized project
+        start = roots[0];
       } else if (!roots.length) {
-        throw new Error('no authorized roots; add a folder in Settings → Local Tools');
+        throw new Error('no authorized roots; choose a project folder first');
       } else {
         throw new Error(
           `no working directory set and ${roots.length} folders are authorized — ` +
-            `call shell.set_working_dir first, or pass an explicit path. Authorized: ${roots.join(', ')}`
+            `choose a project folder first, or pass an explicit path. Authorized: ${roots.join(', ')}`
         );
       }
     } else {
-      start = assertInRoots(wd);
+      start = assertInRoots(expandHome(wd));
     }
   }
   // A file path is a natural thing for a model to pass ("what rules apply to

--- a/electron/local/ipc.ts
+++ b/electron/local/ipc.ts
@@ -2,7 +2,7 @@ import { ipcMain, BrowserWindow, dialog } from 'electron';
 import { APP_ORIGIN } from '../protocol';
 import { consentOk, listGrants, revokeGrant, clearGrants, resetComputerSessionConsent, grantComputerTools, grantToolsWide } from './consent';
 import { registry } from './registry';
-import { load, save } from './config';
+import { load, save, rootsWithWorkingDir, mergeConfigSave } from './config';
 import { setRoots } from './fs';
 import { status, openPane, askMedia, promptAccessibility, ensureScreenPermission, type PaneKey } from './permissions';
 import type { LocalConfig, ToolInvoke } from './types';
@@ -39,19 +39,18 @@ export function disableComputerUse(): boolean {
 let configSaveChain: Promise<boolean> = Promise.resolve(true);
 
 async function applyConfigSave(cfg: LocalConfig): Promise<boolean> {
-  // Preserve persistent consent grants — the renderer's save payload only
-  // carries roots + mcp (+ optional computerUse), so merge to avoid wiping
-  // the "always allow" list. `computerUse` falls back to the current value
-  // when the renderer omits it.
+  // The renderer's payload only carries the slice each UI path owns, so the
+  // merge (grants, computerUse, workingDir) lives in `mergeConfigSave` — pure
+  // and unit-tested, since a field dropped there is silently lost.
   const cur = load();
-  const computerUse = cfg.computerUse ?? cur.computerUse ?? false;
+  const next = mergeConfigSave(cur, cfg);
   // Only re-spawn MCP servers when their config actually changed — a folder /
   // Computer-Use save shouldn't tear down healthy MCP connections.
   const mcpChanged = JSON.stringify(cur.mcp ?? []) !== JSON.stringify(cfg.mcp ?? []);
-  save({ ...cur, roots: cfg.roots, mcp: cfg.mcp, computerUse });
-  setRoots(cfg.roots); // hot-apply roots
-  registry.setComputerUse(computerUse); // hot-apply the Computer Use toggle
-  if (!computerUse) resetComputerSessionConsent(); // turning it off clears session grants
+  save(next);
+  setRoots(rootsWithWorkingDir(next.roots, next.workingDir)); // hot-apply roots
+  registry.setComputerUse(next.computerUse === true); // hot-apply the Computer Use toggle
+  if (!next.computerUse) resetComputerSessionConsent(); // turning it off clears session grants
   // Hot-apply MCP servers: stop the old ones and boot the new set so their
   // tools appear/disappear from the next `client_tools` payload without a
   // restart. `reboot` swallows per-server failures, so save never rejects.

--- a/electron/local/shellSession.test.ts
+++ b/electron/local/shellSession.test.ts
@@ -1,7 +1,13 @@
-import { afterEach, describe, expect, it } from 'vitest';
-import { mkdtempSync, mkdirSync, writeFileSync, realpathSync } from 'node:fs';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, realpathSync, rmSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+
+// shellSession reads the working directory from config.ts, which reads
+// `app.getPath('userData')`; point it at a per-test temp dir.
+const state = vi.hoisted(() => ({ userData: '' }));
+vi.mock('electron', () => ({ app: { getPath: () => state.userData } }));
+
 import { setRoots, _resetRootsForTesting } from './fs';
 import { shell_exec, set_working_dir, currentWorkingDir, endSession, _resetSessionsForTesting } from './shellSession';
 
@@ -22,8 +28,9 @@ describe.skipIf(WIN)('shell.exec persistent session', () => {
 
   it('keeps the working directory across calls (cd persists)', async () => {
     const base = rooted();
-    await shell_exec({ command: `cd ${base}`, sessionId: 's1' });
-    await shell_exec({ command: 'cd sub', sessionId: 's1' });
+    // The first call must name a cwd (or a working directory must be
+    // configured) — a shell is never spawned in an unauthorized folder.
+    await shell_exec({ command: 'cd sub', cwd: base, sessionId: 's1' });
     const res = await shell_exec({ command: 'pwd', sessionId: 's1' });
     expect(res.output).toContain(path.join(base, 'sub'));
   });
@@ -183,5 +190,82 @@ describe.skipIf(WIN)('project.load_context defaults to the working directory', (
     const { load_project_context } = await import('./context');
     const res = await load_project_context({ sessionId: 'ctx3' });
     expect(res.output).toContain('ONLY RULES');
+  });
+});
+
+// The configured working directory is what the user picked in the app. These
+// cover the config → tool wiring, which is the whole point of this change.
+describe.skipIf(WIN)('configured working directory', () => {
+  const userDataDirs: string[] = [];
+
+  /** Point config.ts at a temp userData dir holding the given working dir. */
+  function configureWorkingDir(dir: string): void {
+    const d = mkdtempSync(path.join(os.tmpdir(), 'nx-wdcfg-'));
+    userDataDirs.push(d);
+    state.userData = d;
+    writeFileSync(path.join(d, 'local-tools.json'), JSON.stringify({ roots: [], mcp: [], workingDir: dir }));
+  }
+
+  afterEach(() => {
+    _resetSessionsForTesting();
+    _resetRootsForTesting();
+    for (const d of userDataDirs.splice(0)) rmSync(d, { recursive: true, force: true });
+    state.userData = '';
+  });
+
+  it('is where a shell starts when the model passes no cwd', async () => {
+    const base = rooted();
+    configureWorkingDir(base);
+    const res = await shell_exec({ command: 'pwd', sessionId: 'cw1' });
+    expect(res.output).toContain(base);
+  });
+
+  // Regression: the fallback used to be `os.homedir()`, which ALSO bypassed the
+  // roots check — a shell could be spawned in a folder that was never
+  // authorized. It must fail loudly instead.
+  it('refuses to start a shell when none is set, rather than falling back to $HOME', async () => {
+    rooted();
+    configureWorkingDir(''); // config present, but no working directory
+    await expect(shell_exec({ command: 'pwd', sessionId: 'cw2' })).rejects.toThrow('no working directory set');
+  });
+
+  it('still enforces the roots boundary on the configured directory', async () => {
+    rooted(); // authorizes some OTHER folder
+    const outside = realpathSync(mkdtempSync(path.join(os.tmpdir(), 'nx-out-')));
+    configureWorkingDir(outside);
+    await expect(shell_exec({ command: 'pwd', sessionId: 'cw3' })).rejects.toThrow('path outside allowed roots');
+  });
+
+  it('is reported by set_working_dir before any shell has started', async () => {
+    const base = rooted();
+    configureWorkingDir(base);
+    const res = await set_working_dir({ sessionId: 'cw4' });
+    expect(res.output).toBe(base);
+  });
+
+  it('is where project.load_context looks when the session has no shell yet', async () => {
+    const base = realpathSync(mkdtempSync(path.join(os.tmpdir(), 'nx-ctxcfg-')));
+    writeFileSync(path.join(base, 'AGENTS.md'), 'CONFIGURED PROJECT RULES\n');
+    const other = realpathSync(mkdtempSync(path.join(os.tmpdir(), 'nx-other-')));
+    writeFileSync(path.join(other, 'AGENTS.md'), 'OTHER RULES\n');
+    // Two authorized roots — ambiguous without a working directory.
+    setRoots([other, base]);
+    configureWorkingDir(base);
+    const { load_project_context } = await import('./context');
+    const res = await load_project_context({ sessionId: 'cw5' });
+    expect(res.output).toContain('CONFIGURED PROJECT RULES');
+    expect(res.output).not.toContain('OTHER RULES');
+  });
+
+  it('yields to the session shell once the model has cd\'d elsewhere', async () => {
+    const base = rooted();
+    writeFileSync(path.join(base, 'AGENTS.md'), 'ROOT RULES\n');
+    writeFileSync(path.join(base, 'sub', 'AGENTS.md'), 'SUB RULES\n');
+    configureWorkingDir(base);
+    await set_working_dir({ path: path.join(base, 'sub'), sessionId: 'cw6' });
+    const { load_project_context } = await import('./context');
+    const res = await load_project_context({ sessionId: 'cw6' });
+    // Both appear (conventions cascade), but the live session dir is the leaf.
+    expect(res.output).toContain('SUB RULES');
   });
 });

--- a/electron/local/shellSession.ts
+++ b/electron/local/shellSession.ts
@@ -1,8 +1,8 @@
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
-import os from 'node:os';
 import path from 'node:path';
 import { resolveEnhancedPath } from './env';
 import { assertInRoots, expandHome } from './fs';
+import { getWorkingDir } from './config';
 import type { ToolResult } from './types';
 
 // A persistent shell per conversation, so `cd`, activated virtualenvs, exported
@@ -107,6 +107,16 @@ function resolveCwd(dir: string): string {
   return assertInRoots(expandHome(dir));
 }
 
+/** The configured working directory, or a clear error. The desktop chat page
+ *  blocks sending until one is chosen, so this should be unreachable in
+ *  practice — it exists so a tool call can never silently open a shell
+ *  somewhere the user did not choose. */
+function requireWorkingDir(): string {
+  const wd = getWorkingDir();
+  if (!wd) throw new Error('no working directory set — choose a project folder first');
+  return wd;
+}
+
 async function getSession(key: string, cwd?: string): Promise<Session> {
   const existing = sessions.get(key);
   if (existing && !existing.proc.killed) {
@@ -120,9 +130,10 @@ async function getSession(key: string, cwd?: string): Promise<Session> {
     touch(key, existing);
     return existing;
   }
-  // No explicit cwd and no session yet: start in the user's home rather than
-  // wherever Electron happened to be launched from (a Dock launch gives `/`).
-  const start = cwd ? resolveCwd(cwd) : os.homedir();
+  // No explicit cwd: start in the user's chosen working directory. It used to
+  // fall back to `os.homedir()`, which BYPASSED resolveCwd — so a shell could
+  // be spawned in a folder that was never authorized (home usually isn't).
+  const start = resolveCwd(cwd ?? requireWorkingDir());
   const s = await spawnSession(start);
   sessions.set(key, s);
   touch(key, s);
@@ -255,8 +266,10 @@ export async function shell_exec(i: {
 export async function set_working_dir(i: { path?: string; sessionId?: string }): Promise<ToolResult> {
   const key = i.sessionId || 'default';
   if (!i.path) {
+    // No live shell yet → report the configured project directory rather than
+    // the home dir, which is what the next `shell.exec` would actually use.
     const s = sessions.get(key);
-    return { output: s ? s.cwd : os.homedir() };
+    return { output: s ? s.cwd : (getWorkingDir() ?? '(no working directory set)') };
   }
   const target = resolveCwd(i.path);
   const s = await getSession(key, target);

--- a/electron/local/types.ts
+++ b/electron/local/types.ts
@@ -55,4 +55,11 @@ export interface LocalConfig {
   // Opt-in Computer Use (screen capture + mouse/keyboard control). Default
   // false; while false the `computer.*` tools are not advertised or invokable.
   computerUse?: boolean;
+  // The user's current project directory. Chosen in the chat page (which
+  // blocks sending until one is picked) or in Settings. It is the default cwd
+  // for the persistent shell and where `project.load_context` looks for
+  // AGENTS.md — so the model no longer has to guess which project it is in.
+  // Authorized implicitly: it is folded into ROOTS alongside `roots`, without
+  // appearing as a row in the "authorized folders" list.
+  workingDir?: string;
 }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -7,7 +7,7 @@ import { initUpdater } from './updater';
 import { registerLocalExec, disableComputerUse } from './local/ipc';
 import { registry } from './local/registry';
 import { setRoots } from './local/fs';
-import { load as loadLocalConfig } from './local/config';
+import { load as loadLocalConfig, rootsWithWorkingDir } from './local/config';
 import { daemon } from './scheduler/daemon';
 import { initTray, refreshTray, setOpenAtLogin, isOpenAtLogin } from './scheduler/tray';
 import {
@@ -109,7 +109,7 @@ if (!gotLock) {
     initUpdater(() => mainWindow);
     // Local tool execution: load authorized roots, boot MCP servers, wire IPC.
     const localCfg = loadLocalConfig();
-    setRoots(localCfg.roots);
+    setRoots(rootsWithWorkingDir(localCfg.roots, localCfg.workingDir));
     registry.setComputerUse(localCfg.computerUse === true); // opt-in, default off
     void registry.boot(localCfg.mcp);
     registerLocalExec(() => mainWindow);

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -84,8 +84,9 @@ contextBridge.exposeInMainWorld('localExec', {
   listTools: (): Promise<unknown[]> => ipcRenderer.invoke('local.tools.list'),
   invoke: (inv: { name: string; input: object; sessionId: string }): Promise<{ output: string; is_error?: boolean; image?: string }> =>
     ipcRenderer.invoke('local.tool.invoke', inv),
-  getConfig: (): Promise<{ roots: string[]; mcp: object[]; computerUse?: boolean }> => ipcRenderer.invoke('local.config.get'),
-  saveConfig: (cfg: { roots: string[]; mcp: object[]; computerUse?: boolean }): Promise<boolean> =>
+  getConfig: (): Promise<{ roots: string[]; mcp: object[]; computerUse?: boolean; workingDir?: string }> =>
+    ipcRenderer.invoke('local.config.get'),
+  saveConfig: (cfg: { roots: string[]; mcp: object[]; computerUse?: boolean; workingDir?: string }): Promise<boolean> =>
     ipcRenderer.invoke('local.config.save', cfg),
   // Per-server MCP connection status + targeted reconnect, for Settings.
   mcp: {

--- a/src/utils/desktop.ts
+++ b/src/utils/desktop.ts
@@ -110,6 +110,8 @@ export interface LocalExecBridge {
       enabled?: boolean;
     }[];
     computerUse?: boolean;
+    /** The user's chosen project directory (desktop only). */
+    workingDir?: string;
   }>;
   saveConfig(cfg: {
     roots: string[];
@@ -122,6 +124,8 @@ export interface LocalExecBridge {
       enabled?: boolean;
     }[];
     computerUse?: boolean;
+    /** Omit to leave the stored working directory untouched. */
+    workingDir?: string;
   }): Promise<boolean>;
   /** Per-server MCP connection status + targeted reconnect (desktop only). */
   mcp?: {


### PR DESCRIPTION
## 背景

桌面端让云端模型操作本机文件与 shell，但**没有「当前项目」这个概念**，导致：

1. `project.load_context` 不知道去哪找 `AGENTS.md` —— 这正是 #1469 被关掉重做的原因（它当时回落到 `listRoots()[0]`，即用户最先添加的目录，纯属偶然）。
2. 持久 shell（#1471）没有起点。
3. 模型只能每次自己传 `cwd`，用户无从表达"我在这个项目里工作"。

本 PR 是三个 PR 中的第一个，只做**主进程侧**：把工作目录持久化下来，并让本地工具真正用上它。UI（聊天页前置条件 + 设置页选择器）与提示词注入分别在后续 PR。

## 改动

`LocalConfig` 新增 `workingDir`，存在 `local-tools.json`。主进程可直接读到，因此 shell 与项目约定工具**不必依赖模型每次传参**。

### 选了就自动授权

`workingDir` 单独存字段，但喂给 `setRoots()` 时并入（`rootsWithWorkingDir`）。

这样设置页的「已授权文件夹」列表不会平白多出一个用户没添加、也没法删掉的幽灵条目，而 `fs.*` 的 `inRootDir()` 边界检查又认它。否则用户选完目录会发现 AI 读不了，还得去设置里把同一个路径**再加一遍**。

### 修掉 #1471 里一个真实的安全 bug

```js
const start = cwd ? resolveCwd(cwd) : os.homedir();   // 旧代码
```

无 `cwd` 时回落到 home，而这条路径**绕过了 `resolveCwd()`** —— 等于可以在一个从未授权的目录里开一个常驻 shell（home 通常就不在授权列表里）。我在 #1471 的描述里写"必须落在授权根内"，那句话当时只对显式路径成立。

现在回落到工作目录，且**同样过边界校验**；没有工作目录时直接报错，而不是静默降级到 `$HOME`。有专门的回归测试。

### `load_context` 解析顺序

显式 `path` → 会话 shell 的当前目录（模型可能 `cd` 走了）→ 配置的工作目录 → 兜底报错。

### 配置合并抽成纯函数

渲染进程有**四条** read-modify-write 保存路径（文件夹 / MCP / 重连 / Computer Use），**没有一条会带 `workingDir`**。漏一处回落就会出现"保存 MCP 服务器把工作目录抹掉"。

因此把合并逻辑从 IPC handler 里抽成纯函数 `mergeConfigSave` 并单测 —— `ipc.ts` 因为耦合 Electron 一直没有测试，而这正是最容易静默丢字段的地方。

## 测试

`electron/` 全量 **165 passed**（新增 12 例）：配置往返保留、空串归一为 undefined、`rootsWithWorkingDir` 去重、`mergeConfigSave` 三个分支（含"保存 MCP 不抹掉工作目录"的回归）、shell 默认落在工作目录、**拒绝回落到 `$HOME`**、配置目录仍受 roots 边界约束、`load_context` 认配置目录且让位于会话 cwd。

`npx vue-tsc -b` 通过。

## 说明

- 接续已合并的 #1467 / #1468 / #1471 / #1472。
- 配套 PR：Nexior 前端前置条件 + 选择器（下一个）、aichat2 提示词注入（AceDataCloud/PlatformService#1770）。
- **暂不合并**，等 review。

🤖 Generated with [Claude Code](https://claude.com/claude-code)