### PR TITLE
feat(digitalhuman): 结果卡片删掉引擎名，补上素材回显与剩余时间

### DIFF
--- a/change/@acedatacloud-nexior-e6bfb235-c3d6-4b88-a92a-8c183a225e24.json
+++ b/change/@acedatacloud-nexior-e6bfb235-c3d6-4b88-a92a-8c183a225e24.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "数字人结果卡片：回显素材、补齐尺寸与追踪信息、给等待中的任务一个剩余时间",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/digitalhuman/task/Preview.test.ts
+++ b/src/components/digitalhuman/task/Preview.test.ts
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+import { mount } from '@vue/test-utils';
+import { describe, expect, it, vi } from 'vitest';
+
+// The card embeds a video player whose module reads window.matchMedia at import.
+vi.mock('@/components/common/VideoPlayer.vue', () => ({ default: { name: 'VideoPlayer', render: () => null } }));
+vi.mock('@/components/common/VideoPreview.vue', () => ({
+  default: { name: 'VideoPreview', props: ['url', 'name'], render: () => null }
+}));
+
+import Preview from './Preview.vue';
+import { IDigitalHumanTask } from '@/models';
+
+const mountCard = (task: Partial<IDigitalHumanTask>) =>
+  mount(Preview, {
+    props: { modelValue: task as IDigitalHumanTask },
+    global: {
+      stubs: { ApiCodeButton: true, ReportButton: true, CapabilityPresentation: true, CopyToClipboard: true },
+      mocks: {
+        $t: (key: string, args?: Record<string, unknown>) => (args ? `${key}:${JSON.stringify(args)}` : key),
+        $dayjs: { format: () => '2026-08-01' },
+        $store: { state: { digitalhuman: {} } }
+      }
+    }
+  });
+
+const succeeded = (extra = {}): Partial<IDigitalHumanTask> => ({
+  id: 'task_1',
+  status: 'succeed',
+  created_at: 1_700_000_000,
+  elapsed: 2502,
+  request: { video_url: 'https://cdn.acedata.cloud/face.mp4', text: 'hello' },
+  response: {
+    success: true,
+    task_id: 'task_1',
+    video_url: 'https://cdn.acedata.cloud/out.mp4',
+    duration: 17.2,
+    width: 1280,
+    height: 720,
+    trace_id: 'trace-abc',
+    ...extra
+  }
+});
+
+describe('digitalhuman/task/Preview', () => {
+  // The engine was a half-price billing tier that never changed the output;
+  // naming it on a card only ever confused people.
+  it('never names a lip-sync engine', () => {
+    const html = mountCard(succeeded({ engine: 'latentsync' })).html();
+    expect(html).not.toContain('latentsync');
+    expect(html).not.toContain('heygem');
+  });
+
+  it('shows the frame size, trace id and elapsed time on success', () => {
+    const wrapper = mountCard(succeeded());
+    expect(wrapper.vm.outputSize).toBe('1280×720');
+    expect(wrapper.html()).toContain('trace-abc');
+    expect(wrapper.html()).toContain('2502.00s');
+  });
+
+  it('omits the frame size when the response never reported one', () => {
+    expect(mountCard(succeeded({ width: undefined, height: undefined })).vm.outputSize).toBeUndefined();
+  });
+
+  describe('face echo', () => {
+    // A photo now travels in video_url, so only the extension distinguishes it.
+    it.each([
+      ['https://cdn.acedata.cloud/face.jpg', true],
+      ['https://cdn.acedata.cloud/face.PNG?sig=1', true],
+      ['https://cdn.acedata.cloud/face.mp4', false],
+      ['https://cdn.acedata.cloud/face.mov?x=.png', false]
+    ])('classifies %s', (url, isPhoto) => {
+      const wrapper = mountCard({ ...succeeded(), request: { video_url: url } });
+      expect(wrapper.vm.isPhotoFace).toBe(isPhoto);
+      expect(wrapper.vm.faceUrl).toBe(url);
+    });
+
+    it('still reads a legacy image_url request', () => {
+      const wrapper = mountCard({ ...succeeded(), request: { image_url: 'https://cdn.acedata.cloud/legacy' } });
+      expect(wrapper.vm.isPhotoFace).toBe(true);
+      expect(wrapper.vm.faceUrl).toBe('https://cdn.acedata.cloud/legacy');
+    });
+  });
+
+  describe('in-progress eta', () => {
+    const running = (ageSeconds: number): Partial<IDigitalHumanTask> => ({
+      id: 'task_2',
+      status: 'processing',
+      created_at: Date.now() / 1000 - ageSeconds,
+      response: { success: true, task_id: 'task_2', state: 'processing', progress: 40 }
+    });
+
+    it('counts down in minutes while there is time left', () => {
+      expect(mountCard(running(600)).vm.etaText).toBe('digitalhuman.message.etaRemaining:{"minutes":30}');
+    });
+
+    // Past the estimate the honest answer is "soon", never a negative number.
+    it('degrades to "almost done" once the estimate is spent', () => {
+      expect(mountCard(running(9999)).vm.etaText).toBe('digitalhuman.message.etaAlmostDone');
+    });
+
+    it('has no eta without a creation time', () => {
+      expect(mountCard({ id: 'x', status: 'pending' }).vm.etaText).toBeUndefined();
+    });
+  });
+
+  it('reports the failure reason and trace id when a render dies', () => {
+    const wrapper = mountCard({
+      id: 'task_3',
+      status: 'failed',
+      elapsed: 12,
+      request: { video_url: 'https://cdn.acedata.cloud/face.mp4' },
+      response: { success: false, task_id: 'task_3', error: { message: 'gpu boom' }, trace_id: 'trace-xyz' }
+    });
+    expect(wrapper.vm.isFailure).toBe(true);
+    expect(wrapper.html()).toContain('gpu boom');
+    expect(wrapper.html()).toContain('trace-xyz');
+  });
+});

