### PR TITLE
fix(coding-bridge): 手机端次要控件改成设置对话框

### DIFF
--- a/change/@acedatacloud-nexior-d654d5f3-76c5-44eb-b10e-993dc4b9b898.json
+++ b/change/@acedatacloud-nexior-d654d5f3-76c5-44eb-b10e-993dc4b9b898.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "coding bridge: open the secondary composer controls in a settings dialog on mobile instead of expanding them inline",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/codingBridge/ComposerSettings.vue
+++ b/src/components/codingBridge/ComposerSettings.vue
@@ -1,0 +1,63 @@
+<template>
+  <!-- Desktop: a layout-transparent wrapper, so the controls stay inline flex
+       items of the composer's action row exactly as if this component weren't
+       here. Mobile: the same content moves into a dialog, one labelled row
+       each. The slot is compiled in the parent, so every binding on those
+       controls keeps working untouched in both modes. -->
+  <div v-if="!dialog" class="cb-settings-inline">
+    <slot />
+  </div>
+  <el-dialog
+    v-else
+    :model-value="open"
+    :title="$t('codingBridge.session.settings')"
+    width="min(420px, 92vw)"
+    align-center
+    append-to-body
+    class="cb-settings-dialog"
+    @update:model-value="$emit('update:open', $event)"
+  >
+    <div class="cb-settings-rows">
+      <slot />
+    </div>
+    <template #footer>
+      <el-button type="primary" round @click="$emit('update:open', false)">
+        {{ $t('common.button.close') }}
+      </el-button>
+    </template>
+  </el-dialog>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElButton, ElDialog } from 'element-plus';
+
+export default defineComponent({
+  name: 'CodingBridgeComposerSettings',
+  components: { ElButton, ElDialog },
+  props: {
+    // True on phones: render the controls in a dialog instead of inline.
+    dialog: {
+      type: Boolean,
+      default: false
+    },
+    open: {
+      type: Boolean,
+      default: false
+    }
+  },
+  emits: ['update:open']
+});
+</script>
+
+<style scoped lang="scss">
+.cb-settings-inline {
+  display: contents;
+}
+
+.cb-settings-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+</style>

--- a/src/components/codingBridge/SessionView.scroll.test.ts
+++ b/src/components/codingBridge/SessionView.scroll.test.ts
@@ -58,6 +58,8 @@ const ctx = (overrides: Partial<Ctx> = {}): Ctx => {
     $nextTick: (fn: () => void) => fn(),
     requestCapabilities: () => {},
     syncSessionSettings: () => {},
+    // Unrelated to scrolling, and jsdom has no matchMedia by default.
+    watchSettingsBreakpoint: () => {},
     ...overrides
   } as unknown as Ctx;
   self.scrollToBottom = SessionView.methods.scrollToBottom.bind(self) as () => void;

