### PR TITLE
fix(coding-bridge): 手机端把次要控件收进「⋯」

### DIFF
--- a/change/@acedatacloud-nexior-666fb1ef-4adc-477d-8990-4b2eaea91aac.json
+++ b/change/@acedatacloud-nexior-666fb1ef-4adc-477d-8990-4b2eaea91aac.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "coding bridge: collapse the secondary composer controls behind a compact toggle on mobile so only the backend picker stays on the main row",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/codingBridge/SessionView.vue
+++ b/src/components/codingBridge/SessionView.vue
@@ -263,7 +263,7 @@
               <span ref="attachmentUploadTrigger" class="block h-0 w-0" aria-hidden="true"></span>
             </el-upload>
 
-            <div class="mt-1.5 flex items-center gap-1.5">
+            <div class="cb-actions mt-1.5 flex items-center gap-1.5">
               <button
                 type="button"
                 class="cb-icon-btn"
@@ -274,7 +274,7 @@
                 <attachment-icon :size="'1em' as any" aria-hidden="true" focusable="false" />
               </button>
 
-              <div class="flex min-w-0 flex-1 flex-wrap items-center gap-1.5">
+              <div class="cb-pills flex min-w-0 flex-1 flex-wrap items-center gap-1.5">
                 <!-- Provider is chosen at start and locked once a session is running. -->
                 <el-dropdown v-if="isNewSession" trigger="click" @command="provider = $event">
                   <button type="button" class="cb-pill">
@@ -338,139 +338,98 @@
                   <span class="truncate">{{ providerName(currentSession?.provider || 'claude') }}</span>
                 </span>
 
-                <!-- Model can be switched any time, including mid-session. -->
-                <el-popover ref="modelPopover" trigger="click" placement="top-start" :width="260">
-                  <template #reference>
-                    <button type="button" class="cb-pill">
-                      <ai-icon class="cb-pill__icon" :size="'1em' as any" aria-hidden="true" focusable="false" />
-                      <span class="truncate">{{ model || $t('codingBridge.session.modelDefault') }}</span>
-                      <expand-down-icon
-                        class="cb-pill__caret"
-                        :size="'1em' as any"
-                        aria-hidden="true"
-                        focusable="false"
-                      />
-                    </button>
-                  </template>
-                  <div class="cb-model-menu">
-                    <button type="button" class="cb-model-option" @click="selectModel('')">
-                      <confirm-icon
-                        class="cb-model-option__check"
-                        :class="!model ? 'opacity-100' : 'opacity-0'"
-                        :size="'1em' as any"
-                        aria-hidden="true"
-                        focusable="false"
-                      />
-                      <span class="truncate">{{ $t('codingBridge.session.modelDefault') }}</span>
-                    </button>
-                    <button
-                      v-for="opt in modelOptions"
-                      :key="opt.value"
-                      type="button"
-                      class="cb-model-option"
-                      @click="selectModel(opt.value)"
-                    >
-                      <confirm-icon
-                        class="cb-model-option__check"
-                        :class="opt.value === model ? 'opacity-100' : 'opacity-0'"
-                        :size="'1em' as any"
-                        aria-hidden="true"
-                        focusable="false"
-                      />
-                      <span class="truncate">{{ opt.label }}</span>
-                    </button>
-                    <div v-if="allowCustomModel" class="cb-model-custom">
-                      <el-input
-                        v-model="customModelDraft"
-                        size="small"
-                        :placeholder="$t('codingBridge.session.modelPlaceholder')"
-                        @keyup.enter="applyCustomModel"
+                <!-- Secondary controls. On a phone the composer row can't hold
+                     five pills, so they collapse behind one "…" toggle and drop
+                     onto their own line; `display: contents` on desktop keeps
+                     them inline exactly as before. -->
+                <button
+                  type="button"
+                  class="cb-icon-btn cb-more-btn"
+                  :class="{ 'cb-more-btn--open': moreOpen }"
+                  :title="$t('codingBridge.session.settings')"
+                  :aria-label="$t('codingBridge.session.settings')"
+                  :aria-expanded="moreOpen"
+                  @click="moreOpen = !moreOpen"
+                >
+                  <more-icon :size="'1em' as any" aria-hidden="true" focusable="false" />
+                </button>
+
+                <div class="cb-more" :class="{ 'cb-more--open': moreOpen }">
+                  <!-- Model can be switched any time, including mid-session. -->
+                  <el-popover ref="modelPopover" trigger="click" placement="top-start" :width="260">
+                    <template #reference>
+                      <button type="button" class="cb-pill">
+                        <ai-icon class="cb-pill__icon" :size="'1em' as any" aria-hidden="true" focusable="false" />
+                        <span class="truncate">{{ model || $t('codingBridge.session.modelDefault') }}</span>
+                        <expand-down-icon
+                          class="cb-pill__caret"
+                          :size="'1em' as any"
+                          aria-hidden="true"
+                          focusable="false"
+                        />
+                      </button>
+                    </template>
+                    <div class="cb-model-menu">
+                      <button type="button" class="cb-model-option" @click="selectModel('')">
+                        <confirm-icon
+                          class="cb-model-option__check"
+                          :class="!model ? 'opacity-100' : 'opacity-0'"
+                          :size="'1em' as any"
+                          aria-hidden="true"
+                          focusable="false"
+                        />
+                        <span class="truncate">{{ $t('codingBridge.session.modelDefault') }}</span>
+                      </button>
+                      <button
+                        v-for="opt in modelOptions"
+                        :key="opt.value"
+                        type="button"
+                        class="cb-model-option"
+                        @click="selectModel(opt.value)"
                       >
