### PR TITLE
fix(chat): 执行前确认卡片的样式与 TikTok 卡片回放

### DIFF
--- a/change/@acedatacloud-nexior-3f1b6c2a-9d84-4e77-b5c1-2ae0f9d17c43.json
+++ b/change/@acedatacloud-nexior-3f1b6c2a-9d84-4e77-b5c1-2ae0f9d17c43.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "polish the action confirmation card: match the connector consent card's house style, drop the duplicate tool row above it, and replay the submitted TikTok form read-only once resolved",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/chat/ActionConfirmationCard.vue
+++ b/src/components/chat/ActionConfirmationCard.vue
@@ -29,6 +29,8 @@
         :detail="payload.detail as any"
         :initial-title="initialTitle"
         :duration-sec="payload.preview?.duration_sec ?? 0"
+        :disabled="resolved"
+        :initial-values="submittedValues"
         @validity-change="onValidityChange"
       />
       <GenericFieldList v-else :summary="payload.summary" :fields="payload.fields ?? []" />
@@ -59,7 +61,7 @@ import { ConfirmIcon, WarningIcon } from '@acedatacloud/core/icons/components';
 import { defineComponent, type PropType } from 'vue';
 import GenericFieldList from './GenericFieldList.vue';
 import TikTokPublishForm from './TikTokPublishForm.vue';
