### PR TITLE
Remove unavailable Seedream 3.0 options

### DIFF
--- a/change/@acedatacloud-nexior-seedream-retire-v3.json
+++ b/change/@acedatacloud-nexior-seedream-retire-v3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove unavailable Seedream 3.0 models and migrate persisted selections to a supported model.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/seedream/ConfigPanel.test.ts
+++ b/src/components/seedream/ConfigPanel.test.ts
@@ -49,9 +49,6 @@ describe('seedream/ConfigPanel', () => {
     expect(wrapper.html()).not.toContain('watermark');
     expect(wrapper.findComponent(ImageInput).exists()).toBe(true);
     expect(wrapper.findComponent(ModelSelector).exists()).toBe(true);
-
-    const { wrapper: textOnlyWrapper } = mountPanel([], 'doubao-seedream-3-0-t2i-250415');
-    expect(textOnlyWrapper.findComponent(ImageInput).exists()).toBe(false);
   });
 
   it('automatically switches billing mode when references change', async () => {

--- a/src/components/seedream/config/ModelSelector.test.ts
+++ b/src/components/seedream/config/ModelSelector.test.ts
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+import { shallowMount } from '@vue/test-utils';
+import { describe, expect, it, vi } from 'vitest';
+
+import ModelSelector from './ModelSelector.vue';
+
+const mountSelector = (config: Record<string, unknown>) => {
+  const commit = vi.fn();
+  const wrapper = shallowMount(ModelSelector, {
+    global: {
+      mocks: {
+        $t: (key: string) => key,
+        $store: {
+          state: { seedream: { config } },
+          commit
+        }
+      }
+    }
+  });
+  return { commit, wrapper };
+};
+
+describe('seedream/ModelSelector', () => {
+  it('does not offer unavailable 3.0 models', () => {
+    const { wrapper } = mountSelector({ model: 'doubao-seedream-5-0-260128', size: '2K' });
+    const options = (wrapper.vm as unknown as { options: Array<{ value: string }> }).options;
+
+    expect(options.map((option) => option.value)).not.toContain('doubao-seedream-3-0-t2i-250415');
+    expect(options.map((option) => option.value)).not.toContain('doubao-seededit-3-0-i2i-250628');
+  });
+
+  it('migrates a persisted unavailable model to the supported default', () => {
+    const { commit } = mountSelector({
+      model: 'doubao-seedream-3-0-t2i-250415',
+      size: '1K',
+      seed: 42,
+      guidance_scale: 2.5
+    });
+
+    expect(commit).toHaveBeenCalledWith(
+      'seedream/setConfig',
+      expect.objectContaining({ model: 'doubao-seedream-4-5-251128' })
+    );
+    const migrated = commit.mock.calls[0][1];
+    expect(migrated).not.toHaveProperty('size');
+    expect(migrated).not.toHaveProperty('seed');
+    expect(migrated).not.toHaveProperty('guidance_scale');
+  });
+});

--- a/src/components/seedream/config/ModelSelector.vue
+++ b/src/components/seedream/config/ModelSelector.vue
@@ -24,12 +24,10 @@ import { ElSelect, ElOption, ElMessage, ElMessageBox } from 'element-plus';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import {
   SEEDREAM_DEFAULT_MODEL,
-  SEEDREAM_MODEL_3_0_T2I,
   SEEDREAM_MODEL_4_0,
   SEEDREAM_MODEL_4_5,
   SEEDREAM_MODEL_5_0,
-  SEEDREAM_MODEL_5_0_PRO,
-  SEEDREAM_MODEL_SEEDEDIT_3_0_I2I
+  SEEDREAM_MODEL_5_0_PRO
 } from '@/constants';
 import { findSeedreamConflicts, clearSeedreamConflicts } from '@/utils/seedream/capabilities';
 
@@ -49,9 +47,7 @@ export default defineComponent({
         { value: SEEDREAM_MODEL_5_0_PRO, label: this.$t('seedream.model.seedream50pro') },
         { value: SEEDREAM_MODEL_5_0, label: this.$t('seedream.model.seedream50') },
         { value: SEEDREAM_MODEL_4_5, label: this.$t('seedream.model.seedream45') },
-        { value: SEEDREAM_MODEL_4_0, label: this.$t('seedream.model.seedream40') },
-        { value: SEEDREAM_MODEL_3_0_T2I, label: this.$t('seedream.model.seedream30t2i') },
-        { value: SEEDREAM_MODEL_SEEDEDIT_3_0_I2I, label: this.$t('seedream.model.seededit30i2i') }
+        { value: SEEDREAM_MODEL_4_0, label: this.$t('seedream.model.seedream40') }
       ]
     };
   },
@@ -61,9 +57,14 @@ export default defineComponent({
     }
   },
   mounted() {
-    if (!this.value) {
-      this.applyModel(SEEDREAM_DEFAULT_MODEL);
-    }
+    if (this.value && this.options.some((option) => option.value === this.value)) return;
+
+    const config = { ...(this.$store.state.seedream?.config || {}), model: SEEDREAM_DEFAULT_MODEL };
+    const conflicts = findSeedreamConflicts(config, { model: SEEDREAM_DEFAULT_MODEL });
+    this.$store.commit(
+      'seedream/setConfig',
+      clearSeedreamConflicts(config, conflicts, { model: SEEDREAM_DEFAULT_MODEL })
+    );
   },
   methods: {
     async onChange(val: string) {

--- a/src/constants/seedream.ts
+++ b/src/constants/seedream.ts
@@ -6,8 +6,6 @@ export const SEEDREAM_MODEL_4_0 = 'doubao-seedream-4-0-250828';
 export const SEEDREAM_MODEL_4_5 = 'doubao-seedream-4-5-251128';
 export const SEEDREAM_MODEL_5_0 = 'doubao-seedream-5-0-260128';
 export const SEEDREAM_MODEL_5_0_PRO = 'doubao-seedream-5-0-pro-260628';
-export const SEEDREAM_MODEL_3_0_T2I = 'doubao-seedream-3-0-t2i-250415';
-export const SEEDREAM_MODEL_SEEDEDIT_3_0_I2I = 'doubao-seededit-3-0-i2i-250628';
 
 export const SEEDREAM_DEFAULT_MODEL = SEEDREAM_MODEL_4_5;
 
@@ -38,14 +36,6 @@ export const SEEDREAM_PIXEL_PRESETS: { value: string; ratio: string }[] = [
   { value: '1728x2304', ratio: '3:4' }
 ];
 
-// Per-model `guidance_scale` defaults — read by both GuidanceScaleInput and
-// `utils/seedream/capabilities.ts`. Mirrors the upstream defaults at
-// PlatformService/volcengine/worker/src/handlers/seedream/images.ts.
-export const SEEDREAM_GUIDANCE_SCALE_DEFAULTS: Record<string, number> = {
-  [SEEDREAM_MODEL_3_0_T2I]: 2.5,
-  [SEEDREAM_MODEL_SEEDEDIT_3_0_I2I]: 5.5
-};
-
 export const SEEDREAM_OUTPUT_FORMATS = ['jpeg', 'png'] as const;
 
 // Group / multi-image generation:
@@ -59,9 +49,7 @@ export const SEEDREAM_MODEL_FULL_TO_SHORT: Record<string, string> = {
   [SEEDREAM_MODEL_5_0_PRO]: 'doubao-seedream-5.0-pro',
   [SEEDREAM_MODEL_5_0]: 'doubao-seedream-5.0',
   [SEEDREAM_MODEL_4_5]: 'doubao-seedream-4.5',
-  [SEEDREAM_MODEL_4_0]: 'doubao-seedream-4.0',
-  [SEEDREAM_MODEL_3_0_T2I]: 'doubao-seedream-3.0-t2i',
-  [SEEDREAM_MODEL_SEEDEDIT_3_0_I2I]: 'doubao-seededit-3.0-i2i'
+  [SEEDREAM_MODEL_4_0]: 'doubao-seedream-4.0'
 };
 
 export const getSeedreamShortModel = (model?: string): string | undefined => {

--- a/src/utils/seedream/capabilities.ts
+++ b/src/utils/seedream/capabilities.ts
@@ -11,13 +11,10 @@
 //     supported (image upload, custom seed, group generation, etc.)
 
 import {
-  SEEDREAM_GUIDANCE_SCALE_DEFAULTS,
-  SEEDREAM_MODEL_3_0_T2I,
   SEEDREAM_MODEL_4_0,
   SEEDREAM_MODEL_4_5,
   SEEDREAM_MODEL_5_0,
   SEEDREAM_MODEL_5_0_PRO,
-  SEEDREAM_MODEL_SEEDEDIT_3_0_I2I,
   SEEDREAM_SIZE_1K,
   SEEDREAM_SIZE_2K,
   SEEDREAM_SIZE_3K,
@@ -126,41 +123,6 @@ export function getSeedreamCapabilities(model?: string): ISeedreamCapability {
         groupGeneration: true,
         seed: false,
         guidanceScale: false,
-        outputFormat: false,
-        tools: false
-      };
-    case SEEDREAM_MODEL_3_0_T2I:
-      // 3.0-t2i: text-to-image only, pixel-only sizes.
-      return {
-        image: false,
-        imageRequired: false,
-        sizeTiers: [],
-        sizeAdaptive: false,
-        sizePixel: true,
-        sizePixelDefault: '1024x1024',
-        groupGeneration: false,
-        seed: true,
-        guidanceScale: true,
-        guidanceScaleDefault: SEEDREAM_GUIDANCE_SCALE_DEFAULTS[SEEDREAM_MODEL_3_0_T2I],
-        outputFormat: false,
-        tools: false
-      };
-    case SEEDREAM_MODEL_SEEDEDIT_3_0_I2I:
-      // seededit-3.0-i2i: image-to-image only, pixel-only sizes.
-      // Note: official Volcengine docs limit `seed` to 3.0-t2i only — our
-      // worker is permissive but upstream Volcengine rejects seed on
-      // seededit-3.0-i2i. Keep seed=false here.
-      return {
-        image: true,
-        imageRequired: true,
-        sizeTiers: [],
-        sizeAdaptive: false,
-        sizePixel: true,
-        sizePixelDefault: '1024x1024',
-        groupGeneration: false,
-        seed: false,
-        guidanceScale: true,
-        guidanceScaleDefault: SEEDREAM_GUIDANCE_SCALE_DEFAULTS[SEEDREAM_MODEL_SEEDEDIT_3_0_I2I],
         outputFormat: false,
         tools: false
       };

--- a/src/utils/seedream/request.test.ts
+++ b/src/utils/seedream/request.test.ts
@@ -17,9 +17,9 @@ describe('buildSeedreamRequest', () => {
     });
   });
 
-  it('normalizes actions for text-only and edit-only models', () => {
-    expect(getCompatibleSeedreamAction('edit', 'doubao-seedream-3-0-t2i-250415')).toBe('generate');
-    expect(getCompatibleSeedreamAction('generate', 'doubao-seededit-3-0-i2i-250628')).toBe('edit');
+  it('preserves explicit actions for supported models', () => {
+    expect(getCompatibleSeedreamAction('edit', 'doubao-seedream-4-5-251128')).toBe('edit');
+    expect(getCompatibleSeedreamAction('generate', 'doubao-seedream-4-5-251128')).toBe('generate');
   });
 
   it('removes group options when group generation is inactive', () => {
@@ -39,7 +39,5 @@ describe('buildSeedreamRequest', () => {
     const image = ['one.png', 'two.png'];
     expect(getSeedreamAction('doubao-seedream-4-5-251128', [])).toBe('generate');
     expect(getSeedreamAction('doubao-seedream-4-5-251128', image)).toBe('edit');
-    expect(getSeedreamAction('doubao-seededit-3-0-i2i-250628', [])).toBe('edit');
-    expect(getSeedreamAction('doubao-seedream-3-0-t2i-250415', image)).toBe('generate');
   });
 });


### PR DESCRIPTION
## Summary
- remove unavailable Seedream 3.0 T2I and SeedEdit 3.0 from the Studio model picker
- migrate persisted retired-model configurations to the supported default model
- clear incompatible persisted size, seed, and guidance values during migration
- remove dead v3 capability branches and add regression coverage

## Production evidence
Studio task history exposed repeated failures from model IDs that production no longer serves. Current active models are healthy (18/19 recent requests succeeded); the remaining recent failure was a client-supplied 1K size on 5.0 Lite.

## Validation
- `npm run test:run -- src/components/seedream src/utils/seedream` (4 files, 12 tests passed)
- focused ESLint on changed Seedream files
- `npx beachball check`
- `git diff --check`

## Dependency / rollout
UI half of the coordinated Seedream v3 withdrawal; pair with PlatformService and PlatformBackend PRs.

Rollback: revert this commit to restore model options and old persisted behavior.