-                        <template #append>
-                          <el-button
-                            :disabled="!customModelDraft.trim()"
-                            :aria-label="$t('common.button.confirm')"
-                            :title="$t('common.button.confirm')"
-                            @click="applyCustomModel"
-                          >
-                            <confirm-icon :size="'1em' as any" aria-hidden="true" focusable="false" />
-                          </el-button>
-                        </template>
-                      </el-input>
+                        <confirm-icon
+                          class="cb-model-option__check"
+                          :class="opt.value === model ? 'opacity-100' : 'opacity-0'"
+                          :size="'1em' as any"
+                          aria-hidden="true"
+                          focusable="false"
+                        />
+                        <span class="truncate">{{ opt.label }}</span>
+                      </button>
+                      <div v-if="allowCustomModel" class="cb-model-custom">
+                        <el-input
+                          v-model="customModelDraft"
+                          size="small"
+                          :placeholder="$t('codingBridge.session.modelPlaceholder')"
+                          @keyup.enter="applyCustomModel"
+                        >
+                          <template #append>
+                            <el-button
+                              :disabled="!customModelDraft.trim()"
+                              :aria-label="$t('common.button.confirm')"
+                              :title="$t('common.button.confirm')"
+                              @click="applyCustomModel"
+                            >
+                              <confirm-icon :size="'1em' as any" aria-hidden="true" focusable="false" />
+                            </el-button>
+                          </template>
+                        </el-input>
+                      </div>
                     </div>
-                  </div>
-                </el-popover>
+                  </el-popover>
 