--- a/src/components/codingBridge/SessionView.settings.test.ts
+++ b/src/components/codingBridge/SessionView.settings.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+//
+// The secondary composer controls (model / effort / permission / cwd) render
+// inline on desktop and inside a dialog on phones. That is a structural choice,
+// so it is driven by a matchMedia listener rather than a media query — these
+// cover the switch, including the case that used to strand an open dialog:
+// widening the window while it is showing.
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/assets/images/logos/claude.svg', () => ({ default: 'claude.svg' }));
+vi.mock('@/assets/images/logos/openai.svg', () => ({ default: 'openai.svg' }));
+vi.mock('@/assets/images/logos/github-copilot.svg', () => ({ default: 'copilot.svg' }));
+
+const SessionView = (await import('./SessionView.vue')).default as unknown as {
+  methods: Record<string, (this: Ctx, ...args: unknown[]) => void>;
+  data: () => Record<string, unknown>;
+};
+
+type Ctx = Record<string, unknown> & {
+  mobileSettings: boolean;
+  moreOpen: boolean;
+  settingsMql?: MediaQueryList;
+  watchSettingsBreakpoint: () => void;
+  onSettingsBreakpoint: (event: MediaQueryListEvent) => void;
+};
+
+// A matchMedia stub whose `matches` we control, recording the listener so the
+// test can fire a breakpoint change.
+const stubMatchMedia = (matches: boolean) => {
+  const listeners: ((event: MediaQueryListEvent) => void)[] = [];
+  const mql = {
+    matches,
+    addEventListener: (_: string, fn: (event: MediaQueryListEvent) => void) => listeners.push(fn),
+    removeEventListener: vi.fn()
+  } as unknown as MediaQueryList;
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn(() => mql)
+  );
+  return { mql, listeners };
+};
+
+const ctx = (): Ctx => {
+  const self = { ...SessionView.data() } as unknown as Ctx;
+  self.watchSettingsBreakpoint = SessionView.methods.watchSettingsBreakpoint.bind(self) as () => void;
+  self.onSettingsBreakpoint = SessionView.methods.onSettingsBreakpoint.bind(self) as (
+    event: MediaQueryListEvent
+  ) => void;
+  return self;
+};
+
+describe('coding bridge composer settings breakpoint', () => {
+  it('starts in dialog mode when mounted on a narrow viewport', () => {
+    stubMatchMedia(true);
+    const self = ctx();
+    self.watchSettingsBreakpoint();
+    expect(self.mobileSettings).toBe(true);
+  });
+
+  it('starts inline on a wide viewport', () => {
+    stubMatchMedia(false);
+    const self = ctx();
+    self.watchSettingsBreakpoint();
+    expect(self.mobileSettings).toBe(false);
+  });
+
+  it('switches to dialog mode when the viewport narrows', () => {
+    const { listeners } = stubMatchMedia(false);
+    const self = ctx();
+    self.watchSettingsBreakpoint();
+    listeners.forEach((fn) => fn({ matches: true } as MediaQueryListEvent));
+    expect(self.mobileSettings).toBe(true);
+  });
+
+  it('closes an open dialog when the viewport widens', () => {
+    // Otherwise the controls render inline while `moreOpen` stays true, and the
+    // next narrow resize pops the dialog open unprompted.
+    const { listeners } = stubMatchMedia(true);
+    const self = ctx();
+    self.watchSettingsBreakpoint();
+    self.moreOpen = true;
+    listeners.forEach((fn) => fn({ matches: false } as MediaQueryListEvent));
+    expect(self.mobileSettings).toBe(false);
+    expect(self.moreOpen).toBe(false);
+  });
+
+  it('leaves the controls inline when matchMedia is unavailable', () => {
+    vi.stubGlobal('matchMedia', undefined);
+    const self = ctx();
+    self.watchSettingsBreakpoint();
+    expect(self.mobileSettings).toBe(false);
+    expect(self.settingsMql).toBeUndefined();
+  });
+});

--- a/src/components/codingBridge/SessionView.vue
+++ b/src/components/codingBridge/SessionView.vue
@@ -263,7 +263,7 @@
               <span ref="attachmentUploadTrigger" class="block h-0 w-0" aria-hidden="true"></span>
             </el-upload>
 
-            <div class="cb-actions mt-1.5 flex items-center gap-1.5">
+            <div class="mt-1.5 flex items-center gap-1.5">
               <button
                 type="button"
                 class="cb-icon-btn"
@@ -274,7 +274,7 @@
                 <attachment-icon :size="'1em' as any" aria-hidden="true" focusable="false" />
               </button>
 
-              <div class="cb-pills flex min-w-0 flex-1 flex-wrap items-center gap-1.5">
+              <div class="flex min-w-0 flex-1 flex-wrap items-center gap-1.5">
                 <!-- Provider is chosen at start and locked once a session is running. -->
                 <el-dropdown v-if="isNewSession" trigger="click" @command="provider = $event">
                   <button type="button" class="cb-pill">
@@ -338,161 +338,112 @@
                   <span class="truncate">{{ providerName(currentSession?.provider || 'claude') }}</span>
                 </span>
 
-                <!-- Secondary controls. On a phone the composer row can't hold
-                     five pills, so they collapse behind one "…" toggle and drop
-                     onto their own line; `display: contents` on desktop keeps
-                     them inline exactly as before. -->
+                <!-- Secondary controls. The composer row can't hold five pills
+                     on a phone, so there they collapse behind this button and
+                     open in a dialog; `display: contents` on desktop keeps them
+                     inline in the row exactly as before. -->
                 <button
                   type="button"
                   class="cb-icon-btn cb-more-btn"
