### PR TITLE
fix(upload): 体积天花板抬到 300m，消除超过上限时的残留卡死

### DIFF
--- a/change/@acedatacloud-nexior-b5c8a9e5-1dc2-4d3a-9307-2928c7e8cc2e.json
+++ b/change/@acedatacloud-nexior-b5c8a9e5-1dc2-4d3a-9307-2928c7e8cc2e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "上传体积天花板抬到 300m，消除超过上限时的残留卡死",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/nginx.conf
+++ b/nginx.conf
@@ -65,10 +65,13 @@ server {
     location /api/v1/ {
         proxy_pass https://platform.acedata.cloud;
         proxy_set_header Host platform.acedata.cloud;
-        # Keep >= backend COS_MAX_UPLOAD_BYTES (100MB) so oversized uploads get
-        # Django's JSON 413 instead of an early nginx 413 that EdgeOne turns
-        # into a hang (it does not forward the early reject).
-        client_max_body_size  110m;
+        # Transport ceiling, NOT the user-facing limit — that is the backend's
+        # COS_MAX_UPLOAD_BYTES (100MB), which returns a clean JSON 413. This
+        # must stay well ABOVE it: nginx rejects an oversized body before
+        # reading it, and EdgeOne does not forward that early 413, so the
+        # browser hangs until EdgeOne's own 554. Headroom also covers the
+        # multipart envelope (~212B) so a file at exactly the limit is safe.
+        client_max_body_size  300m;
         proxy_send_timeout 300s;
         proxy_read_timeout 300s;
     }

--- a/src/utils/uploadSize.ts
+++ b/src/utils/uploadSize.ts
@@ -9,12 +9,19 @@
  * element-plus leaves the file `status: 'uploading'` forever, any send button
  * gated on "no upload in flight" greys out permanently.
  *
- * So the browser must refuse oversized files itself. Keep `MAX_UPLOAD_BYTES`
- * at or below the backend's `COS_MAX_UPLOAD_BYTES`, which in turn stays under
- * the nginx limit.
+ * So the browser must refuse oversized files itself. The invariant across the
+ * whole stack, which must never collapse into equality:
+ *
+ *   MAX_UPLOAD_BYTES  ==  COS_MAX_UPLOAD_BYTES (100MB)   ← the user-facing limit
+ *                      <  client_max_body_size / proxy-body-size (300m)
+ *
+ * The last step must be a strict `<` with real headroom: the multipart envelope
+ * adds ~212 bytes, so if the ceiling equalled the limit, a file of exactly
+ * 100MB would trip the nginx reject — reviving the hang at the very size users
+ * are most likely to hit.
  */
 
-/** Mirrors PlatformBackend `COS_MAX_UPLOAD_BYTES`. */
+/** Mirrors PlatformBackend `COS_MAX_UPLOAD_BYTES`. The user-facing limit. */
 export const MAX_UPLOAD_BYTES = 100 * 1024 * 1024;
 
 /** Render a byte count as a short human string ("28.4 MB", "900 KB"). */


### PR DESCRIPTION
## 问题

上一个 PR（#1491）把 `client_max_body_size` 从 20m 抬到 **110m** —— 只比 100MB 上限高 10m。结果超过 110m 的请求又回到原来的失败模式：nginx 在**读 body 之前**拒绝 → EdgeOne 不转发这个早退 413 → 浏览器卡到 554。

**线上实测**：120MB 上传仍然卡死 400s。

## 认知修正

天花板**不是「给用户的上限」**，是**转发上界**。用户上限只有一个 —— 后端 `COS_MAX_UPLOAD_BYTES = 100MB`，返回干净 JSON 413。

天花板必须**远高于**上限而不是贴着它。贴着设反而危险：multipart 信封实测多 **212 字节**，若两者相等，一个**正好 100MB** 的文件会撞上 nginx 早退 —— 在用户最容易碰到的体积上复活这个 bug。

（实测依据：本次会话在 30m 天花板下，30MiB−2048 → 干净 413；30MiB−100 → **卡死 554**。）

## 改动

- `nginx.conf`：`client_max_body_size` 110m → **300m**
- `uploadSize.ts`：把不变式写进注释，明确最后一步必须是**留有余量的严格小于**：

```
MAX_UPLOAD_BYTES == COS_MAX_UPLOAD_BYTES (100MB)   ← 用户上限
                 <  client_max_body_size (300m)     ← 转发天花板
```

**用户可见上限仍是 100MB，本 PR 不改。** 守卫的行为、文案、测试全部不变（10 个测试仍通过）。

## 配套

- PlatformFrontend https://github.com/AceDataCloud/PlatformFrontend/pull/1049
- PlatformBackend https://github.com/AceDataCloud/PlatformBackend/pull/1240

> 推送说明：同 #1491，beachball 的 pre-push 钩子在 git worktree 下有 bug（`git push` 导出 `GIT_DIR` 导致它把 change 文件路径拼成 `change/change/...`）。`npx beachball check --branch origin/main` 是绿的，change 文件也在 commit 里。

🤖 Generated with [Claude Code](https://claude.com/claude-code)