### PR TITLE
feat(seo): serve tenant OG images

### DIFF
--- a/change/@acedatacloud-nexior-79889373-adf5-4f2b-b012-35709d213713.json
+++ b/change/@acedatacloud-nexior-79889373-adf5-4f2b-b012-35709d213713.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "serve dynamic white-label Open Graph cards",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/index.html
+++ b/index.html
@@ -89,7 +89,7 @@
       property="og:description"
       content="AI-powered creative hub — generate images with Midjourney & Flux, create music with Suno, produce videos with Luma & Sora, chat with GPT, Claude, Gemini & DeepSeek."
     />
-    <meta property="og:image" content="https://cdn.acedata.cloud/fdc04a4248.png" />
+    <meta property="og:image" content="https://platform.acedata.cloud/api/v1/og/__OG_HOST__.png" />
     <!-- Twitter Cards -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Ace Data Cloud - AI Hub" />
@@ -97,7 +97,7 @@
       name="twitter:description"
       content="AI-powered creative hub — generate images with Midjourney & Flux, create music with Suno, produce videos with Luma & Sora, chat with GPT, Claude, Gemini & DeepSeek."
     />
-    <meta name="twitter:image" content="https://cdn.acedata.cloud/fdc04a4248.png" />
+    <meta name="twitter:image" content="https://platform.acedata.cloud/api/v1/og/__OG_HOST__.png" />
     <link rel="icon" href="/favicon.ico" sizes="any" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <!--

--- a/nginx.conf
+++ b/nginx.conf
@@ -41,6 +41,10 @@ gzip_types
 
 server_tokens off;
 
+# The built SPA contains one hostname placeholder in its OG image tags. Rewrite
+# HTML at request time so crawlers receive a tenant-specific URL without JS.
+sub_filter_once off;
+
 server {
     listen       80;
     server_name  localhost;
@@ -57,6 +61,8 @@ server {
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header Host $host;
+
+    sub_filter '__OG_HOST__' '$host';
 
     # Host must be the backend's own name, not $host: forwarding
     # studio.acedata.cloud makes EdgeOne route the request back here, looping

--- a/src/utils/seo.ts
+++ b/src/utils/seo.ts
@@ -18,7 +18,10 @@ function getCurrentOrigin(): string {
 // so subsites can fully white-label their <title>, og:*, JSON-LD, etc.
 const FALLBACK_SITE_NAME = 'Ace Data Cloud - AI Hub';
 const FALLBACK_BRAND_NAME = 'Ace Data Cloud';
-const FALLBACK_IMAGE = 'https://cdn.acedata.cloud/fdc04a4248.png';
+function getShareImage(): string {
+  const host = typeof window !== 'undefined' ? window.location.hostname : 'studio.acedata.cloud';
+  return `https://platform.acedata.cloud/api/v1/og/${host}.png`;
+}
 const FALLBACK_DESCRIPTION =
   'AI-powered creative hub — generate images with Midjourney & Flux, create music with Suno, produce videos with Luma & Sora, chat with GPT, Claude, Gemini & DeepSeek.';
 
@@ -26,16 +29,15 @@ const FALLBACK_DESCRIPTION =
 // the AceDataCloud defaults so first-party origins keep working unchanged.
 function brand() {
   const site = (store.state as { site?: Record<string, unknown> } | undefined)?.site as
-    | { title?: string; description?: string; logo?: string }
+    | { title?: string; description?: string }
     | undefined;
   const title = (site?.title || '').trim();
   const description = (site?.description || '').trim();
-  const logo = (site?.logo || '').trim();
   return {
     siteName: title || FALLBACK_SITE_NAME,
     brandName: title || FALLBACK_BRAND_NAME,
     description: description || FALLBACK_DESCRIPTION,
-    image: logo || FALLBACK_IMAGE
+    image: getShareImage()
   };
 }
 


### PR DESCRIPTION
## Summary
- point Open Graph and Twitter image metadata at the dynamic per-host backend endpoint
- rewrite the static SPA placeholder with nginx using the incoming Host, so crawlers receive the correct tenant URL without running JavaScript
- keep runtime SEO updates on the same share-card endpoint instead of reverting to the square site logo

Depends on https://github.com/AceDataCloud/PlatformBackend/pull/1298 and should deploy after it.

## Validation
- `npm run lint:check` (0 errors; 2 pre-existing test warnings)
- `npx vue-tsc -b --pretty false`
- `npm run build:web`
- `sh .husky/pre-push` (passes standalone; Beachball duplicates `change/` only when git invokes it from a worktree)
- built `dist/index.html` retains both `__OG_HOST__` placeholders for nginx substitution
- nginx syntax check unavailable locally because Docker daemon is not running

🤖 Generated with [Claude Code](https://claude.com/claude-code)