### PR TITLE
fix(chat): register the Element Plus components the cards actually use

### DIFF
--- a/change/@acedatacloud-nexior-8c4d1e7f-3b26-4a95-9d18-6f2e0a3b5c71.json
+++ b/change/@acedatacloud-nexior-8c4d1e7f-3b26-4a95-9d18-6f2e0a3b5c71.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "register the Element Plus components each chat card actually uses, so the action confirmation and TikTok publish forms render real inputs, selects, checkboxes and buttons instead of bare text",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/application/Info.vue
+++ b/src/components/application/Info.vue
@@ -60,7 +60,7 @@
 <script lang="ts">
 import { IApplication } from '@/models';
 import { defineComponent } from 'vue';
-import { ElButton, ElIcon } from 'element-plus';
+import { ElButton, ElIcon, ElTag } from 'element-plus';
 import { AnalyticsIcon, ConfirmIcon, CreditsIcon, WalletIcon } from '@acedatacloud/core/icons/components';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 import { isIOS, isRechargeDisabled } from '@/utils';
@@ -73,6 +73,7 @@ export default defineComponent({
     CreditsIcon,
     ElButton,
     ElIcon,
+    ElTag,
     CopyToClipboard,
     WalletIcon
   },

--- a/src/components/chat/ActionConfirmationCard.vue
+++ b/src/components/chat/ActionConfirmationCard.vue
@@ -58,6 +58,7 @@
 
 <script lang="ts">
 import { ConfirmIcon, WarningIcon } from '@acedatacloud/core/icons/components';
+import { ElButton } from 'element-plus';
 import { defineComponent, type PropType } from 'vue';
 import GenericFieldList from './GenericFieldList.vue';
 import TikTokPublishForm from './TikTokPublishForm.vue';
@@ -81,7 +82,7 @@ interface IData {
  */
 export default defineComponent({
   name: 'ActionConfirmationCard',
-  components: { GenericFieldList, TikTokPublishForm, ConfirmIcon, WarningIcon },
+  components: { GenericFieldList, TikTokPublishForm, ConfirmIcon, WarningIcon, ElButton },
   props: {
     payload: {
       type: Object as PropType<IActionConfirmationPayload>,

--- a/src/components/chat/ArtifactBlock.vue
+++ b/src/components/chat/ArtifactBlock.vue
@@ -38,6 +38,7 @@
 
 <script lang="ts">
 import { DocumentIcon as Document } from '@acedatacloud/core/icons/components';
+import { ElIcon, ElImage } from 'element-plus';
 import { defineComponent, type PropType } from 'vue';
 
 import type { IChatArtifact } from '@/models';
@@ -48,7 +49,7 @@ interface IData {
 
 export default defineComponent({
   name: 'ArtifactBlock',
-  components: { Document },
+  components: { Document, ElIcon, ElImage },
   props: {
     artifact: {
       type: Object as PropType<IChatArtifact>,

--- a/src/components/chat/TikTokPublishForm.vue
+++ b/src/components/chat/TikTokPublishForm.vue
@@ -91,6 +91,7 @@
 </template>
 
 <script lang="ts">
+import { ElCheckbox, ElInput, ElOption, ElSelect } from 'element-plus';
 import { defineComponent, type PropType } from 'vue';
 import type { ITikTokPublishDetail, ITikTokPublishValues } from '@/models';
 
@@ -117,6 +118,7 @@ const SELF_ONLY = 'SELF_ONLY';
  */
 export default defineComponent({
   name: 'TikTokPublishForm',
+  components: { ElCheckbox, ElInput, ElOption, ElSelect },
   props: {
     detail: {
       type: Object as PropType<ITikTokPublishDetail>,

--- a/src/components/chat/ToolActivity.vue
+++ b/src/components/chat/ToolActivity.vue
@@ -38,6 +38,7 @@ import {
   ErrorIcon as CircleCloseFilled,
   ExpandRightIcon as ArrowRight
 } from '@acedatacloud/core/icons/components';
+import { ElIcon } from 'element-plus';
 import { defineComponent, PropType } from 'vue';
 import { IChatMessageContentItem } from '@/models';
 
@@ -51,7 +52,7 @@ const TOOL_LABELS: Record<string, string> = {
 
 export default defineComponent({
   name: 'ToolActivity',
-  components: { Loading, CircleCheckFilled, CircleCloseFilled, ArrowRight },
+  components: { Loading, CircleCheckFilled, CircleCloseFilled, ArrowRight, ElIcon },
   props: {
     item: {
       type: Object as PropType<IChatMessageContentItem>,

--- a/src/components/chat/ToolCallBlock.vue
+++ b/src/components/chat/ToolCallBlock.vue
@@ -54,6 +54,7 @@ import {
   ErrorIcon as CircleClose,
   ExpandDownIcon as ArrowDown
 } from '@acedatacloud/core/icons/components';
+import { ElIcon } from 'element-plus';
 import { defineComponent, ref, type PropType } from 'vue';
 
 import ArtifactBlock from './ArtifactBlock.vue';
@@ -61,7 +62,7 @@ import type { IChatToolCall } from '@/models';
 
 export default defineComponent({
   name: 'ToolCallBlock',
-  components: { Loading, CircleCheck, CircleClose, ArrowDown, ArtifactBlock },
+  components: { Loading, CircleCheck, CircleClose, ArrowDown, ArtifactBlock, ElIcon },
   props: {
     toolCall: {
       type: Object as PropType<IChatToolCall>,

--- a/src/components/common/TopHeader.vue
+++ b/src/components/common/TopHeader.vue
@@ -74,7 +74,17 @@ import { defineComponent } from 'vue';
 import defaultAvatar from '@/assets/images/avatar.png';
 import { getBaseUrlAuth, withCurrentUserIdAndSite, isMainOfficial } from '@/utils';
 import { ROUTE_CONSOLE_ROOT, ROUTE_DOWNLOAD, ROUTE_INDEX } from '@/router';
-import { ElCol, ElRow, ElDropdown, ElMenu, ElSubMenu, ElMenuItem, ElDropdownItem, ElButton } from 'element-plus';
+import {
+  ElCol,
+  ElRow,
+  ElDropdown,
+  ElDropdownMenu,
+  ElMenu,
+  ElSubMenu,
+  ElMenuItem,
+  ElDropdownItem,
+  ElButton
+} from 'element-plus';
 import Logo from './Logo.vue';
 import { Browser } from '@capacitor/browser';
 import { isNative, isDesktop, isMacOS } from '@/utils/surface';
@@ -86,6 +96,7 @@ export default defineComponent({
     Logo,
     ElRow,
     ElDropdown,
+    ElDropdownMenu,
     ElMenu,
     ElMenuItem,
     ElDropdownItem,

--- a/src/components/elementPlusRegistration.test.ts
+++ b/src/components/elementPlusRegistration.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'fs';
+import { join, relative, resolve } from 'path';
+
+/**
+ * `main.ts` installs no global Element Plus plugin, so every `<el-*>` tag must
+ * be imported and registered by its own SFC. Vue renders an unregistered
+ * component as bare slot text and warns only at runtime — lint and vue-tsc are
+ * both blind to it, which is how a whole form shipped with no inputs.
+ */
+
+const SRC = resolve(__dirname, '..');
+
+function vueFiles(dir: string): string[] {
+  return readdirSync(dir).flatMap((entry) => {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) return vueFiles(full);
+    return full.endsWith('.vue') ? [full] : [];
+  });
+}
+
+function toPascal(tag: string): string {
+  return (
+    'El' +
+    tag
+      .slice(3)
+      .split('-')
+      .map((w) => w[0].toUpperCase() + w.slice(1))
+      .join('')
+  );
+}
+
+function usedTags(source: string): Set<string> {
+  const template = source.split('<script')[0].replace(/<!--[\s\S]*?-->/g, '');
+  return new Set(Array.from(template.matchAll(/<(el-[a-z0-9-]+)/g), (m) => m[1]));
+}
+
+function importedNames(source: string): Set<string> {
+  const script = source.slice(source.indexOf('<script')).replace(/\/\*[\s\S]*?\*\//g, '');
+  const names = new Set<string>();
+  for (const match of script.matchAll(/import\s*\{([^}]*)\}\s*from\s*['"]element-plus['"]/g)) {
+    for (const raw of match[1].split(',')) {
+      const name = raw
+        .trim()
+        .split(/\s+as\s+/)
+        .pop()
+        ?.trim();
+      if (name?.startsWith('El')) names.add(name);
+    }
+  }
+  return names;
+}
+
+describe('Element Plus component registration', () => {
+  it('every <el-*> tag is imported from element-plus in the same SFC', () => {
+    const offenders: string[] = [];
+    for (const file of vueFiles(SRC)) {
+      const source = readFileSync(file, 'utf-8');
+      const imported = importedNames(source);
+      const missing = Array.from(usedTags(source))
+        .map(toPascal)
+        .filter((name) => !imported.has(name));
+      if (missing.length > 0) {
+        offenders.push(`${relative(SRC, file)}: ${missing.join(', ')}`);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/src/components/midjourney/config/ImageWeightSelector.vue
+++ b/src/components/midjourney/config/ImageWeightSelector.vue
@@ -17,13 +17,14 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElSlider } from 'element-plus';
+import { ElInputNumber, ElSlider } from 'element-plus';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import { MIDJOURNEY_DEFAULT_IMAGE_WEIGHT } from '@/constants';
 
 export default defineComponent({
   name: 'ImageWeightSelector',
   components: {
+    ElInputNumber,
     ElSlider,
     InfoIcon
   },

--- a/src/components/midjourney/config/ModeSelector2.vue
+++ b/src/components/midjourney/config/ModeSelector2.vue
@@ -46,7 +46,7 @@
 <script lang="ts">
 import { ExpandDownIcon as ArrowDown, FastIcon, LightningIcon, RelaxIcon } from '@acedatacloud/core/icons/components';
 import { defineComponent, markRaw } from 'vue';
-import { ElDropdown, ElDropdownItem, ElButton, ElIcon } from 'element-plus';
+import { ElDropdown, ElDropdownItem, ElDropdownMenu, ElButton, ElIcon } from 'element-plus';
 
 export const DEFAULT_MODE = 'fast';
 
@@ -55,6 +55,7 @@ export default defineComponent({
   components: {
     ElButton,
     ElDropdown,
+    ElDropdownMenu,
     ArrowDown,
     ElIcon,
     ElDropdownItem


### PR DESCRIPTION
## The bug

The action confirmation card rendered with **no form controls at all** — "Caption" with no input beneath it, "Who can view this \*" with no select, "Comment / Duet / Stitch" as three bare words with no checkboxes, and "Cancel / 发布" as plain text with no buttons. Every plain-HTML element around them (the video preview, the account line, the labels) rendered fine.

## Root cause

`src/main.ts` installs **no global Element Plus plugin** — only the `vLoading` directive:

```ts
app.use(store);
app.use(i18n);
app.use(MotionPlugin);
app.use(dayjs, { formatString: 'YYYY-MM-DD HH:mm:ss' });
app.directive('loading', vLoading);
```

So every `<el-*>` tag must be imported and registered by its own SFC. Six chat components skipped that step, including both halves of the confirmation card. Vue renders an unregistered component by emitting its slot content as bare text — which is exactly the failure signature:

| Markup | Rendered |
|---|---|
| `<el-checkbox>Comment</el-checkbox>` | `Comment` (no checkbox) |
| `<el-input>` (no text slot) | *nothing* |
| `<el-button>Cancel</el-button>` | `Cancel` (no button chrome) |

## Fix

Registers the components each SFC actually uses:

| File | Added |
|---|---|
| `chat/TikTokPublishForm.vue` | `ElInput` `ElSelect` `ElOption` `ElCheckbox` |
| `chat/ActionConfirmationCard.vue` | `ElButton` |
| `chat/ArtifactBlock.vue` | `ElIcon` `ElImage` |
| `chat/ToolActivity.vue` | `ElIcon` |
| `chat/ToolCallBlock.vue` | `ElIcon` |
| `application/Info.vue` | `ElTag` |
| `common/TopHeader.vue` | `ElDropdownMenu` |
| `midjourney/config/ModeSelector2.vue` | `ElDropdownMenu` |
| `midjourney/config/ImageWeightSelector.vue` | `ElInputNumber` |

The last four were pre-existing, found by an audit of the whole `src/` tree.

## Guard

`src/components/elementPlusRegistration.test.ts` walks every SFC, extracts the `<el-*>` tags used in its template (comments stripped) and asserts each one is imported from `element-plus` in that same file.

This class of bug is invisible to both eslint and `vue-tsc` — Vue only warns at runtime — so a test is the only thing that stops it recurring. Verified it actually catches the real defect: removing the `TikTokPublishForm` import makes it fail with `ElInput, ElSelect, ElOption, ElCheckbox`.

## Verification

- `vitest run` — 139 files, 1149 tests passing
- `vue-tsc -b` — exit 0
- `npm run lint` — 0 errors
- Repo-wide re-scan after the fix — 0 files with unregistered `el-*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)