### PR TITLE
fix(auth): 微信内置浏览器里内嵌登录白屏——接住 wechatMobileRedirect

### DIFF
--- a/change/@acedatacloud-nexior-9f2c4d81-3b07-4e56-a1d9-7c5e0f3a2b64.json
+++ b/change/@acedatacloud-nexior-9f2c4d81-3b07-4e56-a1d9-7c5e0f3a2b64.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(auth): 微信内置浏览器里内嵌登录选微信登录不再白屏",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/common/AuthPanel.vue
+++ b/src/components/common/AuthPanel.vue
@@ -296,6 +296,18 @@ export default defineComponent({
       if (event.data.name === 'logout') {
         this.$store.commit('setAuth', { action: 'login', visible: true });
       }
+      if (event.data.name === 'wechatMobileRedirect') {
+        // WeChat's mobile authorize URL is an empty shell that only works when
+        // the WeChat client sees the TOP window navigate to it — inside the
+        // login iframe it renders blank. So the iframe hands us the URL and we
+        // navigate ourselves. Returns via ?code= on the redirect we passed in.
+        const url = event.data.data?.url;
+        if (typeof url === 'string' && url.startsWith('https://open.weixin.qq.com/')) {
+          window.location.href = url;
+        } else {
+          console.warn('ignored wechatMobileRedirect with unexpected url', url);
+        }
+      }
       if (event.data.name === 'show_qr') {
         const data = event.data.data;
         this.qrLink = data.qrLink;


### PR DESCRIPTION
## 问题

在**微信内置浏览器**里打开 studio、触发内嵌登录、点微信登录 → iframe 整片白屏。

## 根因

微信的移动授权页 `open.weixin.qq.com/connect/oauth2/authorize` 只有 1050 字节，`<body>` 去掉 script 后是空字符串。它 301 到带 `#wechat_redirect` 片段的地址 —— 那是给**微信客户端外壳**的信号，外壳拦截顶层导航、用原生授权界面接管，空壳页本就不该被看见。

但外壳**只监听顶层导航，不管 iframe 内部**。登录 iframe 自己跳 → 空壳被原样渲染 → 白屏。

（该页无 `X-Frame-Options`、无 CSP、无 frame-busting —— 不是被拦，是内容本来就空。）

## 改动

AuthFrontend 侧改为在 iframe 内 `postMessage('wechatMobileRedirect', {url})` 把授权 URL 交上来；本 PR 让 `AuthPanel` 接住并由**宿主自己**导航顶层 —— 这样外壳才拦得到。

安全性：
- URL 校验 `https://open.weixin.qq.com/` 前缀，非法值只记 warn 不跳转
- 来源由既有的 `event.origin === authOrigin && event.source === iframe.contentWindow` 双重校验把关（新消息自动被覆盖）

## 配套 PR（需一起上线）

https://github.com/AceDataCloud/AuthFrontend/pull/258

单独合本 PR 无副作用（没有消息就不触发）；单独合 AuthFrontend 侧则移动端会从"白屏"变成"点了没反应"，所以**建议两个一起合**。

## 验证

- 微信 UA + 跨域 fixture 实跑：宿主正确收到消息并拿到授权 URL；顶层未被 iframe 直接导航
- 负向：伪造来源的 postMessage 被 origin/source 校验挡掉
- `vue-tsc -b`（CI 用的命令）通过

## 仍需真机确认

fixture 验的是浏览器行为。**微信外壳拿到顶层导航后是否如期拉起原生授权**只能在真微信里确认。建议合并后实测：应看到原生授权页而非白屏，授权后回到原页面且已登录。

🤖 Generated with [Claude Code](https://claude.com/claude-code)