### PR TITLE
fix(connectors): 桌面/iOS/Android 的连接器授权按各自的方式打开并回来刷新

### DIFF
--- a/change/@acedatacloud-nexior-7c7e6232-92e8-45d8-b0a8-c7b9818938fb.json
+++ b/change/@acedatacloud-nexior-7c7e6232-92e8-45d8-b0a8-c7b9818938fb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "connectors: connecting a service now works on desktop, iOS and Android — the consent page opens in the right browser for each and the list refreshes when you come back, instead of the click doing nothing (desktop) or leaving the screen stuck (mobile)",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -313,6 +313,32 @@ ipcMain.handle('shell:openExternal', (_e, url: string) => {
   if (allowedExternal(url)) return shell.openExternal(url);
 });
 
+/**
+ * Open a connector's OAuth consent page in the system browser.
+ *
+ * Separate from `shell:openExternal` because the destination is a *provider*
+ * host — accounts.google.com, slack.com, api.notion.com — and those can never
+ * go on `EXTERNAL_HOSTS`: that set also governs `setWindowOpenHandler` and the
+ * navigation guard, so widening it would loosen the whole window's policy for
+ * the sake of one button. Without this handler the connect click is a silent
+ * no-op (deny, then the fallback navigation gets preventDefault'd).
+ *
+ * The URL is not host-checked, because a legitimate one points at an
+ * arbitrary third party. What bounds it instead: it is only ever the
+ * `authorization_url` our own backend just returned, it must be https, and
+ * `shell.openExternal` hands it to the browser rather than to this app. No
+ * `state` is minted here — unlike login, nothing comes back through the
+ * renderer for us to bind it to.
+ */
+ipcMain.handle('connections:openAuthorize', (_e, url: string) => {
+  try {
+    if (new URL(url).protocol !== 'https:') return;
+  } catch {
+    return;
+  }
+  return shell.openExternal(url);
+});
+
 // Current native fullscreen state, so a renderer that subscribes after the
 // window already entered fullscreen still gets the right initial value.
 ipcMain.handle('window:isFullscreen', () => mainWindow?.isFullScreen() ?? false);

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -35,6 +35,13 @@ contextBridge.exposeInMainWorld('desktop', {
   // Open an external https link (payment Page, docs) in the system browser.
   openExternal: (url: string): Promise<void> => ipcRenderer.invoke('shell:openExternal', url),
 
+  // Open a connector's OAuth consent page in the system browser. Separate from
+  // openExternal because the host is a third-party provider, which must not be
+  // added to the external-open allowlist (that set also governs the navigation
+  // guard). Nothing returns through this bridge — the user comes back to the
+  // window and the renderer refetches.
+  openAuthorizeConnector: (url: string): Promise<void> => ipcRenderer.invoke('connections:openAuthorize', url),
+
   // Subscribe to native window fullscreen changes (macOS green button /
   // setFullScreen). Emits the current state immediately, then on every change.
   // In fullscreen the traffic lights are hidden, so the UI drops its inset.

--- a/src/components/connections/BrowseConnectors.vue
+++ b/src/components/connections/BrowseConnectors.vue
@@ -207,7 +207,8 @@ import ConnectorMethodPicker from '@/components/connections/ConnectorMethodPicke
 import BrowserPairingDialog from '@/components/browser/BrowserPairingDialog.vue';
 import BrowserDevicePicker from '@/components/browser/BrowserDevicePicker.vue';
 import type { IBrowserDevice } from '@/models/browserDevice';
-import { openAuthorizePopup, popupReturnUrl } from '@/utils/connections/authorizePopup';
+import { popupReturnUrl } from '@/utils/connections/authorizePopup';
+import { openAuthorizeFlow } from '@/utils/connections/authorizeFlow';
 
 interface ISourceOption {
   key: 'all' | ConnectorSource | 'featured';
@@ -547,14 +548,9 @@ export default defineComponent({
           method_id: method.id
         });
         if (data.type === 'redirect') {
-          // Popup keeps this dialog (and the page behind it) alive; a
-          // blocked popup falls back to the old full-page navigation.
-          const pending = openAuthorizePopup(data.authorization_url);
-          if (!pending) {
-            window.location.href = data.authorization_url;
-            return;
-          }
-          await pending;
+          // Popup (web) / in-app browser (native) / system browser (desktop)
+          // all keep this dialog and the page behind it alive.
+          await openAuthorizeFlow(data.authorization_url);
           this.$emit('installed');
           await this.fetchItems();
           return;
@@ -574,7 +570,11 @@ export default defineComponent({
         ElMessage.success(this.$t('connection.message.installed', { name: item.name }) as string);
         this.$emit('installed', { item, connection_id: data.connection_id });
       } catch (error: any) {
-        ElMessage.error(error?.response?.data?.detail || this.$t('connection.message.installFailed'));
+        ElMessage.error(
+          error?.message === 'desktop-authorize-unsupported'
+            ? (this.$t('connection.message.desktopUpdateRequired') as string)
+            : error?.response?.data?.detail || this.$t('connection.message.installFailed')
+        );
       } finally {
         this.installingId = null;
       }

--- a/src/i18n/ar/connection.json
+++ b/src/i18n/ar/connection.json
@@ -431,6 +431,10 @@
     "message": "فشل الإضافة، يرجى المحاولة لاحقاً.",
     "description": "connection: message.installFailed"
   },
+  "message.desktopUpdateRequired": {
+    "message": "يرجى تحديث عميل سطح المكتب قبل الاتصال.",
+    "description": "الاتصال: message.desktopUpdateRequired"
+  },
   "message.installed": {
     "message": "تمت الإضافة {name}",
     "description": "connection: message.installed"

--- a/src/i18n/de/connection.json
+++ b/src/i18n/de/connection.json
@@ -391,6 +391,10 @@
     "message": "Hinzufügen fehlgeschlagen, bitte versuchen Sie es später erneut.",
     "description": "connection: message.installFailed"
   },
+  "message.desktopUpdateRequired": {
+    "message": "Bitte aktualisieren Sie den Desktop-Client, bevor Sie sich verbinden.",
+    "description": "Verbindung: message.desktopUpdateRequired"
+  },
   "message.installed": {
     "message": "{name} hinzugefügt",
     "description": "connection: message.installed"

--- a/src/i18n/el/connection.json
+++ b/src/i18n/el/connection.json
@@ -431,6 +431,10 @@
     "message": "Η προσθήκη απέτυχε, παρακαλώ δοκιμάστε ξανά αργότερα.",
     "description": "Μήνυμα σφάλματος που δείχνει ότι η προσθήκη απέτυχε."
   },
+  "message.desktopUpdateRequired": {
+    "message": "Παρακαλώ ενημερώστε τον επιτραπέζιο πελάτη πριν συνδεθείτε.",
+    "description": "connection: message.desktopUpdateRequired"
+  },
   "message.installed": {
     "message": "Προστέθηκε {name}",
     "description": "Μήνυμα που δείχνει ότι κάτι έχει προστεθεί."

--- a/src/i18n/en/connection.json
+++ b/src/i18n/en/connection.json
@@ -391,6 +391,10 @@
     "message": "Failed to add, please try again later.",
     "description": "Error message for failed installation."
   },
+  "message.desktopUpdateRequired": {
+    "message": "Please update the desktop app to connect.",
+    "description": "Shown when the desktop shell is too old to open a connector's consent page."
+  },
   "message.installed": {
     "message": "Added {name}",
     "description": "Message indicating a connector has been added."

--- a/src/i18n/es/connection.json
+++ b/src/i18n/es/connection.json
@@ -431,6 +431,10 @@
     "message": "Error al agregar, por favor intenta de nuevo más tarde.",
     "description": "connection: message.installFailed"
   },
+  "message.desktopUpdateRequired": {
+    "message": "Por favor, actualiza el cliente de escritorio antes de conectarte.",
+    "description": "conexión: message.desktopUpdateRequired"
+  },
   "message.installed": {
     "message": "Agregado {name}",
     "description": "connection: message.installed"

--- a/src/i18n/fi/connection.json
+++ b/src/i18n/fi/connection.json
@@ -391,6 +391,10 @@
     "message": "Lisäys epäonnistui, yritä myöhemmin uudelleen.",
     "description": "Ilmoitus, että liittimen lisääminen epäonnistui."
   },
+  "message.desktopUpdateRequired": {
+    "message": "Päivitä työpöytäsovellus ennen yhteyden muodostamista.",
+    "description": "yhteys: message.desktopUpdateRequired"
+  },
   "message.installed": {
     "message": "Lisätty {name}",
     "description": "Ilmoitus, että liitin on lisätty."

--- a/src/i18n/fr/connection.json
+++ b/src/i18n/fr/connection.json
@@ -391,6 +391,10 @@
     "message": "Échec de l'ajout, veuillez réessayer plus tard.",
     "description": "Message indiquant que l'ajout a échoué."
   },
+  "message.desktopUpdateRequired": {
+    "message": "Veuillez mettre à jour le client de bureau avant de vous connecter.",
+    "description": "connection: message.desktopUpdateRequired"
+  },
   "message.installed": {
     "message": "Ajouté {name}",
     "description": "Message indiquant qu'un élément a été ajouté avec succès."

--- a/src/i18n/it/connection.json
+++ b/src/i18n/it/connection.json
@@ -391,6 +391,10 @@
     "message": "Aggiunta fallita, riprova più tardi.",
     "description": "connection: message.installFailed"
   },
+  "message.desktopUpdateRequired": {
+    "message": "Aggiorna il client desktop prima di connetterti.",
+    "description": "connessione: message.desktopUpdateRequired"
+  },
   "message.installed": {
     "message": "Aggiunto {name}",
     "description": "connection: message.installed"

--- a/src/i18n/ja/connection.json
+++ b/src/i18n/ja/connection.json
@@ -431,6 +431,10 @@
     "message": "追加に失敗しました。後でもう一度お試しください。",
     "description": "追加失敗のエラーメッセージ"
   },
+  "message.desktopUpdateRequired": {
+    "message": "デスクトップクライアントを更新してから接続してください。",
+    "description": "接続: message.desktopUpdateRequired"
+  },
   "message.installed": {
     "message": "{name}が追加されました",
     "description": "アイテムが追加されたことを示すメッセージ"

--- a/src/i18n/ko/connection.json
+++ b/src/i18n/ko/connection.json
@@ -431,6 +431,10 @@
     "message": "추가 실패. 나중에 다시 시도하세요.",
     "description": "추가 실패 메시지"
   },
+  "message.desktopUpdateRequired": {
+    "message": "데스크톱 클라이언트를 업데이트한 후 다시 연결하세요.",
+    "description": "connection: message.desktopUpdateRequired"
+  },
   "message.installed": {
     "message": "{name}이(가) 추가되었습니다.",
     "description": "서비스가 추가되었음을 나타내는 메시지"

--- a/src/i18n/pl/connection.json
+++ b/src/i18n/pl/connection.json
@@ -391,6 +391,10 @@
     "message": "Dodanie nie powiodło się, spróbuj ponownie później.",
     "description": "connection: message.installFailed"
   },
+  "message.desktopUpdateRequired": {
+    "message": "Proszę zaktualizować klienta desktopowego przed połączeniem.",
+    "description": "połączenie: message.desktopUpdateRequired"
+  },
   "message.installed": {
     "message": "Dodano {name}",
     "description": "connection: message.installed"

--- a/src/i18n/pt/connection.json
+++ b/src/i18n/pt/connection.json
@@ -391,6 +391,10 @@
     "message": "Falha ao Adicionar, por favor, tente novamente mais tarde.",
     "description": "Mensagem que indica que a adição do conector falhou."
   },
+  "message.desktopUpdateRequired": {
+    "message": "Por favor, atualize o cliente de desktop antes de se conectar.",
+    "description": "conexão: message.desktopUpdateRequired"
+  },
   "message.installed": {
     "message": "Adicionado {name}",
     "description": "Mensagem que indica que o conector foi adicionado com sucesso."

--- a/src/i18n/ru/connection.json
+++ b/src/i18n/ru/connection.json
@@ -431,6 +431,10 @@
     "message": "Не удалось добавить, пожалуйста, попробуйте позже.",
     "description": "Сообщение об ошибке при добавлении соединителя."
   },
+  "message.desktopUpdateRequired": {
+    "message": "Пожалуйста, обновите настольный клиент перед подключением.",
+    "description": "connection: message.desktopUpdateRequired"
+  },
   "message.installed": {
     "message": "Добавлено {name}",
     "description": "Сообщение о том, что соединитель был добавлен."

--- a/src/i18n/sr/connection.json
+++ b/src/i18n/sr/connection.json
@@ -431,6 +431,10 @@
     "message": "Dodavanje nije uspelo, molimo pokušajte ponovo kasnije.",
     "description": "Poruka koja obaveštava o neuspehu dodavanja."
   },
+  "message.desktopUpdateRequired": {
+    "message": "Молимо вас да обновите десктоп клијент пре него што се повежете.",
+    "description": "повезивање: message.desktopUpdateRequired"
+  },
   "message.installed": {
     "message": "Dodato {name}",
     "description": "Poruka koja obaveštava korisnika da je konektor uspešno dodat."

--- a/src/i18n/sv/connection.json
+++ b/src/i18n/sv/connection.json
@@ -391,6 +391,10 @@
     "message": "Tillägg misslyckades, försök igen senare.",
     "description": "connection: message.installFailed"
   },
+  "message.desktopUpdateRequired": {
+    "message": "Vänligen uppdatera skrivbordsappen innan du ansluter.",
+    "description": "connection: message.desktopUpdateRequired"
+  },
   "message.installed": {
     "message": "Tillagd {name}",
     "description": "connection: message.installed"

--- a/src/i18n/uk/connection.json
+++ b/src/i18n/uk/connection.json
@@ -431,6 +431,10 @@
     "message": "Не вдалося додати, будь ласка, спробуйте ще раз пізніше.",
     "description": "Повідомлення про невдале додавання з'єднувача."
   },
+  "message.desktopUpdateRequired": {
+    "message": "Будь ласка, оновіть десктопний клієнт перед підключенням.",
+    "description": "підключення: message.desktopUpdateRequired"
+  },
   "message.installed": {
     "message": "Додано {name}",
     "description": "Повідомлення про успішне додавання з'єднувача."

--- a/src/i18n/zh-CN/connection.json
+++ b/src/i18n/zh-CN/connection.json
@@ -391,6 +391,10 @@
     "message": "添加失败，请稍后重试。",
     "description": "connection: message.installFailed"
   },
+  "message.desktopUpdateRequired": {
+    "message": "请更新桌面客户端后再连接。",
+    "description": "connection: message.desktopUpdateRequired"
+  },
   "message.installed": {
     "message": "已添加 {name}",
     "description": "connection: message.installed"

--- a/src/i18n/zh-TW/connection.json
+++ b/src/i18n/zh-TW/connection.json
@@ -431,6 +431,10 @@
     "message": "添加失敗，請稍後重試。",
     "description": "顯示添加失敗的提示"
   },
+  "message.desktopUpdateRequired": {
+    "message": "請更新桌面客戶端後再連接。",
+    "description": "connection: message.desktopUpdateRequired"
+  },
   "message.installed": {
     "message": "已添加 {name}",
     "description": "顯示已添加的提示"

--- a/src/pages/chat/Conversation.vue
+++ b/src/pages/chat/Conversation.vue
@@ -132,7 +132,8 @@ import ConnectorStrip from '@/components/chat/ConnectorStrip.vue';
 import WorkingDirectoryBar from '@/components/chat/WorkingDirectoryBar.vue';
 import Layout from '@/layouts/Chat.vue';
 import { isImageUrl } from '@/utils/is';
-import { supportsClientTools, isDesktop } from '@/utils/surface';
+import { supportsClientTools, isDesktop, isWeb } from '@/utils/surface';
+import { openAuthorizeFlow } from '@/utils/connections/authorizeFlow';
 import { ensureLoggedIn } from '@/utils/login';
 import { localExec, type LocalToolSpec } from '@/utils/desktop';
 import { getBaseUrlPlatform } from '@/utils';
@@ -147,7 +148,7 @@ import {
 import { hasLoadedConversationMessages } from '@/components/chat/conversationRestore';
 import { reduceBrowserToolExecution } from '@/utils/browserToolExecution';
 import { chatOperator } from '@/operators';
-import { ElDropdown, ElDropdownItem, ElDropdownMenu, ElSkeleton, ElSkeletonItem } from 'element-plus';
+import { ElDropdown, ElDropdownItem, ElDropdownMenu, ElMessage, ElSkeleton, ElSkeletonItem } from 'element-plus';
 
 export interface IData {
   drawer: boolean;
@@ -1264,7 +1265,7 @@ export default defineComponent({
      * deliberately and the rest of the conversation is persisted
      * server-side and restored on return.
      */
-    onAuthorizeConnector(payload: { tool_use_id: string; entry: { connector: string; install_url?: string } }) {
+    async onAuthorizeConnector(payload: { tool_use_id: string; entry: { connector: string; install_url?: string } }) {
       const url = payload.entry?.install_url;
       if (!url) {
         console.warn('authorize click with no install_url', payload);
@@ -1275,7 +1276,26 @@ export default defineComponent({
       // there 404s. Rewrite it to the current group's real conversation
       // route before handing off to AuthFrontend.
       const prefix = this.$route.matched[0]?.path ?? '';
-      window.location.href = repairInstallReturnToUrl(url, prefix);
+      const target = repairInstallReturnToUrl(url, prefix);
+      if (isWeb()) {
+        // `return_to` navigates the tab back here, so a full-page hop is
+        // still the right shape on web.
+        window.location.href = target;
+        return;
+      }
+      // On native/desktop that same hop leaves the app shell for good: the
+      // return lands on studio.acedata.cloud in a browser, not in the app.
+      // Send it outward instead and stay put — `consentReturn` already
+      // resumes the paused tool_use when the connection shows up.
+      try {
+        await openAuthorizeFlow(target);
+      } catch (error: any) {
+        ElMessage.error(
+          error?.message === 'desktop-authorize-unsupported'
+            ? (this.$t('connection.message.desktopUpdateRequired') as string)
+            : error?.message || (this.$t('connection.message.installFailed') as string)
+        );
+      }
     },
     /**
      * Stash any ``?consent=<rid>&connector=<id>`` pair on

--- a/src/pages/console/connectors/Index.vue
+++ b/src/pages/console/connectors/Index.vue
@@ -657,7 +657,8 @@ import ConsolePageHeader from '@/components/console/PageHeader.vue';
 import ConnectorMethodPicker from '@/components/connections/ConnectorMethodPicker.vue';
 import BrowserPairingDialog from '@/components/browser/BrowserPairingDialog.vue';
 import BrowserDevicePicker from '@/components/browser/BrowserDevicePicker.vue';
-import { openAuthorizePopup, popupReturnUrl } from '@/utils/connections/authorizePopup';
+import { popupReturnUrl } from '@/utils/connections/authorizePopup';
+import { openAuthorizeFlow } from '@/utils/connections/authorizeFlow';
 import type { IBrowserDevice } from '@/models/browserDevice';
 
 /** One row of the connection detail overflow menu. */
@@ -1677,18 +1678,23 @@ export default defineComponent({
       }
     },
     /**
-     * Run the consent flow in a popup so this page keeps its state, then
-     * refresh. Falls back to a full-page navigation when the popup is
-     * blocked. We refetch on every outcome — the popup closing is all we
-     * learn, so the server is the authority on what actually connected.
+     * Run the consent flow on this surface, then refresh. Web gets a popup,
+     * native the in-app browser, desktop the system browser — all three
+     * resolve on "the flow ended", and the server is the authority on what
+     * actually connected, so we always refetch.
      */
     async runAuthorizePopup(authorizationUrl: string) {
-      const pending = openAuthorizePopup(authorizationUrl);
-      if (!pending) {
-        window.location.href = authorizationUrl;
+      try {
+        await openAuthorizeFlow(authorizationUrl);
+      } catch (error: any) {
+        this.pendingCreateNew = false;
+        ElMessage.error(
+          error?.message === 'desktop-authorize-unsupported'
+            ? (this.$t('connection.message.desktopUpdateRequired') as string)
+            : error?.message || (this.$t('connection.message.installFailed') as string)
+        );
         return;
       }
-      await pending;
       this.pendingCreateNew = false;
       await this.fetchConnections();
     },

--- a/src/utils/connections/authorizeFlow.test.ts
+++ b/src/utils/connections/authorizeFlow.test.ts
@@ -1,0 +1,152 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const surface = vi.hoisted(() => ({ isNative: vi.fn(() => false), isDesktop: vi.fn(() => false) }));
+const capBrowser = vi.hoisted(() => ({ open: vi.fn(), addListener: vi.fn() }));
+const bridge = vi.hoisted(() => ({ desktopBridge: vi.fn() }));
+const popup = vi.hoisted(() => ({ openAuthorizePopup: vi.fn() }));
+
+vi.mock('../surface', () => surface);
+vi.mock('@capacitor/browser', () => ({ Browser: capBrowser }));
+vi.mock('../desktop', () => bridge);
+vi.mock('./authorizePopup', () => popup);
+
+import { openAuthorizeFlow } from './authorizeFlow';
+
+const URL_UNDER_TEST = 'https://accounts.google.com/o/oauth2/auth?client_id=x';
+
+/** A resolved `browserFinished` subscription, plus the callback it captured. */
+function stubBrowserFinished() {
+  const remove = vi.fn().mockResolvedValue(undefined);
+  let fire = () => {};
+  capBrowser.addListener.mockImplementation((_event: string, cb: () => void) => {
+    fire = cb;
+    return Promise.resolve({ remove });
+  });
+  return { remove, finish: () => fire() };
+}
+
+describe('openAuthorizeFlow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    surface.isNative.mockReturnValue(false);
+    surface.isDesktop.mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('web', () => {
+    it('resolves when the popup closes', async () => {
+      popup.openAuthorizePopup.mockReturnValue(Promise.resolve());
+      await expect(openAuthorizeFlow(URL_UNDER_TEST)).resolves.toBeUndefined();
+      expect(popup.openAuthorizePopup).toHaveBeenCalledWith(URL_UNDER_TEST);
+    });
+
+    it('falls back to a full-page navigation when the popup is blocked', async () => {
+      popup.openAuthorizePopup.mockReturnValue(null);
+      const assign = vi.fn();
+      Object.defineProperty(window, 'location', {
+        value: {
+          ...window.location,
+          set href(v: string) {
+            assign(v);
+          }
+        },
+        writable: true
+      });
+
+      await openAuthorizeFlow(URL_UNDER_TEST);
+      expect(assign).toHaveBeenCalledWith(URL_UNDER_TEST);
+    });
+  });
+
+  describe('native', () => {
+    beforeEach(() => surface.isNative.mockReturnValue(true));
+
+    it('uses the in-app browser, never window.open', async () => {
+      const { finish } = stubBrowserFinished();
+      capBrowser.open.mockResolvedValue(undefined);
+      const openSpy = vi.spyOn(window, 'open');
+
+      const pending = openAuthorizeFlow(URL_UNDER_TEST);
+      await vi.waitFor(() => expect(capBrowser.open).toHaveBeenCalledWith({ url: URL_UNDER_TEST }));
+      finish();
+      await pending;
+
+      // A window.open here would eject to Chrome/Safari and, on Android,
+      // the href fallback would fire the same navigation a second time.
+      expect(openSpy).not.toHaveBeenCalled();
+      expect(popup.openAuthorizePopup).not.toHaveBeenCalled();
+    });
+
+    it('stays pending until the user dismisses the browser', async () => {
+      const { finish } = stubBrowserFinished();
+      capBrowser.open.mockResolvedValue(undefined);
+
+      let settled = false;
+      void openAuthorizeFlow(URL_UNDER_TEST).then(() => {
+        settled = true;
+      });
+      await vi.waitFor(() => expect(capBrowser.open).toHaveBeenCalled());
+      expect(settled).toBe(false);
+
+      finish();
+      await vi.waitFor(() => expect(settled).toBe(true));
+    });
+
+    it('removes the listener so a second authorize does not double-fire', async () => {
+      const { remove, finish } = stubBrowserFinished();
+      capBrowser.open.mockResolvedValue(undefined);
+
+      const pending = openAuthorizeFlow(URL_UNDER_TEST);
+      await vi.waitFor(() => expect(capBrowser.open).toHaveBeenCalled());
+      finish();
+      await pending;
+
+      expect(remove).toHaveBeenCalled();
+    });
+
+    it('resolves rather than hanging when the browser fails to open', async () => {
+      stubBrowserFinished();
+      capBrowser.open.mockRejectedValue(new Error('no browser'));
+      // A rejection that swallowed the promise would leave the caller's
+      // spinner up forever.
+      await expect(openAuthorizeFlow(URL_UNDER_TEST)).resolves.toBeUndefined();
+    });
+  });
+
+  describe('desktop', () => {
+    beforeEach(() => surface.isDesktop.mockReturnValue(true));
+
+    it('hands the url to the main process and resolves on window focus', async () => {
+      const openAuthorizeConnector = vi.fn().mockResolvedValue(undefined);
+      bridge.desktopBridge.mockReturnValue({ openAuthorizeConnector });
+
+      let settled = false;
+      void openAuthorizeFlow(URL_UNDER_TEST).then(() => {
+        settled = true;
+      });
+      await vi.waitFor(() => expect(openAuthorizeConnector).toHaveBeenCalledWith(URL_UNDER_TEST));
+      expect(settled).toBe(false);
+
+      window.dispatchEvent(new Event('focus'));
+      await vi.waitFor(() => expect(settled).toBe(true));
+    });
+
+    it('throws on a desktop shell without the IPC instead of silently doing nothing', async () => {
+      // window.open on desktop is denied by setWindowOpenHandler for any host
+      // off EXTERNAL_HOSTS — which lists no OAuth provider — so a fallback
+      // would look identical to a dead click.
+      bridge.desktopBridge.mockReturnValue({});
+      await expect(openAuthorizeFlow(URL_UNDER_TEST)).rejects.toThrow('desktop-authorize-unsupported');
+    });
+
+    it('never falls back to the web popup', async () => {
+      bridge.desktopBridge.mockReturnValue({});
+      await expect(openAuthorizeFlow(URL_UNDER_TEST)).rejects.toThrow();
+      expect(popup.openAuthorizePopup).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/utils/connections/authorizeFlow.ts
+++ b/src/utils/connections/authorizeFlow.ts
@@ -1,0 +1,113 @@
+/**
+ * Cross-surface connector authorization.
+ *
+ * One entry point, three transports. What every surface must produce is the
+ * same single bit — *the flow ended, go refetch* — because the server is the
+ * authority on what actually connected. What differs is how we learn it:
+ *
+ *  - **web**: a popup, watched via `popup.closed` (see `authorizePopup.ts`).
+ *  - **native**: the Capacitor in-app browser, watched via `browserFinished`.
+ *  - **desktop**: the system browser, watched via window `focus` — Electron
+ *    opens a real browser, so there is no in-app close event to listen for.
+ *
+ * None of these is a message channel; each is something the app can observe on
+ * its own, which is why none needs cross-origin trust.
+ *
+ * ## Why native can't just use `window.open`
+ *
+ * Capacitor hands any off-origin URL to the OS browser and cancels the
+ * WebView load — Android via `Bridge.launchIntent` → `Intent.ACTION_VIEW`,
+ * iOS via `WebViewDelegationHandler` → `UIApplication.open`. So `window.open`
+ * ejects the user out of the app shell, and the `window.location.href`
+ * fallback fires the *same* navigation a second time. Electron is worse: its
+ * `setWindowOpenHandler` denies unconditionally and only opens hosts on
+ * `EXTERNAL_HOSTS` — which lists no OAuth provider — so the click does
+ * nothing at all.
+ *
+ * See `plans/connections-in-nexior/04-native-surface-breakage.md`.
+ *
+ * ## What this does NOT do yet
+ *
+ * The user still has to switch back to the app by hand; we refetch when they
+ * do. Landing them back automatically needs the custom-scheme deep link from
+ * `plans/connections-in-nexior/02-nexior-return-channels.md`.
+ */
+
+import { Browser } from '@capacitor/browser';
+import { isNative, isDesktop } from '../surface';
+import { desktopBridge } from '../desktop';
+import { openAuthorizePopup } from './authorizePopup';
+
+/**
+ * Run the consent flow on whatever surface we are, and resolve once it ends.
+ *
+ * Always resolves — callers refetch rather than branching on an outcome. A
+ * surface that cannot open the URL at all still resolves, so a spinner never
+ * outlives the click.
+ */
+export async function openAuthorizeFlow(authorizationUrl: string): Promise<void> {
+  if (isDesktop()) return openOnDesktop(authorizationUrl);
+  if (isNative()) return openOnNative(authorizationUrl);
+  return openOnWeb(authorizationUrl);
+}
+
+/** Web: popup, falling back to a full-page navigation when it's blocked. */
+async function openOnWeb(authorizationUrl: string): Promise<void> {
+  const pending = openAuthorizePopup(authorizationUrl);
+  if (!pending) {
+    // Navigating away — this page is about to be replaced, so there is
+    // nothing left to refresh.
+    window.location.href = authorizationUrl;
+    return;
+  }
+  await pending;
+}
+
+/**
+ * Native: the Capacitor in-app browser.
+ *
+ * `browserFinished` is the native analogue of `popup.closed` — it fires when
+ * the user dismisses the sheet, whatever the outcome. Deliberately no
+ * `window.location.href` fallback: on Android that is a second top-level
+ * navigation, which Capacitor hands to Chrome all over again.
+ */
+async function openOnNative(authorizationUrl: string): Promise<void> {
+  let handle: { remove: () => Promise<void> } | undefined;
+  try {
+    const finished = new Promise<void>((resolve) => {
+      void Browser.addListener('browserFinished', () => resolve()).then((h) => {
+        handle = h;
+      });
+    });
+    await Browser.open({ url: authorizationUrl });
+    await finished;
+  } catch (error) {
+    // A browser that never opened has nothing to wait for; resolving lets the
+    // caller refetch, which is harmless and clears the spinner.
+    console.warn('in-app browser failed for connector authorize', error);
+  } finally {
+    await handle?.remove();
+  }
+}
+
+/**
+ * Desktop: the system browser via the Electron main process.
+ *
+ * There is no in-app browser to emit `browserFinished`, so we settle on the
+ * next window `focus` — the user coming back is the signal. `visibilitychange`
+ * would not do: the Electron window stays visible behind the browser.
+ */
+async function openOnDesktop(authorizationUrl: string): Promise<void> {
+  const bridge = desktopBridge();
+  if (!bridge?.openAuthorizeConnector) {
+    // Desktop shell older than this IPC. Falling through to window.open would
+    // be a silent no-op (setWindowOpenHandler denies non-allowlisted hosts),
+    // so say so instead of pretending the click worked.
+    throw new Error('desktop-authorize-unsupported');
+  }
+  const returned = new Promise<void>((resolve) => {
+    window.addEventListener('focus', () => resolve(), { once: true });
+  });
+  await bridge.openAuthorizeConnector(authorizationUrl);
+  await returned;
+}

--- a/src/utils/desktop.ts
+++ b/src/utils/desktop.ts
@@ -18,6 +18,14 @@ export interface DesktopBridge {
   onAuthExpired(cb: () => void): () => void;
   /** Open an external https link (payment Page, docs) in the system browser. */
   openExternal(url: string): Promise<void>;
+  /**
+   * Open a connector's OAuth consent page in the system browser.
+   *
+   * Optional: an older desktop shell has no such handler, and falling back to
+   * `window.open` there is a silent no-op (provider hosts aren't on the
+   * external-open allowlist), so callers must check before offering the flow.
+   */
+  openAuthorizeConnector?(url: string): Promise<void>;
   /** Subscribe to native window fullscreen changes (macOS). Fires immediately
    * with the current state, then on every enter/leave. Returns an unsubscribe. */
   onFullscreenChange(cb: (isFullscreen: boolean) => void): () => void;


### PR DESCRIPTION
调研报告：[Index #330](https://github.com/AceDataCloud/Index/pull/330) → `plans/connections-in-nexior/04-native-surface-breakage.md`
前置（已合并，只覆盖 web）：[AuthBackend#397](https://github.com/AceDataCloud/AuthBackend/pull/397) · [AuthFrontend#252](https://github.com/AceDataCloud/AuthFrontend/pull/252) · [Nexior#1482](https://github.com/AceDataCloud/Nexior/pull/1482)

## 问题

连接器授权的三个调用点**没有任何 surface 分支**，而三端的 shell 各自以不同方式处理 `window.open()`，于是三端都不可用、且各坏各的：

| Surface | 症状 |
|---|---|
| **Electron** | 点「连接 Google / Slack / Notion」**完全静默**——不开窗、不跳转、不报错 |
| **Android** | 甩进系统 Chrome，UI 可能**永久卡在「授权中」** |
| **iOS** | 同一 URL 被推进 Safari 两次，列表不刷新 |

Electron 那条是纯代码事实：`setWindowOpenHandler` 对不在 `EXTERNAL_HOSTS` 的 host 无条件 deny 且不开外部浏览器，降级的 `window.location.href` 又被导航 guard `preventDefault()`——而 `EXTERNAL_HOSTS` 里一个 provider 域都没有。GitHub 是唯一例外（它为 /download 页的下载按钮进了白名单）。

## 改法

新增 `openAuthorizeFlow()`：**一个入口，三种传输**，都只产出同一个 bit ——「结束了，去刷新」，因为服务端才是权威。

| Surface | 打开 | 「结束了」信号 |
|---|---|---|
| web | popup（不变） | `popup.closed` |
| native | `Browser.open()` 应用内浏览器 | `browserFinished` |
| desktop | 新 IPC → 系统浏览器 | 窗口 `focus` |

三者都是**应用自己就能观测**的信号，不需要对方配合、不涉及跨域信任——和 web 那批 PR 同一个思路。

### 两个刻意的设计选择

**① Electron 新增专用 IPC，而不是放宽白名单。** `EXTERNAL_HOSTS` 同时管着 `setWindowOpenHandler` 和导航 guard，把 provider 域塞进去等于为一个按钮放宽整个窗口的导航策略。新 handler 只校验 https 并交给 `shell.openExternal`——URL 只会是我们自己后端刚返回的 `authorization_url`，且交给的是浏览器而非本应用。不铸 `state`：不像登录，没有东西经渲染进程回来给它绑定。

**② 老版本桌面 shell 抛错，不静默降级。** 降级到 `window.open` 会被 `setWindowOpenHandler` deny——和现在的死点击一模一样。宁可提示「请更新桌面客户端」。

**③ 移动端刻意不保留 `window.location.href` 降级。** 那正是 Android 二次跳转的根源：那是又一次顶层导航，Capacitor 会再甩一次 Chrome。

## 顺带修掉的

聊天 consent 卡片（`Conversation.vue`）此前是裸 `window.location.href` 指向 `auth.acedata.cloud`。桌面端的 guard 放行 `AUTH_HOSTS`，所以主窗口会**离开 `app://bundle` 导航到 auth 站，之后再无路径回到应用 bundle**。现在 web 保持原样（`return_to` 会把标签页带回来），native/desktop 走外部浏览器并留在原地——`consentReturn` 本来就会在连接出现后恢复暂停的 `tool_use`。

## 测试

`authorizeFlow.test.ts` **15 passed**，含几条防回归断言：
- 原生端**绝不**调 `window.open`（调了就会被弹出应用外，且 Android 上 href 降级会二次跳转）
- 桌面端**绝不**回落到 web popup
- 浏览器打不开时**resolve 而非挂起**（挂起会让 spinner 永远转下去）
- 监听器会 `remove`，第二次授权不会重复触发

`vue-tsc -b` ✅ · `tsc -p electron/tsconfig.json` ✅ · eslint ✅ · `check_i18n_coverage.py` ✅（17 locale × 47 namespace，无英文占位）

## i18n

新增一个 key（`message.desktopUpdateRequired`），18 个 locale 各 +4 行。

> ⚠️ 记录一个坑：`translate_i18n.py --repair` 顺带改写了 **68 个无关文件**的已有翻译（连 `description` 都重写，如 `de/chat.json` 把「Ausführungsmodus」改成「Betriebsmodus」），并把 9 个 locale 的 key 顺序整个打乱。已全部还原，本 PR 的 i18n diff 是干净的 +4/-0 × 18。

## 范围：这是止血，不是终局

**用户仍需手动切回 App**，回来才刷新。自动落回需要 [02-nexior-return-channels](https://github.com/AceDataCloud/Index/blob/main/plans/connections-in-nexior/02-nexior-return-channels.md) 的 custom-scheme deep link（要改 AuthFrontend 的 `nativeRedirect.ts`——它把路径写死成 `://auth/callback`——并需要真机验证周期）。

拆开是因为死点击**是此刻正在发生**的，而 P1 需要设备回归。

## 建议的验证

- **Electron**：GitHub 连接器（唯一恰好在白名单里的）作对照组，再试 Google / Slack / Notion
- **Android**：这次能确认 `window.open()` 那个未证实分支了——若原本是「永久卡在授权中」，本 PR 应一并修掉
- **iOS**：确认 Safari 只被拉起一次

🤖 Generated with [Claude Code](https://claude.com/claude-code)