-import type { IActionConfirmationPayload, IActionConfirmationResult } from '@/models';
+import type { IActionConfirmationPayload, IActionConfirmationResult, ITikTokPublishValues } from '@/models';
 
 interface IData {
   submitting: boolean;
@@ -113,6 +115,16 @@ export default defineComponent({
     initialTitle(): string {
       const detail = this.payload?.detail as Record<string, unknown> | undefined;
       return typeof detail?.suggested_title === 'string' ? detail.suggested_title : '';
+    },
+    /** What the user actually submitted, so a resolved card replays it. */
+    submittedValues(): ITikTokPublishValues | null {
+      if (!this.resolved || !this.previousOutput) return null;
+      try {
+        const parsed = JSON.parse(this.previousOutput) as IActionConfirmationResult;
+        return (parsed?.values as unknown as ITikTokPublishValues) ?? null;
+      } catch {
+        return null;
+      }
     },
     isDestructive(): boolean {
       return this.payload?.severity === 'destructive';
@@ -186,35 +198,48 @@ export default defineComponent({
 </script>
 
 <style lang="scss" scoped>
+// Shape, shadow and enter animation deliberately mirror
+// `<ConnectorConsentCard>` — the two cards sit in the same transcript and a
+// different radius/elevation reads as a different product.
 .action-confirmation-card {
-  border: 1px solid var(--el-border-color);
-  border-radius: 10px;
-  padding: 14px 16px;
+  border: 1px solid var(--el-border-color-lighter);
+  border-radius: 16px;
+  padding: 16px 18px 14px;
   margin: 8px 0;
+  max-width: 100%;
+  font-size: 14px;
   background: var(--el-bg-color);
+  box-shadow:
+    0 4px 16px -8px rgba(0, 0, 0, 0.08),
+    0 1px 2px rgba(0, 0, 0, 0.04);
+  animation: actionConfirmationEnter 280ms cubic-bezier(0.16, 1, 0.3, 1);
 
   &.is-destructive {
     border-color: var(--el-color-danger-light-5);
   }
 
   &.is-resolved {
-    opacity: 0.72;
+    background: var(--el-fill-color-light);
+    box-shadow: none;
+    animation: none;
   }
 
   .acc-header {
     display: flex;
     align-items: center;
     gap: 8px;
-    margin-bottom: 10px;
+    margin-bottom: 8px;
 
     .header-icon {
       color: var(--el-color-primary);
+      font-size: 16px;
       flex-shrink: 0;
     }
 
     .header-title {
-      font-size: 14px;
+      font-size: 15px;
       font-weight: 600;
+      letter-spacing: 0.01em;
       color: var(--el-text-color-primary);
       min-width: 0;
       word-break: break-word;
@@ -228,7 +253,7 @@ export default defineComponent({
   .acc-preview {
     position: relative;
     margin-bottom: 12px;
-    border-radius: 8px;
+    border-radius: 10px;
     overflow: hidden;
     background: var(--el-fill-color-light);
     max-width: 240px;
@@ -256,13 +281,31 @@ export default defineComponent({
     display: flex;
     justify-content: flex-end;
     gap: 8px;
-    margin-top: 14px;
+    margin-top: 10px;
+    padding-top: 8px;
+    border-top: 1px solid var(--el-border-color-lighter);
   }
 
   .acc-resolved-banner {
-    margin-top: 12px;
-    font-size: 12px;
-    color: var(--el-text-color-secondary);
+    margin-top: 10px;
+    padding: 8px 12px;
+    border-radius: 8px;
+    background: var(--el-color-info-light-9);
+    color: var(--el-text-color-regular);
+    font-size: 13px;
+    line-height: 1.5;
+  }
+}
+
+@keyframes actionConfirmationEnter {
+  from {
+    opacity: 0;
+    transform: translateY(8px) scale(0.985);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
   }
 }
 </style>

--- a/src/components/chat/Message.vue
+++ b/src/components/chat/Message.vue
@@ -71,6 +71,10 @@
                   !(
                     item.tool_name === 'request_user_consent' &&
                     (item.status === 'awaiting_input' || item.status === 'done')
+                  ) &&
+                  !(
+                    item.tool_name === 'request_action_confirmation' &&
+                    (item.status === 'awaiting_input' || item.status === 'done')
                   )
                 "
                 :item="item"

--- a/src/components/chat/TikTokPublishForm.vue
+++ b/src/components/chat/TikTokPublishForm.vue
@@ -17,7 +17,8 @@
         type="textarea"
         :rows="3"
         :maxlength="2200"
-        show-word-limit
+        :show-word-limit="!disabled"
+        :disabled="disabled"
         :placeholder="$t('chat.actionConfirmation.tiktok.captionPlaceholder')"
       />
     </div>
@@ -33,6 +34,7 @@
         id="tpf-privacy"
         v-model="form.privacy_level"
         :placeholder="$t('chat.actionConfirmation.tiktok.privacyPlaceholder')"
+        :disabled="disabled"
         class="tpf-select"
       >
         <el-option
@@ -51,15 +53,15 @@
     <div class="tpf-field">
       <span class="tpf-label">{{ $t('chat.actionConfirmation.tiktok.interactions') }}</span>
       <div class="tpf-checks">
-        <el-checkbox v-model="form.allow_comment" :disabled="detail.comment_disabled">
+        <el-checkbox v-model="form.allow_comment" :disabled="disabled || detail.comment_disabled">
           {{ $t('chat.actionConfirmation.tiktok.allowComment') }}
         </el-checkbox>
         <!-- Duet and Stitch do not apply to photo posts. -->
         <template v-if="!detail.is_photo_post">
-          <el-checkbox v-model="form.allow_duet" :disabled="detail.duet_disabled">
+          <el-checkbox v-model="form.allow_duet" :disabled="disabled || detail.duet_disabled">
             {{ $t('chat.actionConfirmation.tiktok.allowDuet') }}
           </el-checkbox>
-          <el-checkbox v-model="form.allow_stitch" :disabled="detail.stitch_disabled">
+          <el-checkbox v-model="form.allow_stitch" :disabled="disabled || detail.stitch_disabled">
             {{ $t('chat.actionConfirmation.tiktok.allowStitch') }}
           </el-checkbox>
         </template>
@@ -67,14 +69,14 @@
     </div>
 
     <div class="tpf-field">
-      <el-checkbox v-model="form.commercial">
+      <el-checkbox v-model="form.commercial" :disabled="disabled">
         {{ $t('chat.actionConfirmation.tiktok.commercial') }}
       </el-checkbox>
       <div v-if="form.commercial" class="tpf-checks tpf-indent">
-        <el-checkbox v-model="form.brand_organic_toggle">
+        <el-checkbox v-model="form.brand_organic_toggle" :disabled="disabled">
           {{ $t('chat.actionConfirmation.tiktok.yourBrand') }}
         </el-checkbox>
-        <el-checkbox v-model="form.brand_content_toggle" :disabled="brandedContentBlocked">
+        <el-checkbox v-model="form.brand_content_toggle" :disabled="disabled || brandedContentBlocked">
           {{ $t('chat.actionConfirmation.tiktok.brandedContent') }}
         </el-checkbox>
         <p v-if="commercialLabel" class="tpf-hint">{{ commercialLabel }}</p>
@@ -129,20 +131,31 @@ export default defineComponent({
     durationSec: {
       type: Number,
       default: 0
+    },
+    /** Resolved replay: freeze every control so history stays read-only. */
+    disabled: {
+      type: Boolean,
+      default: false
+    },
+    /** Values the user actually submitted, replayed from the tool output. */
+    initialValues: {
+      type: Object as PropType<ITikTokPublishValues | null>,
+      default: null
     }
   },
   emits: ['validity-change'],
   data(): { form: IForm } {
+    const submitted = this.initialValues;
     return {
       form: {
-        title: this.initialTitle,
-        privacy_level: '',
-        allow_comment: false,
-        allow_duet: false,
-        allow_stitch: false,
-        commercial: false,
-        brand_organic_toggle: false,
-        brand_content_toggle: false
+        title: submitted?.title ?? this.initialTitle,
+        privacy_level: submitted?.privacy_level ?? '',
+        allow_comment: submitted ? !submitted.disable_comment : false,
+        allow_duet: submitted ? !submitted.disable_duet : false,
+        allow_stitch: submitted ? !submitted.disable_stitch : false,
+        commercial: Boolean(submitted?.brand_organic_toggle || submitted?.brand_content_toggle),
+        brand_organic_toggle: Boolean(submitted?.brand_organic_toggle),
+        brand_content_toggle: Boolean(submitted?.brand_content_toggle)
       }
     };
   },


### PR DESCRIPTION
用户反馈截图里的卡片「太丑了，风格也格格不入」，顺带问 TikTok 的卡片在哪。三处修正：

### 1. 卡片上方多出一行折叠的 "Confirm action"

`Message.vue` 里 `<tool-activity>` 的 `v-if` 给 `ask_user_question` 和 `request_user_consent` 都写了排除条件，唯独漏了 `request_action_confirmation`。结果同一个 tool 块被渲染两次：一行英文折叠条 + 下面的正式卡片。补上排除即可，那行英文 `Confirm action`（来自 `ToolActivity` 的 `name.replace(/_/g,' ')` 兜底）随之消失。

### 2. 样式与站内其他卡片不统一

对齐 `<ConnectorConsentCard>` 的既有观感——两张卡会出现在同一条对话流里，圆角和投影不一致读起来就像两个产品：

| | 之前 | 现在 |
|---|---|---|
| 圆角 | 10px | 16px |
| 阴影 | 无 | 双层柔和投影 |
| 入场 | 无 | `280ms cubic-bezier(.16,1,.3,1)` |
| 标题 | 14px | 15px + `letter-spacing` |
| 按钮区 | 只有 margin | 上分隔线 |
| resolved | 整体 `opacity: .72`（连正文一起糊掉） | 换底色，阴影/动画关闭 |
| 结果条 | 裸小字 | info 底色的胶囊 |

### 3. 已确认的 TikTok 卡片仍然是可编辑的

resolved 之后 `TikTokPublishForm` 照旧渲染活的 `el-input` / `el-select` / `el-checkbox`，历史记录看着像还能改。新增 `disabled` 与 `initialValues` 两个 prop：从 `previousOutput` 里解析出用户当时真正提交的 `values`，回放标题、可见性、互动开关，并冻结全部控件。

### 验证

- `vue-tsc -b` 通过
- `npm run lint` 0 error（2 个 warning 在无关的 `dropUploadMixin.test.ts`，主干既有）
- TikTok 卡片本身在线上已经可用，实测会话（保持在暂停态可直接观察）：https://studio.acedata.cloud/chatgpt/conversations/729372f1-02ff-4f2e-a030-d069ba5e31d5

🤖 Generated with [Claude Code](https://claude.com/claude-code)