### PR TITLE
feat(intro): show only the capabilities a site actually enabled

### DIFF
--- a/change/@acedatacloud-nexior-b83f5a21-7c4e-4d19-a1e6-92cf7b04d833.json
+++ b/change/@acedatacloud-nexior-b83f5a21-7c4e-4d19-a1e6-92cf7b04d833.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "gate /intro capability sections and model cards by the site's enabled features",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/pages/intro/Index.vue
+++ b/src/pages/intro/Index.vue
@@ -10,7 +10,7 @@
           <el-button type="primary" size="large" @click="onStart">
             {{ $t('common.button.startForFree') }}
           </el-button>
-          <el-button size="large" @click="scrollTo('chat')">
+          <el-button v-if="firstSectionKey" size="large" @click="scrollTo(firstSectionKey)">
             {{ $t('intro.button.explore') }}
           </el-button>
         </div>
@@ -155,8 +155,9 @@
 import { ConfirmIcon, NextIcon } from '@acedatacloud/core/icons/components';
 import { defineComponent } from 'vue';
 import { ElButton } from 'element-plus';
-import { CAPABILITY_KEYS } from '@/constants/capabilities';
+import { CAPABILITY_KEYS, type CapabilityKey } from '@/constants/capabilities';
 import { getDefaultRoute } from '@/router';
+import { isMainOfficial } from '@/utils';
 import { INTRO_SECTIONS, INTRO_SHOTS, type ILocalizedImage } from './data';
 
 const CONNECTOR_BULLETS = [
@@ -178,28 +179,71 @@ export default defineComponent({
     };
   },
   computed: {
+    site() {
+      return this.$store.state.site;
+    },
+    enabledFeatures(): Record<string, { enabled?: boolean } | undefined> {
+      return (this.site?.features ?? {}) as Record<string, { enabled?: boolean } | undefined>;
+    },
+    isMainSite(): boolean {
+      return this.site?.origin === 'studio.acedata.cloud' || isMainOfficial();
+    },
+    // Only filter once a site has actually declared a capability set. Before the
+    // site config resolves — and in local dev, where there is none — every key
+    // counts as available, so the page never collapses to a stray card.
+    hasFeatureConfig(): boolean {
+      return CAPABILITY_KEYS.some((key) => this.enabledFeatures[key] !== undefined);
+    },
     isChineseLocale(): boolean {
       return String(this.$i18n.locale).toLowerCase().startsWith('zh');
     },
+    // A white-label subsite only advertises what it actually turned on.
+    availableKeys(): CapabilityKey[] {
+      if (this.isMainSite || !this.hasFeatureConfig) return [...CAPABILITY_KEYS];
+      return CAPABILITY_KEYS.filter((key) => this.enabledFeatures[key]?.enabled);
+    },
     heroStats() {
       return [
-        { value: `${CAPABILITY_KEYS.length}+`, labelKey: 'intro.stat.capabilities' },
-        { value: '20+', labelKey: 'intro.stat.models' },
+        { value: `${this.availableKeys.length}+`, labelKey: 'intro.stat.capabilities' },
+        { value: `${this.visibleEntryCount}+`, labelKey: 'intro.stat.models' },
         { value: '80+', labelKey: 'intro.stat.connectors' }
       ];
     },
+    visibleEntryCount(): number {
+      return this.sections.reduce((n, s) => n + s.entries.length, 0);
+    },
     sections() {
+      const enabled = new Set<string>(this.availableKeys);
       return INTRO_SECTIONS.map((section) => ({
         ...section,
+        entries: section.entries.filter((entry) => !entry.featureKey || enabled.has(entry.featureKey)),
         desktop: this.pick(section.desktop),
         mobile: section.mobile ? this.pick(section.mobile) : undefined
-      }));
+      }))
+        .filter((section) => section.entries.length > 0)
+        .map((section) => ({
+          ...section,
+          // The section's default destination may itself be disabled; fall back
+          // to the first entry that survived filtering.
+          path: section.entries.some((e) => e.path === section.path)
+            ? section.path
+            : (section.entries.find((e) => e.path)?.path ?? section.path)
+        }));
     },