-                  :class="{ 'cb-more-btn--open': moreOpen }"
                   :title="$t('codingBridge.session.settings')"
                   :aria-label="$t('codingBridge.session.settings')"
-                  :aria-expanded="moreOpen"
-                  @click="moreOpen = !moreOpen"
+                  @click="moreOpen = true"
                 >
                   <more-icon :size="'1em' as any" aria-hidden="true" focusable="false" />
                 </button>
 
-                <div class="cb-more" :class="{ 'cb-more--open': moreOpen }">
-                  <!-- Model can be switched any time, including mid-session. -->
-                  <el-popover ref="modelPopover" trigger="click" placement="top-start" :width="260">
-                    <template #reference>
-                      <button type="button" class="cb-pill">
-                        <ai-icon class="cb-pill__icon" :size="'1em' as any" aria-hidden="true" focusable="false" />
-                        <span class="truncate">{{ model || $t('codingBridge.session.modelDefault') }}</span>
-                        <expand-down-icon
-                          class="cb-pill__caret"
-                          :size="'1em' as any"
-                          aria-hidden="true"
-                          focusable="false"
-                        />
-                      </button>
-                    </template>
-                    <div class="cb-model-menu">
-                      <button type="button" class="cb-model-option" @click="selectModel('')">
-                        <confirm-icon
-                          class="cb-model-option__check"
-                          :class="!model ? 'opacity-100' : 'opacity-0'"
-                          :size="'1em' as any"
-                          aria-hidden="true"
-                          focusable="false"
-                        />
-                        <span class="truncate">{{ $t('codingBridge.session.modelDefault') }}</span>
-                      </button>
-                      <button
-                        v-for="opt in modelOptions"
-                        :key="opt.value"
-                        type="button"
-                        class="cb-model-option"
-                        @click="selectModel(opt.value)"
-                      >
-                        <confirm-icon
-                          class="cb-model-option__check"
-                          :class="opt.value === model ? 'opacity-100' : 'opacity-0'"
-                          :size="'1em' as any"
-                          aria-hidden="true"
-                          focusable="false"
-                        />
-                        <span class="truncate">{{ opt.label }}</span>
-                      </button>
-                      <div v-if="allowCustomModel" class="cb-model-custom">
-                        <el-input
-                          v-model="customModelDraft"
-                          size="small"
-                          :placeholder="$t('codingBridge.session.modelPlaceholder')"
-                          @keyup.enter="applyCustomModel"
+                <composer-settings v-model:open="moreOpen" :dialog="mobileSettings">
+                  <!-- Each control carries its own label so the dialog rows can't
+                       drift out of sync with the (conditionally rendered) set of
+                       controls. The label is hidden while inline. -->
+                  <div class="cb-setting" :class="{ 'cb-setting--row': mobileSettings }">
+                    <span v-if="mobileSettings" class="cb-setting__label">
+                      {{ $t('chat.scheduledTasks.form.model') }}
+                    </span>
+                    <!-- Model can be switched any time, including mid-session. -->
+                    <el-popover ref="modelPopover" trigger="click" placement="top-start" :width="260">
+                      <template #reference>
+                        <button type="button" class="cb-pill">
+                          <ai-icon class="cb-pill__icon" :size="'1em' as any" aria-hidden="true" focusable="false" />
+                          <span class="truncate">{{ model || $t('codingBridge.session.modelDefault') }}</span>
+                          <expand-down-icon
+                            class="cb-pill__caret"
+                            :size="'1em' as any"
+                            aria-hidden="true"
+                            focusable="false"
+                          />
+                        </button>
+                      </template>
+                      <div class="cb-model-menu">
+                        <button type="button" class="cb-model-option" @click="selectModel('')">
+                          <confirm-icon
+                            class="cb-model-option__check"
+                            :class="!model ? 'opacity-100' : 'opacity-0'"
+                            :size="'1em' as any"
+                            aria-hidden="true"
+                            focusable="false"
+                          />
+                          <span class="truncate">{{ $t('codingBridge.session.modelDefault') }}</span>
+                        </button>
+                        <button
+                          v-for="opt in modelOptions"
+                          :key="opt.value"
+                          type="button"
+                          class="cb-model-option"
+                          @click="selectModel(opt.value)"
                         >
