### PR TITLE
fix(chat): reveal report action on message hover

### DIFF
--- a/change/@acedatacloud-nexior-c8a4c1f7-1770-4c7d-b53a-34f280b97809.json
+++ b/change/@acedatacloud-nexior-c8a4c1f7-1770-4c7d-b53a-34f280b97809.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "show the chat report action only while hovering or focusing the full message row",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/chat/Message.vue
+++ b/src/components/chat/Message.vue
@@ -699,6 +699,9 @@ export default defineComponent({
     :deep(.report-entry) {
       min-height: 0;
       margin-bottom: 0;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.15s ease;
     }
     :deep(.btn-report) {
       padding: 0;
@@ -707,12 +710,24 @@ export default defineComponent({
     }
   }
 
-  &:hover {
+  &:hover,
+  &:focus-within {
     .operations {
       color: var(--el-text-color-regular);
       .btn-edit {
         visibility: visible;
       }
+      :deep(.report-entry) {
+        opacity: 1;
+        pointer-events: auto;
+      }
+    }
+  }
+
+  @media (hover: none) {
+    .operations :deep(.report-entry) {
+      opacity: 1;
+      pointer-events: auto;
     }
   }
 }


### PR DESCRIPTION
## Summary
- hide the report action until the full message row is hovered or keyboard-focused
- keep the action visible on touch-only devices

## Verification
- `npm run test:run -- src/components/chat/Message.browserTool.test.ts`
- `npx eslint src/components/chat/Message.vue`
- `npm run build:web`
- `npm run verify`