### PR TITLE
fix(skills): 搜索改成常驻输入框，与连接器页一致

### DIFF
--- a/change/@acedatacloud-nexior-582e9cf1-432f-4f8f-af84-7277fc8686b9.json
+++ b/change/@acedatacloud-nexior-582e9cf1-432f-4f8f-af84-7277fc8686b9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "skills: show the search field permanently and match the connector page's toolbar, instead of hiding it behind a magnifier toggle",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/pages/console/skills/Index.vue
+++ b/src/pages/console/skills/Index.vue
@@ -5,82 +5,63 @@
       <!-- Left pane: skill list -->
       <aside class="left-pane">
         <header class="left-header">
-          <div class="left-actions">
-            <button
-              v-if="!searchOpen"
-              class="icon-btn"
-              :aria-label="$t('skill.button.search')"
-              :title="$t('skill.button.search')"
-              @click="openSearch"
-            >
-              <search-icon :size="16" aria-hidden="true" focusable="false" />
-            </button>
-
-            <el-dropdown trigger="click" placement="bottom-end" :hide-on-click="false">
-              <button class="icon-btn" :aria-label="$t('skill.button.add')" :title="$t('skill.button.add')">
-                <add-icon :size="16" aria-hidden="true" focusable="false" />
-              </button>
-              <template #dropdown>
-                <el-dropdown-menu class="add-menu">
-                  <el-dropdown-item @click="onBrowse">
-                    <marketplace-icon class="menu-icon" :size="14" aria-hidden="true" focusable="false" />
-                    {{ $t('skill.menu.browse') }}
-                  </el-dropdown-item>
-                  <el-dropdown-item divided>
-                    <el-dropdown trigger="hover" placement="left-start" :hide-on-click="true">
-                      <span class="submenu-trigger">
-                        <add-icon class="menu-icon" :size="14" aria-hidden="true" focusable="false" />
-                        {{ $t('skill.menu.create') }}
-                        <expand-right-icon class="submenu-arrow" :size="14" aria-hidden="true" focusable="false" />
-                      </span>
-                      <template #dropdown>
-                        <el-dropdown-menu class="add-menu">
-                          <el-dropdown-item disabled>
-                            <ai-create-icon class="menu-icon" :size="14" aria-hidden="true" focusable="false" />
-                            {{ $t('skill.menu.createWithClaude') }}
-                            <span class="badge-soon">{{ $t('skill.menu.soon') }}</span>
-                          </el-dropdown-item>
-                          <el-dropdown-item @click="openWrite">
-                            <write-icon class="menu-icon" :size="14" aria-hidden="true" focusable="false" />
-                            {{ $t('skill.menu.write') }}
-                          </el-dropdown-item>
-                          <el-dropdown-item @click="openUpload">
-                            <upload-icon class="menu-icon" :size="14" aria-hidden="true" focusable="false" />
-                            {{ $t('skill.menu.upload') }}
-                          </el-dropdown-item>
-                        </el-dropdown-menu>
-                      </template>
-                    </el-dropdown>
-                  </el-dropdown-item>
-                </el-dropdown-menu>
-              </template>
-            </el-dropdown>
-          </div>
-        </header>
-
-        <!-- Inline search field -->
-        <div v-if="searchOpen" class="search-row">
           <el-input
-            ref="searchInput"
             v-model="searchQuery"
             class="search-input"
             size="default"
+            clearable
             :placeholder="$t('skill.placeholder.search')"
-            @keydown.escape="closeSearch"
           >
             <template #prefix>
-              <search-icon :size="13" aria-hidden="true" focusable="false" />
+              <search-icon :size="14" aria-hidden="true" focusable="false" />
             </template>
           </el-input>
