### PR TITLE
fix(intro): focus the presentation chrome and card grid

### DIFF
--- a/change/@acedatacloud-nexior-629f3133-c40b-4a0f-b830-f76608fe5040.json
+++ b/change/@acedatacloud-nexior-629f3133-c40b-4a0f-b830-f76608fe5040.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "give /intro a logo-only presentation header, circular product marks, and balanced responsive card rows",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/common/TopHeader.intro.test.ts
+++ b/src/components/common/TopHeader.intro.test.ts
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+import { shallowMount } from '@vue/test-utils';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ROUTE_INTRO } from '@/router';
+import TopHeader from './TopHeader.vue';
+
+const mountHeader = (routeName: string) =>
+  shallowMount(TopHeader, {
+    global: {
+      stubs: {
+        ElRow: { template: '<header><slot /></header>' },
+        ElCol: { template: '<div><slot /></div>' },
+        Logo: { template: '<div class="logo-stub" />' },
+        ElMenu: { template: '<nav class="menu-stub"><slot /></nav>' },
+        ElSubMenu: true,
+        ElMenuItem: true,
+        ElDropdown: true,
+        ElButton: { template: '<button class="login-stub"><slot /></button>' }
+      },
+      mocks: {
+        $t: (key: string) => key,
+        $route: { name: routeName, matched: [{ path: '/intro' }], fullPath: '/intro' },
+        $router: { push: vi.fn() },
+        $store: {
+          state: { site: { id: 'studio', title: 'Ace Data Cloud', features: {} } },
+          getters: { authenticated: true, dark: true, user: { avatar: 'avatar.png' } },
+          dispatch: vi.fn()
+        }
+      }
+    }
+  });
+
+describe('TopHeader /intro presentation mode', () => {
+  it('renders only the centered brand logo', () => {
+    const wrapper = mountHeader(ROUTE_INTRO);
+
+    expect(wrapper.classes()).toContain('minimal-only');
+    expect(wrapper.findAll('.logo-stub')).toHaveLength(1);
+    expect(wrapper.find('.menu-stub').exists()).toBe(false);
+    expect(wrapper.find('.login-stub').exists()).toBe(false);
+    expect(wrapper.find('.avatar').exists()).toBe(false);
+    expect(wrapper.find('.console').exists()).toBe(false);
+  });
+});

--- a/src/components/common/TopHeader.vue
+++ b/src/components/common/TopHeader.vue
@@ -1,12 +1,15 @@
 <template>
-  <el-row class="header" :class="{ 'desktop-chrome': isDesktopChrome, 'is-mac': isMacChrome, 'home-only': isHome }">
-    <el-col v-if="isHome" :span="24" class="brand-col">
+  <el-row
+    class="header"
+    :class="{ 'desktop-chrome': isDesktopChrome, 'is-mac': isMacChrome, 'minimal-only': isMinimalHeader }"
+  >
+    <el-col v-if="isMinimalHeader" :span="24" class="brand-col">
       <logo @click="onHome" />
     </el-col>
     <el-col v-else :md="4" :xs="24" class="brand-col">
       <logo @click="onHome" />
     </el-col>
-    <el-col v-if="!isHome" :md="16" :xs="13">
+    <el-col v-if="!isMinimalHeader" :md="16" :xs="13">
       <el-menu :default-active="active" mode="horizontal" class="menu" :ellipsis="true" @select="onSelect">
         <el-sub-menu :index="products">
           <template #title>{{ $t('common.nav.products') }}</template>
@@ -44,7 +47,7 @@
         ></el-menu-item>
       </el-menu>
     </el-col>