--- a/src/components/digitalhuman/task/Preview.vue
+++ b/src/components/digitalhuman/task/Preview.vue
@@ -22,36 +22,35 @@
         </el-tooltip>
       </div>
       <div class="info">
-        <p v-if="modelValue?.request?.text" class="prompt mt-2">
-          {{ modelValue?.request?.text }}
+        <div v-if="faceUrl || audioUrl" class="flex justify-start items-center gap-2 mt-2 w-full overflow-x-auto">
+          <image-preview v-if="faceUrl && isPhotoFace" :url="faceUrl" name="face" :closable="false" />
+          <video-preview v-else-if="faceUrl" :url="faceUrl" name="face" />
+          <audio-preview v-if="audioUrl" :url="audioUrl" name="audio" />
+        </div>
+        <p class="prompt mt-2">
+          {{ modelValue?.request?.text || voiceLabel }}
           <span v-if="!isTerminal"> - ({{ statusLabel }}) </span>
-        </p>
-        <p v-else class="prompt mt-2">
-          {{ voiceLabel }}
-          <span v-if="!isTerminal"> - ({{ statusLabel }}) </span>
-        </p>
-        <p class="text-xs text-[var(--el-text-color-secondary)] mb-1">
-          <image-icon
-            v-if="modelValue?.request?.image_url"
-            class="mr-1"
-            :size="'1em' as any"
-            aria-hidden="true"
-            focusable="false"
-          />
-          <video-icon v-else class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
-          {{ faceLabel }}
-          <span class="ml-2"
-            ><controls-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />{{
-              engineLabel
-            }}</span
-          >
         </p>
       </div>
 
-      <!-- in-progress: status + percentage -->
+      <!-- in-progress: a 40-minute render needs an ETA, not just a bar -->
       <div v-if="!isTerminal" class="content">
-        <p class="text-xs text-[var(--el-text-color-secondary)] mb-1">{{ statusLabel }}</p>
-        <el-progress :percentage="progressPct" :stroke-width="6" />
+        <el-alert :closable="false" class="info-state">
+          <p class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <time-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
+            {{ statusLabel }}
+          </p>
+          <el-progress :percentage="progressPct" :stroke-width="6" class="mb-2" />
+          <p v-if="etaText" class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <time-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
+            {{ $t('digitalhuman.name.etaLabel') }}: {{ etaText }}
+          </p>
+          <p class="text-[var(--el-text-color-regular)] text-xs mb-0">
+            <magic-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
+            {{ $t('digitalhuman.name.taskId') }}: {{ modelValue?.id }}
+            <copy-to-clipboard :content="modelValue?.id!" />
+          </p>
+        </el-alert>
       </div>
 
       <!-- success: the talking-head video -->