-          <button
-            class="icon-btn icon-btn-sm"
-            :aria-label="$t('common.button.close')"
-            :title="$t('common.button.close')"
-            @click="closeSearch"
-          >
-            <close-icon :size="14" aria-hidden="true" focusable="false" />
-          </button>
-        </div>
+
+          <el-dropdown trigger="click" placement="bottom-end" :hide-on-click="false">
+            <button
+              type="button"
+              class="add-button"
+              :aria-label="$t('skill.button.add')"
+              :title="$t('skill.button.add')"
+            >
+              <add-icon :size="16" aria-hidden="true" focusable="false" />
+            </button>
+            <template #dropdown>
+              <el-dropdown-menu class="add-menu">
+                <el-dropdown-item @click="onBrowse">
+                  <marketplace-icon class="menu-icon" :size="14" aria-hidden="true" focusable="false" />
+                  {{ $t('skill.menu.browse') }}
+                </el-dropdown-item>
+                <el-dropdown-item divided>
+                  <el-dropdown trigger="hover" placement="left-start" :hide-on-click="true">
+                    <span class="submenu-trigger">
+                      <add-icon class="menu-icon" :size="14" aria-hidden="true" focusable="false" />
+                      {{ $t('skill.menu.create') }}
+                      <expand-right-icon class="submenu-arrow" :size="14" aria-hidden="true" focusable="false" />
+                    </span>
+                    <template #dropdown>
+                      <el-dropdown-menu class="add-menu">
+                        <el-dropdown-item disabled>
+                          <ai-create-icon class="menu-icon" :size="14" aria-hidden="true" focusable="false" />
+                          {{ $t('skill.menu.createWithClaude') }}
+                          <span class="badge-soon">{{ $t('skill.menu.soon') }}</span>
+                        </el-dropdown-item>
+                        <el-dropdown-item @click="openWrite">
+                          <write-icon class="menu-icon" :size="14" aria-hidden="true" focusable="false" />
+                          {{ $t('skill.menu.write') }}
+                        </el-dropdown-item>
+                        <el-dropdown-item @click="openUpload">
+                          <upload-icon class="menu-icon" :size="14" aria-hidden="true" focusable="false" />
+                          {{ $t('skill.menu.upload') }}
+                        </el-dropdown-item>
+                      </el-dropdown-menu>
+                    </template>
+                  </el-dropdown>
+                </el-dropdown-item>
+              </el-dropdown-menu>
+            </template>
+          </el-dropdown>
+        </header>
 
         <!-- Sections -->
         <div v-loading="loading" class="left-body">
