### PR TITLE
feat(download): 下载页补上浏览器扩展入口

### DIFF
--- a/change/@acedatacloud-nexior-1055ce2c-a27b-41f5-97d3-d0298a0d2f3f.json
+++ b/change/@acedatacloud-nexior-1055ce2c-a27b-41f5-97d3-d0298a0d2f3f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "下载页新增浏览器扩展入口（Chrome / Edge 双图标）",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/constants/extension.ts
+++ b/src/constants/extension.ts
@@ -1,0 +1,6 @@
+// The rolling pointer is published by PlatformFrontend CI on every merge that
+// touches extension/ — never version-pin it here, or this file needs a PR per
+// extension release (which is exactly the trap the docs link fell into).
+export const BROWSER_EXTENSION_DOWNLOAD_URL = 'https://cdn.acedata.cloud/extension/acedata-extension-latest.zip';
+
+export const BROWSER_EXTENSION_GUIDE_URL = 'https://platform.acedata.cloud/documents/acedataext';

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -31,5 +31,6 @@ export * from './webextrator';
 export * from './fish';
 export * from './surface';
 export * from './mobile';
+export * from './extension';
 export * from './setting';
 export * from './codingBridge';

--- a/src/i18n/ar/common.json
+++ b/src/i18n/ar/common.json
@@ -179,6 +179,10 @@
     "message": "تنزيل لنظام macOS",
     "description": "Text in button for downloading the macOS desktop installer"
   },
+  "button.downloadBrowserExtension": {
+    "message": "تحميل ملحق المتصفح",
+    "description": "Text in button for downloading the Chrome / Edge browser extension package"
+  },
   "button.installIos": {
     "message": "تثبيت iOS",
     "description": "النص في الزر، المستخدم لتثبيت تطبيق iOS"

--- a/src/i18n/de/common.json
+++ b/src/i18n/de/common.json
@@ -179,6 +179,10 @@
     "message": "Für macOS herunterladen",
     "description": "Text in button for downloading the macOS desktop installer"
   },
+  "button.downloadBrowserExtension": {
+    "message": "Browsererweiterung herunterladen",
+    "description": "Text in button for downloading the Chrome / Edge browser extension package"
+  },
   "button.installIos": {
     "message": "iOS installieren",
     "description": "Text im Button, der verwendet wird, um die iOS-Anwendung zu installieren"

--- a/src/i18n/el/common.json
+++ b/src/i18n/el/common.json
@@ -179,6 +179,10 @@
     "message": "Λήψη για macOS",
     "description": "Text in button for downloading the macOS desktop installer"
   },
+  "button.downloadBrowserExtension": {
+    "message": "Κατεβάστε την επέκταση του προγράμματος περιήγησης",
+    "description": "Text in button for downloading the Chrome / Edge browser extension package"
+  },
   "button.installIos": {
     "message": "Εγκατάσταση iOS",
     "description": "Κείμενο στο κουμπί για να εγκαταστήσετε την εφαρμογή iOS"

--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -175,6 +175,10 @@
     "message": "Download for macOS",
     "description": "Text in button for downloading the macOS desktop installer"
   },
+  "button.downloadBrowserExtension": {
+    "message": "Download Browser Extension",
+    "description": "Text in button for downloading the Chrome / Edge browser extension package"
+  },
   "button.installIos": {
     "message": "Install iOS",
     "description": "Text in button for installing the iOS app"

--- a/src/i18n/es/common.json
+++ b/src/i18n/es/common.json
@@ -179,6 +179,10 @@
     "message": "Descargar para macOS",
     "description": "Text in button for downloading the macOS desktop installer"
   },
+  "button.downloadBrowserExtension": {
+    "message": "Descargar extensión del navegador",
+    "description": "Text in button for downloading the Chrome / Edge browser extension package"
+  },
   "button.installIos": {
     "message": "Instalar iOS",
     "description": "Texto en el botón, utilizado para instalar la aplicación de iOS"

--- a/src/i18n/fi/common.json
+++ b/src/i18n/fi/common.json
@@ -179,6 +179,10 @@
     "message": "Lataa macOS:lle",
     "description": "Painikkeen teksti macOS-työpöytäasennusohjelman lataamiseen"
   },
