### PR TITLE
fix(branding): render logos directly from Site config

### DIFF
--- a/change/@acedatacloud-nexior-612c164a-72f2-4adb-9a47-bd43597c3827.json
+++ b/change/@acedatacloud-nexior-612c164a-72f2-4adb-9a47-bd43597c3827.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "render each white-label Site's configured logo on tenant subdomains and custom domains while keeping the built-in wordmark on exact official hosts",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/common/Logo.test.ts
+++ b/src/components/common/Logo.test.ts
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+
+import Logo from './Logo.vue';
+
+const mountLogo = (site: Record<string, unknown>, collapsed = false) =>
+  mount(Logo, {
+    props: { collapsed },
+    global: {
+      mocks: {
+        $store: { state: { site } }
+      }
+    }
+  });
+
+describe('Logo Site branding', () => {
+  it('renders the initialized Site logo without consulting the hostname', () => {
+    const wrapper = mountLogo({ title: 'Customer AI', logo: 'https://cdn.example.com/customer-logo.png' });
+
+    expect(wrapper.get('.brand-logo__image').attributes('src')).toBe('https://cdn.example.com/customer-logo.png');
+    expect(wrapper.get('.brand-logo__image').attributes('alt')).toBe('Customer AI');
+    expect(wrapper.find('.brand-logo__wordmark').exists()).toBe(false);
+  });
+
+  it('falls back from logo to favicon and reverses priority when collapsed', () => {
+    const faviconOnly = mountLogo({ favicon: 'https://cdn.example.com/favicon.png' });
+    expect(faviconOnly.get('.brand-logo__image').attributes('src')).toContain('favicon.png');
+
+    const collapsed = mountLogo(
+      {
+        logo: 'https://cdn.example.com/logo.png',
+        favicon: 'https://cdn.example.com/favicon.png'
+      },
+      true
+    );
+    expect(collapsed.get('.brand-logo__image').attributes('src')).toContain('favicon.png');
+  });
+
+  it('uses the built-in wordmark only when Site branding is absent', () => {
+    const wrapper = mountLogo({ title: 'Unbranded Site' });
+
+    expect(wrapper.find('.brand-logo__image').exists()).toBe(false);
+    expect(wrapper.find('.brand-logo__wordmark').exists()).toBe(true);
+  });
+
+  it('uses the built-in mark for an unbranded collapsed header', () => {
+    const wrapper = mountLogo({ title: 'Unbranded Site' }, true);
+
+    expect(wrapper.find('.brand-logo__image').exists()).toBe(false);
+    expect(wrapper.find('.brand-logo__mark').exists()).toBe(true);
+  });
+});

--- a/src/components/common/Logo.vue
+++ b/src/components/common/Logo.vue
@@ -15,7 +15,6 @@
 import logoMark from '@/assets/images/logos/acedata-mark.png';
 import logoWordmarkMask from '@/assets/images/logos/acedata-wordmark-mask.png';
 import { defineComponent } from 'vue';
-import { isOfficial } from '@/utils/is';
 
 export default defineComponent({
   props: {
@@ -32,16 +31,14 @@ export default defineComponent({
     siteTitle() {
       return this.$store.state.site?.title || 'AceData';
     },
-    // Official hosts render the built-in wordmark (mask + currentColor) so it
-    // flips with dark mode; white-label tenants keep their own raster logo.
+    // Site branding is authoritative on every host. The built-in mark is only
+    // a final fallback when the initialized Site has no logo or favicon.
     tenantLogo(): string {
-      if (isOfficial()) return '';
       const site = this.$store.state.site;
-      const fallback = 'https://platform.acedata.cloud/favicon.ico';
       if (this.collapsed) {
-        return site?.favicon || site?.logo || fallback;
+        return site?.favicon || site?.logo || '';
       }
-      return site?.logo || site?.favicon || fallback;
+      return site?.logo || site?.favicon || '';
     },
     wordmarkStyle() {
       return { '--logo-wordmark-mask': `url(${logoWordmarkMask})` };


### PR DESCRIPTION
## Root cause

The shared `Logo` component did not treat the initialized `Site` as the branding source of truth. It used hostname classification first, so a valid `Site.logo` could be ignored even though the site object already carried the correct brand configuration.

## Fix

Remove hostname-based brand ownership decisions from `Logo` entirely.

The rule is now identical on official hosts, white-label subdomains, and custom domains:

- normal header: `Site.logo` → `Site.favicon` → built-in mark
- collapsed header: `Site.favicon` → `Site.logo` → built-in mark
- alt text: `Site.title`

`studio.acedata.cloud` already has its Ace Data Cloud logo in its Site record, so it remains branded correctly without a hardcoded hostname exception. Brand sites dynamically render their own Site logo for the same reason.

## Verification

- Unit/regression: **10/10 passed**
  - configured Site logo renders directly
  - logo → favicon fallback
  - collapsed favicon-first priority
  - unbranded normal header uses built-in wordmark
  - unbranded collapsed header uses built-in mark
  - existing `/intro` header and capability tests remain green
- Dynamic tenant Playwright E2E with the real Seedance Site values:
  - configured tenant logo rendered: yes
  - alt text equals `Seedance AI Video Generator`: yes
  - built-in wordmark: 0
  - header logos: 1
  - enabled cards: Seedance only
  - page errors: 0
- Confirmed production `studio.acedata.cloud` Site record already contains its official logo URL
- `vue-tsc -b`: passed
- focused ESLint: passed