-                          <template #append>
-                            <el-button
-                              :disabled="!customModelDraft.trim()"
-                              :aria-label="$t('common.button.confirm')"
-                              :title="$t('common.button.confirm')"
-                              @click="applyCustomModel"
-                            >
-                              <confirm-icon :size="'1em' as any" aria-hidden="true" focusable="false" />
-                            </el-button>
-                          </template>
-                        </el-input>
+                          <confirm-icon
+                            class="cb-model-option__check"
+                            :class="opt.value === model ? 'opacity-100' : 'opacity-0'"
+                            :size="'1em' as any"
+                            aria-hidden="true"
+                            focusable="false"
+                          />
+                          <span class="truncate">{{ opt.label }}</span>
+                        </button>
+                        <div v-if="allowCustomModel" class="cb-model-custom">
+                          <el-input
+                            v-model="customModelDraft"
+                            size="small"
+                            :placeholder="$t('codingBridge.session.modelPlaceholder')"
+                            @keyup.enter="applyCustomModel"
+                          >
+                            <template #append>
+                              <el-button
+                                :disabled="!customModelDraft.trim()"
+                                :aria-label="$t('common.button.confirm')"
+                                :title="$t('common.button.confirm')"
+                                @click="applyCustomModel"
+                              >
+                                <confirm-icon :size="'1em' as any" aria-hidden="true" focusable="false" />
+                              </el-button>
+                            </template>
+                          </el-input>
+                        </div>
                       </div>
-                    </div>
-                  </el-popover>
+                    </el-popover>
+                  </div>
 
                   <!-- Effort and permission/edit mode stay editable every turn: the
                        node applies whatever the composer carries on each send, so a
                        resumed conversation can change them per query. -->
-                  <el-dropdown v-if="effortOptions.length > 1" trigger="click" @command="effort = $event">
-                    <button type="button" class="cb-pill">
-                      <performance-icon
-                        class="cb-pill__icon"
-                        :size="'1em' as any"
-                        aria-hidden="true"
-                        focusable="false"
-                      />
-                      <span class="truncate">{{ effortLabel(effort) }}</span>
-                      <expand-down-icon
-                        class="cb-pill__caret"
-                        :size="'1em' as any"
-                        aria-hidden="true"
-                        focusable="false"
-                      />
-                    </button>
-                    <template #dropdown>
-                      <el-dropdown-menu>
-                        <el-dropdown-item v-for="opt in effortOptions" :key="opt.value" :command="opt.value">
-                          <confirm-icon
-                            class="mr-2"
-                            :class="opt.value === effort ? 'opacity-100' : 'opacity-0'"
-                            :size="'1em' as any"
-                            aria-hidden="true"
-                            focusable="false"
-                          />
-                          {{ opt.label }}
-                        </el-dropdown-item>
-                      </el-dropdown-menu>
-                    </template>
-                  </el-dropdown>
-
-                  <el-dropdown trigger="click" @command="permissionMode = $event">
-                    <button type="button" class="cb-pill">
-                      <security-icon class="cb-pill__icon" :size="'1em' as any" aria-hidden="true" focusable="false" />
-                      <span class="truncate">{{ permissionModeLabel(permissionMode) }}</span>
-                      <expand-down-icon
-                        class="cb-pill__caret"
-                        :size="'1em' as any"
-                        aria-hidden="true"
-                        focusable="false"
-                      />
-                    </button>
-                    <template #dropdown>
-                      <el-dropdown-menu>
-                        <el-dropdown-item v-for="opt in permissionModeOptions" :key="opt.value" :command="opt.value">
-                          <confirm-icon
-                            class="mr-2"
-                            :class="opt.value === permissionMode ? 'opacity-100' : 'opacity-0'"
-                            :size="'1em' as any"
-                            aria-hidden="true"
-                            focusable="false"
-                          />
-                          {{ opt.label }}
-                        </el-dropdown-item>
-                      </el-dropdown-menu>
-                    </template>
-                  </el-dropdown>
-
-                  <!-- Working directory: editable for a new or resumed-but-not-yet
-                     -continued session (its first send is a fresh start that
-                     applies the cwd); read-only once a live turn pins it. -->
-                  <el-popover v-if="canPickCwd" trigger="click" placement="top-start" :width="320">
-                    <template #reference>
+                  <div
+                    v-if="effortOptions.length > 1"
+                    class="cb-setting"
+                    :class="{ 'cb-setting--row': mobileSettings }"
+                  >
+                    <span v-if="mobileSettings" class="cb-setting__label">
+                      {{ $t('codingBridge.session.effortLabel') }}
+                    </span>
+                    <el-dropdown trigger="click" @command="effort = $event">
                       <button type="button" class="cb-pill">
