### PR TITLE
fix(console): 统一侧栏与页面布局，根治溢出与直角

### DIFF
--- a/change/@acedatacloud-nexior-3f9a1c72-8d54-4b6e-9c21-7ae0f1d8b3e5.json
+++ b/change/@acedatacloud-nexior-3f9a1c72-8d54-4b6e-9c21-7ae0f1d8b3e5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "console: unify the sidebar and page layout — one source of truth for the sidebar width, nav rows that cannot overflow, and rounded workspace panels",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/connections/BrowseConnectors.vue
+++ b/src/components/connections/BrowseConnectors.vue
@@ -748,9 +748,11 @@ export default defineComponent({
   flex-direction: column;
   gap: 8px;
   padding: 14px;
-  // Same tokens as <el-card>, which every console page uses.
-  border: 1px solid var(--el-card-border-color);
-  border-radius: var(--el-card-border-radius);
+  // Global tokens. `--el-card-*` is scoped inside Element Plus's `.el-card`
+  // rule, so a non-card element never inherits it and falls back to a square
+  // border-radius and `currentColor` border.
+  border: 1px solid var(--app-border-subtle);
+  border-radius: var(--adc-radius-control);
   background: var(--el-card-bg-color);
   transition:
     border-color 0.1s,

--- a/src/components/console/PageHeader.vue
+++ b/src/components/console/PageHeader.vue
@@ -1,0 +1,44 @@
+<template>
+  <div class="page-heading">
+    <h2 class="page-title">{{ title }}</h2>
+    <p v-if="subtitle" class="page-subtitle">{{ subtitle }}</p>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+  name: 'ConsolePageHeader',
+  props: {
+    title: {
+      type: String,
+      required: true
+    },
+    subtitle: {
+      type: String,
+      default: ''
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.page-heading {
+  margin-bottom: 16px;
+  flex: 0 0 auto;
+}
+
+.page-title {
+  font-size: 26px;
+  font-weight: 700;
+  color: var(--el-text-color-primary);
+  margin: 0;
+}
+
+.page-subtitle {
+  margin: 6px 0 0;
+  font-size: 13px;
+  color: var(--el-text-color-secondary);
+}
+</style>

--- a/src/components/console/SidePanel.vue
+++ b/src/components/console/SidePanel.vue
@@ -20,7 +20,6 @@
             focusable="false"
           />
         </span>
-        <span class="suffix"> </span>
       </a>
     </div>
   </div>
@@ -56,7 +55,7 @@ interface ILink {
 }
 
 export default defineComponent({
-  name: 'Navigator',
+  name: 'ConsoleSidePanel',
   components: {
     ExternalLinkIcon
   },
@@ -136,17 +135,20 @@ export default defineComponent({
 </script>
 
 <style lang="scss" scoped>
-$width: 220px;
-$padding-left: 12px;
 .side {
-  padding-left: $padding-left;
-  width: $width;
+  // Width comes from the layout (`--console-side-width` on `.console`) so the
+  // sidebar has exactly one source of truth. The fallback keeps this component
+  // usable if it is ever mounted outside the console layout.
+  width: var(--console-side-width, 220px);
+  padding-left: 12px;
   padding-top: 50px;
   height: 100%;
+  box-sizing: border-box;
+  background-color: var(--app-sidebar-bg);
 }
 
 .links {
-  width: $width - $padding-left;
+  width: 100%;
   display: flex;
   flex-direction: column;
   position: relative;
@@ -157,45 +159,57 @@ $padding-left: 12px;
   .link {
     $height: 40px;
     height: $height;
-    display: block;
+    // Grid instead of a block box with absolutely-positioned bits: the text
+    // column is `minmax(0, 1fr)`, so a long label compresses rather than
+    // pushing the row past the sidebar. Overflow is prevented structurally,
+    // not hidden by an ancestor's `overflow-x`.
+    display: grid;
+    grid-template-columns: 16px minmax(0, 1fr) auto;
+    align-items: center;
+    column-gap: 10px;
     width: 100%;
     border-radius: 10px;
     cursor: pointer;
     position: relative;
     color: var(--el-text-color-primary);
-    line-height: $height;
-    padding-left: 12px;
+    line-height: 1.2;
+    padding: 0 12px;
     transition: background-color 0.15s ease;
-    .suffix {
-      width: 3px;
-      height: $height;
-      position: absolute;
-      right: -5px;
-      margin-right: 5px;
-      border-radius: 3px;
-      display: inline-block;
-    }
     .icon {
       width: 16px;
       height: 16px;
-      // Center the SVG in its own box and reset the inherited tall line-height,
-      // otherwise the icon renders against the link's 36/40px line box and drops
-      // well below the label.
       display: inline-flex;
       align-items: center;
       justify-content: center;
       line-height: 1;
-      vertical-align: middle;
-      margin-right: 10px;
     }
     .text {
       font-size: 14px;
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .outer {
+      display: inline-flex;
+      align-items: center;
+      justify-content: flex-end;
     }
     &.active {
       background-color: var(--el-color-primary-light-9);
       color: var(--el-color-primary);
       font-weight: 500;
-      .suffix {
+      // Indicator drawn inside the row's own box. It used to be a `.suffix`
+      // span at `right: -5px`, which pushed 5px outside the sidebar and was
+      // only invisible because some pages' root element clipped it.
+      &::after {
+        content: '';
+        position: absolute;
+        top: 0;
+        right: 0;
+        width: 3px;
+        height: $height;
+        border-radius: 3px;
         background-color: var(--el-color-primary);
       }
     }
@@ -223,18 +237,16 @@ $padding-left: 12px;
       flex: 1 0 max-content;
       min-width: 96px;
       height: 36px;
-      line-height: 36px;
+      // Center icon + label as a pair; the desktop 3-column grid would
+      // stretch them across the full pill width.
       display: flex;
       align-items: center;
       justify-content: center;
+      gap: 6px;
       padding: 0 12px;
       white-space: nowrap;
 
-      .icon {
-        margin-right: 6px;
-      }
-
-      .suffix {
+      &.active::after {
         display: none;
       }
     }

--- a/src/components/skill/BrowseSkillsDialog.vue
+++ b/src/components/skill/BrowseSkillsDialog.vue
@@ -533,10 +533,12 @@ export default defineComponent({
   grid-template-columns: repeat(2, 1fr);
   gap: 12px;
 }
-/* Same tokens as <el-card>, which every console page uses. */
+/* Global tokens. `--el-card-*` is scoped inside Element Plus's `.el-card`
+   rule, so a non-card element never inherits it and falls back to a square
+   border-radius and `currentColor` border. */
 .directory-card {
-  border: 1px solid var(--el-card-border-color);
-  border-radius: var(--el-card-border-radius);
+  border: 1px solid var(--app-border-subtle);
+  border-radius: var(--adc-radius-control);
   padding: 14px 16px;
   background: var(--el-card-bg-color);
   cursor: pointer;

--- a/src/layouts/Console.vue
+++ b/src/layouts/Console.vue
@@ -2,7 +2,7 @@
   <div class="console">
     <div class="main">
       <side-panel class="side" />
-      <router-view class="panel" />
+      <router-view :class="['panel', `panel--${panelVariant}`]" />
     </div>
     <navigator class="navigator" :direction="mobile ? 'row' : 'column'" />
   </div>
@@ -24,6 +24,15 @@ export default defineComponent({
       mobile: window.innerWidth < 768
     };
   },
+  computed: {
+    // `document` pages flow downwards and let `.panel` scroll; `workspace`
+    // pages (connectors / skills) need a full-height flex column for their
+    // independently-scrolling two-pane UI. Declared per route so pages don't
+    // have to fight `.panel` with their own `height: 100%` wrapper.
+    panelVariant(): string {
+      return (this.$route.meta?.layout as string) || 'document';
+    }
+  },
   mounted() {
     // Stable reference so beforeUnmount can remove it — see Main.vue for
     // the same pattern; without removal each navigation leaked one listener.
@@ -41,6 +50,14 @@ export default defineComponent({
 </script>
 
 <style lang="scss" scoped>
+.console {
+  // Single source of truth for the sidebar width. SidePanel reads this same
+  // variable — previously each file declared its own value (200px here,
+  // 220px there) and this file's higher-specificity `.console .main .side`
+  // silently won, so the sidebar's inner list overflowed by 8px.
+  --console-side-width: 220px;
+}
+
 @media screen and (min-width: 768px) {
   .console {
     width: 100%;
@@ -60,20 +77,30 @@ export default defineComponent({
       display: flex;
       flex-direction: row;
       overflow: hidden;
-      .side {
-        width: 200px;
-        height: 100%;
-        background-color: var(--app-sidebar-bg);
-      }
+
       .panel {
         flex: 1;
         height: 100%;
         padding: 30px;
         background-color: var(--el-bg-color-page);
         min-width: 0;
+        box-sizing: border-box;
+      }
+
+      // Content flows downwards; the panel scrolls it.
+      .panel--document {
         overflow-y: auto;
         overflow-x: hidden;
-        box-sizing: border-box;
+      }
+
+      // Full-height flex column for two-pane pages that scroll their own
+      // panes. Replaces the `.page-shell` wrapper each such page used to
+      // inline to override `.panel`.
+      .panel--workspace {
+        display: flex;
+        flex-direction: column;
+        min-height: 0;
+        overflow: hidden;
       }
     }
   }
@@ -116,6 +143,13 @@ export default defineComponent({
         overflow-x: auto;
         overflow-y: auto;
       }
+
+      // On phones a workspace page grows and scrolls with the panel rather
+      // than trapping its panes in a viewport-height column.
+      .panel--workspace {
+        display: flex;
+        flex-direction: column;
+      }
       .side {
         width: 100%;
         height: auto;
@@ -132,6 +166,8 @@ export default defineComponent({
 <style lang="scss">
 .console {
   .panel {
+    // Bare heading used by the document-style pages. Workspace pages render
+    // <console-page-header>, which owns its own typography.
     .title {
       font-size: 26px;
       font-weight: bold;

--- a/src/layouts/consoleLayout.test.ts
+++ b/src/layouts/consoleLayout.test.ts
@@ -1,0 +1,107 @@
+// @vitest-environment node
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = resolve(__dirname, '../..');
+const source = (relativePath: string) => readFileSync(resolve(ROOT, relativePath), 'utf8');
+
+/**
+ * Element Plus declares these on its own component rules (e.g. `.el-card { … }`),
+ * not on `:root`. Referencing one from an element that is not inside that
+ * component silently resolves to nothing: `border-radius` falls back to 0 (square
+ * corners) and `border-color` to `currentColor`. Both failures render as
+ * "looks almost right", so they survived two review rounds — hence this guard.
+ */
+const COMPONENT_SCOPED_EL_VARS = ['--el-card-border-radius', '--el-card-border-color', '--el-card-padding'];
+
+const walk = (dir: string, acc: string[] = []): string[] => {
+  for (const entry of readdirSync(dir)) {
+    const full = resolve(dir, entry);
+    if (statSync(full).isDirectory()) {
+      walk(full, acc);
+    } else if (entry.endsWith('.vue')) {
+      acc.push(full);
+    }
+  }
+  return acc;
+};
+
+describe('css variable scope guard', () => {
+  it('never reads component-scoped Element Plus vars outside an .el-* rule', () => {
+    const offenders: string[] = [];
+
+    for (const file of walk(resolve(ROOT, 'src'))) {
+      const text = readFileSync(file, 'utf8');
+      for (const variable of COMPONENT_SCOPED_EL_VARS) {
+        if (!text.includes(`var(${variable}`)) continue;
+        // A reference is legitimate only when the rule itself targets the
+        // owning component (`.el-card { … }` / `:deep(.el-card)`), because
+        // then the variable is in scope through the cascade.
+        const owner = variable.split('-').slice(0, 3).join('-').replace('--', '');
+        if (text.includes(`.${owner}`)) continue;
+        offenders.push(`${file.replace(`${ROOT}/`, '')} → var(${variable})`);
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('detects the failure it is meant to catch', () => {
+    // Sanity check on the matcher itself: a synthetic offender must trip it,
+    // otherwise a passing suite would prove nothing.
+    const synthetic = '.some-panel { border-radius: var(--el-card-border-radius); }';
+    const owner = '--el-card-border-radius'.split('-').slice(0, 3).join('-').replace('--', '');
+    expect(synthetic.includes('var(--el-card-border-radius')).toBe(true);
+    expect(synthetic.includes(`.${owner}`)).toBe(false);
+  });
+});
+
+describe('console layout contract', () => {
+  const layout = source('src/layouts/Console.vue');
+  const sidePanel = source('src/components/console/SidePanel.vue');
+
+  it('keeps the sidebar width in exactly one place', () => {
+    // The layout owns the value; SidePanel consumes it. Two hardcoded widths
+    // is what made the nav list overflow its container by 8px.
+    expect(layout).toMatch(/--console-side-width:\s*220px/);
+    expect(sidePanel).toMatch(/width:\s*var\(--console-side-width/);
+    expect(sidePanel).not.toMatch(/\$width:\s*\d+px/);
+    // A layout-side `.side { width }` would out-specify the component again.
+    expect(layout).not.toMatch(/\.side\s*{[^}]*width:\s*\d+px/);
+  });
+
+  it('contains nav rows structurally instead of relying on ancestor clipping', () => {
+    // Grid with a compressible text column cannot overflow; the old markup
+    // used a block row plus an indicator at `right: -5px`, i.e. 5px outside
+    // the sidebar, which only looked fine where an ancestor clipped it.
+    expect(sidePanel).toMatch(/grid-template-columns:\s*16px minmax\(0, 1fr\) auto/);
+    // Strip comments first — the rule below is about declarations, and the
+    // code comments legitimately quote the old `right: -5px` value.
+    const declarations = sidePanel.replace(/\/\/[^\n]*/g, '').replace(/\/\*[\s\S]*?\*\//g, '');
+    expect(declarations).not.toMatch(/right:\s*-\d+px/);
+    expect(sidePanel).toMatch(/&::after\s*{[\s\S]*?right:\s*0;/);
+  });
+
+  it('provides both page shapes from the layout', () => {
+    expect(layout).toMatch(/\.panel--document/);
+    expect(layout).toMatch(/\.panel--workspace/);
+    expect(layout).toMatch(/panelVariant/);
+  });
+
+  it('keeps workspace pages free of their own full-height wrapper', () => {
+    // These two pages used to inline an identical 40-line `.page-shell` block
+    // to fight `.panel`; the layout now supplies it via `meta.layout`.
+    for (const page of ['src/pages/console/connectors/Index.vue', 'src/pages/console/skills/Index.vue']) {
+      expect(source(page)).not.toContain('page-shell');
+    }
+    const routes = source('src/router/console.ts');
+    expect(routes).toMatch(/connectors[\s\S]*?meta:\s*{\s*layout:\s*'workspace'\s*}/);
+    expect(routes).toMatch(/skills[\s\S]*?meta:\s*{\s*layout:\s*'workspace'\s*}/);
+  });
+
+  it('shares one page header component across console pages', () => {
+    expect(source('src/pages/console/connectors/Index.vue')).toContain('console-page-header');
+    expect(source('src/pages/console/skills/Index.vue')).toContain('console-page-header');
+  });
+});

--- a/src/layouts/consoleLayout.test.ts
+++ b/src/layouts/consoleLayout.test.ts
@@ -89,6 +89,20 @@ describe('console layout contract', () => {
     expect(layout).toMatch(/panelVariant/);
   });
 
+  it('makes every console route declare its panel shape', () => {
+    const routes = source('src/router/console.ts');
+    // Every child page must pick a shape. Leaving it implicit is how the two
+    // page types drifted apart in the first place: a new page inherits
+    // whatever the default happens to be and nobody sees the choice. The
+    // parent `/console` record is excluded — it mounts the layout itself and
+    // renders no panel.
+    const children = routes.slice(routes.indexOf('children:'));
+    const entries = children.match(/{\s*path: '[^']*',[\s\S]*?component:/g) || [];
+    expect(entries.length).toBe(8);
+    const undeclared = entries.filter((entry) => !/meta:\s*(DOCUMENT|WORKSPACE)/.test(entry));
+    expect(undeclared).toEqual([]);
+  });
+
   it('keeps workspace pages free of their own full-height wrapper', () => {
     // These two pages used to inline an identical 40-line `.page-shell` block
     // to fight `.panel`; the layout now supplies it via `meta.layout`.
@@ -96,8 +110,8 @@ describe('console layout contract', () => {
       expect(source(page)).not.toContain('page-shell');
     }
     const routes = source('src/router/console.ts');
-    expect(routes).toMatch(/connectors[\s\S]*?meta:\s*{\s*layout:\s*'workspace'\s*}/);
-    expect(routes).toMatch(/skills[\s\S]*?meta:\s*{\s*layout:\s*'workspace'\s*}/);
+    expect(routes).toMatch(/connectors[\s\S]*?meta:\s*WORKSPACE/);
+    expect(routes).toMatch(/skills[\s\S]*?meta:\s*WORKSPACE/);
   });
 
   it('shares one page header component across console pages', () => {

--- a/src/pages/console/connectors/Index.vue
+++ b/src/pages/console/connectors/Index.vue
@@ -1,9 +1,9 @@
 <template>
-  <div class="page-shell">
-    <div class="page-heading">
-      <h2 class="page-title">{{ $t('connection.title.connections') }}</h2>
-      <p class="page-subtitle">{{ $t('connection.message.pageDescription') }}</p>
-    </div>
+  <div class="connectors-page">
+    <console-page-header
+      :title="$t('connection.title.connections')"
+      :subtitle="$t('connection.message.pageDescription')"
+    />
     <div class="connectors-shell">
       <!-- Left pane -->
       <aside class="connectors-list">
@@ -653,6 +653,7 @@ import {
 } from '@/operators/connection';
 import BrowseConnectors from '@/components/connections/BrowseConnectors.vue';
 import ByocCredentialsDialog from '@/components/connections/ByocCredentialsDialog.vue';
+import ConsolePageHeader from '@/components/console/PageHeader.vue';
 import ConnectorMethodPicker from '@/components/connections/ConnectorMethodPicker.vue';
 import BrowserPairingDialog from '@/components/browser/BrowserPairingDialog.vue';
 import BrowserDevicePicker from '@/components/browser/BrowserDevicePicker.vue';
@@ -806,6 +807,7 @@ interface IData {
 export default defineComponent({
   name: 'UserConnections',
   components: {
+    ConsolePageHeader,
     ElButton,
     ElTag,
     ElAvatar,
@@ -2042,40 +2044,11 @@ export default defineComponent({
 </script>
 
 <style lang="scss" scoped>
-// Inlined from AuthFrontend's <page-shell variant="workspace"> — the two-pane
-// layout needs a viewport-height flex column, which Console's scrolling
-// `.panel` doesn't give us.
-.page-shell {
-  height: 100%;
-  min-height: 0;
-  display: flex;
-  flex-direction: column;
-  box-sizing: border-box;
-}
-
-.page-heading {
-  margin-bottom: 16px;
-}
-
-.page-title {
-  font-size: 26px;
-  font-weight: 700;
-  color: var(--el-text-color-primary);
-  margin: 0;
-}
-
-.page-subtitle {
-  margin: 6px 0 0;
-  font-size: 13px;
-  color: var(--el-text-color-secondary);
-}
-
-@media screen and (max-width: 767px) {
-  // On phones let the page grow and scroll instead of trapping content
-  // inside a viewport-height flex column.
-  .page-shell {
-    height: auto;
-  }
+// The full-height flex column comes from the layout (`.panel--workspace`,
+// selected by this route's `meta.layout`), so the page only lays out its
+// own content.
+.connectors-page {
+  display: contents;
 }
 
 .connectors-shell {
@@ -2084,12 +2057,13 @@ export default defineComponent({
   display: grid;
   grid-template-columns: 300px 1fr;
   gap: 0;
-  // Match <el-card>, which every other console page uses: same border token,
-  // same 4px radius, same elevation. `--page-card-radius` used to be here —
-  // an AuthFrontend variable that doesn't exist in Nexior, so the frame
-  // silently rendered square.
-  border: 1px solid var(--el-card-border-color);
-  border-radius: var(--el-card-border-radius);
+  // `--adc-radius-card` / `--app-border-subtle` are global tokens (see
+  // @acedatacloud/core styles.css and _common.scss). The previous
+  // `--el-card-border-radius` was scoped *inside* Element Plus's `.el-card`
+  // rule, so this non-card element never inherited it and silently rendered
+  // square — same failure as the `--page-card-radius` it replaced.
+  border: 1px solid var(--app-border-subtle);
+  border-radius: var(--adc-radius-card);
   background: var(--el-card-bg-color);
   overflow: hidden;
   box-shadow: var(--app-shadow-xs);

--- a/src/pages/console/skills/Index.vue
+++ b/src/pages/console/skills/Index.vue
@@ -1,9 +1,6 @@
 <template>
-  <div class="page-shell">
-    <div class="page-heading">
-      <h2 class="page-title">{{ $t('skill.title.skills') }}</h2>
-      <p class="page-subtitle">{{ $t('skill.message.pageDescription') }}</p>
-    </div>
+  <div class="skills-page">
+    <console-page-header :title="$t('skill.title.skills')" :subtitle="$t('skill.message.pageDescription')" />
     <div class="skills-shell">
       <!-- Left pane: skill list -->
       <aside class="left-pane">
@@ -278,6 +275,7 @@ import {
 } from '@acedatacloud/core/icons/components';
 import { ISkill, skillOperator } from '@/operators/skill';
 import BrowseSkillsDialog from '@/components/skill/BrowseSkillsDialog.vue';
+import ConsolePageHeader from '@/components/console/PageHeader.vue';
 import SkillFilePreview from '@/components/skill/SkillFilePreview.vue';
 import SkillRow from '@/components/skill/SkillRow.vue';
 import UploadSkillDialog from '@/components/skill/UploadSkillDialog.vue';
@@ -306,6 +304,7 @@ interface IData {
 export default defineComponent({
   name: 'UserSkills',
   components: {
+    ConsolePageHeader,
     ElInput,
     ElSwitch,
     ElTag,
@@ -532,49 +531,23 @@ export default defineComponent({
 </script>
 
 <style scoped>
-/* Inlined from AuthFrontend's <page-shell variant="workspace"> — the two-pane
-   layout needs a viewport-height flex column, which Console's scrolling
-   `.panel` doesn't provide. */
-.page-shell {
-  height: 100%;
-  min-height: 0;
-  display: flex;
-  flex-direction: column;
-  box-sizing: border-box;
-}
-
-.page-heading {
-  margin-bottom: 16px;
-}
-
-.page-title {
-  font-size: 26px;
-  font-weight: 700;
-  color: var(--el-text-color-primary);
-  margin: 0;
-}
-
-.page-subtitle {
-  margin: 6px 0 0;
-  font-size: 13px;
-  color: var(--el-text-color-secondary);
-}
-
-@media screen and (max-width: 767px) {
-  .page-shell {
-    height: auto;
-  }
+/* The full-height flex column comes from the layout (`.panel--workspace`,
+   selected by this route's `meta.layout`), so the page only lays out its
+   own content. */
+.skills-page {
+  display: contents;
 }
 
 .skills-shell {
   flex: 1 1 auto;
   min-height: 0;
   display: flex;
-  /* Match <el-card>, which every other console page uses. `--page-card-radius`
-     used to be here — an AuthFrontend variable that doesn't exist in Nexior,
-     so the frame silently rendered square. */
-  border: 1px solid var(--el-card-border-color);
-  border-radius: var(--el-card-border-radius);
+  /* `--adc-radius-card` / `--app-border-subtle` are global tokens. The
+     previous `--el-card-border-radius` was scoped inside Element Plus's
+     `.el-card` rule, so this non-card element never inherited it and
+     silently rendered square. */
+  border: 1px solid var(--app-border-subtle);
+  border-radius: var(--adc-radius-card);
   background: var(--el-card-bg-color);
   overflow: hidden;
   box-shadow: var(--app-shadow-xs);

--- a/src/router/console.ts
+++ b/src/router/console.ts
@@ -10,6 +10,15 @@ import {
   ROUTE_CONSOLE_USAGE_LIST
 } from './constants';
 
+// Which shape of `.panel` the layout gives a page. There is no single mode
+// that serves both: `document` lets the panel scroll (a workspace page would
+// then stretch to its content and its panes would never scroll), while
+// `workspace` clips the panel so each pane scrolls itself (a document page
+// would then have unreachable overflow). Every route states its own, so
+// adding a page is a deliberate choice rather than an inherited default.
+const DOCUMENT = { layout: 'document' };
+const WORKSPACE = { layout: 'workspace' };
+
 export default {
   path: '/console',
   meta: {
@@ -27,31 +36,37 @@ export default {
     {
       path: 'orders',
       name: ROUTE_CONSOLE_ORDER_LIST,
+      meta: DOCUMENT,
       component: () => import('@/pages/console/order/List.vue')
     },
     {
       path: 'orders/:id',
       name: ROUTE_CONSOLE_ORDER_DETAIL,
+      meta: DOCUMENT,
       component: () => import('@/pages/console/order/Detail.vue')
     },
     {
       path: 'applications',
       name: ROUTE_CONSOLE_APPLICATION_LIST,
+      meta: DOCUMENT,
       component: () => import('@/pages/console/application/List.vue')
     },
     {
       path: 'applications/:id/extra',
       name: ROUTE_CONSOLE_APPLICATION_EXTRA,
+      meta: DOCUMENT,
       component: () => import('@/pages/console/application/Extra.vue')
     },
     {
       path: 'applications/:id/subscribe',
       name: ROUTE_CONSOLE_APPLICATION_SUBSCRIBE,
+      meta: DOCUMENT,
       component: () => import('@/pages/console/application/Subscribe.vue')
     },
     {
       path: 'usages',
       name: ROUTE_CONSOLE_USAGE_LIST,
+      meta: DOCUMENT,
       component: () => import('@/pages/console/usage/List.vue')
     },
     // Connector management, ported from auth.acedata.cloud/user/connections.
@@ -61,7 +76,7 @@ export default {
     {
       path: 'connectors',
       name: ROUTE_CONSOLE_CONNECTORS,
-      meta: { layout: 'workspace' },
+      meta: WORKSPACE,
       component: () => import('@/pages/console/connectors/Index.vue')
     },
     // Agent Skills, same deal — ported UI, same flag, AuthFrontend's page
@@ -69,7 +84,7 @@ export default {
     {
       path: 'skills',
       name: ROUTE_CONSOLE_SKILLS,
-      meta: { layout: 'workspace' },
+      meta: WORKSPACE,
       component: () => import('@/pages/console/skills/Index.vue')
     }
   ]

--- a/src/router/console.ts
+++ b/src/router/console.ts
@@ -61,6 +61,7 @@ export default {
     {
       path: 'connectors',
       name: ROUTE_CONSOLE_CONNECTORS,
+      meta: { layout: 'workspace' },
       component: () => import('@/pages/console/connectors/Index.vue')
     },
     // Agent Skills, same deal — ported UI, same flag, AuthFrontend's page
@@ -68,6 +69,7 @@ export default {
     {
       path: 'skills',
       name: ROUTE_CONSOLE_SKILLS,
+      meta: { layout: 'workspace' },
       component: () => import('@/pages/console/skills/Index.vue')
     }
   ]


### PR DESCRIPTION
## 背景

Studio 控制台的连接器页迁移过来后，暴露出三个症状：侧栏菜单溢出、右侧面板直角、五个页面「实现不对等」。

排查后发现三者是**同一类根因**：同一个盒子的尺寸/形态由多个文件各写一半，没有单一事实源。

## 根因（均经编译产物与真实浏览器测量验证）

### 1. 侧栏宽度被双重声明，高特异性的一方静默获胜

| 来源 | 编译后选择器 | 特异性 | 声明 |
|---|---|---|---|
| `SidePanel.vue` | `.side[data-v-…]` | (0,2,0) | `width: 220px` |
| `Console.vue` | `.console .main .side[data-v-…]` | **(0,4,0)** | `width: 200px` ← 覆盖 |

SidePanel 按 220px 算出 `.links: 208px`，运行时容器却是 200px，且缺 `box-sizing`（实际盒宽 212px），再叠加指示条 `right: -5px`。**无头浏览器实测溢出 20px。**

### 2. 溢出一直存在，只是此前被裁掉了

`.panel` 编译后带 `overflow-x: hidden`，而 `class="panel"` 是 `<router-view>` 透传给**页面根元素**的：

| 页面 | 根元素 | 结果 |
|---|---|---|
| 订单 / 申请 / 使用历史 | `<el-row>` | `.panel` 生效 → 溢出被裁 → 高亮块被削平、指示条不可见 |
| 连接器 / 技能 | 自建 `.page-shell`（`height:100%; display:flex`）| 另起布局上下文 → 溢出显形 |

**与标签长短无关**，取决于根元素类型。前三页是"被裁得看不见"，不是"没有 bug"。

### 3. 圆角/边框失效 —— 同一失败模式的第二次

```css
/* Element Plus */
.el-card{--el-card-border-color:…;--el-card-border-radius:4px;…}
```

这两个变量定义在 **`.el-card` 规则内部**，不在 `:root`（EP 的 `index.css` 与 `dark/css-vars.css` 均已 grep 确认）。`.connectors-shell` 不是 el-card 后代 → `border-radius` 回退 `0`（直角）、`border-color` 回退 `currentColor`（边框偏亮）。

这与它所替换的 `--page-card-radius` 是**完全相同的失败模式** —— 换了个名字的同一个坑。

### 4. 两套滚动模型在同一容器里对抗

layout 契约是「layout 负责滚动、页面往下长」。连接器/技能需要双栏各自滚动，于是**各自内联一份 40 行 `.page-shell`** 去对抗 `.panel`（两文件逐字重复）。

## 改动

1. **侧栏宽度单一事实源** —— layout 定义 `--console-side-width: 220px`，SidePanel 读取；删除 layout 侧的桌面 `.side` 宽度规则；补 `box-sizing: border-box`。
2. **菜单项结构性防溢出** —— 改用 `grid-template-columns: 16px minmax(0,1fr) auto`（参考 PlatformFrontend），文字列可压缩；指示条从盒外 `right:-5px` 移入盒内 `::after{right:0}`。
3. **圆角/边框改用真实全局 token** —— `--adc-radius-card` / `--adc-radius-control` / `--app-border-subtle`（4 处）。
4. **layout 提供两种页面形态** —— 路由 `meta.layout` 选择 `.panel--document` / `.panel--workspace`；页头抽为 `<console-page-header>`；删除两份重复的 `page-shell`。
5. **顺带修复组件撞名** —— SidePanel 的 `name` 原本是 `'Navigator'`，与 `common/Navigator.vue` 同名且被同一 layout 同时注册，改为 `'ConsoleSidePanel'`。

未新建 `_console.scss`：共享的东西放进 layout 与组件即可。

## 验证

**关键验收项：移除 `.panel` 的 `overflow-x:hidden` 后侧栏是否仍不溢出** —— 用于区分「真修好」与「换个姿势掩盖」。以无头浏览器测量真实几何：

```
新实现  clip=ON   side.width=220  overflow=0px   OK
新实现  clip=OFF  side.width=220  overflow=0px   OK   ← 含超长测试标签
旧实现  clip=ON   side.width=212  overflow=20px  FAIL
旧实现  clip=OFF  side.width=212  overflow=20px  FAIL ← 探针确实能抓到原 bug
```

- `src/layouts/consoleLayout.test.ts` 新增守卫：CSS 变量作用域检查（含对匹配器自身的 sanity check）+ 上述四项契约
- `npx vue-tsc -b` 通过（CI 用的是 `-b`）
- `npx eslint` 改动文件全部干净
- **1020 项单测全通过**（120 个测试文件），生产构建成功
- 编译产物确认：桌面段 `.side` 只剩一条宽度规则

无新增 i18n key。

🤖 Generated with [Claude Code](https://claude.com/claude-code)