-                <!-- Effort and permission/edit mode stay editable every turn: the
-                     node applies whatever the composer carries on each send, so a
-                     resumed conversation can change them per query. -->
-                <el-dropdown v-if="effortOptions.length > 1" trigger="click" @command="effort = $event">
-                  <button type="button" class="cb-pill">
-                    <performance-icon class="cb-pill__icon" :size="'1em' as any" aria-hidden="true" focusable="false" />
-                    <span class="truncate">{{ effortLabel(effort) }}</span>
-                    <expand-down-icon
-                      class="cb-pill__caret"
-                      :size="'1em' as any"
-                      aria-hidden="true"
-                      focusable="false"
-                    />
-                  </button>
-                  <template #dropdown>
-                    <el-dropdown-menu>
-                      <el-dropdown-item v-for="opt in effortOptions" :key="opt.value" :command="opt.value">
-                        <confirm-icon
-                          class="mr-2"
-                          :class="opt.value === effort ? 'opacity-100' : 'opacity-0'"
-                          :size="'1em' as any"
-                          aria-hidden="true"
-                          focusable="false"
-                        />
-                        {{ opt.label }}
-                      </el-dropdown-item>
-                    </el-dropdown-menu>
-                  </template>
-                </el-dropdown>
-
-                <el-dropdown trigger="click" @command="permissionMode = $event">
-                  <button type="button" class="cb-pill">
-                    <security-icon class="cb-pill__icon" :size="'1em' as any" aria-hidden="true" focusable="false" />
-                    <span class="truncate">{{ permissionModeLabel(permissionMode) }}</span>
-                    <expand-down-icon
-                      class="cb-pill__caret"
-                      :size="'1em' as any"
-                      aria-hidden="true"
-                      focusable="false"
-                    />
-                  </button>
-                  <template #dropdown>
-                    <el-dropdown-menu>
-                      <el-dropdown-item v-for="opt in permissionModeOptions" :key="opt.value" :command="opt.value">
-                        <confirm-icon
-                          class="mr-2"
-                          :class="opt.value === permissionMode ? 'opacity-100' : 'opacity-0'"
-                          :size="'1em' as any"
-                          aria-hidden="true"
-                          focusable="false"
-                        />
-                        {{ opt.label }}
-                      </el-dropdown-item>
-                    </el-dropdown-menu>
-                  </template>
-                </el-dropdown>
-
-                <!-- Working directory: editable for a new or resumed-but-not-yet
-                     -continued session (its first send is a fresh start that
-                     applies the cwd); read-only once a live turn pins it. -->
-                <el-popover v-if="canPickCwd" trigger="click" placement="top-start" :width="320">
-                  <template #reference>
+                  <!-- Effort and permission/edit mode stay editable every turn: the
+                       node applies whatever the composer carries on each send, so a
+                       resumed conversation can change them per query. -->
+                  <el-dropdown v-if="effortOptions.length > 1" trigger="click" @command="effort = $event">
                     <button type="button" class="cb-pill">
-                      <folder-open-icon
+                      <performance-icon
                         class="cb-pill__icon"
                         :size="'1em' as any"
                         aria-hidden="true"
                         focusable="false"
                       />
-                      <span class="truncate">{{ cwd || $t('codingBridge.session.cwdDefault') }}</span>
+                      <span class="truncate">{{ effortLabel(effort) }}</span>
                       <expand-down-icon
                         class="cb-pill__caret"
                         :size="'1em' as any"
@@ -478,34 +437,98 @@
                         focusable="false"
                       />
                     </button>
-                  </template>
-                  <el-input
-                    v-model="cwd"
-                    size="small"
-                    clearable
-                    class="cb-cwd-input"
-                    :placeholder="$t('codingBridge.session.cwdPlaceholder')"
-                  >
-                    <template #suffix>
-                      <span
-                        class="cb-cwd-browse"
-                        role="button"
-                        tabindex="0"
-                        :title="$t('codingBridge.directory.title')"
-                        :aria-label="$t('codingBridge.directory.title')"
-                        @click="openDirectory"
-                        @keydown.enter.prevent="openDirectory"
-                        @keydown.space.prevent="openDirectory"
-                      >
-                        <folder-open-icon :size="'1em' as any" aria-hidden="true" focusable="false" />
-                      </span>
+                    <template #dropdown>
+                      <el-dropdown-menu>
+                        <el-dropdown-item v-for="opt in effortOptions" :key="opt.value" :command="opt.value">
+                          <confirm-icon
+                            class="mr-2"
+                            :class="opt.value === effort ? 'opacity-100' : 'opacity-0'"
+                            :size="'1em' as any"
+                            aria-hidden="true"
+                            focusable="false"
+                          />
+                          {{ opt.label }}
+                        </el-dropdown-item>
+                      </el-dropdown-menu>
                     </template>
