### PR TITLE
Fix task preview spacing and Kling speech text

### DIFF
--- a/change/@acedatacloud-nexior-6fc51f61-89f0-4fe0-bdb5-65fed73993f4.json
+++ b/change/@acedatacloud-nexior-6fc51f61-89f0-4fe0-bdb5-65fed73993f4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "优化生成任务预览间距并恢复口播文本展示",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/flux/task/Preview.vue
+++ b/src/components/flux/task/Preview.vue
@@ -286,7 +286,7 @@ $left-width: 70px;
         font-size: 16px;
         font-weight: bold;
         color: var(--el-text-color-regular);
-        margin-bottom: 15px;
+        margin-bottom: 0;
         white-space: normal;
         word-break: break-word;
         overflow-wrap: anywhere;
@@ -294,6 +294,7 @@ $left-width: 70px;
     }
 
     .content {
+      margin-top: 8px;
       word-break: break-word;
       overflow-wrap: anywhere;
       .el-alert {

--- a/src/components/kling/task/Preview.test.ts
+++ b/src/components/kling/task/Preview.test.ts
@@ -128,6 +128,23 @@ describe('kling/task/Preview', () => {
     expect(wrapper.find('.info + .content').exists()).toBe(true);
   });
 
+  it('keeps media-only request context visible when no prompt or speech text was stored', () => {
+    const wrapper = mountPreview({
+      ...task,
+      request: { video_url: 'https://cdn.example.com/speaker.mp4' },
+      response: {
+        success: false,
+        task_id: 'kling-task',
+        error: { message: 'Generation failed' }
+      }
+    });
+
+    expect(wrapper.find('.info').exists()).toBe(true);
+    expect(wrapper.find('.request-media').exists()).toBe(true);
+    expect(wrapper.find('.prompt').exists()).toBe(false);
+    expect(wrapper.find('.info + .content').exists()).toBe(true);
+  });
+
   it.each([
     { state: 'failed', error: { message: 'Generation failed' } },
     { error: { message: 'Provider rejected the task' } }

--- a/src/components/kling/task/Preview.test.ts
+++ b/src/components/kling/task/Preview.test.ts
@@ -108,6 +108,26 @@ describe('kling/task/Preview', () => {
     expect(wrapper.findComponent({ name: 'WarningIcon' }).exists()).toBe(true);
   });
 
+  it('shows stored speech text and keeps failure details separated from request media', () => {
+    const wrapper = mountPreview({
+      ...task,
+      request: {
+        video_url: 'https://cdn.example.com/speaker.mp4',
+        text: 'Hello from AceData',
+        voice_id: 'voice-1'
+      },
+      response: {
+        success: false,
+        task_id: 'kling-task',
+        error: { message: 'The model did not detect a human' }
+      }
+    });
+
+    expect(wrapper.find('.prompt').text()).toBe('Hello from AceData');
+    expect(wrapper.find('.request-media').exists()).toBe(true);
+    expect(wrapper.find('.info + .content').exists()).toBe(true);
+  });
+
   it.each([
     { state: 'failed', error: { message: 'Generation failed' } },
     { error: { message: 'Provider rejected the task' } }

--- a/src/components/kling/task/Preview.vue
+++ b/src/components/kling/task/Preview.vue
@@ -21,10 +21,13 @@
           </button>
         </el-tooltip>
       </div>
-      <div class="info">
+      <div
+        v-if="referenceImages.length > 0 || referenceVideos.length > 0 || referenceAudios.length > 0 || displayText"
+        class="info"
+      >
         <div
           v-if="referenceImages.length > 0 || referenceVideos.length > 0 || referenceAudios.length > 0"
-          class="flex justify-start items-center gap-2 mt-2 w-full overflow-x-auto"
+          class="request-media flex justify-start items-center gap-2 w-full overflow-x-auto"
         >
           <image-preview
             v-for="(image, idx) in referenceImages"
@@ -46,8 +49,8 @@
             :name="audio.name"
           />
         </div>
-        <p v-if="modelValue?.request?.prompt" class="prompt mt-2">
-          {{ modelValue?.request?.prompt }}
+        <p v-if="displayText" class="prompt">
+          {{ displayText }}
           <span v-if="!modelValue?.response"> - ({{ $t('kling.status.pending') }}) </span>
           <span v-else-if="isWaiting"> - ({{ $t('kling.status.processing') }}) </span>
         </p>
@@ -70,11 +73,7 @@
             </el-button>
           </el-tooltip>
           <api-code-button path="/kling/videos" :body="modelValue?.request" />
-          <report-button
-            service="kling"
-            :target-id="modelValue?.id"
-            :snapshot="{ prompt: modelValue?.request?.prompt }"
-          />
+          <report-button service="kling" :target-id="modelValue?.id" :snapshot="{ prompt: displayText }" />
         </div>
         <el-alert :closable="false" class="mt-2 success">
           <p class="text-[var(--el-text-color-regular)] text-xs mb-2">
@@ -219,6 +218,9 @@ export default defineComponent({
     config() {
       return this.$store.state.kling?.config;
     },
+    displayText(): string {
+      return this.modelValue?.request?.prompt?.trim() || this.modelValue?.request?.text?.trim() || '';
+    },
     referenceImages(): { url: string; name: string }[] {
       const images: { url: string; name: string }[] = [];
       const startImageUrl = this.modelValue?.request?.start_image_url;
@@ -356,12 +358,16 @@ $left-width: 70px;
     }
 
     .info {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      margin-top: 8px;
       overflow: hidden;
       .prompt {
         font-size: 16px;
         font-weight: bold;
         color: var(--el-text-color-regular);
-        margin-bottom: 10px;
+        margin: 0;
         white-space: normal;
         word-break: break-word;
         overflow-wrap: anywhere;
@@ -369,6 +375,7 @@ $left-width: 70px;
     }
 
     .content {
+      margin-top: 8px;
       word-break: break-word;
       overflow-wrap: anywhere;
       .el-alert {

--- a/src/components/luma/task/Preview.vue
+++ b/src/components/luma/task/Preview.vue
@@ -300,7 +300,7 @@ $left-width: 70px;
         font-size: 14px;
         font-weight: bold;
         color: var(--el-text-color-regular);
-        margin-bottom: 10px;
+        margin-bottom: 0;
         white-space: normal;
         word-break: break-word;
         overflow-wrap: anywhere;
@@ -308,6 +308,7 @@ $left-width: 70px;
     }
 
     .content {
+      margin-top: 8px;
       word-break: break-word;
       overflow-wrap: anywhere;
       .el-alert {

--- a/src/components/seedream/task/Preview.test.ts
+++ b/src/components/seedream/task/Preview.test.ts
@@ -31,7 +31,7 @@ describe('seedream/task/Preview', () => {
     });
   });
 
-  it('adds request-context spacing only when a failed task has no prompt', () => {
+  it('uses the same spaced content container whether a failed task has a prompt or not', () => {
     const mountFailure = (prompt?: string | null) =>
       shallowMount(Preview, {
         props: {
@@ -50,9 +50,9 @@ describe('seedream/task/Preview', () => {
         }
       });
 
-    expect(mountFailure().find('.content').classes()).toContain('mt-[15px]');
-    expect(mountFailure(null).find('.content').classes()).toContain('mt-[15px]');
-    expect(mountFailure('').find('.content').classes()).toContain('mt-[15px]');
-    expect(mountFailure('A lighthouse').find('.content').classes()).not.toContain('mt-[15px]');
+    expect(mountFailure().find('.content').classes()).toEqual(['content']);
+    expect(mountFailure(null).find('.content').classes()).toEqual(['content']);
+    expect(mountFailure('').find('.content').classes()).toEqual(['content']);
+    expect(mountFailure('A lighthouse').find('.content').classes()).toEqual(['content']);
   });
 });

--- a/src/components/seedream/task/Preview.vue
+++ b/src/components/seedream/task/Preview.vue
@@ -109,10 +109,7 @@
           </p>
         </el-alert>
       </div>
-      <div
-        v-else-if="modelValue?.response?.success === false"
-        :class="{ content: true, 'mt-[15px]': !modelValue?.request?.prompt }"
-      >
+      <div v-else-if="modelValue?.response?.success === false" class="content">
         <el-alert :closable="false" class="failure">
           <template #template>
             <warning-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
@@ -357,7 +354,7 @@ $left-width: 70px;
         font-size: 16px;
         font-weight: bold;
         color: var(--el-text-color-regular);
-        margin-bottom: 15px;
+        margin-bottom: 0;
         white-space: normal;
         word-break: break-word;
         overflow-wrap: anywhere;
@@ -365,6 +362,7 @@ $left-width: 70px;
     }
 
     .content {
+      margin-top: 8px;
       word-break: break-word;
       overflow-wrap: anywhere;
       .el-alert {

--- a/src/components/sora/task/Preview.vue
+++ b/src/components/sora/task/Preview.vue
@@ -289,7 +289,7 @@ $left-width: 70px;
         font-size: 16px;
         font-weight: bold;
         color: var(--el-text-color-regular);
-        margin-bottom: 10px;
+        margin-bottom: 0;
         white-space: normal;
         word-break: break-word;
         overflow-wrap: anywhere;
@@ -297,6 +297,7 @@ $left-width: 70px;
     }
 
     .content {
+      margin-top: 8px;
       word-break: break-word;
       overflow-wrap: anywhere;
 

--- a/src/components/veo/task/Preview.vue
+++ b/src/components/veo/task/Preview.vue
@@ -320,7 +320,7 @@ $left-width: 70px;
         font-size: 16px;
         font-weight: bold;
         color: var(--el-text-color-regular);
-        margin-bottom: 10px;
+        margin-bottom: 0;
         white-space: normal;
         word-break: break-word;
         overflow-wrap: anywhere;
@@ -328,6 +328,7 @@ $left-width: 70px;
     }
 
     .content {
+      margin-top: 8px;
       word-break: break-word;
       overflow-wrap: anywhere;
       .el-alert {

--- a/src/models/kling.ts
+++ b/src/models/kling.ts
@@ -65,6 +65,12 @@ export interface IKlingTalkingPhotoConfig {
 export interface IKlingTalkingPhotoRequest {
   image_url: string;
   audio_url: string;
+  video_url?: string;
+  text?: string;
+  voice_id?: string;
+  voice_speed?: number;
+  voice_language?: string;
+  audio_type?: string;
   prompt?: string;
   model?: string;
   duration?: number;


### PR DESCRIPTION
## Summary

- keep task status and metadata cards consistently separated from request previews across Kling, Luma, Sora, Veo, Flux, and Seedream
- show Kling speech text when historical talking-video tasks store user input in `request.text` instead of `request.prompt`
- replace Seedream's failure-only spacing workaround with the shared content spacing rule

## Validation

- `vitest run` for the six affected task preview suites: 33 tests passed
- `npx vue-tsc --noEmit`
- targeted ESLint and Prettier checks
- `npx beachball check`
- `git diff --check`