### PR TITLE
fix(nginx): 安全头一条都没发出去，/auth/ 还能被绕过

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,7 @@ RUN npm run build:ssg && node scripts/ssg-shell.mjs
 FROM nginx:stable-alpine as production-stage
 COPY --from=build-stage /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
+# Included by nginx.conf from every location that sets its own add_header.
+COPY security-headers.conf /etc/nginx/security-headers.conf
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/change/@acedatacloud-nexior-3a7f9c21-5d84-4e16-b9a3-6f2c81d45e7b.json
+++ b/change/@acedatacloud-nexior-3a7f9c21-5d84-4e16-b9a3-6f2c81d45e7b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "nginx: send security headers on every route and serve /auth/ variants uniformly (CASA remediation)",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/nginx.conf
+++ b/nginx.conf
@@ -46,9 +46,9 @@ server {
     server_name  localhost;
 
     # ---- Security headers ----
-    add_header X-Content-Type-Options "nosniff" always;
-    add_header X-Frame-Options "SAMEORIGIN" always;
-    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    # Also included per-location wherever a local add_header appears — nginx
+    # drops inherited add_headers as soon as a location sets one of its own.
+    include /etc/nginx/security-headers.conf;
 
     # ---- Set shared proxy headers once here ----
     # Make sure to include these BEFORE your location blocks.
@@ -78,6 +78,7 @@ server {
         root /usr/share/nginx/html;
         try_files $uri =404;
         add_header Cache-Control "public, max-age=31536000, immutable" always;
+        include /etc/nginx/security-headers.conf;
         access_log off;
     }
 
@@ -86,6 +87,7 @@ server {
         add_header Cache-Control "no-cache, no-store, max-age=0, must-revalidate" always;
         add_header Pragma "no-cache" always;
         add_header Expires "0" always;
+        include /etc/nginx/security-headers.conf;
     }
 
     # Serve /.well-known/llms.txt as alias to /llms.txt (llmstxt.org spec)
@@ -102,12 +104,14 @@ server {
         alias /usr/share/nginx/html/well-known/apple-app-site-association;
         default_type application/json;
         add_header Cache-Control "public, max-age=3600" always;
+        include /etc/nginx/security-headers.conf;
     }
 
     location = /.well-known/assetlinks.json {
         alias /usr/share/nginx/html/well-known/assetlinks.json;
         default_type application/json;
         add_header Cache-Control "public, max-age=3600" always;
+        include /etc/nginx/security-headers.conf;
     }
 
     # Invite landing (only hit when the app is NOT installed; otherwise the OS
@@ -120,6 +124,24 @@ server {
         proxy_set_header Host platform.acedata.cloud;
     }
 
+    # dist/auth/ is an empty intermediate directory (the SSG build only emits
+    # dist/auth/login/{index,index.ssg}.html), so `try_files $uri/` reaches a
+    # directory nginx refuses to list → 403, while a non-matching variant
+    # (/auth%20/) falls through to the SPA shell → 200. A scanner reads that
+    # pair as an access-control bypass (CASA scan 2026-07-20, findings #1, #10).
+    #
+    # Matches ONLY the bare directory, so the SSG rewrite in `location /` still
+    # owns /auth/login: rewriting here would re-enter this block and nginx
+    # would abort the redirect cycle with a 500.
+    location ~ "^/auth/?$" {
+        root /usr/share/nginx/html;
+        try_files /index.html =404;
+        add_header Cache-Control "no-cache, no-store, max-age=0, must-revalidate" always;
+        add_header Pragma "no-cache" always;
+        add_header Expires "0" always;
+        include /etc/nginx/security-headers.conf;
+    }
+
     location / {
         root   /usr/share/nginx/html;
         index  index.html index.htm;
@@ -127,10 +149,13 @@ server {
         if ($ssg_page != '') {
             rewrite ^ $ssg_page last;
         }
-        try_files   $uri    $uri/   /index.html;
+        # `$uri/index.html` rather than `$uri/`: a directory without an
+        # index.html would 403 instead of falling through (see /auth above).
+        try_files   $uri    $uri/index.html   /index.html;
         add_header Cache-Control "no-cache, no-store, max-age=0, must-revalidate" always;
         add_header Pragma "no-cache" always;
         add_header Expires "0" always;
+        include /etc/nginx/security-headers.conf;
     }
 
     error_page   500 502 503 504  /50x.html;

--- a/security-headers.conf
+++ b/security-headers.conf
@@ -1,0 +1,10 @@
+# Security headers, included in EVERY location that sets its own add_header.
+#
+# nginx's add_header does NOT inherit: a location with any add_header of its
+# own drops every add_header from the parent level. Setting these once in the
+# server block silently loses them wherever a Cache-Control is set — which is
+# how studio.acedata.cloud shipped with none of them (CASA scan 2026-07-20,
+# findings #2 and #5). Include this file alongside any local add_header.
+add_header X-Content-Type-Options "nosniff" always;
+add_header X-Frame-Options "SAMEORIGIN" always;
+add_header Referrer-Policy "strict-origin-when-cross-origin" always;


### PR DESCRIPTION
CASA 扫描（2026-07-20，目标 `studio.acedata.cloud`）10 条告警里 4 条出在 nginx 配置上，本 PR 修掉这 4 条：

| # | 标题 | 等级 |
|---|---|---|
| 1 | Bypassing 403 | Low |
| 2 | Missing Anti-clickjacking Header | Low |
| 5 | X-Content-Type-Options Header Missing | Info |
| 10 | User Agent Fuzzer | Info |

## 安全头（#2、#5）

`server` 块里三个头写得好好的，线上一个都没返回：

```
curl -sI https://studio.acedata.cloud/ | grep -ci 'x-frame-options'   # 0
```

nginx 的 `add_header` **不继承**——某个 location 只要自己写了一个 `add_header`，父层的全部失效。`location /` 为了控缓存写了 `Cache-Control/Pragma/Expires`，顺手把三个安全头一起丢了。五个 location 都中招（`/assets/`、`= /index.html`、`/`、两个 well-known）。

抽成 `security-headers.conf`，凡是自带 `add_header` 的 location 一律 `include`。放在 `/etc/nginx/` 而不是 `conf.d/`——后者会被 `include conf.d/*.conf` 通配到 http 层当成一份独立配置加载。

## 403 绕过（#1、#10）

```
/auth/      403      ← 目录存在但没有 index.html，nginx 拒绝列目录
/auth%20/   200      ← 不匹配任何文件，try_files 落到 SPA shell
```

SSG 只产出 `dist/auth/login/`，`dist/auth/` 是个空的中间目录。扫描器看到这对 403/200 判定成访问控制绕过。把 `$uri/` 换成 `$uri/index.html`，任何没有 index.html 的目录都直接落到 shell 而不是 403；`/auth` 再加一个显式块兜底。

#10 User Agent Fuzzer 命中的也是 `/auth/`（不同 UA 下 403/200 不一致），同一个根因。

## 验证

在 `nginx:stable-alpine` 容器里用模拟产物实测：

```
403 parity:
  /auth  /auth/  /auth%20/  /auth/%20/  /auth/login  /auth/login/  /auth/nope
  → 全部 200

security headers（9 条路径，含 /assets/、两个 well-known、SPA fallback）:
  → 全部 3/3

对照组 origin/main：
  /auth/ 403 vs /auth%20/ 200，头 0/3        ✅ 复现
```

缓存策略未变（assets 仍 `immutable`，HTML 仍 `no-store`）。

## 已知无关问题

`?features=ssr` 走 SSG 会 500（rewrite 循环）。**这不是本 PR 引入的**——`origin/main` 的配置在同一测试环境下行为完全一致，线上也是 500：

```
curl -so /dev/null -w '%{http_code}' 'https://studio.acedata.cloud/auth/login?features=ssr'   # 500
```

超出 CASA 范围，留给 SSG 单独处理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)