+    firstSectionKey(): string | undefined {
+      return this.sections[0]?.key;
+    },
+    // Lead with chat when the site has it; otherwise borrow the first surviving
+    // section's shot so a subsite never opens on a capability it disabled.
     heroDesktop(): string {
-      return this.pick(INTRO_SHOTS.chatDesktop);
+      const chat = this.sections.find((s) => s.key === 'chat');
+      return chat
+        ? this.pick(INTRO_SHOTS.chatDesktop)
+        : (this.sections[0]?.desktop ?? this.pick(INTRO_SHOTS.chatDesktop));
     },
     heroMobile(): string {
-      return this.pick(INTRO_SHOTS.chatMobile);
+      const chat = this.sections.find((s) => s.key === 'chat');
+      return chat ? this.pick(INTRO_SHOTS.chatMobile) : (this.sections[0]?.mobile ?? this.pick(INTRO_SHOTS.chatMobile));
     },
     connectorShot(): string {
       return this.pick(INTRO_SHOTS.connectorsDesktop);

--- a/src/pages/intro/data.ts
+++ b/src/pages/intro/data.ts
@@ -3,6 +3,8 @@ export interface ILocalizedImage {
   en: string;
 }
 
+import type { CapabilityKey } from '@/constants/capabilities';
+
 const image = (zh: string, en: string): ILocalizedImage => ({ zh, en });
 
 // Captured from the live product (desktop + mobile, zh + en) and uploaded to the
@@ -102,10 +104,17 @@ export interface IIntroEntry {
   /** Public product / model name. Never an upstream provider name. */
   name: string;
   descriptionKey: string;
+  /** Site feature flag gating this entry; omitted entries are always shown. */
+  featureKey?: CapabilityKey;
+  /** Route for this entry, used to retarget the section CTA when the section's
+   *  default destination is disabled for the site. */
+  path?: string;
 }
 
 export interface IIntroSection {
   key: string;
+  /** Section is hidden when none of these features are enabled for the site. */
+  featureKeys: CapabilityKey[];
   eyebrowKey: string;
   titleKey: string;
   subtitleKey: string;
@@ -119,18 +128,21 @@ export interface IIntroSection {
 export const INTRO_SECTIONS: IIntroSection[] = [
   {
     key: 'chat',
+    featureKeys: ['chatgpt', 'claude', 'gemini', 'grok', 'deepseek', 'kimi'],
     eyebrowKey: 'intro.eyebrow.chat',
     titleKey: 'intro.title.chat',
     subtitleKey: 'intro.subtitle.chat',
     bulletKeys: ['intro.bullet.chat.models', 'intro.bullet.chat.multimodal', 'intro.bullet.chat.agentic'],
     entries: [
-      { name: 'ChatGPT', descriptionKey: 'intro.model.chatgpt' },
-      { name: 'Claude', descriptionKey: 'intro.model.claude' },
-      { name: 'Gemini', descriptionKey: 'intro.model.gemini' },
-      { name: 'Grok', descriptionKey: 'intro.model.grok' },
-      { name: 'DeepSeek', descriptionKey: 'intro.model.deepseek' },
-      { name: 'Kimi', descriptionKey: 'intro.model.kimi' },
-      { name: 'GLM', descriptionKey: 'intro.model.glm' }
+      { name: 'ChatGPT', descriptionKey: 'intro.model.chatgpt', featureKey: 'chatgpt', path: '/chatgpt' },
+      { name: 'Claude', descriptionKey: 'intro.model.claude', featureKey: 'claude', path: '/claude' },
+      { name: 'Gemini', descriptionKey: 'intro.model.gemini', featureKey: 'gemini', path: '/gemini' },
+      { name: 'Grok', descriptionKey: 'intro.model.grok', featureKey: 'grok', path: '/grok' },
+      { name: 'DeepSeek', descriptionKey: 'intro.model.deepseek', featureKey: 'deepseek', path: '/deepseek' },
+      { name: 'Kimi', descriptionKey: 'intro.model.kimi', featureKey: 'kimi', path: '/kimi' },
+      // GLM has no capability key of its own; it rides the ChatGPT surface, so
+      // gate it on that rather than letting it survive a chat-less subsite.
+      { name: 'GLM', descriptionKey: 'intro.model.glm', featureKey: 'chatgpt', path: '/chatgpt' }
     ],
     path: '/chatgpt',
     desktop: INTRO_SHOTS.chatDesktop,
@@ -138,17 +150,18 @@ export const INTRO_SECTIONS: IIntroSection[] = [
   },
   {
     key: 'image',
+    featureKeys: ['midjourney', 'nanobanana', 'openaiimage', 'seedream', 'flux', 'qrart'],
     eyebrowKey: 'intro.eyebrow.image',
     titleKey: 'intro.title.image',
     subtitleKey: 'intro.subtitle.image',
     bulletKeys: ['intro.bullet.image.models', 'intro.bullet.image.editing', 'intro.bullet.image.resolution'],
     entries: [
-      { name: 'Midjourney', descriptionKey: 'intro.model.midjourney' },
-      { name: 'Nano Banana', descriptionKey: 'intro.model.nanobanana' },
-      { name: 'GPT Image', descriptionKey: 'intro.model.gptimage' },
-      { name: 'Seedream', descriptionKey: 'intro.model.seedream' },
-      { name: 'Flux', descriptionKey: 'intro.model.flux' },
-      { name: 'QR Art', descriptionKey: 'intro.model.qrart' }
+      { name: 'Midjourney', descriptionKey: 'intro.model.midjourney', featureKey: 'midjourney', path: '/midjourney' },
+      { name: 'Nano Banana', descriptionKey: 'intro.model.nanobanana', featureKey: 'nanobanana', path: '/nanobanana' },
+      { name: 'GPT Image', descriptionKey: 'intro.model.gptimage', featureKey: 'openaiimage', path: '/openaiimage' },
+      { name: 'Seedream', descriptionKey: 'intro.model.seedream', featureKey: 'seedream', path: '/seedream' },
+      { name: 'Flux', descriptionKey: 'intro.model.flux', featureKey: 'flux', path: '/flux' },
+      { name: 'QR Art', descriptionKey: 'intro.model.qrart', featureKey: 'qrart', path: '/qrart' }
     ],
     path: '/nanobanana',
     desktop: INTRO_SHOTS.midjourneyDesktop,
@@ -156,21 +169,22 @@ export const INTRO_SECTIONS: IIntroSection[] = [
   },
   {
     key: 'video',
+    featureKeys: ['kling', 'veo', 'sora', 'seedance', 'hailuo', 'luma', 'wan', 'pixverse', 'grokvideo', 'omni'],
     eyebrowKey: 'intro.eyebrow.video',
     titleKey: 'intro.title.video',
     subtitleKey: 'intro.subtitle.video',
     bulletKeys: ['intro.bullet.video.models', 'intro.bullet.video.control', 'intro.bullet.video.quality'],
     entries: [
-      { name: 'Kling', descriptionKey: 'intro.model.kling' },
-      { name: 'Veo', descriptionKey: 'intro.model.veo' },
-      { name: 'Sora', descriptionKey: 'intro.model.sora' },
-      { name: 'Seedance', descriptionKey: 'intro.model.seedance' },
-      { name: 'Hailuo', descriptionKey: 'intro.model.hailuo' },
-      { name: 'Luma', descriptionKey: 'intro.model.luma' },
-      { name: 'Wan', descriptionKey: 'intro.model.wan' },
-      { name: 'Pixverse', descriptionKey: 'intro.model.pixverse' },
-      { name: 'Grok Imagine', descriptionKey: 'intro.model.grokvideo' },
-      { name: 'Omni', descriptionKey: 'intro.model.omni' }
+      { name: 'Kling', descriptionKey: 'intro.model.kling', featureKey: 'kling', path: '/kling' },
+      { name: 'Veo', descriptionKey: 'intro.model.veo', featureKey: 'veo', path: '/veo' },
+      { name: 'Sora', descriptionKey: 'intro.model.sora', featureKey: 'sora', path: '/sora' },
+      { name: 'Seedance', descriptionKey: 'intro.model.seedance', featureKey: 'seedance', path: '/seedance' },
+      { name: 'Hailuo', descriptionKey: 'intro.model.hailuo', featureKey: 'hailuo', path: '/hailuo' },
+      { name: 'Luma', descriptionKey: 'intro.model.luma', featureKey: 'luma', path: '/luma' },
+      { name: 'Wan', descriptionKey: 'intro.model.wan', featureKey: 'wan', path: '/wan' },
+      { name: 'Pixverse', descriptionKey: 'intro.model.pixverse', featureKey: 'pixverse', path: '/pixverse' },
+      { name: 'Grok Imagine', descriptionKey: 'intro.model.grokvideo', featureKey: 'grokvideo', path: '/grokvideo' },
+      { name: 'Omni', descriptionKey: 'intro.model.omni', featureKey: 'omni', path: '/omni' }
     ],
     path: '/kling',
     desktop: INTRO_SHOTS.klingDesktop,
@@ -178,14 +192,15 @@ export const INTRO_SECTIONS: IIntroSection[] = [
   },
   {
     key: 'music',
+    featureKeys: ['suno', 'producer', 'fish'],
     eyebrowKey: 'intro.eyebrow.music',
     titleKey: 'intro.title.music',
     subtitleKey: 'intro.subtitle.music',
     bulletKeys: ['intro.bullet.music.models', 'intro.bullet.music.control', 'intro.bullet.music.voice'],
     entries: [
-      { name: 'Suno', descriptionKey: 'intro.model.suno' },
-      { name: 'Producer', descriptionKey: 'intro.model.producer' },
-      { name: 'Fish Audio', descriptionKey: 'intro.model.fish' }
+      { name: 'Suno', descriptionKey: 'intro.model.suno', featureKey: 'suno', path: '/suno' },
+      { name: 'Producer', descriptionKey: 'intro.model.producer', featureKey: 'producer', path: '/producer' },
+      { name: 'Fish Audio', descriptionKey: 'intro.model.fish', featureKey: 'fish', path: '/fish' }
     ],
     path: '/suno',
     desktop: INTRO_SHOTS.sunoDesktop,
@@ -193,6 +208,7 @@ export const INTRO_SECTIONS: IIntroSection[] = [
   },
   {
     key: 'production',
+    featureKeys: ['maestro', 'digitalhuman', 'poivelle'],
     eyebrowKey: 'intro.eyebrow.production',
     titleKey: 'intro.title.production',
     subtitleKey: 'intro.subtitle.production',
@@ -202,9 +218,14 @@ export const INTRO_SECTIONS: IIntroSection[] = [
       'intro.bullet.production.languages'
     ],
     entries: [
-      { name: 'Maestro', descriptionKey: 'intro.model.maestro' },
-      { name: 'Digital Human', descriptionKey: 'intro.model.digitalhuman' },
-      { name: 'Poivelle', descriptionKey: 'intro.model.poivelle' }
+      { name: 'Maestro', descriptionKey: 'intro.model.maestro', featureKey: 'maestro', path: '/maestro' },
+      {
+        name: 'Digital Human',
+        descriptionKey: 'intro.model.digitalhuman',
+        featureKey: 'digitalhuman',
+        path: '/digital-human'
+      },
+      { name: 'Poivelle', descriptionKey: 'intro.model.poivelle', featureKey: 'poivelle', path: '/poivelle' }
     ],
     path: '/maestro',
     desktop: INTRO_SHOTS.maestroDesktop,
@@ -212,14 +233,25 @@ export const INTRO_SECTIONS: IIntroSection[] = [
   },
   {
     key: 'tools',
+    featureKeys: ['serp', 'webextrator', 'codingBridge'],
     eyebrowKey: 'intro.eyebrow.tools',
     titleKey: 'intro.title.tools',
     subtitleKey: 'intro.subtitle.tools',
     bulletKeys: ['intro.bullet.tools.search', 'intro.bullet.tools.extract', 'intro.bullet.tools.coding'],
     entries: [
-      { name: 'SERP', descriptionKey: 'intro.model.serp' },
-      { name: 'WebExtrator', descriptionKey: 'intro.model.webextrator' },
-      { name: 'Coding Bridge', descriptionKey: 'intro.model.codingbridge' }
+      { name: 'SERP', descriptionKey: 'intro.model.serp', featureKey: 'serp', path: '/serp' },
+      {
+        name: 'WebExtrator',
+        descriptionKey: 'intro.model.webextrator',
+        featureKey: 'webextrator',
+        path: '/webextrator'
+      },
+      {
+        name: 'Coding Bridge',
+        descriptionKey: 'intro.model.codingbridge',
+        featureKey: 'codingBridge',
+        path: '/coding-bridge'
+      }
     ],
     path: '/serp',
     desktop: INTRO_SHOTS.serpDesktop


### PR DESCRIPTION
## Why

`/intro` advertised all six sections and 32 model cards regardless of the site's configuration. A white-label subsite with only image generation enabled still pitched chat, video, music, and digital humans — and its hero still claimed "32+ capabilities" while linking to pages that site had turned off.

`/home` already filters its showcase and capability strip against `site.features`. This brings `/intro` in line.

## What

Every section and every model card now carries its capability key and is filtered against the site's enabled features.

| Scenario | Result |
|---|---|
| Main site | 6 sections, 32 cards |
| Subsite: chat only | 1 section, 3 cards (ChatGPT, Claude, GLM) |
| Subsite: image + music | 2 sections, 3 cards |
| Subsite: video only | 1 section, 2 cards |

Hero counters derive from what survived filtering instead of from constants, so a subsite no longer overstates its own catalogue.

Three follow-on cases the filtering exposed:

- **Section CTAs could point at a disabled page.** Each entry now carries its route, and a section whose default target is disabled retargets to the first entry that survived.
- **The hero screenshot was always the chat page.** It now falls back to the first remaining section's screenshot when chat is off.
- **GLM had no capability key**, so it would have survived on a chat-less subsite. It is gated on the chat surface it actually rides.

## The failure mode this had to avoid

Filtering only kicks in once a site has actually **declared** a capability set. Before the site config resolves — and in local dev, where there is none — every key counts as available.

Without that guard the page collapsed to a single stray card (the one entry that happened to lack a feature key) with a `0+` hero stat. My first cut had exactly this bug; the scenario test below is what caught it.

## Verification

Tested by intercepting the site-config response and asserting the rendered output for each scenario:

```
PASS  main site           sections=[chat,image,video,music,production,tools] cards=32 stat=32+
PASS  subsite: chat only  sections=[chat]        cards=3  stat=2+
PASS  subsite: img+music  sections=[image,music] cards=3  stat=3+
PASS  subsite: video only sections=[video]       cards=2  stat=2+
```

Also re-ran the layout audit at 1920 / 1440 / 1180 / 834 / 414px in both locales — **0 findings** (no overflow, distortion, clipping, or stretched orphan cards) — plus `vue-tsc -b` and `eslint src` clean.