+  "button.downloadBrowserExtension": {
+    "message": "Lataa selainlaajennus",
+    "description": "Text in button for downloading the Chrome / Edge browser extension package"
+  },
   "button.installIos": {
     "message": "Asenna iOS",
     "description": "Painikkeen teksti, jota käytetään iOS-sovelluksen asentamiseen"

--- a/src/i18n/fr/common.json
+++ b/src/i18n/fr/common.json
@@ -179,6 +179,10 @@
     "message": "Télécharger pour macOS",
     "description": "Text in button for downloading the macOS desktop installer"
   },
+  "button.downloadBrowserExtension": {
+    "message": "Télécharger l'extension du navigateur",
+    "description": "Text in button for downloading the Chrome / Edge browser extension package"
+  },
   "button.installIos": {
     "message": "Installer iOS",
     "description": "Texte dans le bouton, utilisé pour installer l'application iOS"

--- a/src/i18n/it/common.json
+++ b/src/i18n/it/common.json
@@ -179,6 +179,10 @@
     "message": "Scarica per macOS",
     "description": "Text in button for downloading the macOS desktop installer"
   },
+  "button.downloadBrowserExtension": {
+    "message": "Scarica estensione del browser",
+    "description": "Text in button for downloading the Chrome / Edge browser extension package"
+  },
   "button.installIos": {
     "message": "Installa iOS",
     "description": "Testo nel pulsante, utilizzato per installare l'app iOS"

--- a/src/i18n/ja/common.json
+++ b/src/i18n/ja/common.json
@@ -179,6 +179,10 @@
     "message": "macOS 版をダウンロード",
     "description": "macOSデスクトップインストーラーのダウンロードボタンのテキスト"
   },
+  "button.downloadBrowserExtension": {
+    "message": "ブラウザ拡張をダウンロード",
+    "description": "Text in button for downloading the Chrome / Edge browser extension package"
+  },
   "button.installIos": {
     "message": "iOSをインストール",
     "description": "ボタンのテキスト、iOSアプリをインストールするため"

--- a/src/i18n/ko/common.json
+++ b/src/i18n/ko/common.json
@@ -179,6 +179,10 @@
     "message": "macOS용 다운로드",
     "description": "Text in button for downloading the macOS desktop installer"
   },
+  "button.downloadBrowserExtension": {
+    "message": "브라우저 확장 프로그램 다운로드",
+    "description": "Text in button for downloading the Chrome / Edge browser extension package"
+  },
   "button.installIos": {
     "message": "iOS 설치",
     "description": "버튼의 텍스트, iOS 애플리케이션을 설치하는 데 사용"

--- a/src/i18n/pl/common.json
+++ b/src/i18n/pl/common.json
@@ -179,6 +179,10 @@
     "message": "Pobierz dla macOS",
     "description": "Text in button for downloading the macOS desktop installer"
   },
+  "button.downloadBrowserExtension": {
+    "message": "Pobierz rozszerzenie przeglądarki",
+    "description": "Text in button for downloading the Chrome / Edge browser extension package"
+  },
   "button.installIos": {
     "message": "Zainstaluj iOS",
     "description": "Tekst w przycisku, używany do instalacji aplikacji iOS"

--- a/src/i18n/pt/common.json
+++ b/src/i18n/pt/common.json
@@ -179,6 +179,10 @@
     "message": "Baixar para macOS",
     "description": "Text in button for downloading the macOS desktop installer"
   },
+  "button.downloadBrowserExtension": {
+    "message": "Baixar extensão do navegador",
+    "description": "Text in button for downloading the Chrome / Edge browser extension package"
+  },
   "button.installIos": {
     "message": "Instalar iOS",
     "description": "Texto no botão para instalar o aplicativo iOS"

--- a/src/i18n/ru/common.json
+++ b/src/i18n/ru/common.json
@@ -179,6 +179,10 @@
     "message": "Скачать для macOS",
     "description": "Text in button for downloading the macOS desktop installer"
   },
+  "button.downloadBrowserExtension": {
+    "message": "Скачать расширение для браузера",
+    "description": "Text in button for downloading the Chrome / Edge browser extension package"
+  },
   "button.installIos": {
     "message": "Установить для iOS",
     "description": "Текст в кнопке, используемый для установки приложения для iOS"

--- a/src/i18n/sr/common.json
+++ b/src/i18n/sr/common.json
@@ -179,6 +179,10 @@
     "message": "Преузми за macOS",
     "description": "Text in button for downloading the macOS desktop installer"
   },
