### PR TITLE
feat(console): 连接器/技能/浏览器设备正式发布，移除 feature flag

### DIFF
--- a/change/@acedatacloud-nexior-4178492a-868b-4619-9cde-4d0ff1e68979.json
+++ b/change/@acedatacloud-nexior-4178492a-868b-4619-9cde-4d0ff1e68979.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "connectors, skills and browser devices are now managed in Studio for everyone",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/electron/local/shellSession.test.ts
+++ b/electron/local/shellSession.test.ts
@@ -20,7 +20,10 @@ function rooted() {
   return base;
 }
 
-describe.skipIf(WIN)('shell.exec persistent session', () => {
+// Each case spawns a real shell and waits for round-trips, so these are
+// sensitive to machine load when the full suite runs in parallel. 5s (the
+// vitest default) is not enough headroom on a busy CI box.
+describe.skipIf(WIN)('shell.exec persistent session', { timeout: 20_000 }, () => {
   afterEach(() => {
     _resetSessionsForTesting();
     _resetRootsForTesting();

--- a/src/components/chat/Composer.vue
+++ b/src/components/chat/Composer.vue
@@ -435,14 +435,10 @@ export default defineComponent({
       });
     },
     onOpenSkills() {
-      // Routes to Studio's own skills page when `connections-in-studio` is
-      // on, else opens auth.acedata.cloud in a new tab (today's behaviour).
       openSkillsManager(this.$router);
     },
     onOpenConnections() {
-      // Routes to Studio's own connector page when `connections-in-studio`
-      // is on, else opens auth.acedata.cloud in a new tab (the historical
-      // behaviour). Either way auth stays the OAuth broker + vault.
+      // auth.acedata.cloud stays the OAuth broker + vault; only the UI is here.
       openConnectionsManager(undefined, this.$router);
     }
   }

--- a/src/components/console/SidePanel.vue
+++ b/src/components/console/SidePanel.vue
@@ -45,7 +45,7 @@ import {
   ROUTE_CONSOLE_USAGE_LIST,
   ROUTE_INDEX
 } from '@/router';
-import { isFeatureEnabled, isOfficial } from '@/utils';
+import { isOfficial } from '@/utils';
 
 interface ILink {
   key: string;
@@ -72,7 +72,7 @@ export default defineComponent({
       return this.$store.getters.user;
     },
     links(): ILink[] {
-      let links: ILink[] = [
+      const links: ILink[] = [
         {
           key: 'application-list',
           text: this.$t('console.menu.applicationList'),
@@ -90,31 +90,26 @@ export default defineComponent({
           text: this.$t('console.menu.usageList'),
           name: ROUTE_CONSOLE_USAGE_LIST,
           icon: HistoryIcon
-        }
-      ];
-
-      // Connector + skill management are still rolling out; until the flag
-      // is on everywhere, both are managed at auth.acedata.cloud.
-      if (isFeatureEnabled('connections-in-studio')) {
-        links.push({
+        },
+        {
           key: 'connectors',
           text: this.$t('console.menu.connectors'),
           name: ROUTE_CONSOLE_CONNECTORS,
           icon: ConnectionIcon
-        });
-        links.push({
+        },
+        {
           key: 'skills',
           text: this.$t('console.menu.skills'),
           name: ROUTE_CONSOLE_SKILLS,
           icon: SkillIcon
-        });
-        links.push({
+        },
+        {
           key: 'browser-devices',
           text: this.$t('console.menu.browserDevices'),
           name: ROUTE_CONSOLE_BROWSER_DEVICES,
           icon: DesktopIcon
-        });
-      }
+        }
+      ];
 
       // Order history stays visible on iOS — purchases now happen in-app via
       // Apple IAP, so users should see their orders.

--- a/src/router/console.ts
+++ b/src/router/console.ts
@@ -70,18 +70,16 @@ export default {
       meta: DOCUMENT,
       component: () => import('@/pages/console/usage/List.vue')
     },
-    // Connector management, ported from auth.acedata.cloud/user/connections.
-    // The route always exists (so a deep link works for testers); the sidebar
-    // entry and the in-app links are gated on the `connections-in-studio`
-    // feature flag. AuthFrontend's page stays live for PlatformFrontend/Dify.
+    // Connector management. auth.acedata.cloud stays the OAuth broker and
+    // credential vault; its page also stays live because PlatformFrontend
+    // links to it and ~28 MCP servers register it as an OAuth redirect_uri.
     {
       path: 'connectors',
       name: ROUTE_CONSOLE_CONNECTORS,
       meta: WORKSPACE,
       component: () => import('@/pages/console/connectors/Index.vue')
     },
-    // Agent Skills, same deal — ported UI, same flag, AuthFrontend's page
-    // stays live.
+    // Agent Skills — same split: UI here, data still owned by AuthBackend.
     {
       path: 'skills',
       name: ROUTE_CONSOLE_SKILLS,

--- a/src/utils/connections.ts
+++ b/src/utils/connections.ts
@@ -1,53 +1,25 @@
 /**
  * Where "manage my connections" goes.
  *
- * Studio now has its own connector page at `/console/connectors`, but the
- * rollout is gated: until `connections-in-studio` is on, connections are
- * still managed at auth.acedata.cloud (which stays the OAuth broker and
- * credential vault either way — only the UI moved).
+ * Studio owns the connector UI at `/console/connectors`. auth.acedata.cloud
+ * stays the OAuth broker and credential vault — only the UI lives here.
  */
 
 import type { Router } from 'vue-router';
-import { withCurrentUserIdAndSite } from './crossSiteUser';
-import { isFeatureEnabled } from './featureFlag';
-
-const CONNECTIONS_MANAGER_URL = 'https://auth.acedata.cloud/user/connections';
-
-/** True when the in-Studio connector page should be used. */
-export function useStudioConnections(): boolean {
-  return isFeatureEnabled('connections-in-studio');
-}
 
 /**
  * Open connection management.
  *
- * Flag on → push Studio's own `/console/connectors` route (no tab switch,
- * no page reload, chat state preserved). Flag off → the historical
- * behaviour: open auth.acedata.cloud in a new tab, annotated with
- * `return_url` (so it can offer a way back), `user_id` (so AuthFrontend
- * catches a cross-site identity mismatch and re-auths) and `site` (so it
- * renders the calling subsite's white-label logo).
- *
- * `router` is optional so existing callers keep working; without it the
- * flag-on path falls back to a same-origin navigation.
+ * `router` is optional so existing callers keep working; without it this
+ * falls back to a same-origin navigation.
  */
 export function openConnectionsManager(provider?: string, router?: Router): void {
-  if (useStudioConnections()) {
-    const query = provider ? { connect: provider } : undefined;
-    if (router) {
-      void router.push({ path: '/console/connectors', query });
-      return;
-    }
-    const target = new URL('/console/connectors', window.location.origin);
-    if (provider) target.searchParams.set('connect', provider);
-    window.location.href = target.toString();
+  const query = provider ? { connect: provider } : undefined;
+  if (router) {
+    void router.push({ path: '/console/connectors', query });
     return;
   }
-
-  const url = new URL(CONNECTIONS_MANAGER_URL);
-  url.searchParams.set('return_url', window.location.href);
-  if (provider) {
-    url.searchParams.set('provider', provider);
-  }
-  window.open(withCurrentUserIdAndSite(url.toString()), '_blank', 'noopener,noreferrer');
+  const target = new URL('/console/connectors', window.location.origin);
+  if (provider) target.searchParams.set('connect', provider);
+  window.location.href = target.toString();
 }

--- a/src/utils/skills/openSkillsManager.ts
+++ b/src/utils/skills/openSkillsManager.ts
@@ -1,39 +1,22 @@
 /**
  * Where "manage my skills" goes.
  *
- * Studio now has its own skills page at `/console/skills`, but the rollout
- * is gated: until `connections-in-studio` is on, skills are still managed
- * at auth.acedata.cloud (which remains the owner of the data either way —
- * only the UI moved).
+ * Studio owns the skills UI at `/console/skills`; auth.acedata.cloud remains
+ * the owner of the data — only the UI lives here.
  */
 
 import type { Router } from 'vue-router';
-import { withCurrentUserIdAndSite } from '../crossSiteUser';
-import { isFeatureEnabled } from '../featureFlag';
-
-const SKILLS_MANAGER_URL = 'https://auth.acedata.cloud/user/skills';
-
-/** True when the in-Studio skills page should be used. */
-export function useStudioSkills(): boolean {
-  return isFeatureEnabled('connections-in-studio');
-}
 
 /**
  * Open skill management.
  *
- * Flag on → push Studio's own `/console/skills` route. Flag off → the
- * historical behaviour: open auth.acedata.cloud in a new tab, annotated
- * with `user_id` (so AuthFrontend catches a cross-site identity mismatch)
- * and `site` (so it renders the calling subsite's white-label logo).
+ * `router` is optional so existing callers keep working; without it this
+ * falls back to a same-origin navigation.
  */
 export function openSkillsManager(router?: Router): void {
-  if (useStudioSkills()) {
-    if (router) {
-      void router.push({ path: '/console/skills' });
-      return;
-    }
-    window.location.href = new URL('/console/skills', window.location.origin).toString();
+  if (router) {
+    void router.push({ path: '/console/skills' });
     return;
   }
-  window.open(withCurrentUserIdAndSite(SKILLS_MANAGER_URL), '_blank', 'noopener');
+  window.location.href = new URL('/console/skills', window.location.origin).toString();
 }


### PR DESCRIPTION
连接器 / 技能 / 浏览器设备三个页面已验证可用，去掉 `connections-in-studio` 门控，对所有用户放出。

## 改了什么

- **侧栏**：三个入口从 flag 分支里拿出来，常驻显示
- **`openConnectionsManager` / `openSkillsManager`**：删掉跳 `auth.acedata.cloud` 的旧分支，直接 `router.push` 到 Studio 自己的路由。两个 `useStudioConnections` / `useStudioSkills` 判定函数随之删除（无其他调用方）
- 清掉随之失效的 `isFeatureEnabled` import 和几处过期注释

改完全仓 `grep connections-in-studio` 零命中。

## 没有动的：auth.acedata.cloud

它仍然是 OAuth broker + 凭据保险库，`/user/connections` 页面也**继续保留**。调研（全仓穷举）查到它还有真实消费方：

- `PlatformFrontend/src/components/console/Navigator.vue:286,292` —— 控制台菜单的活链接
- **约 28 个 MCP** 把 `https://auth.acedata.cloud/user/connections` 写死成 OAuth `redirect_uris`（`MCPs/*/core/oauth.py`）
- `PlatformService/aichat2` 运行时错误文案 + 测试断言、`Skills/` 47 个文件、`AuthBackend/app/seeds/connectors.yaml` 12 处用户可见文案、25 篇营销文档

所以本次只改 **UI 归属**，不动任何契约。

顺带修正一处过时注释：原文写「stays live for PlatformFrontend/**Dify**」，但 Dify 早已不引用该页面（只剩 SSO 集成），PlatformFrontend 那半句才成立。

## 一处看似无关的改动：electron 测试超时 5s → 20s

`electron/local/shellSession.test.ts` 会 spawn 真实 shell 并等待多次往返，本来就贴着 vitest 的 5s 默认超时。本次删掉两个模块后 src 侧套件跑得更快，并发窗口变化把它挤过了临界点。

**不是猜测，是量出来的**：

| | 全套连跑 | 隔离跑 |
|---|---|---|
| 干净 main | 4/4 通过 | — |
| 本次改动（超时 5s） | 1/3 通过 | 5/5 通过 |
| 本次改动（超时 20s） | **4/4 通过** | — |

隔离跑 5/5 全过说明代码没问题，是调度问题；而干净 main 4/4 全过说明确实是我这次改动触发的，不能推给「它本来就脆」。所以调宽超时而不是加重试或跳过——那样只会把问题藏起来。

## 验证

lint 0 error、`vue-tsc -b` 通过、1069 测试连跑 4 次全绿、构建通过、i18n 门禁通过。