@@ -69,14 +68,27 @@
           />
         </div>
         <el-alert :closable="false" class="mt-2 success">
+          <p v-if="modelValue?.response?.duration" class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <time-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
+            {{ $t('digitalhuman.name.duration') }}: {{ modelValue?.response?.duration?.toFixed(1) }}s
+          </p>
+          <p v-if="outputSize" class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <fullscreen-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
+            {{ $t('digitalhuman.name.outputSize') }}: {{ outputSize }}
+          </p>
           <p class="text-[var(--el-text-color-regular)] text-xs mb-2">
-            <user-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
+            <magic-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
             {{ $t('digitalhuman.name.taskId') }}: {{ modelValue?.id }}
             <copy-to-clipboard :content="modelValue?.id!" />
           </p>
-          <p v-if="modelValue?.elapsed" class="text-[var(--el-text-color-regular)] text-xs mb-0">
+          <p v-if="modelValue?.elapsed" class="text-[var(--el-text-color-regular)] text-xs mb-2">
             <time-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
             {{ $t('digitalhuman.name.elapsed') }}: {{ modelValue?.elapsed?.toFixed(2) }}s
+          </p>
+          <p v-if="modelValue?.response?.trace_id" class="text-[var(--el-text-color-regular)] text-xs mb-0">
+            <channel-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
+            {{ $t('digitalhuman.name.traceId') }}: {{ modelValue?.response?.trace_id }}
+            <copy-to-clipboard :content="modelValue?.response?.trace_id" />
           </p>
         </el-alert>
       </div>
@@ -89,13 +101,23 @@
             {{ $t('digitalhuman.name.failure') }}
           </template>
           <p class="text-[var(--el-text-color-regular)] text-xs mb-2">
-            <user-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
+            <magic-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
             {{ $t('digitalhuman.name.taskId') }}: {{ modelValue?.id }}
             <copy-to-clipboard :content="modelValue?.id!" />
           </p>
-          <p v-if="failureReason" class="text-[var(--el-text-color-regular)] text-xs mb-0">
+          <p v-if="failureReason" class="text-[var(--el-text-color-regular)] text-xs mb-2">
             <info-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
             {{ $t('digitalhuman.name.failureReason') }}: {{ failureReason }}
+            <copy-to-clipboard :content="failureReason" />
+          </p>
+          <p v-if="modelValue?.elapsed" class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <time-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
+            {{ $t('digitalhuman.name.elapsed') }}: {{ modelValue?.elapsed?.toFixed(2) }}s
+          </p>
+          <p v-if="modelValue?.response?.trace_id" class="text-[var(--el-text-color-regular)] text-xs mb-0">
+            <channel-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
+            {{ $t('digitalhuman.name.traceId') }}: {{ modelValue?.response?.trace_id }}
+            <copy-to-clipboard :content="modelValue?.response?.trace_id" />
           </p>
         </el-alert>
       </div>
@@ -105,13 +127,12 @@
 
 <script lang="ts">
 import {
-  ControlsIcon,
+  ChannelIcon,
   DeleteIcon,
-  ImageIcon,
+  FullscreenIcon,
   InfoIcon,
+  MagicIcon,
   TimeIcon,
-  UserIcon,
-  VideoIcon,
   WarningIcon
 } from '@acedatacloud/core/icons/components';
 import { defineComponent } from 'vue';
@@ -121,26 +142,36 @@ import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 import VideoPlayer from '@/components/common/VideoPlayer.vue';
 import ApiCodeButton from '@/components/common/ApiCodeButton.vue';
 import ReportButton from '@/components/common/ReportButton.vue';