-                  </el-input>
-                </el-popover>
-                <span v-else-if="currentSession?.cwd" class="cb-pill cb-pill--static">
-                  <folder-open-icon class="cb-pill__icon" :size="'1em' as any" aria-hidden="true" focusable="false" />
-                  <span class="truncate">{{ currentSession?.cwd }}</span>
-                </span>
+                  </el-dropdown>
+
+                  <el-dropdown trigger="click" @command="permissionMode = $event">
+                    <button type="button" class="cb-pill">
+                      <security-icon class="cb-pill__icon" :size="'1em' as any" aria-hidden="true" focusable="false" />
+                      <span class="truncate">{{ permissionModeLabel(permissionMode) }}</span>
+                      <expand-down-icon
+                        class="cb-pill__caret"
+                        :size="'1em' as any"
+                        aria-hidden="true"
+                        focusable="false"
+                      />
+                    </button>
+                    <template #dropdown>
+                      <el-dropdown-menu>
+                        <el-dropdown-item v-for="opt in permissionModeOptions" :key="opt.value" :command="opt.value">
+                          <confirm-icon
+                            class="mr-2"
+                            :class="opt.value === permissionMode ? 'opacity-100' : 'opacity-0'"
+                            :size="'1em' as any"
+                            aria-hidden="true"
+                            focusable="false"
+                          />
+                          {{ opt.label }}
+                        </el-dropdown-item>
+                      </el-dropdown-menu>
+                    </template>
+                  </el-dropdown>
+
+                  <!-- Working directory: editable for a new or resumed-but-not-yet
+                     -continued session (its first send is a fresh start that
+                     applies the cwd); read-only once a live turn pins it. -->
+                  <el-popover v-if="canPickCwd" trigger="click" placement="top-start" :width="320">
+                    <template #reference>
+                      <button type="button" class="cb-pill">
+                        <folder-open-icon
+                          class="cb-pill__icon"
+                          :size="'1em' as any"
+                          aria-hidden="true"
+                          focusable="false"
+                        />
+                        <span class="truncate">{{ cwd || $t('codingBridge.session.cwdDefault') }}</span>
+                        <expand-down-icon
+                          class="cb-pill__caret"
+                          :size="'1em' as any"
+                          aria-hidden="true"
+                          focusable="false"
+                        />
+                      </button>
+                    </template>
+                    <el-input
+                      v-model="cwd"
+                      size="small"
+                      clearable
+                      class="cb-cwd-input"
+                      :placeholder="$t('codingBridge.session.cwdPlaceholder')"
+                    >
+                      <template #suffix>
+                        <span
+                          class="cb-cwd-browse"
+                          role="button"
+                          tabindex="0"
+                          :title="$t('codingBridge.directory.title')"
+                          :aria-label="$t('codingBridge.directory.title')"
+                          @click="openDirectory"
+                          @keydown.enter.prevent="openDirectory"
+                          @keydown.space.prevent="openDirectory"
+                        >
+                          <folder-open-icon :size="'1em' as any" aria-hidden="true" focusable="false" />
+                        </span>
+                      </template>
+                    </el-input>
+                  </el-popover>
+                  <span v-else-if="currentSession?.cwd" class="cb-pill cb-pill--static">
+                    <folder-open-icon class="cb-pill__icon" :size="'1em' as any" aria-hidden="true" focusable="false" />
+                    <span class="truncate">{{ currentSession?.cwd }}</span>
+                  </span>
+                </div>
               </div>
 
               <el-button