-                        <folder-open-icon
+                        <performance-icon
                           class="cb-pill__icon"
                           :size="'1em' as any"
                           aria-hidden="true"
                           focusable="false"
                         />
-                        <span class="truncate">{{ cwd || $t('codingBridge.session.cwdDefault') }}</span>
+                        <span class="truncate">{{ effortLabel(effort) }}</span>
                         <expand-down-icon
                           class="cb-pill__caret"
                           :size="'1em' as any"
@@ -500,35 +451,123 @@
                           focusable="false"
                         />
                       </button>
-                    </template>
-                    <el-input
-                      v-model="cwd"
-                      size="small"
-                      clearable
-                      class="cb-cwd-input"
-                      :placeholder="$t('codingBridge.session.cwdPlaceholder')"
-                    >
-                      <template #suffix>
-                        <span
-                          class="cb-cwd-browse"
-                          role="button"
-                          tabindex="0"
-                          :title="$t('codingBridge.directory.title')"
-                          :aria-label="$t('codingBridge.directory.title')"
-                          @click="openDirectory"
-                          @keydown.enter.prevent="openDirectory"
-                          @keydown.space.prevent="openDirectory"
-                        >
-                          <folder-open-icon :size="'1em' as any" aria-hidden="true" focusable="false" />
-                        </span>
+                      <template #dropdown>
+                        <el-dropdown-menu>
+                          <el-dropdown-item v-for="opt in effortOptions" :key="opt.value" :command="opt.value">
+                            <confirm-icon
+                              class="mr-2"
+                              :class="opt.value === effort ? 'opacity-100' : 'opacity-0'"
+                              :size="'1em' as any"
+                              aria-hidden="true"
+                              focusable="false"
+                            />
+                            {{ opt.label }}
+                          </el-dropdown-item>
+                        </el-dropdown-menu>
                       </template>