@@ -245,7 +226,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, nextTick } from 'vue';
+import { defineComponent } from 'vue';
 import {
   ElInput,
   ElSwitch,
@@ -261,7 +242,6 @@ import {
 import {
   AddIcon,
   AiCreateIcon,
-  CloseIcon,
   DeleteIcon,
   ExpandDownIcon,
   ExpandRightIcon,
@@ -293,7 +273,6 @@ interface IData {
   personalOpen: boolean;
   globalsOpen: boolean;
 
-  searchOpen: boolean;
   searchQuery: string;
 
   uploadVisible: boolean;
@@ -314,7 +293,6 @@ export default defineComponent({
     ElDropdownItem,
     AddIcon,
     AiCreateIcon,
-    CloseIcon,
     DeleteIcon,
     ExpandDownIcon,
     ExpandRightIcon,
@@ -345,7 +323,6 @@ export default defineComponent({
       personalOpen: true,
       globalsOpen: true,
 
-      searchOpen: false,
       searchQuery: '',
 
       uploadVisible: false,
@@ -431,19 +408,6 @@ export default defineComponent({
       } else {
         this.expandedSkillIds.push(skill.id);
       }
-    },
-
-    openSearch() {
-      this.searchOpen = true;
-      nextTick(() => {
-        const input = this.$refs.searchInput as { focus?: () => void } | undefined;
-        input?.focus?.();
-      });
-    },
-
-    closeSearch() {
-      this.searchOpen = false;
-      this.searchQuery = '';
     },
 
     openUpload() {
@@ -574,14 +538,30 @@ html.dark .skills-shell {
 .left-header {
   display: flex;
   align-items: center;
-  justify-content: flex-end;
-  padding: 16px 16px 8px;
+  gap: 8px;
+  padding: 14px 14px 12px;
 }
 
-.left-actions {
+/* Matches the connector page's toolbar button so the two console pages read
+   as one surface. */
+.add-button {
+  flex: 0 0 auto;
+  width: 34px;
+  height: 34px;
+  border: 1px solid var(--el-border-color-lighter);
+  border-radius: 8px;
+  background: var(--el-bg-color);
+  color: var(--el-text-color-regular);
+  cursor: pointer;
   display: flex;
-  gap: 4px;
   align-items: center;
+  justify-content: center;
+  transition: all 0.15s;
+
+  &:hover {
+    border-color: var(--el-color-primary);
+    color: var(--el-color-primary);
+  }
 }
 
 .icon-btn {
@@ -603,23 +583,10 @@ html.dark .skills-shell {
   background: var(--el-fill-color);
 }
 
-.icon-btn-sm {
-  width: 26px;
-  height: 26px;
-  font-size: 12px;
-}
-
-.search-row {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 0 12px 8px;
-}
-
 /* Styling comes from the global `.el-input__wrapper` rules in _common.scss,
    so the field matches every other input in the console. */
 .search-input {
-  flex: 1;
+  flex: 1 1 auto;
 }
 
 .left-body {

--- a/src/pages/console/skills/searchAffordance.test.ts
+++ b/src/pages/console/skills/searchAffordance.test.ts
@@ -1,0 +1,50 @@
+// @vitest-environment node
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = resolve(__dirname, '../../../..');
+const source = (relativePath: string) => readFileSync(resolve(ROOT, relativePath), 'utf8');
+
+const SKILLS = 'src/pages/console/skills/Index.vue';
+const CONNECTORS = 'src/pages/console/connectors/Index.vue';
+
+/**
+ * The two list pages sit one nav item apart, so any difference in how their
+ * left pane is searched reads as two different products. Skills used to hide
+ * its field behind a magnifier toggle while connectors showed a permanent
+ * input — these lock the shared shape so they cannot drift apart again.
+ */
+describe('console list pages share one search affordance', () => {
+  it('keeps the search field always visible on both pages', () => {
+    for (const page of [SKILLS, CONNECTORS]) {
+      const src = source(page);
+      const field = src.match(/<el-input[\s\S]*?class="search-input"[\s\S]*?\/el-input>/);
+      expect(field, `${page} has no .search-input`).not.toBeNull();
+      // A `v-if`/`v-show` on the field (or a wrapper toggled by open-state)
+      // is exactly the toggle behaviour this guard exists to prevent.
+      expect(field![0]).not.toMatch(/v-(if|show)=/);
+      expect(src).not.toMatch(/searchOpen/);
+    }
+  });
+
+  it('gives both pages the same toolbar button', () => {
+    for (const page of [SKILLS, CONNECTORS]) {
+      const src = source(page);
+      expect(src, `${page} should use .add-button`).toMatch(/class="add-button"/);
+      expect(src).toMatch(/\.add-button\s*{[^}]*width:\s*34px/);
+      expect(src).toMatch(/\.add-button\s*{[^}]*height:\s*34px/);
+    }
+  });
+
+  it('uses identical toolbar metrics on both pages', () => {
+    const metrics = [SKILLS, CONNECTORS].map((page) => {
+      const src = source(page);
+      const bar = src.match(/\.(?:left-header|list-toolbar)\s*{([^}]*)}/);
+      expect(bar, `${page} has no toolbar rule`).not.toBeNull();
+      const pick = (prop: string) => bar![1].match(new RegExp(`${prop}:\\s*([^;]+);`))?.[1].trim();
+      return { gap: pick('gap'), padding: pick('padding'), align: pick('align-items') };
+    });
+    expect(metrics[0]).toEqual(metrics[1]);
+  });
+});


### PR DESCRIPTION
技能页的搜索藏在放大镜按钮后面，点开才出现一行带 × 的输入框；而隔壁连接器页是常驻搜索框。两个页面只差一个导航项，这种差异读起来像两个产品。

## 改了什么

搜索框改成常驻，与「+」按钮同处一行 —— 就是连接器页 `.list-toolbar` 的结构。顺带发现两边的「+」按钮也不一样，一并对齐：

| | 之前（技能页） | 现在（= 连接器页） |
|---|---|---|
| 搜索框 | 放大镜按钮 → 点开才出现，带 × 关闭 | 常驻 `el-input`，`clearable` |
| 「+」按钮 | 32px，无边框透明 | 34px，`1px` 边框 + `8px` 圆角，hover 变主色 |
| 工具栏 | `justify-content: flex-end`，`padding: 16px 16px 8px` | `gap: 8px`，`padding: 14px 14px 12px` |

「+」的多级下拉（浏览 / 创建 → Claude、手写、上传）保持不变，只动搜索与按钮样式。

顺带删掉随之失效的 `searchOpen` 状态、`openSearch` / `closeSearch` 方法、`.search-row` / `.left-actions` / `.icon-btn-sm` 三条死 CSS，以及不再使用的 `CloseIcon`、`nextTick` import。`.icon-btn` 保留 —— 右侧详情面板的「更多」按钮还在用。

`skill.button.search`（放大镜的 aria-label）现在没人引用了，但我留着没删：删它要动 18 个语言文件，而它是个通用词，将来可能复用；i18n 检查器只查缺失不查多余，不会报错。

## 测试

新增 `searchAffordance.test.ts`，把「两页共用一套搜索形态」固化成三条断言：

- 搜索框在两页都必须常驻（字段上不能有 `v-if`/`v-show`，源码里不能再出现 `searchOpen`）
- 两页都用 `.add-button` 且尺寸是 34×34
- 两页工具栏的 `gap` / `padding` / `align-items` 必须完全相等

**这三条在改动前的代码上是全红的**（我把 `Index.vue` 临时还原到 `origin/main` 验证过），所以它们在测真东西，不是恒真断言。

## 验证

lint 0 error、`vue-tsc -b` 通过、1069 个测试全绿、构建通过、i18n 门禁通过。

**没有截图**：页面在 auth guard 后面，本地和线上都需要登录态，而我手上只有 API key、没有可用于浏览器登录的账号。所以一致性是靠上面那个源码级契约测试保证的，不是肉眼确认的 —— 合并后建议你在 studio 上扫一眼。
