### PR TITLE
refactor(connectors): 授权 popup 只等窗口关闭，自定义 MCP 也走 popup

### DIFF
--- a/change/@acedatacloud-nexior-5728554d-9739-446d-bada-f530f8bf88bc.json
+++ b/change/@acedatacloud-nexior-5728554d-9739-446d-bada-f530f8bf88bc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "connectors: the authorization popup now closes itself on every outcome, including custom MCP servers, instead of leaving a window open that has to be dismissed by hand",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/pages/console/connectors/Index.vue
+++ b/src/pages/console/connectors/Index.vue
@@ -1677,9 +1677,8 @@ export default defineComponent({
     /**
      * Run the consent flow in a popup so this page keeps its state, then
      * refresh. Falls back to a full-page navigation when the popup is
-     * blocked. We refetch on every outcome — including a manually closed
-     * popup — because the connection may have landed server-side even if
-     * we never got the message.
+     * blocked. We refetch on every outcome — the popup closing is all we
+     * learn, so the server is the authority on what actually connected.
      */
     async runAuthorizePopup(authorizationUrl: string) {
       const pending = openAuthorizePopup(authorizationUrl);
@@ -1823,15 +1822,11 @@ export default defineComponent({
           client_id: this.customClientId || undefined,
           client_secret: this.customClientSecret || undefined,
           provider: 'mcp',
-          // Custom MCP (DCR) returns through AuthFrontend's
-          // /user/connections/callback, which does the token exchange
-          // client-side before honouring return_url — a different flow from
-          // the preset-provider popup. Keep it on the full-page path until
-          // that callback learns to emit the popup message too.
-          return_url: window.location.href
+          return_url: popupReturnUrl()
         });
         if (data?.authorization_url) {
-          window.location.href = data.authorization_url;
+          this.customDialogVisible = false;
+          await this.runAuthorizePopup(data.authorization_url);
         }
       } catch (error: any) {
         ElMessage.error(error?.response?.data?.detail || error?.message || 'Failed to start authorization');

--- a/src/utils/connections/authorizePopup.test.ts
+++ b/src/utils/connections/authorizePopup.test.ts
@@ -5,11 +5,14 @@ import { openAuthorizePopup, popupReturnUrl } from './authorizePopup';
 const AUTH_ORIGIN = 'https://auth.acedata.cloud';
 
 describe('popupReturnUrl', () => {
-  it('points at the AuthFrontend lander and carries our origin', () => {
+  it('points at the AuthFrontend lander', () => {
     const url = new URL(popupReturnUrl());
     expect(url.origin).toBe(AUTH_ORIGIN);
     expect(url.pathname).toBe('/connections/popup-return');
-    expect(url.searchParams.get('opener_origin')).toBe(window.location.origin);
+  });
+
+  it('carries no opener origin — nothing is posted back', () => {
+    expect(new URL(popupReturnUrl()).search).toBe('');
   });
 });
 
@@ -32,30 +35,42 @@ describe('openAuthorizePopup', () => {
     expect(openAuthorizePopup('https://provider.example/authorize')).toBeNull();
   });
 
-  it('resolves with the payload posted by the lander', async () => {
+  it('resolves once the popup closes', async () => {
     const popup = fakePopup();
     openSpy = vi.spyOn(window, 'open').mockReturnValue(popup as unknown as Window);
 
     const pending = openAuthorizePopup('https://provider.example/authorize');
     expect(pending).not.toBeNull();
 
-    window.dispatchEvent(
-      new MessageEvent('message', {
-        origin: AUTH_ORIGIN,
-        source: popup as unknown as Window,
-        data: { name: 'connection-result', data: { status: 'success', connection_id: 'c1' } }
-      })
-    );
-
-    await expect(pending).resolves.toEqual({ status: 'success', connection_id: 'c1' });
-    expect(popup.close).toHaveBeenCalled();
+    popup.closed = true;
+    await vi.advanceTimersByTimeAsync(600);
+    await expect(pending).resolves.toBeUndefined();
   });
 
-  it('ignores messages from another origin', async () => {
+  it('stays pending while the popup is still open', async () => {
     const popup = fakePopup();
     openSpy = vi.spyOn(window, 'open').mockReturnValue(popup as unknown as Window);
 
     const pending = openAuthorizePopup('https://provider.example/authorize');
+    let settled = false;
+    void pending?.then(() => {
+      settled = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(settled).toBe(false);
+  });
+
+  it('is not settled by a message — a spoofed one must not end the flow early', async () => {
+    const popup = fakePopup();
+    openSpy = vi.spyOn(window, 'open').mockReturnValue(popup as unknown as Window);
+
+    const pending = openAuthorizePopup('https://provider.example/authorize');
+    let settled = false;
+    void pending?.then(() => {
+      settled = true;
+    });
+
     window.dispatchEvent(
       new MessageEvent('message', {
         origin: 'https://evil.com',
@@ -64,37 +79,7 @@ describe('openAuthorizePopup', () => {
       })
     );
 
-    // Not settled by the spoofed message — only the popup closing ends it.
-    popup.closed = true;
     await vi.advanceTimersByTimeAsync(600);
-    await expect(pending).resolves.toBeNull();
-  });
-
-  it('ignores messages from a different window on the trusted origin', async () => {
-    const popup = fakePopup();
-    openSpy = vi.spyOn(window, 'open').mockReturnValue(popup as unknown as Window);
-
-    const pending = openAuthorizePopup('https://provider.example/authorize');
-    window.dispatchEvent(
-      new MessageEvent('message', {
-        origin: AUTH_ORIGIN,
-        source: { other: true } as unknown as Window,
-        data: { name: 'connection-result', data: { status: 'success', connection_id: 'stolen' } }
-      })
-    );
-
-    popup.closed = true;
-    await vi.advanceTimersByTimeAsync(600);
-    await expect(pending).resolves.toBeNull();
-  });
-
-  it('resolves null when the user closes the popup without authorizing', async () => {
-    const popup = fakePopup();
-    openSpy = vi.spyOn(window, 'open').mockReturnValue(popup as unknown as Window);
-
-    const pending = openAuthorizePopup('https://provider.example/authorize');
-    popup.closed = true;
-    await vi.advanceTimersByTimeAsync(600);
-    await expect(pending).resolves.toBeNull();
+    expect(settled).toBe(false);
   });
 });

--- a/src/utils/connections/authorizePopup.ts
+++ b/src/utils/connections/authorizePopup.ts
@@ -4,83 +4,48 @@
  * `auth.acedata.cloud` stays the OAuth broker and credential vault — this
  * only changes *how the result gets back to Studio*. Instead of navigating
  * the whole tab (which drops chat drafts and in-memory state), we open the
- * provider consent flow in a popup and wait for AuthFrontend's
- * `/connections/popup-return` landing page to postMessage the outcome back.
+ * provider consent flow in a popup and wait for it to close.
+ *
+ * We watch `popup.closed` rather than listening for a message, because that
+ * is the one signal every outcome produces — consent granted, consent
+ * denied, token exchange failed, user gave up — and observing it needs no
+ * cooperation from the popup and no cross-origin trust. AuthFrontend's
+ * `/connections/popup-return` is the single exit every terminal state lands
+ * on, and it closes itself. The server is the authority on what connected,
+ * so callers refetch instead of reading a posted payload.
  *
  * Degradations, in order:
  *  - popup blocked (`window.open` → null) → fall back to a full-page
  *    navigation with the original `return_url`, i.e. today's behaviour;
- *  - user closes the popup manually → the `closed` poll resolves so callers
- *    can refresh rather than hang;
- *  - message never arrives → callers still refresh on resolve, and the
- *    connection landed server-side regardless.
+ *  - the lander can't `close()` (some browsers refuse it after a
+ *    cross-origin navigation) → the user closes it and the poll fires.
  */
 
 import { getBaseUrlAuth } from '../baseUrl';
 
-export interface IConnectionPopupResult {
-  status: string;
-  provider?: string;
-  connection_id?: string;
-  connector?: string;
-  consent?: string;
-}
-
 /** Where AuthBackend should 302 once the OAuth round-trip finishes. */
 export function popupReturnUrl(): string {
-  const url = new URL('/connections/popup-return', getBaseUrlAuth());
-  url.searchParams.set('opener_origin', window.location.origin);
-  return url.toString();
+  return new URL('/connections/popup-return', getBaseUrlAuth()).toString();
 }
 
 const POPUP_FEATURES = 'popup=yes,width=600,height=760,noopener=no,noreferrer=no';
 
 /**
- * Open `authorizationUrl` in a popup and resolve once the flow ends.
+ * Open `authorizationUrl` in a popup and resolve once it closes.
  *
- * Resolves with the posted result, or `null` when the popup was blocked
- * (caller should fall back to a full-page redirect) or closed without a
- * message (caller should just refetch — the connect may still have
- * succeeded).
+ * Returns `null` when the popup was blocked, so the caller can fall back to
+ * a full-page redirect. Otherwise the promise resolves when the flow ends,
+ * whatever the outcome — callers refetch rather than branch on it.
  */
-export function openAuthorizePopup(authorizationUrl: string): Promise<IConnectionPopupResult | null> | null {
+export function openAuthorizePopup(authorizationUrl: string): Promise<void> | null {
   const popup = window.open(authorizationUrl, 'acedata-connect', POPUP_FEATURES);
   if (!popup) return null;
 
-  const authOrigin = new URL(getBaseUrlAuth()).origin;
-
-  return new Promise<IConnectionPopupResult | null>((resolve) => {
-    let settled = false;
-
-    const finish = (result: IConnectionPopupResult | null) => {
-      if (settled) return;
-      settled = true;
-      window.removeEventListener('message', onMessage);
-      window.clearInterval(timer);
-      resolve(result);
-    };
-
-    // Validate BOTH the origin and the sending window — origin alone would
-    // let any other frame from auth.acedata.cloud speak for the popup.
-    const onMessage = (event: MessageEvent) => {
-      if (event.origin !== authOrigin) return;
-      if (event.source !== popup) return;
-      const payload = event.data as { name?: string; data?: IConnectionPopupResult };
-      if (!payload || payload.name !== 'connection-result') return;
-      finish(payload.data ?? { status: 'success' });
-      try {
-        popup.close();
-      } catch {
-        // already gone / cross-origin — the landing page closes itself
-      }
-    };
-
-    window.addEventListener('message', onMessage);
-
-    // The popup can be dismissed by the user at any point; without this the
-    // promise would never settle and the caller's spinner would stick.
+  return new Promise<void>((resolve) => {
     const timer = window.setInterval(() => {
-      if (popup.closed) finish(null);
+      if (!popup.closed) return;
+      window.clearInterval(timer);
+      resolve();
     }, 500);
   });
 }


### PR DESCRIPTION
配套 AuthBackend https://github.com/AceDataCloud/AuthBackend/pull/397 · AuthFrontend https://github.com/AceDataCloud/AuthFrontend/pull/252

## 问题

连接 DCR 类连接器（自定义 MCP）后，授权 popup 停在「连接完成，正在返回…／可以关闭此窗口」不自动关闭。连接本身是成功的。

## 根因不在这个仓库，但修法在

落地页要不要关窗，取决于 postMessage 投递成没投递成，而投递需要后端签发的 token —— DCR 回调路径从不签。补签名不是正解，因为**这个 payload 我们根本没在用**：

```ts
await pending;                    // 返回值直接丢弃
await this.fetchConnections();    // 真正做事的是这行
```

`Index.vue:1690` 和 `BrowseConnectors.vue:557` 都是这个形状。主窗口需要的只有一个 bit：「结束了，去刷新」。

而 `openAuthorizePopup` 里那条被当成兜底的 `popup.closed` 轮询，其实是**唯一一条对所有终态都成立的路径** —— 窗口关没关是 opener 自己就能观测的事实，不需要 popup 配合、不涉及跨域信任。原来的主路径 postMessage 六种终态只有一种能触发。

所以把主次颠倒过来。

## 改动

- 删 postMessage 监听、`IConnectionPopupResult`、`popupReturnUrl()` 里的 `opener_origin` 参数
- 返回类型从 `Promise<IConnectionPopupResult | null> | null` 收窄为 `Promise<void> | null`，语义就是「结束了」（`null` 仍表示 popup 被拦、调用方降级全页跳转）
- **`onConnectCustom` 撤销全页跳转豁免**：那条注释说的「等 callback 学会发 popup 消息再改」已不适用 —— 落地页现在无条件自关，不需要「学会发消息」。手填 MCP 服务器不再刷掉整个 Studio 页面、丢失聊天草稿

## 测试

`authorizePopup.test.ts` 6 passed。原来验证「消息投递 / 拒绝伪造 origin / 拒绝其他窗口」的三个用例，替换为验证新契约：
- 关窗才 resolve
- 窗口还开着就一直 pending
- **消息不再能提前结束流程**（保留一个伪造 `connection-result` 的用例，断言它不 settle —— 这条防的是「有人把监听加回来」）

`vue-tsc -b` 通过，eslint 干净。

## 已知未覆盖

原生端（iOS / Android / Electron）的连接器授权是**另一个已经存在的问题**：三端都没有 popup 语义，`window.open()` 各自以不同方式失败，与本次重构无关也不因它变差。已单独调研，另行跟进。

本 PR 只处理 web。

🤖 Generated with [Claude Code](https://claude.com/claude-code)