### PR TITLE
fix(report): 举报图标与相邻操作按钮对齐，颜色改用次级文字色

### DIFF
--- a/change/@acedatacloud-nexior-2f258af6-f56c-4824-bbd6-4d21e40391a7.json
+++ b/change/@acedatacloud-nexior-2f258af6-f56c-4824-bbd6-4d21e40391a7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "举报按钮与相邻操作按钮垂直对齐，颜色改用次级文字色",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/chat/Message.vue
+++ b/src/components/chat/Message.vue
@@ -653,8 +653,20 @@ export default defineComponent({
     // source of truth for spacing and the icons line up cleanly.
     :deep(.icon-copy),
     :deep(.icon-check),
-    :deep(.icon-sync) {
+    :deep(.icon-sync),
+    :deep(.btn-report) {
       margin-left: 0;
+    }
+    // ReportButton is sized for the 24px action chips on result cards; here
+    // the row is icon-only, so drop that sizing and inherit this row's.
+    :deep(.report-entry) {
+      min-height: 0;
+      margin-bottom: 0;
+    }
+    :deep(.btn-report) {
+      padding: 0;
+      font-size: inherit;
+      color: inherit;
     }
   }
 

--- a/src/components/common/ReportButton.vue
+++ b/src/components/common/ReportButton.vue
@@ -74,17 +74,29 @@ export default defineComponent({
 <style lang="scss" scoped>
 .report-entry {
   display: inline-flex;
+  // Sibling action chips are 24px tall el-buttons and the row is
+  // `align-items: baseline`; a bare icon has no text baseline to align on, so
+  // it floated ~3px high. Match their box height and center within it instead.
+  align-self: center;
+  align-items: center;
+  min-height: 24px;
+  // Siblings carry this so the row stays even once it wraps.
+  margin-bottom: 10px;
 }
 .btn-report {
   display: inline-flex;
   align-items: center;
-  padding: 0;
+  padding: 0 2px;
   border: 0;
   background: transparent;
   margin-left: 5px;
   cursor: pointer;
-  color: inherit;
+  // `inherit` picked up the card's pale body color; use the same secondary
+  // token the other muted controls (delete, copy) use.
+  color: var(--el-text-color-secondary);
   line-height: 1;
+  font-size: 15px;
+  transition: color 0.15s ease;
   &:hover {
     color: var(--el-color-danger);
   }


### PR DESCRIPTION
## 问题

用户反馈举报图标「比较丑，颜色和位置感觉对不齐」，上下和旁边的按钮没对上。

在线上量了一下，确实有三处不一致：

| | 胶囊按钮 | 举报图标 |
|---|---|---|
| 高度 | 24px | 14px |
| 垂直中线 | -12367 | **-12370（高 3px）** |
| `margin-bottom` | 10px | 0（换行后错位）|
| 颜色 | — | `rgb(207,211,220)` 发白发飘 |

## 根因

`.operations` 用的是 `align-items: baseline`，而**裸图标没有文字基线可对齐**，所以浮在了偏上的位置。

`ApiCodeButton` 早前踩过同一个坑，它的注释里明确记着 `align-self: center` 在生产环境**不奏效**、最后改用了 `flex-start`。但两者情况不同：那是个图标+文字混排的 `el-button`（合成基线被图标拉偏），本组件是纯图标 —— 把盒子高度补齐到 24px 之后 `align-self: center` 就能对齐了，实测偏差 **0.00px**。

颜色原本写的是 `inherit`，会继承卡片正文色导致发白；改用 `--el-text-color-secondary`，和删除、复制等次级控件保持一致，hover 仍变红。

## 聊天气泡要单独处理

聊天的 `.operations` 是**另一套布局**（`align-items: center` + `gap: 10px` + 统一 14px，并且会显式清掉子组件自带的 `margin-left`，让父级 `gap` 成为唯一间距来源）。

为结果卡准备的 24px 盒子和 `margin-bottom` 会破坏这套布局，因此在 `Message.vue` 里一并中和掉（沿用它既有的 `:deep()` 清零写法）。

## 验证

分别复刻两处**真实的行结构**（结果卡：3 个 `btn-action` 胶囊 + baseline 对齐；聊天：复制 + 重新生成 + 举报）后测量：

| 场景 | 中线偏差 |
|---|---|
| 结果卡操作区 | **0.00px** |
| 聊天气泡操作区 | **0.01px**（间距 23.3 / 23.4px 均匀）|

另外验证：窄视口换行后仍对齐；暗色模式颜色正常（`rgb(144,147,153)`）。

`lint` / `vue-tsc` / **1069 项测试** 全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)