+  "button.downloadBrowserExtension": {
+    "message": "Preuzmi ekstenziju za pregledač",
+    "description": "Text in button for downloading the Chrome / Edge browser extension package"
+  },
   "button.installIos": {
     "message": "Instaliraj iOS",
     "description": "Tekst u dugmetu, koji se koristi za instalaciju iOS aplikacije"

--- a/src/i18n/sv/common.json
+++ b/src/i18n/sv/common.json
@@ -179,6 +179,10 @@
     "message": "Ladda ner för macOS",
     "description": "Text in button for downloading the macOS desktop installer"
   },
+  "button.downloadBrowserExtension": {
+    "message": "Ladda ner webbläsartillägg",
+    "description": "Text in button for downloading the Chrome / Edge browser extension package"
+  },
   "button.installIos": {
     "message": "Installera iOS",
     "description": "Text i knappen för att installera iOS-appen"

--- a/src/i18n/uk/common.json
+++ b/src/i18n/uk/common.json
@@ -179,6 +179,10 @@
     "message": "Завантажити для macOS",
     "description": "Text in button for downloading the macOS desktop installer"
   },
+  "button.downloadBrowserExtension": {
+    "message": "Завантажити розширення для браузера",
+    "description": "Text in button for downloading the Chrome / Edge browser extension package"
+  },
   "button.installIos": {
     "message": "Встановити iOS",
     "description": "Текст у кнопці, що використовується для встановлення iOS додатку"

--- a/src/i18n/zh-CN/common.json
+++ b/src/i18n/zh-CN/common.json
@@ -179,6 +179,10 @@
     "message": "下载 macOS 版",
     "description": "Text in button for downloading the macOS desktop installer"
   },
+  "button.downloadBrowserExtension": {
+    "message": "下载浏览器扩展",
+    "description": "按钮中的文本，用于下载 Chrome / Edge 浏览器扩展安装包"
+  },
   "button.installIos": {
     "message": "安装 iOS",
     "description": "按钮中的文本，用于安装 iOS 应用"

--- a/src/i18n/zh-TW/common.json
+++ b/src/i18n/zh-TW/common.json
@@ -179,6 +179,10 @@
     "message": "下載 macOS 版",
     "description": "Text in button for downloading the macOS desktop installer"
   },
