### PR TITLE
fix(chat): 加号菜单技能/连接去掉外链图标

### DIFF
--- a/change/@acedatacloud-nexior-4b1e7c02-5d38-4a91-8c6f-2e9d0f7a3b15.json
+++ b/change/@acedatacloud-nexior-4b1e7c02-5d38-4a91-8c6f-2e9d0f7a3b15.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(chat): 输入框加号菜单的技能/连接不再显示外链图标（已是站内页面）",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/chat/Composer.vue
+++ b/src/components/chat/Composer.vue
@@ -81,12 +81,10 @@
             <el-dropdown-item @click="onOpenSkills">
               <magic-icon class="menu-icon" :size="'1em' as any" aria-hidden="true" focusable="false" />
               <span>{{ $t('chat.composer.skills') }}</span>
-              <external-link-icon class="menu-external" :size="'1em' as any" aria-hidden="true" focusable="false" />
             </el-dropdown-item>
             <el-dropdown-item @click="onOpenConnections">
               <connection-icon class="menu-icon" :size="'1em' as any" aria-hidden="true" focusable="false" />
               <span>{{ $t('chat.composer.connections') }}</span>
-              <external-link-icon class="menu-external" :size="'1em' as any" aria-hidden="true" focusable="false" />
             </el-dropdown-item>
           </el-dropdown-menu>
         </template>
@@ -146,7 +144,6 @@
 import {
   AddIcon,
   ConnectionIcon,
-  ExternalLinkIcon,
   FileTextIcon,
   MagicIcon,
   MicrophoneIcon,
@@ -188,7 +185,6 @@ export default defineComponent({
   components: {
     AddIcon,
     ConnectionIcon,
-    ExternalLinkIcon,
     FileTextIcon,
     MagicIcon,
     MicrophoneIcon,
@@ -488,11 +484,6 @@ html:root body textarea.input:focus-visible {
     width: 16px;
     margin-right: 8px;
     color: var(--el-text-color-regular);
-  }
-  .menu-external {
-    margin-left: 8px;
-    font-size: 11px;
-    color: var(--el-text-color-secondary);
   }
 }
 </style>


### PR DESCRIPTION
## 问题

输入框加号菜单里「技能」和「连接」右侧带着外链图标（↗），但这两项现在都是 `router.push` 到站内页面：

- 技能 → `/console/skills`
- 连接 → `/console/connectors`

图标是从 auth.acedata.cloud 迁移过来之前的残留，现在会误导用户以为点了会跳出站外。

## 改动

- 移除两个 `el-dropdown-item` 里的 `external-link-icon`
- 清掉不再使用的 `ExternalLinkIcon` 导入/注册和 `.menu-external` 样式

侧边栏 `console/SidePanel.vue` 的外链图标是 `v-if="!link.name && link.href"` 条件渲染，当前所有菜单项都是站内路由所以本来就不显示，无需改动。`EntityCard.vue` 的外链图标指向真实的引用来源网页，保留。

🤖 Generated with [Claude Code](https://claude.com/claude-code)