-    <el-col v-if="!isHome" :md="4" :xs="11">
+    <el-col v-if="!isMinimalHeader" :md="4" :xs="11">
       <div v-if="!authenticated" class="mt-4 pr-10">
         <el-button type="primary" class="float-right" size="small" round @click="onLogin">{{
           $t('common.button.login')
@@ -74,7 +77,7 @@
 import { defineComponent } from 'vue';
 import defaultAvatar from '@/assets/images/avatar.png';
 import { getBaseUrlAuth, withCurrentUserIdAndSite, isMainOfficial } from '@/utils';
-import { ROUTE_CONSOLE_ROOT, ROUTE_DOWNLOAD, ROUTE_INDEX } from '@/router';
+import { ROUTE_CONSOLE_ROOT, ROUTE_DOWNLOAD, ROUTE_INDEX, ROUTE_INTRO } from '@/router';
 import {
   ElCol,
   ElRow,
@@ -120,8 +123,8 @@ export default defineComponent({
     active() {
       return this.$route.matched?.[0]?.path;
     },
-    isHome() {
-      return this.$route.name === ROUTE_INDEX;
+    isMinimalHeader() {
+      return this.$route.name === ROUTE_INDEX || this.$route.name === ROUTE_INTRO;
     },
     user() {
       return this.$store.getters?.user;
@@ -238,7 +241,7 @@ $height: 64px;
     padding-left: 84px; // clear the macOS traffic lights (x:16 + 3 dots)
   }
 
-  &.home-only .brand-col {
+  &.minimal-only .brand-col {
     justify-content: center;
     padding-right: 0;
     padding-left: 0;

--- a/src/pages/intro/Index.test.ts
+++ b/src/pages/intro/Index.test.ts
@@ -118,6 +118,7 @@ describe('/intro site capability filtering', () => {
     expect(logos).toHaveLength(cards.length);
     expect(logos.every((logo) => Boolean(logo.attributes('src')))).toBe(true);
     expect(logos.some((logo) => logo.attributes('src') === CHAT_MODEL_ICON_GLM)).toBe(true);
+    expect(wrapper.find('.model-grid').attributes('style')).toContain('--model-grid-columns: 5');
   });
 
   it('uses outward-facing campaign headlines instead of configuration labels', () => {

--- a/src/pages/intro/Index.vue
+++ b/src/pages/intro/Index.vue
@@ -95,7 +95,14 @@
           </div>
         </div>
 
-        <div class="model-grid">
+        <div
+          class="model-grid"
+          :style="{
+            '--model-grid-columns': Math.min(section.entries.length, 5),
+            '--model-grid-columns-tablet': Math.min(section.entries.length, 3),
+            '--model-grid-columns-mobile': Math.min(section.entries.length, 2)
+          }"
+        >
           <article v-for="entry in section.entries" :key="entry.name" class="model-card">
             <div class="model-card__heading">
               <span class="model-card__logo" aria-hidden="true">
@@ -707,21 +714,26 @@ export default defineComponent({
 // divide evenly into the column count, and an auto-fill grid leaves the last row
 // with a single orphaned card. Centering makes a short last row look deliberate.
 .model-grid {
+  --model-grid-active-columns: var(--model-grid-columns);
+  --model-grid-gap: 18px;
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
-  gap: 16px;
-  margin-top: 64px;
+  gap: var(--model-grid-gap);
+  width: 100%;
+  max-width: calc(
+    var(--model-grid-active-columns) * 228px + (var(--model-grid-active-columns) - 1) * var(--model-grid-gap)
+  );
+  margin: 64px auto 0;
 }
 
 .model-card {
-  // grow: 0 keeps a lone last-row card the same size as its siblings instead of
-  // stretching it across the full row.
-  flex: 0 1 clamp(240px, calc(25% - 16px), 300px);
+  flex: 0 1
+    calc((100% - (var(--model-grid-active-columns) - 1) * var(--model-grid-gap)) / var(--model-grid-active-columns));
   min-width: 0;
   padding: 24px;
   border: 1px solid var(--app-border-subtle);
-  border-radius: 16px;
+  border-radius: 18px;
   background: var(--el-bg-color);
   box-shadow: 0 8px 24px rgba(8, 18, 28, 0.04);
   transition:
@@ -746,18 +758,21 @@ export default defineComponent({
     flex: none;
     display: grid;
     place-items: center;
-    width: 42px;
-    height: 42px;
+    width: 46px;
+    height: 46px;
     overflow: hidden;
-    border: 1px solid var(--app-border-subtle);
-    border-radius: 12px;
-    background: color-mix(in srgb, var(--el-bg-color) 84%, var(--intro-accent));
+    border: 1px solid color-mix(in srgb, var(--intro-accent) 20%, var(--app-border-subtle));
+    border-radius: 50%;
+    background: color-mix(in srgb, var(--el-bg-color) 90%, var(--intro-accent));
+    box-shadow:
+      inset 0 0 0 1px rgba(255, 255, 255, 0.04),
+      0 5px 14px rgba(5, 14, 24, 0.12);
 
     img {
       display: block;
-      width: 28px;
-      height: 28px;
-      object-fit: contain;
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
     }
   }
 
@@ -822,6 +837,10 @@ export default defineComponent({
       order: 0;
     }
   }
+
+  .model-grid {
+    --model-grid-active-columns: var(--model-grid-columns-tablet);
+  }
 }
 
 @media (max-width: 768px) {
@@ -872,13 +891,25 @@ export default defineComponent({
   }
 
   .model-grid {
+    --model-grid-active-columns: var(--model-grid-columns-mobile);
+    --model-grid-gap: 12px;
+    max-width: 100%;
     margin-top: 40px;
-    gap: 12px;
   }
 
   .model-card {
-    flex-basis: calc(50% - 6px);
-    padding: 16px 18px;
+    padding: 18px;
+
+    &__heading {
+      align-items: flex-start;
+      flex-direction: column;
+      gap: 10px;
+    }
+
+    &__logo {
+      width: 42px;
+      height: 42px;
+    }
   }
 
   .final-cta h2 {


### PR DESCRIPTION
## Presentation chrome

`/intro` now behaves as a standalone public product presentation rather than an application screen.

The sticky header renders **one centered brand logo only**. It no longer renders:

- product/navigation menus
- login controls
- language and theme switches
- account avatar
- console entry point

`/home` keeps the same existing logo-only behavior; all product screens keep the regular application header.

## Product marks

The previous logo treatment placed a small logo inside a large rounded square, creating too much dead space and a box-inside-box effect.

The replacement uses:

- 46px circular brand marks
- full-bleed image crop (`object-fit: cover`)
- restrained brand-tinted border/background
- subtle depth without an extra inner frame
- 42px mobile size

## Balanced product rows

The screenshot showed five chat products rendered as 4 + 1, leaving GLM floating alone in a wide empty area.

Column count now follows each section’s actual visible product count:

- desktop: up to 5 columns — all five chat products fit in one row
- tablet: up to 3 columns
- mobile: 2 columns
- sparse sections keep standard centered card widths instead of stretching to fill the viewport

## Verification

- Unit/regression tests: **6/6 passed**
  - `/intro` header contains exactly one Logo
  - menu/login/avatar/console are absent
  - 5-column chat grid is asserted
  - capability filtering and logo coverage remain protected
- Playwright, zh/en × desktop/mobile: **4/4 passed**
  - header visible children: 1
  - header logos: 1
  - menus/login/avatar/console: 0
  - product marks: 16/16 loaded
  - circular marks: 16/16
  - full-bleed crop: 16/16
  - chat first row: 5 desktop / 2 mobile
  - equal card widths per viewport
  - horizontal overflow: 0
  - Midjourney remains absent
  - page errors: 0
- `vue-tsc -b`: passed
- `eslint src`: 0 errors (2 existing warnings in an unrelated test)
- i18n coverage: 17 locales × 48 namespaces, clean