-                    </el-input>
-                  </el-popover>
-                  <span v-else-if="currentSession?.cwd" class="cb-pill cb-pill--static">
-                    <folder-open-icon class="cb-pill__icon" :size="'1em' as any" aria-hidden="true" focusable="false" />
-                    <span class="truncate">{{ currentSession?.cwd }}</span>
-                  </span>
-                </div>
+                    </el-dropdown>
+                  </div>
+
+                  <div class="cb-setting" :class="{ 'cb-setting--row': mobileSettings }">
+                    <span v-if="mobileSettings" class="cb-setting__label">
+                      {{ $t('codingBridge.session.permissionModeLabel') }}
+                    </span>
+                    <el-dropdown trigger="click" @command="permissionMode = $event">
+                      <button type="button" class="cb-pill">
+                        <security-icon
+                          class="cb-pill__icon"
+                          :size="'1em' as any"
+                          aria-hidden="true"
+                          focusable="false"
+                        />
+                        <span class="truncate">{{ permissionModeLabel(permissionMode) }}</span>
+                        <expand-down-icon
+                          class="cb-pill__caret"
+                          :size="'1em' as any"
+                          aria-hidden="true"
+                          focusable="false"
+                        />
+                      </button>
+                      <template #dropdown>
+                        <el-dropdown-menu>
+                          <el-dropdown-item v-for="opt in permissionModeOptions" :key="opt.value" :command="opt.value">
+                            <confirm-icon
+                              class="mr-2"
+                              :class="opt.value === permissionMode ? 'opacity-100' : 'opacity-0'"
+                              :size="'1em' as any"
+                              aria-hidden="true"
+                              focusable="false"
+                            />
+                            {{ opt.label }}
+                          </el-dropdown-item>
+                        </el-dropdown-menu>
+                      </template>
+                    </el-dropdown>
+                  </div>
+
+                  <!-- Working directory: editable for a new or resumed-but-not-yet
+                     -continued session (its first send is a fresh start that
+                     applies the cwd); read-only once a live turn pins it. -->
+                  <div
+                    v-if="canPickCwd || currentSession?.cwd"
+                    class="cb-setting"
+                    :class="{ 'cb-setting--row': mobileSettings }"
+                  >
+                    <span v-if="mobileSettings" class="cb-setting__label">
+                      {{ $t('common.settings.localToolsWorkingDirTitle') }}
+                    </span>
+                    <el-popover v-if="canPickCwd" trigger="click" placement="top-start" :width="320">
+                      <template #reference>
+                        <button type="button" class="cb-pill">
+                          <folder-open-icon
+                            class="cb-pill__icon"
+                            :size="'1em' as any"
+                            aria-hidden="true"
+                            focusable="false"
+                          />
+                          <span class="truncate">{{ cwd || $t('codingBridge.session.cwdDefault') }}</span>
+                          <expand-down-icon
+                            class="cb-pill__caret"
+                            :size="'1em' as any"
+                            aria-hidden="true"
+                            focusable="false"
+                          />
+                        </button>
+                      </template>
+                      <el-input
+                        v-model="cwd"
+                        size="small"
+                        clearable
+                        class="cb-cwd-input"
+                        :placeholder="$t('codingBridge.session.cwdPlaceholder')"
+                      >
+                        <template #suffix>
+                          <span
+                            class="cb-cwd-browse"
+                            role="button"
+                            tabindex="0"
+                            :title="$t('codingBridge.directory.title')"
+                            :aria-label="$t('codingBridge.directory.title')"
+                            @click="openDirectory"
+                            @keydown.enter.prevent="openDirectory"
+                            @keydown.space.prevent="openDirectory"
+                          >
+                            <folder-open-icon :size="'1em' as any" aria-hidden="true" focusable="false" />
+                          </span>
+                        </template>
+                      </el-input>
+                    </el-popover>
+                    <span v-else class="cb-pill cb-pill--static">
+                      <folder-open-icon
+                        class="cb-pill__icon"
+                        :size="'1em' as any"
+                        aria-hidden="true"
+                        focusable="false"
+                      />
+                      <span class="truncate">{{ currentSession?.cwd }}</span>
+                    </span>
+                  </div>
+                </composer-settings>
               </div>
 
               <el-button
@@ -596,6 +635,7 @@ import {
 } from 'element-plus';
 import TranscriptItem from './TranscriptItem.vue';
 import ThinkingIndicator from './ThinkingIndicator.vue';
+import ComposerSettings from './ComposerSettings.vue';
 import DirectoryDialog from './DirectoryDialog.vue';
 import AskUserQuestionCard from '@/components/chat/AskUserQuestionCard.vue';
 import { isAskUserQuestionRequest, questionPayload } from './askUserQuestion';
