### PR TITLE
fix(release): 版本基线抬到 3.350.0，解开 publish 的死循环

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acedatacloud/nexior",
-  "version": "3.349.2",
+  "version": "3.350.0",
   "author": "Ace Data Cloud <office@acedata.cloud>",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## 问题

`publish` workflow 自 08-01 04:02 起**连续失败十余次**（早于本次举报功能的所有合并），每次都是同一个错：

```
ERROR: Attempting to publish package versions that already exist in the registry:
  • @acedatacloud/nexior@3.350.0
```

后果是**版本号不再自动递增**——`package.json` 从 07-31 起就卡在 `3.349.2`。这会连带影响 Android/iOS 的每日自动发版，因为 `versionCode` 是由 `package.json` 换算出来的（`3.349.2` → `64902`），版本不动 = 每天都在尝试上传同一个 versionCode。

## 死循环是怎么形成的

1. `package.json` 停在 `3.349.2`
2. `change/` 里累积了 29 个 change file（含 7 个 minor），beachball 每次都算出 `3.350.0`
3. 而 `3.350.0` 已被占用 —— npm 版本号一经发布**永久不可复用**，撤包也不行
4. workflow 里本有自愈逻辑，但它只在「本地版本 **低于** npm latest」时同步基线；这里本地更高，**永远不触发**

于是每次重算、每次撞同一个号。

## 改动

把 baseline 抬到 `3.350.0` 本身，让 beachball 从其之上开始计算。

**本地实测验证过**（而非推断）：将 baseline 设为 `3.350.0` 后跑 `beachball bump`，得到 **`3.351.0`**，成功避开冲突。验证完已完整还原（`bump` 会顺带清空 `change/` 并改写 CHANGELOG / package-lock），**本 PR 只含 `package.json` 一行改动**。

## 影响

publish 恢复后：
- 版本号自动递增恢复
- Android/iOS 每日自动发版不再卡在同一个 versionCode
- 堆积的 29 个 change file 会在下次成功 publish 时正常消费掉

🤖 Generated with [Claude Code](https://claude.com/claude-code)