### PR TITLE
Fix subsite management custom-domain routing

### DIFF
--- a/change/@acedatacloud-nexior-1b839819-0140-41c2-a29b-cbc808e48670.json
+++ b/change/@acedatacloud-nexior-1b839819-0140-41c2-a29b-cbc808e48670.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "管理分站时优先打开已生效的绑定域名",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/setting/Subsite.test.ts
+++ b/src/components/setting/Subsite.test.ts
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+import { flushPromises, shallowMount } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const siteOperatorMock = vi.hoisted(() => ({
+  getAll: vi.fn(),
+  create: vi.fn(),
+  delete: vi.fn()
+}));
+
+const siteDomainOperatorMock = vi.hoisted(() => ({
+  getAll: vi.fn()
+}));
+
+vi.mock('@/operators', () => ({
+  siteOperator: siteOperatorMock,
+  siteDomainOperator: siteDomainOperatorMock
+}));
+
+import SubsiteSetting from './Subsite.vue';
+import { SiteDomainStatus, type ISite } from '@/models';
+
+const site: ISite = {
+  id: 'site-1',
+  origin: 'brand.studio.acedata.cloud'
+};
+
+const mountComponent = () =>
+  shallowMount(SubsiteSetting, {
+    global: {
+      mocks: {
+        $t: (key: string) => key,
+        $store: {
+          state: {
+            site: {
+              origin: 'studio.acedata.cloud',
+              features: { subsite: { subdomain_zone: 'studio.acedata.cloud' } }
+            }
+          },
+          getters: { user: { id: 'user-1' } }
+        }
+      },
+      stubs: {
+        Plus: true,
+        SectionNotice: true
+      }
+    }
+  });
+
+describe('setting/Subsite', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    siteOperatorMock.getAll.mockResolvedValue({ data: { items: [] } });
+    siteDomainOperatorMock.getAll.mockResolvedValue({ data: { items: [] } });
+  });
+
+  it('opens settings on an active custom domain', async () => {
+    const open = vi.spyOn(window, 'open').mockImplementation(() => null);
+    const wrapper = mountComponent();
+    await flushPromises();
+    await wrapper.setData({
+      domainsBySite: {
+        'site-1': [
+          { hostname: 'pending.example.com', status: SiteDomainStatus.Pending },
+          { hostname: 'studio.example.com', status: SiteDomainStatus.Active }
+        ]
+      }
+    });
+
+    (wrapper.vm as unknown as { onManageSite: (row: ISite) => void }).onManageSite(site);
+
+    expect(open).toHaveBeenCalledWith('https://studio.example.com/?dialog=settings', '_blank', 'noopener');
+  });
+
+  it('falls back to the default subdomain when no custom domain is active', async () => {
+    const open = vi.spyOn(window, 'open').mockImplementation(() => null);
+    const wrapper = mountComponent();
+    await flushPromises();
+    await wrapper.setData({
+      domainsBySite: {
+        'site-1': [{ hostname: 'pending.example.com', status: SiteDomainStatus.Pending }]
+      }
+    });
+
+    (wrapper.vm as unknown as { onManageSite: (row: ISite) => void }).onManageSite(site);
+
+    expect(open).toHaveBeenCalledWith('https://brand.studio.acedata.cloud/?dialog=settings', '_blank', 'noopener');
+  });
+});

--- a/src/components/setting/Subsite.vue
+++ b/src/components/setting/Subsite.vue
@@ -437,6 +437,10 @@ export default defineComponent({
     },
     onManageSite(row: ISite) {
       if (!row.origin) return;
+      const activeDomain = this.customDomainsFor(row).find(
+        (domain) => domain.status === SiteDomainStatus.Active && domain.hostname
+      );
+      const hostname = activeDomain?.hostname || row.origin;
       // Open the subsite at its root and signal the user-settings dialog
       // to auto-open via the `?dialog=settings` query flag. The root
       // route still redirects to whatever the subsite's default landing
@@ -445,7 +449,7 @@ export default defineComponent({
       // pops the settings dialog. This avoids the blank `/settings`
       // page race where SettingsIndex dispatches `open-user-settings`
       // before UserCenter's listener is registered.
-      window.open(`https://${row.origin}/?dialog=settings`, '_blank', 'noopener');
+      window.open(`https://${hostname}/?dialog=settings`, '_blank', 'noopener');
     },
     async onDeleteSite(row: ISite) {
       if (!row.id || !row.origin) return;


### PR DESCRIPTION
## Summary
- open a subsite's settings through its first active custom domain
- fall back to the default `*.studio.acedata.cloud` origin when no custom domain is active
- add focused regression coverage for both routing paths

## Validation
- `npx vitest run src/components/setting/Subsite.test.ts --reporter=verbose`
- `npx eslint src/components/setting/Subsite.vue src/components/setting/Subsite.test.ts`
- `npx vue-tsc -b`
- `npx beachball check`