@@ -673,6 +713,7 @@ export default defineComponent({
     ElSkeletonItem,
     TranscriptItem,
     ThinkingIndicator,
+    ComposerSettings,
     DirectoryDialog,
     AskUserQuestionCard,
     CopyToClipboard
@@ -692,10 +733,15 @@ export default defineComponent({
       provider: 'claude',
       effort: '',
       directoryVisible: false,
-      // Mobile only: whether the collapsed secondary pills (model / effort /
-      // permission / cwd) are expanded. Ignored at md+ where they're always
-      // inline.
+      // Mobile only: whether the settings dialog holding the secondary controls
+      // (model / effort / permission / cwd) is open. Ignored at md+, where they
+      // render inline in the composer row.
       moreOpen: false,
+      // Whether those controls belong in a dialog. This is a structural choice
+      // (dialog vs inline), not styling, so it can't live in a media query —
+      // tracked here and kept in sync by a matchMedia listener.
+      mobileSettings: false,
+      settingsMql: undefined as MediaQueryList | undefined,
       slashMenuOpen: false,
       slashActiveIndex: 0,
       // Id of the prompt event being edited; when set, sending rewinds the
@@ -1084,6 +1130,7 @@ export default defineComponent({
     // its events in the store, so no watcher fires — open it at the newest turn.
     this.scrollToBottom();
     this.observeTranscript();
+    this.watchSettingsBreakpoint();
   },
   updated() {
     // The transcript is behind `v-if="currentNode"`, so on a reload it appears
@@ -1094,8 +1141,28 @@ export default defineComponent({
     this.transcriptObserver?.disconnect();
     this.transcriptObserver = undefined;
     this.observedTranscript = undefined;
+    this.settingsMql?.removeEventListener('change', this.onSettingsBreakpoint);
+    this.settingsMql = undefined;
   },
   methods: {
+    // Matches the `md` breakpoint the composer styles use. Below it the
+    // secondary controls open in a dialog instead of crowding the row.
+    watchSettingsBreakpoint() {
+      if (typeof window === 'undefined' || !window.matchMedia) {
+        return;
+      }
+      this.settingsMql = window.matchMedia('(max-width: 767px)');
+      this.mobileSettings = this.settingsMql.matches;
+      this.settingsMql.addEventListener('change', this.onSettingsBreakpoint);
+    },
+    onSettingsBreakpoint(event: MediaQueryListEvent) {
+      this.mobileSettings = event.matches;
+      // Rotating a phone to landscape (or resizing a desktop window down) must
+      // not leave a dialog-only flag set while the controls render inline.
+      if (!event.matches) {
+        this.moreOpen = false;
+      }
+    },
     requestCapabilities() {
       if (this.currentNodeId) {
         this.$store.dispatch('codingBridge/getCapabilities', this.currentNodeId);
@@ -1752,71 +1819,55 @@ export default defineComponent({
   }
 }
 
-// Secondary composer controls. At md+ this wrapper is invisible to layout
-// (`display: contents`), so its pills stay inline in the same flex row as
-// before. On a phone it becomes a full-width line that collapses behind the
-// "…" toggle, leaving only the backend pill on the main row.
-.cb-more {
+// One secondary control. Inline (desktop) the wrapper is invisible to layout so
+// the pill stays a flex item of the composer row; in the mobile dialog it
+// becomes a labelled, full-width row.
+.cb-setting {
   display: contents;
+
+  &--row {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  &__label {
+    font-size: 12px;
+    color: var(--app-text-subtle);
+  }
+
+  // The control is sometimes the pill itself, sometimes an el-dropdown /
+  // el-popover wrapper around one — stretch whichever it is.
+  &--row > *:not(&__label) {
+    width: 100%;
+  }
+
+  &--row .cb-pill {
+    width: 100%;
+    max-width: none;
+    height: 40px;
+    padding: 0 14px;
+    font-size: 13px;
+    justify-content: flex-start;
+  }
+
+  // Right-align every chevron so the rows read as one list.
+  &--row .cb-pill__caret {
+    margin-left: auto;
+  }
 }
 
-// The "…" toggle only exists on phones. Tailwind's `md:hidden` can't do this
-// here: `.cb-icon-btn[data-v-*]` (0,2,0) outranks `.md\:hidden` (0,1,0), so the
-// button would stay visible on desktop — the same reason `.cb-devices-btn`
-// above sets its own breakpoint rule.
+// The settings button only exists on phones. Tailwind's `md:hidden` can't do
+// this here: `.cb-icon-btn[data-v-*]` (0,2,0) outranks `.md\:hidden` (0,1,0),
+// so the button would stay visible on desktop — the same reason
+// `.cb-devices-btn` above sets its own breakpoint rule.
 .cb-more-btn {
   display: none;
 }
 
 @media (max-width: 767px) {
-  // Let the action row wrap so the expanded panel can claim a line of its own
-  // at the composer's full width. `cb-pills` steps out of the layout so its
-  // children become direct flex items of that wrapping row — otherwise the
-  // panel stays trapped in the narrow middle column (which shares a nowrap row
-  // with the attach and Send buttons) and every pill lands on its own line.
-  .cb-actions {
-    flex-wrap: wrap;
-  }
-
-  .cb-pills {
-    display: contents;
-  }
-
-  .cb-more {
-    display: none;
-    order: 1;
-    flex: 1 0 100%;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 6px;
-
-    &--open {
-      display: flex;
-    }
-
-    // The panel is only ~340px wide, so let each control shrink to share a line
-    // rather than keeping its natural width and claiming one of its own. Some
-    // children are the pill itself, others an el-dropdown/el-popover wrapper
-    // around it — hence the direct-child selector. `0 1` (not `1 1`): growing
-    // would let the first pill swallow the whole line.
-    > * {
-      flex: 0 1 auto;
-      min-width: 0;
-    }
-
-    .cb-pill {
-      max-width: 100%;
-      justify-content: flex-start;
-    }
-  }
-
   .cb-more-btn {
     display: inline-flex;
-
-    &--open {
-      color: var(--el-color-primary);
-      border-color: var(--el-color-primary-light-5);
-    }
   }
 }
 


### PR DESCRIPTION
接 #1484 的后续。上个 PR 把次要控件收进「⋯」之后是**就地展开**成几行，仍然堆在输入框上方，看着还是挤。这次改成真正的对话框。

## 改动

点「⋯」打开「会话设置」对话框，四项各占一行、带标签、控件撑满整宽：

| | 之前（#1484） | 现在 |
|---|---|---|
| 手机 | 点开后就地展开 4 行 pill，composer 高 222px | 弹出对话框，composer 保持 120px |
| 标签 | 无（只有裸值，"中"、"D:\Projects" 脱离上下文看不懂） | 每行带标签 |

桌面端**完全不变**：新的 `ComposerSettings` 包装组件在 md+ 用 `display: contents`，pill 仍是输入行的 flex 子项。

### 两个实现上的判断

**标签由每个控件自己带，不按位置对应。** 一开始我传了个 label 数组按顺序配对，实测发现模板注释也会生成 vnode，导致"推理强度"配到了模型控件上、还多出 3 个空行。按位置分配这种写法，以后加一个控件或改一处 `v-if` 顺序就会静默错位，所以改成每个控件自带标签。

**用 matchMedia 而不是媒体查询。** "渲染成对话框还是内联"是结构选择不是样式，CSS 管不了。顺带处理了一个边界：对话框开着时把窗口拉宽，必须同时关掉它 —— 否则控件已经回到内联而 `moreOpen` 仍为 true，下次变窄会自己弹出来。

## i18n

复用现有译文（会话设置 / 模型 / 推理强度 / 权限模式 / 工作目录 / 关闭），18 个语言均已存在，**不涉及翻译流程**。

## 验证

在 dev server 上用 Playwright 驱动真实组件实测（临时挂载页验证后已删除）：

- **手机 390px**：对话框正常弹出，四行标签与控件一一对应（Model→Default model、Reasoning effort→Default、Permission mode→Bypass all permissions、Working directory→Default directory）
- **桌面 1280px**：五个 pill 一行、`top` 全为 827（同一行）、composer 高 114px、无「⋯」按钮、对话框不进 DOM
- **交互**：对话框内权限下拉能开并选中，pill 随之更新为 "Plan mode (read-only)"；Close 按钮正常关闭
- **断点切换**：1280→390 实时切成 1 个 pill + 按钮；**对话框开着时拉宽回 1280，对话框正确消失并还原 5 个内联 pill**

新增 5 个断点行为的单测（含上面那个 resize 边界）。`eslint` / `vue-tsc -b` / `vitest`（25 个测试）均通过。

> 修 `SessionView.scroll.test.ts` 的一行：它的手搓 mock context 会直接调 `mounted`，需要给新增的 `watchSettingsBreakpoint` 补个 stub（与既有的 `requestCapabilities` / `syncSessionSettings` 同样处理）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)