### PR TITLE
fix(desktop): 聊天顶栏控件被窗口拖拽区吞掉、点不动

### DIFF
--- a/change/@acedatacloud-nexior-2926f71d-a68c-4259-92f1-85b11215a3eb.json
+++ b/change/@acedatacloud-nexior-2926f71d-a68c-4259-92f1-85b11215a3eb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "桌面端修复：聊天顶栏的模型选择器等控件被窗口拖拽区吞掉、无法点击",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/common/DesktopDragBar.vue
+++ b/src/components/common/DesktopDragBar.vue
@@ -57,8 +57,10 @@ export default defineComponent({
   height: 32px;
   z-index: 100; // below status-floating(200), above router-view content
   -webkit-app-region: drag;
-  // Do NOT eat clicks — underlying UI (credits pill, nav rail, close/max/min)
-  // still gets pointer events. Only the window-drag hit-test uses this element.
+  // `pointer-events: none` does NOT let clicks through to what's underneath:
+  // the drag hit-test happens in the compositor, before pointer-events and
+  // regardless of z-index. Anything this bar overlaps must opt out itself with
+  // `-webkit-app-region: no-drag`.
   pointer-events: none;
 }
 

--- a/src/pages/chat/Conversation.vue
+++ b/src/pages/chat/Conversation.vue
@@ -1705,6 +1705,15 @@ export default defineComponent({
   justify-content: space-between;
   padding: 0 16px;
   z-index: 100;
+
+  // The desktop drag bar covers the top 32px and its hit-test beats z-index
+  // and `pointer-events`, so controls under it must opt out or they can't be
+  // clicked at all (same fix as the Credits pill in application/Status.vue).
+  .selector,
+  .byok-badge,
+  .toolbar-more {
+    -webkit-app-region: no-drag;
+  }
 }
 
 .selector {


### PR DESCRIPTION
## 问题

macOS 桌面端聊天页，顶部的**模型选择器点不动**——不是响应慢，是连 `mousedown` 都收不到。

## 根因

`<DesktopDragBar>` 在窗口顶部铺了一条 32px 的隐形拖拽条（无边框窗口需要它才能拖动）。聊天工具栏高 45px，模型选择器中心在 **y≈22.5**，正好被盖住。

拖拽条上写了 `pointer-events: none`，注释也声称"不会吃掉点击"。**这个假设是错的**：drag 区域的命中测试在合成阶段完成，早于 `pointer-events`，也不受 `z-index` 影响。被它覆盖的元素必须自己声明 `-webkit-app-region: no-drag` 才可点击。

Credits 药丸（`application/Status.vue`）当初正是这么修的，工具栏这几个控件漏了 —— 这也解释了为什么截图里 Credits 正常、模型选择器不行。

## 验证

最小 Electron 复现逐一排除了其它解法（均无效）：`pointer-events: none`、给按钮加 `no-drag` 但仍被覆盖、把拖拽条 `z-index` 压到内容之下。唯一有效的是被覆盖元素自身 `no-drag`。

真实桌面构建下读取 `.toolbar .selector` 的 computed style 做前后对照：

| | `-webkit-app-region` | 结果 |
|---|---|---|
| 修复前 | `none` | 点击被拖拽区吞掉 |
| 修复后 | `no-drag` | 可点击 |

> 注：Playwright/CDP 的合成点击**测不出**这个 bug（绕过 OS 命中测试），必须用真实鼠标事件或 computed style 验证。

## 改动

- `Conversation.vue`：给 `.selector` / `.byok-badge` / `.toolbar-more` 加 `no-drag`
- `DesktopDragBar.vue`：订正那句误导性注释（bug 的源头）

作用域限定在聊天工具栏内，不影响窗口拖拽本身（空白区域照常可拖）。