+import AudioPreview from '@/components/common/AudioPreview.vue';
+import ImagePreview from '@/components/common/ImagePreview.vue';
+import VideoPreview from '@/components/common/VideoPreview.vue';
+import { DIGITALHUMAN_ETA_SECONDS } from '@/constants';
+
+// A photo now travels in `video_url` like a clip does, so the extension is the
+// only thing that still tells the two apart (same test the worker applies).
+const IMAGE_EXTS = ['.jpg', '.jpeg', '.png', '.webp', '.bmp', '.gif'];
 
 export default defineComponent({
   name: 'TaskPreview',
   components: {
-    DeleteIcon,
-    ElTooltip,
-    ControlsIcon,
-    ImageIcon,
-    InfoIcon,
-    TimeIcon,
-    UserIcon,
-    VideoIcon,
-    WarningIcon,
-    CopyToClipboard,
-    ElAlert,
-    ElProgress,
-    VideoPlayer,
-    ElButton,
     ApiCodeButton,
-    ReportButton
+    AudioPreview,
+    ChannelIcon,
+    CopyToClipboard,
+    DeleteIcon,
+    ElAlert,
+    ElButton,
+    ElProgress,
+    ElTooltip,
+    FullscreenIcon,
+    ImagePreview,
+    InfoIcon,
+    MagicIcon,
+    ReportButton,
+    TimeIcon,
+    VideoPlayer,
+    VideoPreview,
+    WarningIcon
   },
   props: {
     modelValue: {
@@ -175,13 +206,34 @@ export default defineComponent({
         ? (this.$t('digitalhuman.name.audioDriven') as string)
         : (this.$t('digitalhuman.name.textDriven') as string);
     },
-    faceLabel(): string {
-      return this.modelValue?.request?.image_url
-        ? (this.$t('digitalhuman.name.facePhoto') as string)
-        : (this.$t('digitalhuman.name.faceVideo') as string);
+    faceUrl(): string | undefined {
+      return this.modelValue?.request?.video_url || this.modelValue?.request?.image_url;
     },
-    engineLabel(): string {
-      return this.modelValue?.request?.engine || this.modelValue?.response?.engine || 'latentsync';
+    isPhotoFace(): boolean {
+      if (this.modelValue?.request?.image_url) return true;
+      const path = (this.faceUrl || '').split('?')[0].toLowerCase();
+      return IMAGE_EXTS.some((ext) => path.endsWith(ext));
+    },
+    audioUrl(): string | undefined {
+      return this.modelValue?.request?.audio_url;
+    },
+    outputSize(): string | undefined {
+      const { width, height } = this.modelValue?.response || {};
+      return width && height ? `${width}×${height}` : undefined;
+    },
+    /**
+     * Rough time remaining. The progress bar alone cannot carry expectations
+     * here: it jumps between a handful of fixed checkpoints and then sits
+     * still for many minutes.
+     */
+    etaText(): string | undefined {
+      const startedAt = parseFloat((this.modelValue?.created_at || '').toString());
+      if (!startedAt) return undefined;
+      const remaining = DIGITALHUMAN_ETA_SECONDS - (Date.now() / 1000 - startedAt);
+      if (remaining <= 60) {
+        return this.$t('digitalhuman.message.etaAlmostDone') as string;
+      }
+      return this.$t('digitalhuman.message.etaRemaining', { minutes: Math.ceil(remaining / 60) }) as string;
     },
     statusLabel(): string {
       const s = this.status;
@@ -314,6 +366,9 @@ $left-width: 70px;
         }
         &.success {
           border-color: var(--el-color-success);
+        }
+        &.info-state {
+          border-color: var(--el-color-info);
         }
         :deep(p:last-child) {
           margin-bottom: 0;

--- a/src/i18n/ar/digitalhuman.json
+++ b/src/i18n/ar/digitalhuman.json
@@ -271,14 +271,6 @@
     "message": "على وشك الانتهاء",
     "description": "قريب من الانتهاء"
   },
-  "name.faceVideo": {
-    "message": "فيديو",
-    "description": "خيار فيديو الوجه"
-  },
-  "name.facePhoto": {
-    "message": "صورة",
-    "description": "خيار صورة الوجه"
-  },
   "name.face": {
     "message": "مصدر الوجه",
     "description": "حقل مصدر الوجه"

--- a/src/i18n/de/digitalhuman.json
+++ b/src/i18n/de/digitalhuman.json
@@ -271,14 +271,6 @@
     "message": "Fast fertig",
     "description": "Beinahe abgeschlossen"
   },
-  "name.faceVideo": {
-    "message": "Video",
-    "description": "Bezeichnung für das Gesichtsvideo auf einer Aufgabenkarte"
-  },
-  "name.facePhoto": {
-    "message": "Foto",
-    "description": "Option für das Gesichtsfoto"
-  },
   "name.face": {
     "message": "Gesichtsquelle",
     "description": "Feld für die Gesichtsquelle"

--- a/src/i18n/el/digitalhuman.json
+++ b/src/i18n/el/digitalhuman.json
@@ -271,14 +271,6 @@
     "message": "Σχεδόν ολοκληρώθηκε",
     "description": "Σχεδόν ολοκληρωμένο"
   },
-  "name.faceVideo": {
-    "message": "Βίντεο",
-    "description": "Επιλογή βίντεο προσώπου"
-  },
-  "name.facePhoto": {
-    "message": "Φωτογραφία",
-    "description": "Επιλογή φωτογραφίας προσώπου"
-  },
   "name.face": {
     "message": "Πηγή προσώπου",
     "description": "Πεδίο πηγής προσώπου"

--- a/src/i18n/en/digitalhuman.json
+++ b/src/i18n/en/digitalhuman.json
@@ -270,13 +270,5 @@
   "message.etaAlmostDone": {
     "message": "almost done",
     "description": "Nearly finished"
-  },
-  "name.faceVideo": {
-    "message": "Video",
-    "description": "Face kind label on a task card"
-  },
-  "name.facePhoto": {
-    "message": "Photo",
-    "description": "Face kind label on a task card"
   }
 }

--- a/src/i18n/es/digitalhuman.json
+++ b/src/i18n/es/digitalhuman.json
@@ -271,14 +271,6 @@
     "message": "Casi terminado",
     "description": "Casi finalizado"
   },
-  "name.faceVideo": {
-    "message": "Vídeo",
-    "description": "Etiqueta de vídeo de cara en una tarjeta de tarea"
-  },
-  "name.facePhoto": {
-    "message": "Foto",
-    "description": "Opción de foto facial"
-  },
   "name.face": {
     "message": "Fuente facial",
     "description": "Campo de fuente facial"

--- a/src/i18n/fi/digitalhuman.json
+++ b/src/i18n/fi/digitalhuman.json
@@ -271,14 +271,6 @@
     "message": "Lähes valmis",
     "description": "Lähestyy valmistumista"
   },
-  "name.faceVideo": {
-    "message": "Video",
-    "description": "Kasvovideo-merkintä tehtäväkortilla"
-  },
-  "name.facePhoto": {
-    "message": "Kuva",
-    "description": "Kasvokuvavaihtoehto"
-  },
   "name.face": {
     "message": "Kasvojen lähde",
     "description": "Kasvojen lähdekenttä"

--- a/src/i18n/fr/digitalhuman.json
+++ b/src/i18n/fr/digitalhuman.json
@@ -271,14 +271,6 @@
     "message": "Presque terminé",
     "description": "Presque terminé"
   },
-  "name.faceVideo": {
-    "message": "Vidéo",
-    "description": "Option de vidéo du visage"
-  },
-  "name.facePhoto": {
-    "message": "Photo",
-    "description": "Étiquette de photo de visage sur une carte de tâche"
-  },
   "name.face": {
     "message": "Source du visage",
     "description": "Champ de la source du visage"

--- a/src/i18n/it/digitalhuman.json
+++ b/src/i18n/it/digitalhuman.json
@@ -271,14 +271,6 @@
     "message": "Quasi completato",
     "description": "Quasi finito"
   },
-  "name.faceVideo": {
-    "message": "Video",
-    "description": "Etichetta video facciale su una scheda attività"
-  },
-  "name.facePhoto": {
-    "message": "Foto",
-    "description": "Opzione foto del volto"
-  },
   "name.face": {
     "message": "Fonte del volto",
     "description": "Campo della fonte del volto"

--- a/src/i18n/ja/digitalhuman.json
+++ b/src/i18n/ja/digitalhuman.json
@@ -271,14 +271,6 @@
     "message": "ほぼ完了",
     "description": "ほぼ完了しています"
   },
-  "name.faceVideo": {
-    "message": "動画",
-    "description": "顔動画オプション"
-  },
-  "name.facePhoto": {
-    "message": "写真",
-    "description": "顔写真オプション"
-  },
   "name.face": {
     "message": "顔のソース",
     "description": "顔ソースフィールド"

--- a/src/i18n/ko/digitalhuman.json
+++ b/src/i18n/ko/digitalhuman.json
@@ -271,14 +271,6 @@
     "message": "거의 완료됨",
     "description": "거의 완료된 상태"
   },
-  "name.faceVideo": {
-    "message": "비디오",
-    "description": "얼굴 비디오 옵션"
-  },
-  "name.facePhoto": {
-    "message": "사진",
-    "description": "얼굴 사진 옵션"
-  },
   "name.face": {
     "message": "얼굴 소스",
     "description": "얼굴 소스 필드"

--- a/src/i18n/pl/digitalhuman.json
+++ b/src/i18n/pl/digitalhuman.json
@@ -271,14 +271,6 @@
     "message": "Prawie gotowe",
     "description": "Prawie zakończone"
   },
-  "name.faceVideo": {
-    "message": "Wideo",
-    "description": "Opcja wideo twarzy"
-  },
-  "name.facePhoto": {
-    "message": "Zdjęcie",
-    "description": "Opcja zdjęcia twarzy"
-  },
   "name.face": {
     "message": "Źródło twarzy",
     "description": "Pole źródła twarzy"

--- a/src/i18n/pt/digitalhuman.json
+++ b/src/i18n/pt/digitalhuman.json
@@ -271,14 +271,6 @@
     "message": "Quase concluído",
     "description": "Quase finalizado"
   },
-  "name.faceVideo": {
-    "message": "Vídeo",
-    "description": "Opção de vídeo facial"
-  },
-  "name.facePhoto": {
-    "message": "Foto",
-    "description": "Opção de foto facial"
-  },
   "name.face": {
     "message": "Fonte facial",
     "description": "Campo de fonte facial"

--- a/src/i18n/ru/digitalhuman.json
+++ b/src/i18n/ru/digitalhuman.json
@@ -271,14 +271,6 @@
     "message": "Почти завершено",
     "description": "Почти завершено"
   },
-  "name.faceVideo": {
-    "message": "Видео",
-    "description": "Опция видео лица"
-  },
-  "name.facePhoto": {
-    "message": "Фото",
-    "description": "Опция фото лица"
-  },
   "name.face": {
     "message": "Источник лица",
     "description": "Поле источника лица"

--- a/src/i18n/sr/digitalhuman.json
+++ b/src/i18n/sr/digitalhuman.json
@@ -271,14 +271,6 @@
     "message": "Skoro završeno",
     "description": "Gotovo je završeno"
   },
-  "name.faceVideo": {
-    "message": "Видео",
-    "description": "Опција видео лица"
-  },
-  "name.facePhoto": {
-    "message": "Фотографија",
-    "description": "Опција фотографије лица"
-  },
   "name.face": {
     "message": "Извор лица",
     "description": "Поље извора лица"

--- a/src/i18n/sv/digitalhuman.json
+++ b/src/i18n/sv/digitalhuman.json
@@ -271,14 +271,6 @@
     "message": "Nästan klart",
     "description": "Nästan färdig"
   },
-  "name.faceVideo": {
-    "message": "Video",
-    "description": "Ansiktsvideoetikett på en uppgift"
-  },
-  "name.facePhoto": {
-    "message": "Foto",
-    "description": "Alternativ för ansiktsfoto"
-  },
   "name.face": {
     "message": "Ansiktskälla",
     "description": "Fält för ansiktskälla"

--- a/src/i18n/uk/digitalhuman.json
+++ b/src/i18n/uk/digitalhuman.json
@@ -271,14 +271,6 @@
     "message": "Незабаром завершиться",
     "description": "Майже закінчено"
   },
-  "name.faceVideo": {
-    "message": "Відео",
-    "description": "Опція для відео обличчя"
-  },
-  "name.facePhoto": {
-    "message": "Фото",
-    "description": "Опція для фото обличчя"
-  },
   "name.face": {
     "message": "Джерело обличчя",
     "description": "Поле для джерела обличчя"

--- a/src/i18n/zh-CN/digitalhuman.json
+++ b/src/i18n/zh-CN/digitalhuman.json
@@ -270,13 +270,5 @@
   "message.etaAlmostDone": {
     "message": "即将完成",
     "description": "Nearly finished"
-  },
-  "name.faceVideo": {
-    "message": "视频",
-    "description": "Face kind label on a task card"
-  },
-  "name.facePhoto": {
-    "message": "照片",
-    "description": "Face kind label on a task card"
   }
 }

--- a/src/i18n/zh-TW/digitalhuman.json
+++ b/src/i18n/zh-TW/digitalhuman.json
@@ -271,14 +271,6 @@
     "message": "即將完成",
     "description": "幾乎完成"
   },
-  "name.faceVideo": {
-    "message": "影片",
-    "description": "Face video option"
-  },
-  "name.facePhoto": {
-    "message": "照片",
-    "description": "Face photo option"
-  },
   "name.face": {
     "message": "臉部來源",
     "description": "Face source field"


### PR DESCRIPTION
数字人页重做的最后一步。前三步：#1506（顺手 bug + 图标）、PlatformBackend#1249（统一计价）/ PlatformService#1803（照片模式 P0）、#1508（配置面板）。

> 接替 #1509 —— 那个 PR 的 base 指向 #1508 的分支，#1508 合并时分支被删，PR 随之自动关闭。内容相同，重新基于 main。

## 「视频 / 非 / latentsync」的真相

那个「非」**不是文字**。是 `ControlsIcon`（`@acedatacloud/core` 把它映射到 lucide 的 `SlidersHorizontal` —— 两竖三横的滑杆）在 `text-xs` 下的视觉塌缩。整行实为「[图标]视频 [图标]latentsync」，窄容器换行后看起来像三行。

`engineLabel` 那个 computed 还硬编码了 `|| 'latentsync'` 兜底、连 i18n 都没走。整行连同 computed 一起删 —— 引擎已经不是用户该看见的东西（#1508 已从输入面板移除，PlatformBackend#1249 已统一计价）。

## 腾出来的位置放什么

**顶部回显素材**（与 `seedance/task/Preview.vue` 同构）：这次用的脸（视频出首帧 / 照片出缩略图）和声音（可试听）。

**成功态**从 2 项补到 5 项：视频时长、画面尺寸、任务 ID、耗时、**追踪 ID** —— `trace_id` 后端一直在返回（`dh_store.public()` 就有），白白没显示。

**失败态**补上耗时和追踪 ID，失败原因加一键复制。

## 等待态：42 分钟的任务不能只给一条进度条

实测一次渲染 2502 秒。而进度只在 `dh_store._PERCENT_FLOOR` 的 3 / 8 和 `pipeline_adapter` 写死的 40 / 55 / 85 几个点上跳，中间长时间纹丝不动 —— 用户看着一个卡住的数字，无从判断是正常还是死了。

改成带剩余时间的提示（以实测值为基准 + `created_at` 反推），超出预估后降级为「即将完成」，**绝不显示负数**。

## 照片的识别

PlatformService#1803 之后照片和视频一样走 `video_url`，所以回显时靠扩展名区分，判据与 worker 侧 `pipeline.py` 的 `IMAGE_EXTS` 一致。老任务里的 `image_url` 仍然认。

## 验证

```
npx vue-tsc -b     # 通过
npx vitest run     # 通过（新增 12 个）
python3 scripts/check_i18n_coverage.py   # 17 locale × 47 namespace OK
```

新增测试里有一条是**防回归**的：断言渲染结果不含 `latentsync` / `heygem` 字样。另外覆盖了扩展名分类的四种情形（含 `face.mov?x=.png` 这种查询串里带图片后缀的陷阱）、ETA 的倒数/超时/无创建时间三种情况。

🤖 Generated with [Claude Code](https://claude.com/claude-code)