### PR TITLE
fix(chat): 工作目录入口移到输入框下方

### DIFF
--- a/change/@acedatacloud-nexior-ef3ee96a-158f-4d64-a957-f26d0a2c2d2c.json
+++ b/change/@acedatacloud-nexior-ef3ee96a-158f-4d64-a957-f26d0a2c2d2c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(chat): 工作目录入口移到输入框下方，改为低调的页脚样式",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/chat/WorkingDirectoryBar.test.ts
+++ b/src/components/chat/WorkingDirectoryBar.test.ts
@@ -67,13 +67,22 @@ describe('WorkingDirectoryBar', () => {
     bridge.value = makeBridge();
     const { wrapper } = mountBar('');
     expect(wrapper.text()).toContain('chat.workingDir.choose');
-    expect(wrapper.find('.working-dir-pill').exists()).toBe(false);
+    expect(wrapper.find('.working-dir-link').exists()).toBe(false);
   });
 
-  it('shows the chosen directory as a pill', () => {
+  it('shows the chosen directory as a quiet footer link', () => {
     bridge.value = makeBridge();
     const { wrapper } = mountBar('/Users/me/proj');
-    expect(wrapper.find('.working-dir-pill').exists()).toBe(true);
+    expect(wrapper.find('.working-dir-link').exists()).toBe(true);
+  });
+
+  // Placement: the chosen state is absolutely positioned so a long path can
+  // never push the centered disclaimer off-center; the call-to-action state
+  // stays in flow so the button doesn't overlap it.
+  it('only takes the row out of flow once a directory is chosen', () => {
+    bridge.value = makeBridge();
+    expect(mountBar('').wrapper.find('.working-dir').classes()).toContain('working-dir--unset');
+    expect(mountBar('/Users/me/proj').wrapper.find('.working-dir').classes()).not.toContain('working-dir--unset');
   });
 
   it('shortens a deep path so it cannot dominate the composer row', () => {

--- a/src/components/chat/WorkingDirectoryBar.vue
+++ b/src/components/chat/WorkingDirectoryBar.vue
@@ -2,15 +2,21 @@
   <!-- The conversation's working directory — the project the AI operates in.
        Desktop only; renders nothing everywhere else. Two states:
          • not chosen  → a call to action; the composer is disabled until it is
-         • chosen      → a compact pill that switches project on click
+         • chosen      → a quiet footer link that switches project on click
        Self-contained + placement-agnostic, like <connector-strip>. -->
-  <div v-if="supported" class="working-dir">
+  <div v-if="supported" class="working-dir" :class="{ 'working-dir--unset': !workingDirectory }">
     <el-button v-if="!workingDirectory" size="small" type="primary" :loading="picking" @click="onPick">
       <folder-icon :size="'1em' as any" aria-hidden="true" focusable="false" />
       {{ $t('chat.workingDir.choose') }}
     </el-button>
-    <el-tooltip v-else effect="dark" :content="$t('chat.workingDir.switchHint')" placement="top">
-      <span class="working-dir-pill" role="button" tabindex="0" @click="onPick" @keydown.enter="onPick">
+    <el-tooltip v-else effect="dark" placement="top">
+      <template #content>
+        <div class="working-dir-tip">
+          <div>{{ workingDirectory }}</div>
+          <div class="working-dir-tip__hint">{{ $t('chat.workingDir.switchHint') }}</div>
+        </div>
+      </template>
+      <span class="working-dir-link" role="button" tabindex="0" @click="onPick" @keydown.enter="onPick">
         <folder-icon :size="'1em' as any" aria-hidden="true" focusable="false" />
         <span class="working-dir-path">{{ displayPath }}</span>
       </span>
@@ -103,20 +109,37 @@ export default defineComponent({
 .working-dir {
   display: flex;
   align-items: center;
+  // Sits in the composer's footer row, left of the centered disclaimer.
+  // Absolute so a long path can never shove the disclaimer off-center.
+  position: absolute;
+  left: 0;
+  max-width: 45%;
 }
-.working-dir-pill {
+// The call-to-action state is a full button, not a text chip. Keeping it in
+// normal flow lets it share the row with the disclaimer instead of overlapping
+// it; the row is centered, so the two sit together under the composer.
+.working-dir--unset {
+  position: static;
+  max-width: none;
+}
+.working-dir-tip__hint {
+  margin-top: 2px;
+  opacity: 0.7;
+}
+// Deliberately understated: this is ambient status, not an action to draw the
+// eye. Matches the disclaimer's size/color so the footer reads as one line.
+.working-dir-link {
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  max-width: 320px;
-  padding: 2px 8px;
-  border-radius: 999px;
+  min-width: 0;
   font-size: 12px;
-  color: var(--el-text-color-regular);
-  background: var(--el-fill-color-light);
+  color: var(--el-text-color-secondary);
   cursor: pointer;
-  &:hover {
-    background: var(--el-fill-color);
+  transition: color 0.15s;
+  &:hover,
+  &:focus-visible {
+    color: var(--el-text-color-regular);
   }
 }
 .working-dir-path {

--- a/src/pages/chat/Conversation.vue
+++ b/src/pages/chat/Conversation.vue
@@ -85,10 +85,7 @@
           />
         </div>
         <div class="starter">
-          <div class="composer-connectors">
-            <working-directory-bar />
-            <connector-strip />
-          </div>
+          <div class="composer-connectors"><connector-strip /></div>
           <composer
             v-model:question="question"
             :answering="answering"
@@ -98,7 +95,10 @@
             @submit="onSubmit"
             @stop="onStop"
           />
-          <disclaimer class="composer-disclaimer" />
+          <div class="composer-footer">
+            <working-directory-bar />
+            <disclaimer class="composer-disclaimer" />
+          </div>
         </div>
       </div>
     </template>
@@ -1692,6 +1692,21 @@ export default defineComponent({
       display: none;
     }
   }
+  // Footer row under the composer: working directory on the left, disclaimer
+  // centered. The disclaimer stays optically centered on the composer because
+  // it is the flex item that grows; the directory chip is absolutely
+  // positioned so its width can't push the text off-center.
+  .composer-footer {
+    position: relative;
+    width: 100%;
+    max-width: 800px;
+    margin: 8px auto 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 20px;
+    gap: 8px;
+  }
   .composer-disclaimer {
     width: 100%;
     max-width: 800px;
@@ -1699,6 +1714,10 @@ export default defineComponent({
     text-align: center;
     font-size: 12px;
     color: var(--el-text-color-secondary);
+  }
+  // Inside the footer the outer margin/width are already applied by the row.
+  .composer-footer .composer-disclaimer {
+    margin: 0;
   }
   &.empty {
     position: relative;


### PR DESCRIPTION
## 问题

工作目录入口原先和一排圆形连接器图标挤在输入框**上方**同一行：一个是带底色的方角胶囊，旁边是一堆圆形头像，形状和语义都不搭，视觉上很突兀。

![before](https://github.com/user-attachments/assets/placeholder)

## 改动

- **位置**：移到输入框**下方**，与免责声明同一行。
- **样式**：由带底色的胶囊改为**与免责声明同字号（12px）同颜色**的纯文本链接 —— 这是环境状态而非需要吸引注意的操作，不该比正文更抢眼。hover 时才提亮。
- **布局稳定性**：已选状态**绝对定位**，因此再长的路径也不会把居中的免责声明挤偏；未选状态是个完整按钮，保持在正常流里与免责声明并排，避免重叠。
- **tooltip**：改为显示**完整路径** + 切换提示。标签本身是截断的（`…/nested/proj`），原先只提示"点击切换"没有信息量。

行为完全不变：门禁逻辑、保存顺序、自动授权都没动。

## 测试

`WorkingDirectoryBar.test.ts` 新增 1 例锁定布局契约（只有已选状态脱离文档流），其余更新为新的类名。

```
src/ 全量：Test Files 109 passed | Tests 857 passed
vue-tsc -b 通过
```

## 说明

接续已合并的 #1478 / #1479。**暂不合并**，等你看过效果。

🤖 Generated with [Claude Code](https://claude.com/claude-code)