+  "button.downloadBrowserExtension": {
+    "message": "下載瀏覽器擴展",
+    "description": "Text in button for downloading the Chrome / Edge browser extension package"
+  },
   "button.installIos": {
     "message": "安裝 iOS",
     "description": "按鈕中的文字，用於安裝 iOS 應用"

--- a/src/pages/download/Index.vue
+++ b/src/pages/download/Index.vue
@@ -45,6 +45,13 @@
             <font-awesome-icon :icon="faApple" class="btn-icon" />
             {{ $t('common.button.getOnAppStore') }}
           </el-button>
+          <el-button round size="large" tag="a" :href="extensionDownloadUrl" target="_blank">
+            <span class="btn-icons">
+              <font-awesome-icon :icon="faChrome" />
+              <font-awesome-icon :icon="faEdge" />
+            </span>
+            {{ $t('common.button.downloadBrowserExtension') }}
+          </el-button>
           <el-button round size="large" class="btn-ghost" @click="openSupport">
             {{ $t('common.nav.support') }}
           </el-button>
@@ -273,9 +280,10 @@ import { defineComponent } from 'vue';
 import { ElButton } from 'element-plus';
 import QrCode from 'vue-qrcode';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { faAndroid, faApple, faGooglePlay, faWindows } from '@fortawesome/free-brands-svg-icons';
+import { faAndroid, faApple, faChrome, faEdge, faGooglePlay, faWindows } from '@fortawesome/free-brands-svg-icons';
 import defaultLogo from '@/assets/images/logo.png';
 import {
+  BROWSER_EXTENSION_DOWNLOAD_URL,
   DESKTOP_RELEASES_URL,
   MOBILE_ANDROID_DOWNLOAD_URL,
   MOBILE_ANDROID_PLAY_STORE_URL,
@@ -298,6 +306,8 @@ export default defineComponent({
     return {
       faAndroid,
       faApple,
+      faChrome,
+      faEdge,
       faGooglePlay,
       faWindows
     };
@@ -326,6 +336,9 @@ export default defineComponent({
     },
     hasAppStore() {
       return !!MOBILE_IOS_APP_STORE_URL;
+    },
+    extensionDownloadUrl() {
+      return BROWSER_EXTENSION_DOWNLOAD_URL;
     },
     iosDownloadUrl() {
       return MOBILE_IOS_DOWNLOAD_URL;
@@ -507,6 +520,13 @@ export default defineComponent({
 }
 
 .btn-icon {
+  margin-right: 8px;
+}
+
+.btn-icons {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
   margin-right: 8px;
 }
 
@@ -811,6 +831,12 @@ html.dark .qr__img {
   .hero__actions :deep(.el-button) {
     width: 100%;
     margin-left: 0;
+    // el-button is nowrap by default, which clips the longest translations
+    // (Greek "Κατεβάστε την επέκταση…") on a phone-width row.
+    height: auto;
+    min-height: 40px;
+    padding-block: 8px;
+    white-space: normal;
   }
 }
 </style>


### PR DESCRIPTION
## 问题

`studio.acedata.cloud/download` 只发 Android / iOS / Windows / macOS，浏览器扩展**没有任何入口** —— 用户只能从文档里那个手工上传的哈希名 zip 拿包。

## 改动

按钮行里加一个「下载浏览器扩展」，Chrome + Edge 双图标共用一个下载地址（两个浏览器装的是同一个包），指向 PlatformFrontend CI 刚上线的滚动指针：

```
https://cdn.acedata.cloud/extension/acedata-extension-latest.zip
```

地址放在新的 `src/constants/extension.ts`，**不带版本号** —— 否则每次扩展发版都要给这个文件提一个 PR，正是文档链接踩过的坑。

选双图标单按钮而不是 Chrome / Edge 两个按钮：移动端规则会把每个 action 按钮拉成整行，拆成两个的话手机上就是 5 行。

## 顺手修一个我自己引入的窄屏截断

`el-button` 默认 `white-space: nowrap`，而这条文案是这一行里最长的。希腊语在 390px 下会被硬裁成「…περιήγ」、双图标整个被挤掉：

| 修复前 | 修复后 |
|---|---|
| ![before](https://cdn.acedata.cloud/uploads/47017049-52d1-401f-9b8b-7f48b2b2cf26) | ![after](https://cdn.acedata.cloud/uploads/096ec89e-b28e-4f62-b4e3-0935c107b020) |

移动端规则改成允许换行 + 高度自适应（40px → auto/min-height）。**确认过这是我引入的**：把现有三个按钮的文案都换成希腊语实测，`overflows` 全是 `false` —— 它们文案短，碰不到这个边界；只有新按钮会。桌面端媒体查询之外不受影响（实测仍是 nowrap / 40px）。

## 验证

Playwright 起本地 dev（路由守卫限定 `studio.acedata.cloud`，所以拦截该 host 映射到 localhost 才进得去页面）：

- **按钮渲染**：文案 / `href` 指向 CDN / `svgCount: 2`（双图标）
- **样式生效**：`.btn-icons` 实测 `display:flex, gap:6px, margin-right:8px`，两个 svg 尺寸一致，hit-test 确认图标是自身中心点的命中元素（不是被别的层盖住）
- **1440px**：四个按钮同排、无溢出
- **390px**：四个按钮各占一行、不出视口
- **最长文案（希腊语 51 字符）**：修复前 `overflows: true`，修复后 `false`、高度 40→46px、图标仍可见
- `vue-tsc -b` / `eslint` / `prettier --check` / `check_i18n_coverage.py` 全绿

## i18n

只加一个 key `common.button.downloadBrowserExtension`，18 个语言全部是**真翻译**（不是英文占位）。

⚠️ 过程中踩到已知的 `translate_i18n.py --repair` 坑：它会重译任何"仍等于英文种子"的值，一跑就改了 **134 个文件 / 855 增 783 删**，把 Midjourney 的风格预设专有名词给译了 —— `Unreal Engine` → `Απίστευτη Μηχανή`、`Octane Render` → `Octane Απόδοση`、`Van Gogh` → `Estilo Van Gogh`。已全部 `git checkout origin/main -- src/i18n/` 还原，只把我这一个 key 的译文重新写回去。所以本 PR 的 i18n diff 是**干净的 18 个文件 × 纯 +4 行、零删除**。

## 依赖

PlatformFrontend #1032（CDN 流水线）已合并并跑出第一个产物，实测：

```
HTTP/2 200
content-type: application/zip
cache-control: public, must-revalidate, max-age=300
content-length: 99164
```

下载解压确认 8 个文件、`manifest.json` 在包根部、version `0.7.19`、无 `__MACOSX/`、无 `.map`。所以这个按钮上线即可用，不会指向 404。