@@ -547,6 +570,7 @@ import {
   FileIcon,
   FolderOpenIcon,
   HistoryIcon,
+  MoreIcon,
   PerformanceIcon,
   RedoIcon,
   SecurityIcon,
@@ -630,6 +654,7 @@ export default defineComponent({
     FileIcon,
     FolderOpenIcon,
     HistoryIcon,
+    MoreIcon,
     PerformanceIcon,
     RedoIcon,
     SecurityIcon,
@@ -667,6 +692,10 @@ export default defineComponent({
       provider: 'claude',
       effort: '',
       directoryVisible: false,
+      // Mobile only: whether the collapsed secondary pills (model / effort /
+      // permission / cwd) are expanded. Ignored at md+ where they're always
+      // inline.
+      moreOpen: false,
       slashMenuOpen: false,
       slashActiveIndex: 0,
       // Id of the prompt event being edited; when set, sending rewinds the
@@ -1512,7 +1541,9 @@ export default defineComponent({
 <style scoped lang="scss">
 // Mobile-only devices entry in the header (replaces the old floating button).
 .cb-devices-btn {
-  display: inline-flex;
+  // Mobile-only entry to the device drawer. `md:hidden` on the element does
+  // nothing against this scoped rule's higher specificity, so gate it here.
+  display: none;
   flex: none;
   align-items: center;
   justify-content: center;
@@ -1531,6 +1562,12 @@ export default defineComponent({
   &:hover {
     color: var(--el-color-primary);
     border-color: var(--el-color-primary-light-5);
+  }
+}
+
+@media (max-width: 767px) {
+  .cb-devices-btn {
+    display: inline-flex;
   }
 }
 
@@ -1712,6 +1749,74 @@ export default defineComponent({
   &:hover {
     color: var(--el-color-primary);
     border-color: var(--el-color-primary-light-5);
+  }
+}
+
+// Secondary composer controls. At md+ this wrapper is invisible to layout
+// (`display: contents`), so its pills stay inline in the same flex row as
+// before. On a phone it becomes a full-width line that collapses behind the
+// "…" toggle, leaving only the backend pill on the main row.
+.cb-more {
+  display: contents;
+}
+
+// The "…" toggle only exists on phones. Tailwind's `md:hidden` can't do this
+// here: `.cb-icon-btn[data-v-*]` (0,2,0) outranks `.md\:hidden` (0,1,0), so the
+// button would stay visible on desktop — the same reason `.cb-devices-btn`
+// above sets its own breakpoint rule.
+.cb-more-btn {
+  display: none;
+}
+
+@media (max-width: 767px) {
+  // Let the action row wrap so the expanded panel can claim a line of its own
+  // at the composer's full width. `cb-pills` steps out of the layout so its
+  // children become direct flex items of that wrapping row — otherwise the
+  // panel stays trapped in the narrow middle column (which shares a nowrap row
+  // with the attach and Send buttons) and every pill lands on its own line.
+  .cb-actions {
+    flex-wrap: wrap;
+  }
+
+  .cb-pills {
+    display: contents;
+  }
+
+  .cb-more {
+    display: none;
+    order: 1;
+    flex: 1 0 100%;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 6px;
+
+    &--open {
+      display: flex;
+    }
+
+    // The panel is only ~340px wide, so let each control shrink to share a line
+    // rather than keeping its natural width and claiming one of its own. Some
+    // children are the pill itself, others an el-dropdown/el-popover wrapper
+    // around it — hence the direct-child selector. `0 1` (not `1 1`): growing
+    // would let the first pill swallow the whole line.
+    > * {
+      flex: 0 1 auto;
+      min-width: 0;
+    }
+
+    .cb-pill {
+      max-width: 100%;
+      justify-content: flex-start;
+    }
+  }
+
+  .cb-more-btn {
+    display: inline-flex;
+
+    &--open {
+      color: var(--el-color-primary);
+      border-color: var(--el-color-primary-light-5);
+    }
   }
 }
 


### PR DESCRIPTION
## 问题

手机上 coding bridge 的输入框底部并排挤了五个 pill —— 后端、模型、推理强度、权限模式、工作目录。390px 宽度下它们换行堆成一片，占掉大半个输入区。

## 改动

主行只保留**后端选择**（Claude Code / Codex），其余四项折叠到一个「⋯」入口后面，点开后占满整行展开。桌面端通过 `display: contents` 保持完全原样：五个 pill 仍在一行，composer 高度 114px 与改动前一致。

复用了已有的 `codingBridge.session.settings` 这个 i18n key（18 个语言都已存在、此前未被使用），所以不涉及翻译流程。

### 顺带修的一个既有 bug

`md:hidden` 在这个组件里根本不生效：scoped 样式的 `.cb-devices-btn[data-v-*]`（特异性 0,2,0）压过 Tailwind 的 `.md\:hidden`（0,1,0）。也就是说那个本该只在手机出现的「设备」按钮，桌面端一直显示着。两个按钮现在都改用自己的媒体查询规则。

## 验证

在 dev server 上用 Playwright 实测真实组件（临时挂载页验证后已删除），非仅看 CSS：

| | 手机 390px | 桌面 1280px |
|---|---|---|
| 折叠态 | 主行只有 `Claude Code`，composer 高 120px | 五个 pill 一行，高 114px（与改动前相同） |
| 「⋯」按钮 | 显示 | 隐藏 |
| 展开态 | 四项分行排列，高 222px | — |

交互也逐个点过：权限下拉能正常打开并选中（pill 文案随之更新为 "Plan mode (read-only)"）、模型 popover 正常列出选项、折叠再展开后所选值保留。全程无控制台错误。

`eslint` / `vue-tsc -b` / `vitest`（20 个测试）均通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)