### PR TITLE
fix(chat): enrich TikTok publish confirmation

### DIFF
--- a/change/@acedatacloud-nexior-tiktok-confirm-card.json
+++ b/change/@acedatacloud-nexior-tiktok-confirm-card.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Turn TikTok publishing confirmation into a complete review screen with reliable media fallback, validated account settings, clear disabled reasons, and linked policy guidance.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/chat/ActionConfirmationCard.test.ts
+++ b/src/components/chat/ActionConfirmationCard.test.ts
@@ -11,6 +11,7 @@ const global = {
   },
   stubs: {
     FontAwesomeIcon: { template: '<i />' },
+    ExternalLinkIcon: { template: '<i />' },
     'el-button': {
       props: ['type', 'loading', 'disabled', 'text'],
       emits: ['click'],
@@ -114,5 +115,33 @@ describe('ActionConfirmationCard', () => {
       preview: { type: 'video', url: 'https://x/v.mp4', duration_sec: 95 }
     });
     expect(wrapper.text()).toContain('1:35');
+  });
+
+  it('uses an inline video player and replaces it with a safe fallback on error', async () => {
+    const wrapper = mountCard({
+      ...BASE,
+      preview: { type: 'video', url: 'https://cdn.example.com/video.mp4', duration_sec: 10 }
+    });
+    const video = wrapper.find('video');
+    expect(video.attributes('playsinline')).toBeDefined();
+    await video.trigger('error');
+    expect(wrapper.find('video').exists()).toBe(false);
+    const link = wrapper.find('.preview-fallback a');
+    expect(link.attributes('href')).toBe('https://cdn.example.com/video.mp4');
+    expect(link.attributes('target')).toBe('_blank');
+    expect(link.attributes('rel')).toBe('noopener noreferrer');
+  });
+
+  it('renders malformed TikTok history as a blocked TikTok form instead of a generic blank card', () => {
+    const wrapper = mountCard({
+      action_confirmation_id: 'actconf_tiktok',
+      kind: 'tiktok.publish',
+      title: '发布到 TikTok',
+      preview: { type: 'video', url: 'https://cdn.example.com/video.mp4' },
+      detail: {}
+    });
+    expect(wrapper.findComponent({ name: 'TikTokPublishForm' }).exists()).toBe(true);
+    expect(wrapper.text()).toContain('chat.actionConfirmation.tiktok.detailsUnavailable');
+    expect((wrapper.vm as any).bodyValid).toBe(false);
   });
 });

--- a/src/components/chat/ActionConfirmationCard.vue
+++ b/src/components/chat/ActionConfirmationCard.vue
@@ -1,53 +1,108 @@
 <template>
-  <div class="action-confirmation-card" :class="{ 'is-resolved': resolved, 'is-destructive': isDestructive }">
+  <div
+    class="action-confirmation-card"
+    :class="{
+      'is-resolved': resolved,
+      'is-destructive': isDestructive,
+      'is-tiktok': isTikTokPublish
+    }"
+  >
     <div class="acc-header">
-      <component :is="headerIcon" class="header-icon" :size="'1em' as any" aria-hidden="true" focusable="false" />
-      <span class="header-title">{{ payload.title }}</span>
-    </div>
-
-    <div v-if="payload.preview" class="acc-preview">
-      <video
-        v-if="payload.preview.type === 'video'"
-        class="preview-media"
-        :src="payload.preview.url"
-        controls
-        preload="metadata"
-      />
-      <img v-else class="preview-media" :src="payload.preview.url" :alt="payload.title" />
-      <span v-if="payload.preview.duration_sec" class="preview-duration">
-        {{ formattedDuration }}
+      <div class="acc-heading">
+        <span v-if="isTikTokPublish" class="acc-brand-mark" aria-hidden="true">♪</span>
+        <component
+          :is="headerIcon"
+          v-else
+          class="header-icon"
+          :size="'1em' as any"
+          aria-hidden="true"
+          focusable="false"
+        />
+        <div class="acc-heading-copy">
+          <span v-if="isTikTokPublish" class="acc-eyebrow">TikTok</span>
+          <span class="header-title">{{ payload.title }}</span>
+        </div>
+      </div>
+      <span v-if="isTikTokPublish && !resolved" class="acc-review-badge">
+        {{ $t('chat.actionConfirmation.tiktok.reviewBadge') }}
       </span>
     </div>
 
-    <div class="acc-body">
-      <!-- Kind-specific bodies register here. Unknown kinds fall through to
-           the generic list so a worker that ships a new kind first still
-           renders something actionable. -->
-      <TikTokPublishForm
-        v-if="isTikTokPublish"
-        ref="tiktokForm"
-        :detail="payload.detail as any"
-        :initial-title="initialTitle"
-        :duration-sec="payload.preview?.duration_sec ?? 0"
-        :disabled="resolved"
-        :initial-values="submittedValues"
-        @validity-change="onValidityChange"
-      />
-      <GenericFieldList v-else :summary="payload.summary" :fields="payload.fields ?? []" />
+    <p v-if="payload.summary" class="acc-summary">{{ payload.summary }}</p>
+
+    <div class="acc-content" :class="{ 'has-tiktok-layout': isTikTokPublish }">
+      <div v-if="payload.preview" class="acc-preview" :class="{ 'has-error': mediaFailed }">
+        <div v-if="!mediaReady && !mediaFailed" class="preview-loading" aria-live="polite">
+          <span class="preview-spinner" />
+          <span>{{ $t('chat.actionConfirmation.mediaLoading') }}</span>
+        </div>
+        <video
+          v-if="payload.preview.type === 'video' && !mediaFailed"
+          class="preview-media"
+          :class="{ 'is-ready': mediaReady }"
+          :src="payload.preview.url"
+          controls
+          playsinline
+          preload="metadata"
+          @loadedmetadata="onMediaReady"
+          @canplay="onMediaReady"
+          @error="onMediaError"
+        />
+        <img
+          v-else-if="payload.preview.type === 'image' && !mediaFailed"
+          class="preview-media"
+          :class="{ 'is-ready': mediaReady }"
+          :src="payload.preview.url"
+          :alt="payload.title"
+          @load="onMediaReady"
+          @error="onMediaError"
+        />
+        <div v-else class="preview-fallback" role="alert">
+          <span class="fallback-icon">!</span>
+          <strong>{{ $t('chat.actionConfirmation.mediaUnavailable') }}</strong>
+          <span>{{ $t('chat.actionConfirmation.mediaUnavailableHint') }}</span>
+          <a :href="payload.preview.url" target="_blank" rel="noopener noreferrer">
+            {{ $t('chat.actionConfirmation.openMedia') }}
+            <external-link-icon :size="'1em' as any" aria-hidden="true" focusable="false" />
+          </a>
+        </div>
+        <span v-if="formattedDuration && !mediaFailed" class="preview-duration">
+          {{ formattedDuration }}
+        </span>
+      </div>
+
+      <div class="acc-body">
+        <TikTokPublishForm
+          v-if="isTikTokPublish"
+          ref="tiktokForm"
+          :detail="(payload.detail ?? {}) as any"
+          :initial-title="initialTitle"
+          :duration-sec="payload.preview?.duration_sec ?? 0"
+          :disabled="resolved"
+          :initial-values="submittedValues"
+          @validity-change="onValidityChange"
+        />
+        <GenericFieldList v-else :summary="payload.summary" :fields="payload.fields ?? []" />
+      </div>
     </div>
 
     <div v-if="!resolved" class="acc-actions">
-      <el-button text :disabled="submitting" @click="onCancel">
-        {{ $t('chat.actionConfirmation.cancel') }}
-      </el-button>
-      <el-button
-        :type="isDestructive ? 'danger' : 'primary'"
-        :loading="submitting"
-        :disabled="!bodyValid"
-        @click="onConfirm"
-      >
-        {{ confirmLabel }}
-      </el-button>
+      <p v-if="!bodyValid && validationReason" class="acc-validation" role="status">
+        {{ validationReason }}
+      </p>
+      <div class="acc-buttons">
+        <el-button text :disabled="submitting" @click="onCancel">
+          {{ $t('chat.actionConfirmation.cancel') }}
+        </el-button>
+        <el-button
+          :type="isDestructive ? 'danger' : 'primary'"
+          :loading="submitting"
+          :disabled="!bodyValid"
+          @click="onConfirm"
+        >
+          {{ confirmLabel }}
+        </el-button>
+      </div>
     </div>
 
     <div v-else class="acc-resolved-banner">
@@ -57,7 +112,7 @@
 </template>
 
 <script lang="ts">
-import { ConfirmIcon, WarningIcon } from '@acedatacloud/core/icons/components';
+import { ConfirmIcon, ExternalLinkIcon, WarningIcon } from '@acedatacloud/core/icons/components';
 import { ElButton } from 'element-plus';
 import { defineComponent, type PropType } from 'vue';
 import GenericFieldList from './GenericFieldList.vue';
@@ -68,21 +123,14 @@ interface IData {
   submitting: boolean;
   resolvedConfirmed: boolean | null;
   bodyValid: boolean;
+  validationReason: string;
+  mediaReady: boolean;
+  mediaFailed: boolean;
 }
 
-/**
- * Gate for an irreversible external action. Rendered inline on a
- * `tool_use` block paused with `pending_action_confirmation`.
- *
- * Not to be confused with `<ConnectorConsentCard>`: that one asks "do you
- * have permission for this connector?" once, when the capability is
- * missing. This asks "should I do this, this time?" and fires before
- * every such action — a user with TikTok already connected still gets
- * this card for each video.
- */
 export default defineComponent({
   name: 'ActionConfirmationCard',
-  components: { GenericFieldList, TikTokPublishForm, ConfirmIcon, WarningIcon, ElButton },
+  components: { GenericFieldList, TikTokPublishForm, ConfirmIcon, ExternalLinkIcon, WarningIcon, ElButton },
   props: {
     payload: {
       type: Object as PropType<IActionConfirmationPayload>,
@@ -92,7 +140,6 @@ export default defineComponent({
       type: Boolean,
       default: false
     },
-    /** Prior `output` JSON when replaying a resolved block from history. */
     previousOutput: {
       type: String,
       default: ''
@@ -103,21 +150,20 @@ export default defineComponent({
     return {
       submitting: false,
       resolvedConfirmed: null,
-      // Kind bodies that collect input flip this via `validity-change`;
-      // bodies without input leave it true so the button stays enabled.
-      bodyValid: true
+      bodyValid: true,
+      validationReason: '',
+      mediaReady: false,
+      mediaFailed: false
     };
   },
   computed: {
     isTikTokPublish(): boolean {
-      return this.payload?.kind === 'tiktok.publish' && !!this.payload?.detail;
+      return this.payload?.kind === 'tiktok.publish';
     },
-    /** Model-suggested caption, editable by the user in the kind body. */
     initialTitle(): string {
       const detail = this.payload?.detail as Record<string, unknown> | undefined;
       return typeof detail?.suggested_title === 'string' ? detail.suggested_title : '';
     },
-    /** What the user actually submitted, so a resolved card replays it. */
     submittedValues(): ITikTokPublishValues | null {
       if (!this.resolved || !this.previousOutput) return null;
       try {
@@ -137,7 +183,9 @@ export default defineComponent({
       return this.payload?.confirm_label || (this.$t('chat.actionConfirmation.confirm') as string);
     },
     formattedDuration(): string {
-      const total = Math.round(this.payload?.preview?.duration_sec ?? 0);
+      const value = this.payload?.preview?.duration_sec;
+      if (!value || !Number.isFinite(value)) return '';
+      const total = Math.round(value);
       const mm = Math.floor(total / 60);
       const ss = total % 60;
       return `${mm}:${String(ss).padStart(2, '0')}`;
@@ -157,10 +205,13 @@ export default defineComponent({
         this.submitting = false;
         this.resolvedConfirmed = this.parsePreviousConfirmed();
       }
+    },
+    'payload.preview.url'() {
+      this.mediaReady = false;
+      this.mediaFailed = false;
     }
   },
   methods: {
-    /** Recover the confirm/cancel outcome when re-rendering history. */
     parsePreviousConfirmed(): boolean {
       if (!this.previousOutput) return false;
       try {
@@ -180,10 +231,18 @@ export default defineComponent({
       if (confirmed && values) result.values = values;
       this.$emit('submit', result);
     },
-    onValidityChange(valid: boolean): void {
+    onValidityChange(valid: boolean, reason = ''): void {
       this.bodyValid = valid;
+      this.validationReason = reason;
     },
-    /** Pull the edited values out of the active kind body, if any. */
+    onMediaReady(): void {
+      this.mediaReady = true;
+      this.mediaFailed = false;
+    },
+    onMediaError(): void {
+      this.mediaReady = false;
+      this.mediaFailed = true;
+    },
     collectValues(): Record<string, unknown> | undefined {
       const form = this.$refs.tiktokForm as { collect?: () => Record<string, unknown> } | undefined;
       return form?.collect ? form.collect() : undefined;
@@ -199,21 +258,20 @@ export default defineComponent({
 </script>
 
 <style lang="scss" scoped>
-// Shape, shadow and enter animation deliberately mirror
-// `<ConnectorConsentCard>` — the two cards sit in the same transcript and a
-// different radius/elevation reads as a different product.
 .action-confirmation-card {
+  width: min(100%, 760px);
   border: 1px solid var(--el-border-color-lighter);
-  border-radius: 16px;
-  padding: 16px 18px 14px;
-  margin: 8px 0;
-  max-width: 100%;
+  border-radius: 18px;
+  padding: 18px;
+  margin: 10px 0;
   font-size: 14px;
   background: var(--el-bg-color);
-  box-shadow:
-    0 4px 16px -8px rgba(0, 0, 0, 0.08),
-    0 1px 2px rgba(0, 0, 0, 0.04);
+  box-shadow: 0 14px 40px -28px rgb(0 0 0 / 45%);
   animation: actionConfirmationEnter 280ms cubic-bezier(0.16, 1, 0.3, 1);
+
+  &.is-tiktok {
+    border-color: color-mix(in srgb, var(--el-border-color) 72%, #25f4ee 28%);
+  }
 
   &.is-destructive {
     border-color: var(--el-color-danger-light-5);
@@ -224,77 +282,254 @@ export default defineComponent({
     box-shadow: none;
     animation: none;
   }
+}
 
-  .acc-header {
-    display: flex;
+.acc-header,
+.acc-heading,
+.acc-buttons {
+  display: flex;
+  align-items: center;
+}
+
+.acc-header {
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.acc-heading {
+  gap: 10px;
+  min-width: 0;
+}
+
+.header-icon {
+  color: var(--el-color-primary);
+  font-size: 17px;
+  flex-shrink: 0;
+}
+
+.acc-brand-mark {
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  flex: 0 0 34px;
+  border-radius: 11px;
+  color: #fff;
+  font-size: 20px;
+  font-weight: 800;
+  background: #111;
+  box-shadow:
+    -2px 0 #25f4ee,
+    2px 0 #fe2c55;
+}
+
+.acc-heading-copy {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.acc-eyebrow {
+  color: var(--el-text-color-secondary);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.header-title {
+  color: var(--el-text-color-primary);
+  font-size: 16px;
+  font-weight: 650;
+  line-height: 1.35;
+  word-break: break-word;
+}
+
+.acc-review-badge {
+  padding: 4px 9px;
+  flex-shrink: 0;
+  border-radius: 999px;
+  color: var(--el-color-warning-dark-2);
+  font-size: 11px;
+  font-weight: 600;
+  background: var(--el-color-warning-light-9);
+}
+
+.acc-summary {
+  margin: 12px 0 0;
+  color: var(--el-text-color-regular);
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+.acc-content {
+  margin-top: 14px;
+
+  &.has-tiktok-layout {
+    display: grid;
+    grid-template-columns: minmax(190px, 0.72fr) minmax(300px, 1.28fr);
+    gap: 18px;
+    align-items: start;
+  }
+}
+
+.acc-preview {
+  position: relative;
+  min-height: 270px;
+  border: 1px solid var(--el-border-color-lighter);
+  border-radius: 14px;
+  overflow: hidden;
+  background: linear-gradient(145deg, rgb(37 244 238 / 8%), rgb(254 44 85 / 7%)), #0d0f12;
+
+  .preview-media {
+    display: block;
+    width: 100%;
+    height: 100%;
+    min-height: 270px;
+    max-height: 440px;
+    opacity: 0;
+    object-fit: contain;
+    transition: opacity 180ms ease;
+
+    &.is-ready {
+      opacity: 1;
+    }
+  }
+}
+
+.preview-loading,
+.preview-fallback {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: 10px;
+  padding: 22px;
+  color: rgb(255 255 255 / 68%);
+  text-align: center;
+  font-size: 12px;
+}
+
+.preview-spinner {
+  width: 24px;
+  height: 24px;
+  border: 2px solid rgb(255 255 255 / 20%);
+  border-top-color: #25f4ee;
+  border-radius: 50%;
+  animation: previewSpin 700ms linear infinite;
+}
+
+.preview-fallback {
+  position: relative;
+  min-height: 270px;
+
+  strong {
+    color: #fff;
+    font-size: 14px;
+  }
+
+  a {
+    display: inline-flex;
     align-items: center;
-    gap: 8px;
-    margin-bottom: 8px;
+    gap: 5px;
+    margin-top: 4px;
+    color: #25f4ee;
+    font-weight: 600;
+    text-decoration: none;
+  }
+}
 
-    .header-icon {
-      color: var(--el-color-primary);
-      font-size: 16px;
-      flex-shrink: 0;
-    }
+.fallback-icon {
+  display: grid;
+  place-items: center;
+  width: 32px;
+  height: 32px;
+  border: 1px solid rgb(255 255 255 / 25%);
+  border-radius: 50%;
+  color: #fff;
+  font-weight: 700;
+}
 
-    .header-title {
-      font-size: 15px;
-      font-weight: 600;
-      letter-spacing: 0.01em;
-      color: var(--el-text-color-primary);
-      min-width: 0;
-      word-break: break-word;
-    }
+.preview-duration {
+  position: absolute;
+  right: 9px;
+  bottom: 9px;
+  padding: 3px 7px;
+  border-radius: 6px;
+  color: #fff;
+  font-size: 11px;
+  background: rgb(0 0 0 / 70%);
+  backdrop-filter: blur(8px);
+}
+
+.acc-body {
+  min-width: 0;
+}
+
+.acc-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 16px;
+  padding-top: 12px;
+  border-top: 1px solid var(--el-border-color-lighter);
+}
+
+.acc-validation {
+  margin: 0;
+  color: var(--el-color-warning-dark-2);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.acc-buttons {
+  justify-content: flex-end;
+  gap: 8px;
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
+.acc-resolved-banner {
+  margin-top: 12px;
+  padding: 9px 12px;
+  border-radius: 9px;
+  background: var(--el-color-info-light-9);
+  color: var(--el-text-color-regular);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+@media (max-width: 680px) {
+  .action-confirmation-card {
+    padding: 15px;
+    border-radius: 16px;
   }
 
-  &.is-destructive .acc-header .header-icon {
-    color: var(--el-color-danger);
+  .acc-content.has-tiktok-layout {
+    grid-template-columns: minmax(0, 1fr);
   }
 
-  .acc-preview {
-    position: relative;
-    margin-bottom: 12px;
-    border-radius: 10px;
-    overflow: hidden;
-    background: var(--el-fill-color-light);
-    max-width: 240px;
-
-    .preview-media {
-      display: block;
-      width: 100%;
-      max-height: 320px;
-      object-fit: contain;
-    }
-
-    .preview-duration {
-      position: absolute;
-      right: 6px;
-      bottom: 6px;
-      padding: 1px 6px;
-      border-radius: 4px;
-      font-size: 11px;
-      color: #fff;
-      background: rgb(0 0 0 / 60%);
-    }
+  .acc-preview,
+  .acc-preview .preview-media,
+  .preview-fallback {
+    min-height: 220px;
+    max-height: 360px;
   }
 
   .acc-actions {
-    display: flex;
-    justify-content: flex-end;
-    gap: 8px;
-    margin-top: 10px;
-    padding-top: 8px;
-    border-top: 1px solid var(--el-border-color-lighter);
+    align-items: stretch;
+    flex-direction: column;
   }
 
-  .acc-resolved-banner {
-    margin-top: 10px;
-    padding: 8px 12px;
-    border-radius: 8px;
-    background: var(--el-color-info-light-9);
-    color: var(--el-text-color-regular);
-    font-size: 13px;
-    line-height: 1.5;
+  .acc-buttons {
+    width: 100%;
+
+    :deep(.el-button) {
+      flex: 1;
+    }
   }
 }
 
@@ -307,6 +542,12 @@ export default defineComponent({
   to {
     opacity: 1;
     transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes previewSpin {
+  to {
+    transform: rotate(360deg);
   }
 }
 </style>

--- a/src/components/chat/TikTokPublishForm.test.ts
+++ b/src/components/chat/TikTokPublishForm.test.ts
@@ -72,13 +72,16 @@ describe('TikTokPublishForm', () => {
   it('starts with NO privacy selected — TikTok forbids a default', () => {
     const wrapper = mountForm();
     expect((wrapper.vm as any).form.privacy_level).toBe('');
-    expect(wrapper.emitted('validity-change')?.[0]).toEqual([false]);
+    expect(wrapper.emitted('validity-change')?.[0]).toEqual([
+      false,
+      'chat.actionConfirmation.tiktok.selectPrivacyFirst'
+    ]);
   });
 
   it('becomes valid once a privacy level is chosen', async () => {
     const wrapper = mountForm();
     await wrapper.find('select').setValue('PUBLIC_TO_EVERYONE');
-    expect(wrapper.emitted('validity-change')?.at(-1)).toEqual([true]);
+    expect(wrapper.emitted('validity-change')?.at(-1)).toEqual([true, '']);
   });
 
   it('leaves every interaction toggle unchecked by default', () => {
@@ -105,7 +108,7 @@ describe('TikTokPublishForm', () => {
   it('rejects a video longer than the account cap', () => {
     const wrapper = mountForm({ max_video_post_duration_sec: 60 }, { durationSec: 90 });
     expect(wrapper.text()).toContain('tooLong');
-    expect(wrapper.emitted('validity-change')?.[0]).toEqual([false]);
+    expect(wrapper.emitted('validity-change')?.[0]).toEqual([false, 'chat.actionConfirmation.tiktok.useShorterVideo']);
   });
 
   it('blocks branded content while the post is private', async () => {
@@ -132,19 +135,45 @@ describe('TikTokPublishForm', () => {
     const vm = wrapper.vm as any;
     vm.form.commercial = true;
     await wrapper.vm.$nextTick();
-    expect(wrapper.emitted('validity-change')?.at(-1)).toEqual([false]);
+    expect(wrapper.emitted('validity-change')?.at(-1)).toEqual([
+      false,
+      'chat.actionConfirmation.tiktok.selectDisclosureType'
+    ]);
   });
 
-  it('uses the same declaration for branded-only and both — there are only two strings', async () => {
+  it('shows official music and branded-content policy links', async () => {
     const wrapper = mountForm();
+    expect(wrapper.findAll('.tpf-policy-links a')).toHaveLength(1);
+    expect(wrapper.find('.tpf-policy-links a').attributes('href')).toContain('music-usage-confirmation');
+    expect(wrapper.find('.tpf-policy-links a').attributes('rel')).toBe('noopener noreferrer');
+
     const vm = wrapper.vm as any;
     vm.form.commercial = true;
     vm.form.brand_content_toggle = true;
     await wrapper.vm.$nextTick();
-    const brandedOnly = vm.musicDeclaration;
-    vm.form.brand_organic_toggle = true;
-    await wrapper.vm.$nextTick();
-    expect(vm.musicDeclaration).toBe(brandedOnly);
+    const links = wrapper.findAll('.tpf-policy-links a');
+    expect(links).toHaveLength(2);
+    expect(links[1].attributes('href')).toContain('bc-policy');
+  });
+
+  it('blocks publishing and replaces the empty dropdown when creator info is incomplete', () => {
+    const wrapper = mount(TikTokPublishForm, {
+      props: {
+        detail: {
+          creator_nickname: '',
+          privacy_level_options: [],
+          comment_disabled: false,
+          duet_disabled: false,
+          stitch_disabled: false,
+          max_video_post_duration_sec: 600
+        }
+      },
+      global
+    });
+    expect(wrapper.find('select').exists()).toBe(false);
+    expect(wrapper.text()).toContain('detailsUnavailable');
+    expect(wrapper.text()).toContain('noPrivacyOptions');
+    expect(wrapper.emitted('validity-change')?.[0]).toEqual([false, 'chat.actionConfirmation.tiktok.fixDetailsFirst']);
   });
 
   it('inverts allow_* into the API disable_* fields', async () => {

--- a/src/components/chat/TikTokPublishForm.vue
+++ b/src/components/chat/TikTokPublishForm.vue
@@ -1,92 +1,141 @@
 <template>
   <div class="tiktok-publish-form">
-    <p class="tpf-account">
-      {{ $t('chat.actionConfirmation.tiktok.postingTo') }}
-      <strong>{{ detail.creator_nickname }}</strong>
-    </p>
-
-    <p v-if="tooLong" class="tpf-error">
-      {{ $t('chat.actionConfirmation.tiktok.tooLong', { max: detail.max_video_post_duration_sec }) }}
-    </p>
-
-    <div class="tpf-field">
-      <label class="tpf-label" for="tpf-caption">{{ $t('chat.actionConfirmation.tiktok.caption') }}</label>
-      <el-input
-        id="tpf-caption"
-        v-model="form.title"
-        type="textarea"
-        :rows="3"
-        :maxlength="2200"
-        :show-word-limit="!disabled"
-        :disabled="disabled"
-        :placeholder="$t('chat.actionConfirmation.tiktok.captionPlaceholder')"
-      />
+    <div class="tpf-account" :class="{ 'is-missing': !hasCreator }">
+      <img v-if="detail.creator_avatar_url" class="tpf-avatar" :src="detail.creator_avatar_url" alt="" />
+      <span v-else class="tpf-avatar tpf-avatar-fallback" aria-hidden="true">
+        {{ creatorInitial }}
+      </span>
+      <div class="tpf-account-copy">
+        <span>{{ $t('chat.actionConfirmation.tiktok.postingTo') }}</span>
+        <strong>{{ creatorName }}</strong>
+      </div>
+      <span v-if="hasCreator" class="tpf-connected">{{ $t('chat.actionConfirmation.tiktok.connected') }}</span>
     </div>
 
-    <!-- No default value: TikTok's guidelines require the user to pick the
-         privacy level manually from the exact options creator_info returned. -->
-    <div class="tpf-field">
-      <label class="tpf-label" for="tpf-privacy">
-        {{ $t('chat.actionConfirmation.tiktok.privacy') }}
-        <span class="tpf-required">*</span>
-      </label>
-      <el-select
-        id="tpf-privacy"
-        v-model="form.privacy_level"
-        :placeholder="$t('chat.actionConfirmation.tiktok.privacyPlaceholder')"
-        :disabled="disabled"
-        class="tpf-select"
-      >
-        <el-option
-          v-for="opt in privacyOptions"
-          :key="opt"
-          :label="privacyLabel(opt)"
-          :value="opt"
-          :disabled="isPrivacyDisabled(opt)"
+    <div v-if="metadataMissing" class="tpf-blocking-error" role="alert">
+      <strong>{{ $t('chat.actionConfirmation.tiktok.detailsUnavailable') }}</strong>
+      <span>{{ $t('chat.actionConfirmation.tiktok.detailsUnavailableHint') }}</span>
+    </div>
+
+    <div v-if="tooLong" class="tpf-blocking-error" role="alert">
+      <strong>{{ $t('chat.actionConfirmation.tiktok.videoTooLongTitle') }}</strong>
+      <span>{{ $t('chat.actionConfirmation.tiktok.tooLong', { max: detail.max_video_post_duration_sec }) }}</span>
+    </div>
+
+    <section class="tpf-section">
+      <div class="tpf-section-heading">
+        <span>{{ $t('chat.actionConfirmation.tiktok.postDetails') }}</span>
+        <span class="tpf-required-note">{{ $t('chat.actionConfirmation.tiktok.requiredNote') }}</span>
+      </div>
+
+      <div class="tpf-field">
+        <label class="tpf-label" for="tpf-caption">{{ $t('chat.actionConfirmation.tiktok.caption') }}</label>
+        <el-input
+          id="tpf-caption"
+          v-model="form.title"
+          type="textarea"
+          :rows="3"
+          :maxlength="2200"
+          :show-word-limit="!disabled"
+          :disabled="disabled || metadataMissing"
+          resize="none"
+          :placeholder="$t('chat.actionConfirmation.tiktok.captionPlaceholder')"
         />
-      </el-select>
-      <p v-if="selfOnlyBlocked" class="tpf-hint">
-        {{ $t('chat.actionConfirmation.tiktok.brandedNotPrivate') }}
-      </p>
-    </div>
+      </div>
 
-    <div class="tpf-field">
-      <span class="tpf-label">{{ $t('chat.actionConfirmation.tiktok.interactions') }}</span>
+      <div class="tpf-field">
+        <label class="tpf-label" for="tpf-privacy">
+          {{ $t('chat.actionConfirmation.tiktok.privacy') }}
+          <span class="tpf-required">*</span>
+        </label>
+        <el-select
+          v-if="hasPrivacyOptions"
+          id="tpf-privacy"
+          v-model="form.privacy_level"
+          :placeholder="$t('chat.actionConfirmation.tiktok.privacyPlaceholder')"
+          :disabled="disabled"
+          class="tpf-select"
+          popper-class="tiktok-privacy-popper"
+        >
+          <el-option
+            v-for="opt in privacyOptions"
+            :key="opt"
+            :label="privacyLabel(opt)"
+            :value="opt"
+            :disabled="isPrivacyDisabled(opt)"
+          />
+        </el-select>
+        <div v-else class="tpf-empty-control">
+          {{ $t('chat.actionConfirmation.tiktok.noPrivacyOptions') }}
+        </div>
+        <p v-if="selfOnlyBlocked" class="tpf-hint is-warning">
+          {{ $t('chat.actionConfirmation.tiktok.brandedNotPrivate') }}
+        </p>
+      </div>
+    </section>
+
+    <section class="tpf-section">
+      <div class="tpf-section-heading">{{ $t('chat.actionConfirmation.tiktok.interactions') }}</div>
+      <p class="tpf-section-description">{{ $t('chat.actionConfirmation.tiktok.interactionsHint') }}</p>
       <div class="tpf-checks">
-        <el-checkbox v-model="form.allow_comment" :disabled="disabled || detail.comment_disabled">
+        <el-checkbox v-model="form.allow_comment" :disabled="disabled || metadataMissing || detail.comment_disabled">
           {{ $t('chat.actionConfirmation.tiktok.allowComment') }}
         </el-checkbox>
-        <!-- Duet and Stitch do not apply to photo posts. -->
         <template v-if="!detail.is_photo_post">
-          <el-checkbox v-model="form.allow_duet" :disabled="disabled || detail.duet_disabled">
+          <el-checkbox v-model="form.allow_duet" :disabled="disabled || metadataMissing || detail.duet_disabled">
             {{ $t('chat.actionConfirmation.tiktok.allowDuet') }}
           </el-checkbox>
-          <el-checkbox v-model="form.allow_stitch" :disabled="disabled || detail.stitch_disabled">
+          <el-checkbox v-model="form.allow_stitch" :disabled="disabled || metadataMissing || detail.stitch_disabled">
             {{ $t('chat.actionConfirmation.tiktok.allowStitch') }}
           </el-checkbox>
         </template>
       </div>
-    </div>
+      <p v-if="disabledInteractions" class="tpf-hint">
+        {{ $t('chat.actionConfirmation.tiktok.disabledByAccount', { list: disabledInteractions }) }}
+      </p>
+    </section>
 
-    <div class="tpf-field">
-      <el-checkbox v-model="form.commercial" :disabled="disabled">
+    <section class="tpf-section">
+      <div class="tpf-section-heading">{{ $t('chat.actionConfirmation.tiktok.disclosure') }}</div>
+      <el-checkbox v-model="form.commercial" :disabled="disabled || metadataMissing">
         {{ $t('chat.actionConfirmation.tiktok.commercial') }}
       </el-checkbox>
-      <div v-if="form.commercial" class="tpf-checks tpf-indent">
+      <p class="tpf-section-description">{{ $t('chat.actionConfirmation.tiktok.commercialHint') }}</p>
+      <div v-if="form.commercial" class="tpf-commercial-options">
         <el-checkbox v-model="form.brand_organic_toggle" :disabled="disabled">
-          {{ $t('chat.actionConfirmation.tiktok.yourBrand') }}
+          <span class="tpf-option-copy">
+            <strong>{{ $t('chat.actionConfirmation.tiktok.yourBrand') }}</strong>
+            <small>{{ $t('chat.actionConfirmation.tiktok.yourBrandHint') }}</small>
+          </span>
         </el-checkbox>
         <el-checkbox v-model="form.brand_content_toggle" :disabled="disabled || brandedContentBlocked">
-          {{ $t('chat.actionConfirmation.tiktok.brandedContent') }}
+          <span class="tpf-option-copy">
+            <strong>{{ $t('chat.actionConfirmation.tiktok.brandedContent') }}</strong>
+            <small>{{ $t('chat.actionConfirmation.tiktok.brandedContentHint') }}</small>
+          </span>
         </el-checkbox>
-        <p v-if="commercialLabel" class="tpf-hint">{{ commercialLabel }}</p>
-        <p v-if="brandedContentBlocked" class="tpf-hint">
+        <p v-if="commercialLabel" class="tpf-hint is-info">{{ commercialLabel }}</p>
+        <p v-if="brandedContentBlocked" class="tpf-hint is-warning">
           {{ $t('chat.actionConfirmation.tiktok.brandedNotPrivate') }}
         </p>
       </div>
-    </div>
+    </section>
 
-    <p class="tpf-declaration">{{ musicDeclaration }}</p>
+    <aside class="tpf-policy">
+      <div class="tpf-policy-icon" aria-hidden="true">✓</div>
+      <div>
+        <strong>{{ $t('chat.actionConfirmation.tiktok.beforePublishing') }}</strong>
+        <p>{{ policyIntro }}</p>
+        <div class="tpf-policy-links">
+          <a :href="musicUsageUrl" target="_blank" rel="noopener noreferrer">
+            {{ $t('chat.actionConfirmation.tiktok.musicUsageLink') }}
+          </a>
+          <a v-if="form.brand_content_toggle" :href="brandedContentUrl" target="_blank" rel="noopener noreferrer">
+            {{ $t('chat.actionConfirmation.tiktok.brandedPolicyLink') }}
+          </a>
+        </div>
+      </div>
+    </aside>
   </div>
 </template>
 
@@ -107,15 +156,9 @@ interface IForm {
 }
 
 const SELF_ONLY = 'SELF_ONLY';
+const MUSIC_USAGE_URL = 'https://www.tiktok.com/legal/page/global/music-usage-confirmation/en';
+const BRANDED_CONTENT_URL = 'https://www.tiktok.com/legal/page/global/bc-policy/en';
 
-/**
- * `kind === 'tiktok.publish'` body for `<ActionConfirmationCard>`.
- *
- * The constraints here are TikTok guideline requirements, not preferences:
- * privacy options come from `creator_info` with no default, interaction
- * toggles start unchecked and grey out when the creator disabled them, and
- * branded content cannot be combined with a private post.
- */
 export default defineComponent({
   name: 'TikTokPublishForm',
   components: { ElCheckbox, ElInput, ElOption, ElSelect },
@@ -124,22 +167,18 @@ export default defineComponent({
       type: Object as PropType<ITikTokPublishDetail>,
       required: true
     },
-    /** Suggested caption from the model; the user can edit it. */
     initialTitle: {
       type: String,
       default: ''
     },
-    /** Video length, checked against `max_video_post_duration_sec`. */
     durationSec: {
       type: Number,
       default: 0
     },
-    /** Resolved replay: freeze every control so history stays read-only. */
     disabled: {
       type: Boolean,
       default: false
     },
-    /** Values the user actually submitted, replayed from the tool output. */
     initialValues: {
       type: Object as PropType<ITikTokPublishValues | null>,
       default: null
@@ -163,17 +202,34 @@ export default defineComponent({
   },
   computed: {
     privacyOptions(): string[] {
-      return this.detail?.privacy_level_options ?? [];
+      return Array.isArray(this.detail?.privacy_level_options)
+        ? this.detail.privacy_level_options.filter((option): option is string => typeof option === 'string' && !!option)
+        : [];
+    },
+    hasPrivacyOptions(): boolean {
+      return this.privacyOptions.length > 0;
+    },
+    hasCreator(): boolean {
+      return typeof this.detail?.creator_nickname === 'string' && !!this.detail.creator_nickname.trim();
+    },
+    creatorName(): string {
+      return this.hasCreator
+        ? this.detail.creator_nickname
+        : (this.$t('chat.actionConfirmation.tiktok.unknownAccount') as string);
+    },
+    creatorInitial(): string {
+      return this.hasCreator ? this.detail.creator_nickname.trim().charAt(0).toUpperCase() : '?';
+    },
+    metadataMissing(): boolean {
+      return !this.hasCreator || !this.hasPrivacyOptions;
     },
     tooLong(): boolean {
       const max = this.detail?.max_video_post_duration_sec ?? 0;
       return max > 0 && this.durationSec > max;
     },
-    /** Branded content may not be private, so block it while SELF_ONLY. */
     brandedContentBlocked(): boolean {
       return this.form.privacy_level === SELF_ONLY;
     },
-    /** …and symmetrically, block SELF_ONLY once branded content is on. */
     selfOnlyBlocked(): boolean {
       return this.form.commercial && this.form.brand_content_toggle;
     },
@@ -186,20 +242,40 @@ export default defineComponent({
       }
       return '';
     },
-    /** Two strings only — "branded content" and "both" share one. */
-    musicDeclaration(): string {
-      const branded = this.form.commercial && this.form.brand_content_toggle;
-      const key = branded ? 'chat.actionConfirmation.tiktok.musicBranded' : 'chat.actionConfirmation.tiktok.music';
+    disabledInteractions(): string {
+      const labels: string[] = [];
+      if (this.detail?.comment_disabled) labels.push(this.$t('chat.actionConfirmation.tiktok.allowComment') as string);
+      if (!this.detail?.is_photo_post && this.detail?.duet_disabled) {
+        labels.push(this.$t('chat.actionConfirmation.tiktok.allowDuet') as string);
+      }
+      if (!this.detail?.is_photo_post && this.detail?.stitch_disabled) {
+        labels.push(this.$t('chat.actionConfirmation.tiktok.allowStitch') as string);
+      }
+      return labels.join('、');
+    },
+    policyIntro(): string {
+      const key = this.form.brand_content_toggle
+        ? 'chat.actionConfirmation.tiktok.policyIntroBranded'
+        : 'chat.actionConfirmation.tiktok.policyIntro';
       return this.$t(key) as string;
     },
-    isValid(): boolean {
-      if (!this.form.privacy_level) return false;
-      if (this.tooLong) return false;
-      // Disclosure on ⇒ at least one of the two must be picked.
+    musicUsageUrl(): string {
+      return MUSIC_USAGE_URL;
+    },
+    brandedContentUrl(): string {
+      return BRANDED_CONTENT_URL;
+    },
+    validationReason(): string {
+      if (this.metadataMissing) return this.$t('chat.actionConfirmation.tiktok.fixDetailsFirst') as string;
+      if (this.tooLong) return this.$t('chat.actionConfirmation.tiktok.useShorterVideo') as string;
+      if (!this.form.privacy_level) return this.$t('chat.actionConfirmation.tiktok.selectPrivacyFirst') as string;
       if (this.form.commercial && !this.form.brand_organic_toggle && !this.form.brand_content_toggle) {
-        return false;
+        return this.$t('chat.actionConfirmation.tiktok.selectDisclosureType') as string;
       }
-      return true;
+      return '';
+    },
+    isValid(): boolean {
+      return !this.validationReason;
     },
     values(): ITikTokPublishValues {
       return {
@@ -214,10 +290,10 @@ export default defineComponent({
     }
   },
   watch: {
-    isValid: {
+    validationReason: {
       immediate: true,
-      handler(valid: boolean) {
-        this.$emit('validity-change', valid);
+      handler(reason: string) {
+        this.$emit('validity-change', !reason, reason);
       }
     },
     'form.privacy_level'(level: string) {
@@ -241,11 +317,8 @@ export default defineComponent({
         FOLLOWER_OF_CREATOR: 'chat.actionConfirmation.tiktok.privacyFollowers',
         SELF_ONLY: 'chat.actionConfirmation.tiktok.privacySelf'
       };
-      // Unknown option: show the raw value rather than dropping it — the
-      // list must mirror what creator_info returned.
       return known[option] ? (this.$t(known[option]) as string) : option;
     },
-    /** Read by the parent card on confirm. */
     collect(): ITikTokPublishValues {
       return this.values;
     }
@@ -258,64 +331,246 @@ export default defineComponent({
   display: flex;
   flex-direction: column;
   gap: 12px;
+}
 
-  .tpf-account {
-    margin: 0;
+.tpf-account {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border: 1px solid var(--el-border-color-lighter);
+  border-radius: 12px;
+  background: var(--el-fill-color-extra-light);
+
+  &.is-missing {
+    border-color: var(--el-color-danger-light-5);
+  }
+}
+
+.tpf-avatar {
+  width: 34px;
+  height: 34px;
+  flex: 0 0 34px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.tpf-avatar-fallback {
+  display: grid;
+  place-items: center;
+  color: #fff;
+  font-weight: 700;
+  background: linear-gradient(135deg, #25f4ee, #111 48%, #fe2c55);
+}
+
+.tpf-account-copy {
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  flex-direction: column;
+
+  span {
+    color: var(--el-text-color-secondary);
+    font-size: 11px;
+  }
+
+  strong {
+    overflow: hidden;
+    color: var(--el-text-color-primary);
     font-size: 13px;
-    color: var(--el-text-color-regular);
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
+}
 
-  .tpf-error {
-    margin: 0;
+.tpf-connected {
+  color: var(--el-color-success);
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.tpf-blocking-error {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding: 10px 12px;
+  border: 1px solid var(--el-color-danger-light-5);
+  border-radius: 10px;
+  color: var(--el-color-danger);
+  font-size: 12px;
+  line-height: 1.45;
+  background: var(--el-color-danger-light-9);
+}
+
+.tpf-section {
+  padding: 12px;
+  border: 1px solid var(--el-border-color-lighter);
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--el-bg-color) 92%, var(--el-fill-color-light) 8%);
+}
+
+.tpf-section-heading {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 10px;
+  color: var(--el-text-color-primary);
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.tpf-required-note,
+.tpf-section-description {
+  color: var(--el-text-color-secondary);
+  font-size: 10px;
+  font-weight: 400;
+}
+
+.tpf-section-description {
+  margin: -5px 0 9px;
+  line-height: 1.45;
+}
+
+.tpf-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+
+  & + & {
+    margin-top: 11px;
+  }
+}
+
+.tpf-label {
+  color: var(--el-text-color-regular);
+  font-size: 11px;
+  font-weight: 500;
+}
+
+.tpf-required {
+  color: var(--el-color-danger);
+}
+
+.tpf-select {
+  width: 100%;
+  min-width: 0;
+}
+
+.tpf-empty-control {
+  padding: 10px 12px;
+  border: 1px dashed var(--el-color-danger-light-5);
+  border-radius: 8px;
+  color: var(--el-color-danger);
+  font-size: 12px;
+  background: var(--el-color-danger-light-9);
+}
+
+.tpf-checks {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 18px;
+}
+
+.tpf-commercial-options {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 8px;
+  padding: 10px;
+  border-radius: 9px;
+  background: var(--el-fill-color-light);
+}
+
+.tpf-option-copy {
+  display: inline-flex;
+  flex-direction: column;
+  vertical-align: middle;
+
+  strong {
+    color: var(--el-text-color-primary);
     font-size: 12px;
-    color: var(--el-color-danger);
+    font-weight: 550;
   }
 
-  .tpf-field {
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-    min-width: 0;
+  small {
+    color: var(--el-text-color-secondary);
+    font-size: 10px;
+  }
+}
+
+.tpf-hint {
+  margin: 5px 0 0;
+  color: var(--el-text-color-secondary);
+  font-size: 10px;
+  line-height: 1.4;
+
+  &.is-warning {
+    color: var(--el-color-warning-dark-2);
   }
 
-  .tpf-label {
+  &.is-info {
+    color: var(--el-color-primary);
+  }
+}
+
+.tpf-policy {
+  display: flex;
+  gap: 10px;
+  padding: 11px 12px;
+  border-radius: 12px;
+  color: var(--el-text-color-regular);
+  background: var(--el-color-info-light-9);
+
+  strong {
+    color: var(--el-text-color-primary);
     font-size: 12px;
-    color: var(--el-text-color-secondary);
   }
 
-  .tpf-required {
-    color: var(--el-color-danger);
+  p {
+    margin: 3px 0 6px;
+    font-size: 10px;
+    line-height: 1.5;
   }
+}
 
-  .tpf-select {
-    width: 100%;
-    min-width: 0;
-  }
+.tpf-policy-icon {
+  display: grid;
+  place-items: center;
+  width: 22px;
+  height: 22px;
+  flex: 0 0 22px;
+  border-radius: 50%;
+  color: #fff;
+  font-size: 11px;
+  font-weight: 700;
+  background: var(--el-color-primary);
+}
 
-  .tpf-checks {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 12px;
-  }
+.tpf-policy-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 12px;
 
-  .tpf-indent {
-    margin-top: 6px;
-    padding-left: 20px;
-    flex-direction: column;
-    gap: 6px;
-  }
+  a {
+    color: var(--el-color-primary);
+    font-size: 10px;
+    font-weight: 600;
+    text-decoration: none;
 
-  .tpf-hint {
-    margin: 0;
-    font-size: 11px;
-    color: var(--el-text-color-secondary);
+    &:hover {
+      text-decoration: underline;
+    }
   }
+}
 
-  .tpf-declaration {
-    margin: 0;
-    font-size: 11px;
-    line-height: 1.6;
-    color: var(--el-text-color-secondary);
-  }
+:deep(.el-textarea__inner),
+:deep(.el-select__wrapper) {
+  border-radius: 9px;
+}
+
+:deep(.el-checkbox) {
+  height: auto;
+  margin-right: 0;
 }
 </style>

--- a/src/i18n/ar/chat.json
+++ b/src/i18n/ar/chat.json
@@ -1370,9 +1370,57 @@
     "message": "تم الإلغاء",
     "description": "بطاقة تأكيد التنفيذ: رسالة الانهيار بعد إلغاء المستخدم"
   },
+  "actionConfirmation.mediaLoading": {
+    "message": "جارٍ تحميل معاينة الوسائط...",
+    "description": "تأكيد قبل التنفيذ: حالة تحميل الوسائط"
+  },
+  "actionConfirmation.mediaUnavailable": {
+    "message": "لا يمكن تشغيل المعاينة هنا",
+    "description": "تأكيد قبل التنفيذ: عنوان فشل تشغيل الوسائط"
+  },
+  "actionConfirmation.mediaUnavailableHint": {
+    "message": "قد تكون روابط الوسائط قد انتهت صلاحيتها، أو أن المتصفح الحالي لا يدعم هذا التنسيق. يرجى فتح الملف الأصلي للتأكيد قبل النشر.",
+    "description": "تأكيد قبل التنفيذ: وصف فشل تشغيل الوسائط"
+  },
+  "actionConfirmation.openMedia": {
+    "message": "فتح الملف الأصلي",
+    "description": "تأكيد قبل التنفيذ: فتح رابط الوسائط"
+  },
+  "actionConfirmation.tiktok.reviewBadge": {
+    "message": "تأكيد قبل النشر",
+    "description": "تأكيد نشر TikTok: علامة حالة بطاقة التأكيد"
+  },
   "actionConfirmation.tiktok.postingTo": {
     "message": "نشر إلى",
     "description": "تأكيد نشر TikTok: علامة الحساب"
+  },
+  "actionConfirmation.tiktok.connected": {
+    "message": "متصل",
+    "description": "تأكيد نشر TikTok: حالة اتصال الحساب"
+  },
+  "actionConfirmation.tiktok.unknownAccount": {
+    "message": "معلومات الحساب غير متاحة",
+    "description": "تأكيد نشر TikTok: نص موضع عند نقص اسم الحساب"
+  },
+  "actionConfirmation.tiktok.detailsUnavailable": {
+    "message": "إعدادات النشر غير جاهزة بعد",
+    "description": "تأكيد نشر TikTok: عنوان نقص معلومات المنشئ"
+  },
+  "actionConfirmation.tiktok.detailsUnavailableHint": {
+    "message": "فشل في قراءة نطاق الرؤية المدعوم من هذا الحساب. يرجى إلغاء الطلب والسماح للمساعد بإعادة الحصول على إعدادات نشر TikTok.",
+    "description": "تأكيد نشر TikTok: وصف نقص معلومات المنشئ"
+  },
+  "actionConfirmation.tiktok.videoTooLongTitle": {
+    "message": "مدة الفيديو لا تتوافق مع حد الحساب",
+    "description": "تأكيد نشر TikTok: عنوان الفيديو الطويل"
+  },
+  "actionConfirmation.tiktok.postDetails": {
+    "message": "محتوى النشر",
+    "description": "تأكيد نشر TikTok: عنوان مجموعة إعدادات المحتوى"
+  },
+  "actionConfirmation.tiktok.requiredNote": {
+    "message": "* مطلوب",
+    "description": "تأكيد نشر TikTok: وصف الحقول المطلوبة"
   },
   "actionConfirmation.tiktok.caption": {
     "message": "نص",
@@ -1389,6 +1437,10 @@
   "actionConfirmation.tiktok.privacyPlaceholder": {
     "message": "يرجى الاختيار…",
     "description": "تأكيد نشر TikTok: نص العنصر النائب للنطاق المرئي، لا يمكن أن يكون له قيمة افتراضية حسب متطلبات TikTok"
+  },
+  "actionConfirmation.tiktok.noPrivacyOptions": {
+    "message": "لم يتم الحصول على نطاق رؤية متاح، لا يمكن النشر حالياً",
+    "description": "تأكيد نشر TikTok: نطاق الرؤية فارغ"
   },
   "actionConfirmation.tiktok.privacyPublic": {
     "message": "الجميع",
@@ -1410,6 +1462,14 @@
     "message": "السماح بالتفاعلات",
     "description": "تأكيد نشر TikTok: علامة مجموعة زر التفاعل"
   },
+  "actionConfirmation.tiktok.interactionsHint": {
+    "message": "يمكن فقط تفعيل طرق التفاعل المسموح بها حالياً لهذا الحساب؛ بشكل افتراضي جميعها مغلقة.",
+    "description": "تأكيد نشر TikTok: وصف مفتاح التفاعل"
+  },
+  "actionConfirmation.tiktok.disabledByAccount": {
+    "message": "تم تعطيل هذا الحساب: {list}",
+    "description": "تأكيد نشر TikTok: قدرة التفاعل المعطلة للحساب"
+  },
   "actionConfirmation.tiktok.allowComment": {
     "message": "تعليق",
     "description": "زر التفاعل في TikTok: السماح بالتعليقات"
@@ -1422,17 +1482,33 @@
     "message": "تجميع",
     "description": "زر التفاعل في TikTok: السماح بالتجميع"
   },
+  "actionConfirmation.tiktok.disclosure": {
+    "message": "الإفصاح عن المحتوى",
+    "description": "تأكيد نشر TikTok: عنوان مجموعة المحتوى التجاري"
+  },
   "actionConfirmation.tiktok.commercial": {
     "message": "هذا محتوى تجاري",
     "description": "تأكيد نشر TikTok: زر الكشف عن المحتوى التجاري"
+  },
+  "actionConfirmation.tiktok.commercialHint": {
+    "message": "إذا كان المحتوى يروج لعلامة تجارية أو منتج أو خدمة، يرجى الإفصاح حسب الواقع.",
+    "description": "تأكيد نشر TikTok: وصف الإفصاح عن المحتوى التجاري"
   },
   "actionConfirmation.tiktok.yourBrand": {
     "message": "علامتك التجارية",
     "description": "محتوى تجاري على تيك توك: ترويج للأعمال الخاصة بك"
   },
+  "actionConfirmation.tiktok.yourBrandHint": {
+    "message": "قم بالترويج لنفسك أو للعمل الذي تديره",
+    "description": "محتوى تجاري على TikTok: توضيح لترويج الأعمال الخاصة"
+  },
   "actionConfirmation.tiktok.brandedContent": {
     "message": "محتوى العلامة التجارية",
     "description": "محتوى تجاري في TikTok: تعاون مدفوع"
+  },
+  "actionConfirmation.tiktok.brandedContentHint": {
+    "message": "الترويج لطرف ثالث مقابل الدفع أو الهدايا أو فوائد أخرى",
+    "description": "محتوى تجاري TikTok: شرح التعاون المدفوع"
   },
   "actionConfirmation.tiktok.labelPromotional": {
     "message": "سيتم وضع علامة على الفيديو كـ \"محتوى ترويجي\"",
@@ -1449,6 +1525,42 @@
   "actionConfirmation.tiktok.tooLong": {
     "message": "الفيديو يتجاوز الحد الأقصى للمدة لهذا الحساب ({max} ثانية)",
     "description": "تأكيد نشر TikTok: خطأ طول الفيديو الزائد"
+  },
+  "actionConfirmation.tiktok.beforePublishing": {
+    "message": "يرجى التأكيد قبل النشر",
+    "description": "تأكيد نشر TikTok: عنوان شرح السياسة"
+  },
+  "actionConfirmation.tiktok.policyIntro": {
+    "message": "بالنقر على \"نشر\"، فإنك تؤكد أنك تمتلك حقوق استخدام المحتوى والموسيقى، وتوافق على شروط استخدام الموسيقى الخاصة بـ TikTok.",
+    "description": "تأكيد نشر TikTok: شرح سياسة المحتوى العادي"
+  },
+  "actionConfirmation.tiktok.policyIntroBranded": {
+    "message": "بالنقر على \"نشر\"، فإنك تؤكد أن المعلومات التي تم الإفصاح عنها دقيقة، وتوافق على سياسة المحتوى العلامة التجارية وشروط استخدام الموسيقى الخاصة بـ TikTok.",
+    "description": "تأكيد نشر TikTok: شرح سياسة المحتوى العلامة التجارية"
+  },
+  "actionConfirmation.tiktok.musicUsageLink": {
+    "message": "عرض \"تأكيد استخدام الموسيقى\"",
+    "description": "تأكيد نشر TikTok: رابط تأكيد استخدام الموسيقى"
+  },
+  "actionConfirmation.tiktok.brandedPolicyLink": {
+    "message": "عرض \"سياسة المحتوى العلامة التجارية\"",
+    "description": "تأكيد نشر TikTok: رابط سياسة المحتوى العلامة التجارية"
+  },
+  "actionConfirmation.tiktok.fixDetailsFirst": {
+    "message": "معلومات النشر غير مكتملة، يرجى إلغاء الطلب وإعادة إنشاء بطاقة التأكيد",
+    "description": "تأكيد نشر TikTok: سبب تعطيل الزر عند نقص التفاصيل"
+  },
+  "actionConfirmation.tiktok.useShorterVideo": {
+    "message": "يرجى استخدام فيديو يتوافق مع حد الطول لهذا الحساب",
+    "description": "تأكيد نشر TikTok: سبب تعطيل الزر بسبب طول الفيديو الزائد"
+  },
+  "actionConfirmation.tiktok.selectPrivacyFirst": {
+    "message": "يرجى اختيار من يمكنه رؤية هذا الفيديو",
+    "description": "تأكيد نشر TikTok: سبب تعطيل الزر عند عدم اختيار نطاق الرؤية"
+  },
+  "actionConfirmation.tiktok.selectDisclosureType": {
+    "message": "يرجى اختيار نوع المحتوى التجاري",
+    "description": "تأكيد نشر TikTok: سبب تعطيل الزر عند عدم اختيار نوع الإفصاح التجاري"
   },
   "actionConfirmation.tiktok.music": {
     "message": "نشر يعني أنك توافق على \"تأكيد استخدام الموسيقى\" من TikTok",

--- a/src/i18n/de/chat.json
+++ b/src/i18n/de/chat.json
@@ -1370,9 +1370,57 @@
     "message": "Abgebrochen",
     "description": "Hinweis nach Abbruch der Aktion durch den Benutzer im Bestätigungsfeld"
   },
+  "actionConfirmation.mediaLoading": {
+    "message": "Lade Medienvorschau…",
+    "description": "Bestätigungs-Karte vor der Ausführung: Status des Medienladens"
+  },
+  "actionConfirmation.mediaUnavailable": {
+    "message": "Vorschau kann hier nicht abgespielt werden",
+    "description": "Bestätigungs-Karte vor der Ausführung: Titel für fehlgeschlagenes Medienabspielen"
+  },
+  "actionConfirmation.mediaUnavailableHint": {
+    "message": "Der Medienlink könnte abgelaufen sein oder der aktuelle Browser unterstützt dieses Format nicht. Bitte öffnen Sie die Originaldatei zur Bestätigung vor der Veröffentlichung.",
+    "description": "Bestätigungs-Karte vor der Ausführung: Erklärung für fehlgeschlagenes Medienabspielen"
+  },
+  "actionConfirmation.openMedia": {
+    "message": "Originaldatei öffnen",
+    "description": "Bestätigungs-Karte vor der Ausführung: Medienlink öffnen"
+  },
+  "actionConfirmation.tiktok.reviewBadge": {
+    "message": "Bestätigung vor der Veröffentlichung",
+    "description": "TikTok Veröffentlichungsbestätigung: Statuslabel der Karte"
+  },
   "actionConfirmation.tiktok.postingTo": {
     "message": "Veröffentlichen an",
     "description": "Bestätigungsfeld für TikTok: Kontolabel"
+  },
+  "actionConfirmation.tiktok.connected": {
+    "message": "Verbunden",
+    "description": "TikTok Veröffentlichungsbestätigung: Status der Kontoverbindung"
+  },
+  "actionConfirmation.tiktok.unknownAccount": {
+    "message": "Kontoinformationen nicht verfügbar",
+    "description": "TikTok Veröffentlichungsbestätigung: Platzhaltertext bei fehlendem Kontonamen"
+  },
+  "actionConfirmation.tiktok.detailsUnavailable": {
+    "message": "Veröffentlichungseinstellungen sind noch nicht bereit",
+    "description": "TikTok Veröffentlichungsbestätigung: Titel für fehlende Creator-Informationen"
+  },
+  "actionConfirmation.tiktok.detailsUnavailableHint": {
+    "message": "Die unterstützten Sichtbarkeitsbereiche des Kontos konnten nicht abgerufen werden. Bitte brechen Sie ab und lassen Sie den Assistenten die TikTok Veröffentlichungseinstellungen erneut abrufen.",
+    "description": "TikTok Veröffentlichungsbestätigung: Erklärung für fehlende Creator-Informationen"
+  },
+  "actionConfirmation.tiktok.videoTooLongTitle": {
+    "message": "Videolänge entspricht nicht den Kontobeschränkungen",
+    "description": "TikTok Veröffentlichungsbestätigung: Titel für zu langes Video"
+  },
+  "actionConfirmation.tiktok.postDetails": {
+    "message": "Veröffentlichungsinhalt",
+    "description": "TikTok Veröffentlichungsbestätigung: Titel für die Inhaltseinstellungen"
+  },
+  "actionConfirmation.tiktok.requiredNote": {
+    "message": "* Pflichtfeld",
+    "description": "TikTok Veröffentlichungsbestätigung: Erklärung für Pflichtfelder"
   },
   "actionConfirmation.tiktok.caption": {
     "message": "Bildunterschrift",
@@ -1389,6 +1437,10 @@
   "actionConfirmation.tiktok.privacyPlaceholder": {
     "message": "Bitte auswählen…",
     "description": "Bestätigungsfeld für TikTok: Platzhalter für Sichtbarkeit, darf laut TikTok keine Standardwerte haben"
+  },
+  "actionConfirmation.tiktok.noPrivacyOptions": {
+    "message": "Es konnten keine verfügbaren Sichtbarkeitsbereiche abgerufen werden, Veröffentlichung ist derzeit nicht möglich",
+    "description": "TikTok Veröffentlichungsbestätigung: Sichtbarkeitsbereich ist leer"
   },
   "actionConfirmation.tiktok.privacyPublic": {
     "message": "Alle",
@@ -1410,6 +1462,14 @@
     "message": "Interaktionen erlauben",
     "description": "Bestätigungsfeld für TikTok: Gruppierungslabel für Interaktionsschalter"
   },
+  "actionConfirmation.tiktok.interactionsHint": {
+    "message": "Nur die derzeit erlaubten Interaktionsmöglichkeiten dieses Kontos können aktiviert werden; standardmäßig sind alle deaktiviert.",
+    "description": "TikTok Veröffentlichungsbestätigung: Erklärung zu den Interaktionsschaltern"
+  },
+  "actionConfirmation.tiktok.disabledByAccount": {
+    "message": "Dieses Konto ist deaktiviert: {list}",
+    "description": "TikTok Veröffentlichungsbestätigung: Interaktionsfähigkeiten des deaktivierten Kontos"
+  },
   "actionConfirmation.tiktok.allowComment": {
     "message": "Kommentare",
     "description": "TikTok Interaktionsschalter: Kommentare erlauben"
@@ -1422,17 +1482,33 @@
     "message": "Zusammenfügen",
     "description": "TikTok Interaktionsschalter: Stitch erlauben"
   },
+  "actionConfirmation.tiktok.disclosure": {
+    "message": "Inhalte offenlegen",
+    "description": "TikTok Veröffentlichungsbestätigung: Titel für kommerzielle Inhalte"
+  },
   "actionConfirmation.tiktok.commercial": {
     "message": "Dies ist kommerzieller Inhalt",
     "description": "Bestätigungsfeld für TikTok: Offenlegungsschalter für kommerziellen Inhalt"
+  },
+  "actionConfirmation.tiktok.commercialHint": {
+    "message": "Bitte legen Sie offen, wenn Inhalte eine Marke, ein Produkt oder eine Dienstleistung fördern.",
+    "description": "TikTok Veröffentlichungsbestätigung: Erklärung zur Offenlegung kommerzieller Inhalte"
   },
   "actionConfirmation.tiktok.yourBrand": {
     "message": "Ihre Marke",
     "description": "TikTok Geschäftsinhalte: Förderung des eigenen Unternehmens"
   },
+  "actionConfirmation.tiktok.yourBrandHint": {
+    "message": "Bewerben Sie sich selbst oder Ihr Unternehmen",
+    "description": "TikTok Geschäftsinhalte: Erklärung zur Bewerbung des eigenen Unternehmens"
+  },
   "actionConfirmation.tiktok.brandedContent": {
     "message": "Markeninhalt",
     "description": "TikTok kommerzieller Inhalt: bezahlte Partnerschaft"
+  },
+  "actionConfirmation.tiktok.brandedContentHint": {
+    "message": "Förderung Dritter aufgrund von Zahlungen, Geschenken oder anderen Vorteilen",
+    "description": "TikTok kommerzielle Inhalte: Beschreibung für bezahlte Kooperation"
   },
   "actionConfirmation.tiktok.labelPromotional": {
     "message": "Video wird als „Werbeinhalte“ gekennzeichnet",
@@ -1449,6 +1525,42 @@
   "actionConfirmation.tiktok.tooLong": {
     "message": "Video überschreitet die maximale Dauer dieses Kontos ({max} Sekunden)",
     "description": "Bestätigungsfeld für TikTok: Fehler bei zu langem Video"
+  },
+  "actionConfirmation.tiktok.beforePublishing": {
+    "message": "Bitte bestätigen Sie vor der Veröffentlichung",
+    "description": "TikTok Veröffentlichungsbestätigung: Titel der Richtlinienbeschreibung"
+  },
+  "actionConfirmation.tiktok.policyIntro": {
+    "message": "Durch Klicken auf „Veröffentlichen“ bestätigen Sie, dass Sie die Nutzungsrechte an den Inhalten und der Musik besitzen und den Nutzungsbedingungen von TikTok zustimmen.",
+    "description": "TikTok Veröffentlichungsbestätigung: Erklärung zu den allgemeinen Inhaltsrichtlinien"
+  },
+  "actionConfirmation.tiktok.policyIntroBranded": {
+    "message": "Durch Klicken auf „Veröffentlichen“ bestätigen Sie, dass die Offenlegungsinformationen korrekt sind und Sie den Richtlinien für Markeninhalte und den Nutzungsbedingungen von TikTok zustimmen.",
+    "description": "TikTok Veröffentlichungsbestätigung: Erklärung zu den Richtlinien für Markeninhalte"
+  },
+  "actionConfirmation.tiktok.musicUsageLink": {
+    "message": "Musiknutzungsbestätigung ansehen",
+    "description": "TikTok Veröffentlichungsbestätigung: Link zur Musiknutzungsbestätigung"
+  },
+  "actionConfirmation.tiktok.brandedPolicyLink": {
+    "message": "Markeninhalt-Richtlinien ansehen",
+    "description": "TikTok Veröffentlichungsbestätigung: Link zu den Markeninhalt-Richtlinien"
+  },
+  "actionConfirmation.tiktok.fixDetailsFirst": {
+    "message": "Veröffentlichungsinformationen unvollständig, bitte abbrechen und die Bestätigungskarte neu generieren",
+    "description": "TikTok Veröffentlichungsbestätigung: Grund für die Deaktivierung des Buttons bei fehlenden Details"
+  },
+  "actionConfirmation.tiktok.useShorterVideo": {
+    "message": "Bitte verwenden Sie ein Video, das den Zeitbeschränkungen dieses Kontos entspricht",
+    "description": "TikTok Veröffentlichungsbestätigung: Grund für die Deaktivierung des Buttons bei zu langen Videos"
+  },
+  "actionConfirmation.tiktok.selectPrivacyFirst": {
+    "message": "Bitte wählen Sie, wer dieses Video sehen kann",
+    "description": "TikTok Veröffentlichungsbestätigung: Grund für die Deaktivierung des Buttons bei nicht ausgewähltem Sichtbarkeitsbereich"
+  },
+  "actionConfirmation.tiktok.selectDisclosureType": {
+    "message": "Bitte wählen Sie den Typ des kommerziellen Inhalts",
+    "description": "TikTok Veröffentlichungsbestätigung: Grund für die Deaktivierung des Buttons bei nicht ausgewähltem Offenlegungstyp"
   },
   "actionConfirmation.tiktok.music": {
     "message": "Mit der Veröffentlichung stimmen Sie der TikTok „Musiknutzungsbestätigung“ zu",

--- a/src/i18n/el/chat.json
+++ b/src/i18n/el/chat.json
@@ -926,7 +926,7 @@
   },
   "scheduledTasks.humanize.cronRaw": {
     "message": "Cron: {cron}",
-    "description": "Ανθρώπινα αναγνώσιμο: Αρχικό Cron"
+    "description": "Ανθρώπινα αναγνώσιμο: Ακατέργαστο Cron"
   },
   "scheduledTasks.humanize.once": {
     "message": "Μία φορά {time}",
@@ -1370,9 +1370,57 @@
     "message": "Έχει ακυρωθεί",
     "description": "Κάρτα επιβεβαίωσης πριν από την εκτέλεση: Υπόδειξη μετά την ακύρωση από τον χρήστη"
   },
+  "actionConfirmation.mediaLoading": {
+    "message": "Φορτώνει την προεπισκόπηση πολυμέσων…",
+    "description": "Επιβεβαίωση πριν από την εκτέλεση: κατάσταση φόρτωσης πολυμέσων"
+  },
+  "actionConfirmation.mediaUnavailable": {
+    "message": "Δεν είναι δυνατή η αναπαραγωγή προεπισκόπησης εδώ",
+    "description": "Επιβεβαίωση πριν από την εκτέλεση: τίτλος αποτυχίας αναπαραγωγής πολυμέσων"
+  },
+  "actionConfirmation.mediaUnavailableHint": {
+    "message": "Ο σύνδεσμος πολυμέσων μπορεί να έχει λήξει ή ο τρέχων περιηγητής δεν υποστηρίζει αυτή τη μορφή. Παρακαλώ ανοίξτε το αρχικό αρχείο πριν από την δημοσίευση.",
+    "description": "Επιβεβαίωση πριν από την εκτέλεση: περιγραφή αποτυχίας αναπαραγωγής πολυμέσων"
+  },
+  "actionConfirmation.openMedia": {
+    "message": "Άνοιγμα αρχικού αρχείου",
+    "description": "Επιβεβαίωση πριν από την εκτέλεση: άνοιγμα συνδέσμου πολυμέσων"
+  },
+  "actionConfirmation.tiktok.reviewBadge": {
+    "message": "Επιβεβαίωση πριν από την δημοσίευση",
+    "description": "Επιβεβαίωση δημοσίευσης TikTok: ετικέτα κατάστασης κάρτας"
+  },
   "actionConfirmation.tiktok.postingTo": {
     "message": "Δημοσίευση σε",
     "description": "Επιβεβαίωση δημοσίευσης TikTok: Ετικέτα λογαριασμού"
+  },
+  "actionConfirmation.tiktok.connected": {
+    "message": "Συνδεδεμένο",
+    "description": "Επιβεβαίωση δημοσίευσης TikTok: κατάσταση σύνδεσης λογαριασμού"
+  },
+  "actionConfirmation.tiktok.unknownAccount": {
+    "message": "Πληροφορίες λογαριασμού μη διαθέσιμες",
+    "description": "Επιβεβαίωση δημοσίευσης TikTok: κείμενο κράτησης θέσης όταν λείπει το ψευδώνυμο λογαριασμού"
+  },
+  "actionConfirmation.tiktok.detailsUnavailable": {
+    "message": "Οι ρυθμίσεις δημοσίευσης δεν είναι έτοιμες",
+    "description": "Επιβεβαίωση δημοσίευσης TikTok: τίτλος έλλειψης πληροφοριών δημιουργού"
+  },
+  "actionConfirmation.tiktok.detailsUnavailableHint": {
+    "message": "Δεν ήταν δυνατή η ανάγνωση της ορατότητας που υποστηρίζει αυτός ο λογαριασμός. Παρακαλώ ακυρώστε και αφήστε τον βοηθό να ανακτήσει ξανά τις ρυθμίσεις δημοσίευσης TikTok.",
+    "description": "Επιβεβαίωση δημοσίευσης TikTok: περιγραφή έλλειψης πληροφοριών δημιουργού"
+  },
+  "actionConfirmation.tiktok.videoTooLongTitle": {
+    "message": "Η διάρκεια του βίντεο δεν πληροί τους περιορισμούς του λογαριασμού",
+    "description": "Επιβεβαίωση δημοσίευσης TikTok: Τίτλος υπερβολικής διάρκειας βίντεο"
+  },
+  "actionConfirmation.tiktok.postDetails": {
+    "message": "Περιεχόμενο δημοσίευσης",
+    "description": "Επιβεβαίωση δημοσίευσης TikTok: τίτλος ομάδας ρυθμίσεων περιεχομένου"
+  },
+  "actionConfirmation.tiktok.requiredNote": {
+    "message": "* Υποχρεωτικό",
+    "description": "Επιβεβαίωση δημοσίευσης TikTok: περιγραφή υποχρεωτικών πεδίων"
   },
   "actionConfirmation.tiktok.caption": {
     "message": "Κείμενο",
@@ -1389,6 +1437,10 @@
   "actionConfirmation.tiktok.privacyPlaceholder": {
     "message": "Επιλέξτε…",
     "description": "Επιβεβαίωση δημοσίευσης TikTok: Θέση κράτησης για την ορατότητα, σύμφωνα με τις απαιτήσεις του TikTok δεν μπορεί να έχει προεπιλεγμένη τιμή"
+  },
+  "actionConfirmation.tiktok.noPrivacyOptions": {
+    "message": "Δεν ελήφθη διαθέσιμη ορατότητα, δεν μπορεί να δημοσιευθεί προς το παρόν",
+    "description": "Επιβεβαίωση δημοσίευσης TikTok: ορατότητα κενή"
   },
   "actionConfirmation.tiktok.privacyPublic": {
     "message": "Όλοι",
@@ -1410,6 +1462,14 @@
     "message": "Επιτρέπεται η αλληλεπίδραση",
     "description": "Επιβεβαίωση δημοσίευσης TikTok: Ετικέτα ομάδας διακόπτη αλληλεπίδρασης"
   },
+  "actionConfirmation.tiktok.interactionsHint": {
+    "message": "Μπορείτε να ενεργοποιήσετε μόνο τους τρέχοντες επιτρεπόμενους τρόπους αλληλεπίδρασης αυτού του λογαριασμού; προεπιλογή όλα κλειστά.",
+    "description": "Επιβεβαίωση δημοσίευσης TikTok: περιγραφή διακόπτη αλληλεπίδρασης"
+  },
+  "actionConfirmation.tiktok.disabledByAccount": {
+    "message": "Αυτός ο λογαριασμός έχει απενεργοποιηθεί: {list}",
+    "description": "Επιβεβαίωση δημοσίευσης TikTok: αλληλεπιδραστικές δυνατότητες απενεργοποιημένες"
+  },
   "actionConfirmation.tiktok.allowComment": {
     "message": "Σχόλια",
     "description": "Διακόπτης αλληλεπίδρασης TikTok: Επιτρέπεται η σχόλια"
@@ -1422,17 +1482,33 @@
     "message": "Ράψιμο",
     "description": "Διακόπτης αλληλεπίδρασης TikTok: Επιτρέπεται το ράψιμο"
   },
+  "actionConfirmation.tiktok.disclosure": {
+    "message": "Αποκάλυψη περιεχομένου",
+    "description": "Επιβεβαίωση δημοσίευσης TikTok: τίτλος ομάδας εμπορικού περιεχομένου"
+  },
   "actionConfirmation.tiktok.commercial": {
     "message": "Αυτό είναι εμπορικό περιεχόμενο",
     "description": "Επιβεβαίωση δημοσίευσης TikTok: Διακόπτης αποκάλυψης εμπορικού περιεχομένου"
+  },
+  "actionConfirmation.tiktok.commercialHint": {
+    "message": "Εάν το περιεχόμενο προωθεί μια μάρκα, προϊόν ή υπηρεσία, παρακαλώ αποκαλύψτε την πραγματική κατάσταση.",
+    "description": "Επιβεβαίωση δημοσίευσης TikTok: περιγραφή αποκάλυψης εμπορικού περιεχομένου"
   },
   "actionConfirmation.tiktok.yourBrand": {
     "message": "Η μάρκα σας",
     "description": "Περιεχόμενο TikTok για επιχειρήσεις: Προώθηση της δικής σας επιχείρησης"
   },
+  "actionConfirmation.tiktok.yourBrandHint": {
+    "message": "Προωθήστε τον εαυτό σας ή την επιχείρησή σας",
+    "description": "Εμπορικό περιεχόμενο TikTok: Περιγραφή προώθησης της δικής σας επιχείρησης"
+  },
   "actionConfirmation.tiktok.brandedContent": {
     "message": "Περιεχόμενο μάρκας",
     "description": "Εμπορικό περιεχόμενο TikTok: Πληρωμένη συνεργασία"
+  },
+  "actionConfirmation.tiktok.brandedContentHint": {
+    "message": "Προώθηση τρίτου μέρους λόγω πληρωμής, δώρων ή άλλων ωφελημάτων",
+    "description": "Εμπορικό περιεχόμενο TikTok: περιγραφή πληρωμένης συνεργασίας"
   },
   "actionConfirmation.tiktok.labelPromotional": {
     "message": "Το βίντεο θα επισημανθεί ως «προωθητικό περιεχόμενο»",
@@ -1449,6 +1525,42 @@
   "actionConfirmation.tiktok.tooLong": {
     "message": "Το βίντεο υπερβαίνει το όριο διάρκειας αυτού του λογαριασμού ({max} δευτερόλεπτα)",
     "description": "Επιβεβαίωση δημοσίευσης TikTok: Σφάλμα υπερβολικής διάρκειας βίντεο"
+  },
+  "actionConfirmation.tiktok.beforePublishing": {
+    "message": "Παρακαλώ επιβεβαιώστε πριν από την δημοσίευση",
+    "description": "Επιβεβαίωση δημοσίευσης TikTok: τίτλος πολιτικής"
+  },
+  "actionConfirmation.tiktok.policyIntro": {
+    "message": "Κάνοντας κλικ στο «Δημοσίευση» επιβεβαιώνετε ότι έχετε τα δικαιώματα χρήσης του περιεχομένου και της μουσικής και συμφωνείτε με τους όρους χρήσης μουσικής του TikTok.",
+    "description": "Επιβεβαίωση δημοσίευσης TikTok: περιγραφή πολιτικής κανονικού περιεχομένου"
+  },
+  "actionConfirmation.tiktok.policyIntroBranded": {
+    "message": "Κάνοντας κλικ στο «Δημοσίευση» επιβεβαιώνετε ότι οι πληροφορίες αποκάλυψης είναι ακριβείς και συμφωνείτε με την πολιτική εμπορικού περιεχομένου και τους όρους χρήσης μουσικής του TikTok.",
+    "description": "Επιβεβαίωση δημοσίευσης TikTok: περιγραφή πολιτικής εμπορικού περιεχομένου"
+  },
+  "actionConfirmation.tiktok.musicUsageLink": {
+    "message": "Δείτε την «Επιβεβαίωση Χρήσης Μουσικής»",
+    "description": "Επιβεβαίωση δημοσίευσης TikTok: σύνδεσμος επιβεβαίωσης χρήσης μουσικής"
+  },
+  "actionConfirmation.tiktok.brandedPolicyLink": {
+    "message": "Δείτε την «Πολιτική Εμπορικού Περιεχομένου»",
+    "description": "Επιβεβαίωση δημοσίευσης TikTok: σύνδεσμος πολιτικής εμπορικού περιεχομένου"
+  },
+  "actionConfirmation.tiktok.fixDetailsFirst": {
+    "message": "Οι πληροφορίες δημοσίευσης είναι ελλιπείς, παρακαλώ ακυρώστε και ξαναδημιουργήστε την κάρτα επιβεβαίωσης",
+    "description": "Επιβεβαίωση δημοσίευσης TikTok: λόγος απενεργοποίησης κουμπιού λόγω έλλειψης λεπτομερειών"
+  },
+  "actionConfirmation.tiktok.useShorterVideo": {
+    "message": "Παρακαλώ χρησιμοποιήστε ένα βίντεο που να πληροί τους περιορισμούς διάρκειας αυτού του λογαριασμού",
+    "description": "Επιβεβαίωση δημοσίευσης TikTok: Λόγος απενεργοποίησης κουμπιού λόγω υπερβολικής διάρκειας βίντεο"
+  },
+  "actionConfirmation.tiktok.selectPrivacyFirst": {
+    "message": "Παρακαλώ επιλέξτε ποιος μπορεί να δει αυτό το βίντεο",
+    "description": "Επιβεβαίωση δημοσίευσης TikTok: λόγος απενεργοποίησης κουμπιού λόγω μη επιλογής ορατότητας"
+  },
+  "actionConfirmation.tiktok.selectDisclosureType": {
+    "message": "Παρακαλώ επιλέξτε τύπο εμπορικής αποκάλυψης",
+    "description": "Επιβεβαίωση δημοσίευσης TikTok: λόγος απενεργοποίησης κουμπιού λόγω μη επιλογής τύπου αποκάλυψης"
   },
   "actionConfirmation.tiktok.music": {
     "message": "Η δημοσίευση σημαίνει ότι συμφωνείτε με την «Επιβεβαίωση Χρήσης Μουσικής» του TikTok",

--- a/src/i18n/en/chat.json
+++ b/src/i18n/en/chat.json
@@ -1296,9 +1296,57 @@
     "message": "Cancelled",
     "description": "Collapsed banner after the user cancels the action"
   },
+  "actionConfirmation.mediaLoading": {
+    "message": "Loading media preview…",
+    "description": "Media loading state on the action confirmation card"
+  },
+  "actionConfirmation.mediaUnavailable": {
+    "message": "Preview cannot play here",
+    "description": "Media playback failure title on the action confirmation card"
+  },
+  "actionConfirmation.mediaUnavailableHint": {
+    "message": "The media link may have expired, or this browser may not support its format. Open the original before publishing.",
+    "description": "Media playback failure explanation on the action confirmation card"
+  },
+  "actionConfirmation.openMedia": {
+    "message": "Open original",
+    "description": "Link to open confirmation media"
+  },
+  "actionConfirmation.tiktok.reviewBadge": {
+    "message": "Review before posting",
+    "description": "TikTok confirmation card status badge"
+  },
   "actionConfirmation.tiktok.postingTo": {
-    "message": "Posting to",
+    "message": "Posting to this account",
     "description": "TikTok publish confirmation: account label"
+  },
+  "actionConfirmation.tiktok.connected": {
+    "message": "Connected",
+    "description": "TikTok publish confirmation: account connection status"
+  },
+  "actionConfirmation.tiktok.unknownAccount": {
+    "message": "Account unavailable",
+    "description": "TikTok publish confirmation: missing account placeholder"
+  },
+  "actionConfirmation.tiktok.detailsUnavailable": {
+    "message": "Publishing settings are not ready",
+    "description": "TikTok publish confirmation: missing creator details title"
+  },
+  "actionConfirmation.tiktok.detailsUnavailableHint": {
+    "message": "The available visibility settings could not be read. Cancel and ask the assistant to reload your TikTok publishing settings.",
+    "description": "TikTok publish confirmation: missing creator details explanation"
+  },
+  "actionConfirmation.tiktok.videoTooLongTitle": {
+    "message": "This video exceeds the account limit",
+    "description": "TikTok publish confirmation: video duration error title"
+  },
+  "actionConfirmation.tiktok.postDetails": {
+    "message": "Post details",
+    "description": "TikTok publish confirmation: post settings section title"
+  },
+  "actionConfirmation.tiktok.requiredNote": {
+    "message": "* Required",
+    "description": "TikTok publish confirmation: required fields note"
   },
   "actionConfirmation.tiktok.caption": {
     "message": "Caption",
@@ -1313,8 +1361,12 @@
     "description": "TikTok publish confirmation: privacy dropdown label"
   },
   "actionConfirmation.tiktok.privacyPlaceholder": {
-    "message": "Select…",
+    "message": "Select who can view",
     "description": "TikTok publish confirmation: privacy placeholder; TikTok forbids a default value"
+  },
+  "actionConfirmation.tiktok.noPrivacyOptions": {
+    "message": "No visibility options were returned, so this post cannot be published yet",
+    "description": "TikTok publish confirmation: privacy options missing"
   },
   "actionConfirmation.tiktok.privacyPublic": {
     "message": "Everyone",
@@ -1333,8 +1385,16 @@
     "description": "TikTok privacy level: self only"
   },
   "actionConfirmation.tiktok.interactions": {
-    "message": "Allow interactions",
+    "message": "Interaction permissions",
     "description": "TikTok publish confirmation: interaction toggles group label"
+  },
+  "actionConfirmation.tiktok.interactionsHint": {
+    "message": "Only interactions currently available on this account can be enabled. All start off.",
+    "description": "TikTok publish confirmation: interaction settings explanation"
+  },
+  "actionConfirmation.tiktok.disabledByAccount": {
+    "message": "Disabled by this account: {list}",
+    "description": "TikTok publish confirmation: interactions disabled by the account"
   },
   "actionConfirmation.tiktok.allowComment": {
     "message": "Comment",
@@ -1348,17 +1408,33 @@
     "message": "Stitch",
     "description": "TikTok interaction toggle: allow stitch"
   },
+  "actionConfirmation.tiktok.disclosure": {
+    "message": "Content disclosure",
+    "description": "TikTok publish confirmation: commercial disclosure section title"
+  },
   "actionConfirmation.tiktok.commercial": {
     "message": "This is commercial content",
     "description": "TikTok publish confirmation: commercial disclosure toggle"
   },
+  "actionConfirmation.tiktok.commercialHint": {
+    "message": "Disclose content that promotes a brand, product, or service.",
+    "description": "TikTok publish confirmation: commercial disclosure explanation"
+  },
   "actionConfirmation.tiktok.yourBrand": {
-    "message": "Your brand",
+    "message": "Promoting your own brand",
     "description": "TikTok commercial content: promoting own business"
+  },
+  "actionConfirmation.tiktok.yourBrandHint": {
+    "message": "Promotes you or a business you operate",
+    "description": "TikTok commercial content: own brand explanation"
   },
   "actionConfirmation.tiktok.brandedContent": {
     "message": "Branded content",
     "description": "TikTok commercial content: paid partnership"
+  },
+  "actionConfirmation.tiktok.brandedContentHint": {
+    "message": "Promotes a third party in exchange for payment, gifts, or another incentive",
+    "description": "TikTok commercial content: paid partnership explanation"
   },
   "actionConfirmation.tiktok.labelPromotional": {
     "message": "Your video will be labeled as 'Promotional content'",
@@ -1376,12 +1452,40 @@
     "message": "This video exceeds the account limit of {max} seconds",
     "description": "TikTok publish confirmation: video too long error"
   },
-  "actionConfirmation.tiktok.music": {
-    "message": "By posting, you agree to TikTok's Music Usage Confirmation",
-    "description": "TikTok publish confirmation: music usage declaration"
+  "actionConfirmation.tiktok.beforePublishing": {
+    "message": "Before you publish",
+    "description": "TikTok publish confirmation: policy notice title"
   },
-  "actionConfirmation.tiktok.musicBranded": {
-    "message": "By posting, you agree to TikTok's Branded Content Policy and Music Usage Confirmation",
-    "description": "TikTok publish confirmation: declaration when branded content is checked"
+  "actionConfirmation.tiktok.policyIntro": {
+    "message": "By clicking Publish, you confirm that you have the rights to the content and music and agree to TikTok's music terms.",
+    "description": "TikTok publish confirmation: standard policy notice"
+  },
+  "actionConfirmation.tiktok.policyIntroBranded": {
+    "message": "By clicking Publish, you confirm that the disclosure is accurate and agree to TikTok's branded content and music terms.",
+    "description": "TikTok publish confirmation: branded policy notice"
+  },
+  "actionConfirmation.tiktok.musicUsageLink": {
+    "message": "Read Music Usage Confirmation",
+    "description": "TikTok publish confirmation: music usage link"
+  },
+  "actionConfirmation.tiktok.brandedPolicyLink": {
+    "message": "Read Branded Content Policy",
+    "description": "TikTok publish confirmation: branded content policy link"
+  },
+  "actionConfirmation.tiktok.fixDetailsFirst": {
+    "message": "Publishing details are incomplete — cancel and regenerate this confirmation",
+    "description": "TikTok publish confirmation: disabled button reason for missing details"
+  },
+  "actionConfirmation.tiktok.useShorterVideo": {
+    "message": "Choose a video within this account's duration limit",
+    "description": "TikTok publish confirmation: disabled button reason for long video"
+  },
+  "actionConfirmation.tiktok.selectPrivacyFirst": {
+    "message": "Choose who can view this video",
+    "description": "TikTok publish confirmation: disabled button reason for missing privacy"
+  },
+  "actionConfirmation.tiktok.selectDisclosureType": {
+    "message": "Choose a commercial content type",
+    "description": "TikTok publish confirmation: disabled button reason for missing disclosure type"
   }
 }

--- a/src/i18n/es/chat.json
+++ b/src/i18n/es/chat.json
@@ -814,7 +814,7 @@
   },
   "scheduledTasks.run.reason.error": {
     "message": "Error",
-    "description": "Error al ejecutar"
+    "description": "Se produjo un error durante la ejecución"
   },
   "scheduledTasks.run.reason.unknown": {
     "message": "Error desconocido"
@@ -927,7 +927,7 @@
   },
   "scheduledTasks.humanize.cronRaw": {
     "message": "Cron: {cron}",
-    "description": "Legible por humanos: Cron original"
+    "description": "Legible para humanos: Cron original"
   },
   "scheduledTasks.humanize.once": {
     "message": "Una vez a las {time}",
@@ -1371,9 +1371,57 @@
     "message": "Cancelado",
     "description": "Tarjeta de confirmación antes de ejecutar: mensaje colapsado después de que el usuario cancela"
   },
+  "actionConfirmation.mediaLoading": {
+    "message": "Cargando vista previa del medio...",
+    "description": "Confirmación previa a la acción: estado de carga del medio"
+  },
+  "actionConfirmation.mediaUnavailable": {
+    "message": "No se puede reproducir la vista previa aquí",
+    "description": "Confirmación previa a la acción: título de fallo en la reproducción del medio"
+  },
+  "actionConfirmation.mediaUnavailableHint": {
+    "message": "El enlace del medio puede haber expirado, o el navegador actual no soporta este formato. Por favor, abre el archivo original para confirmarlo antes de publicar.",
+    "description": "Confirmación previa a la acción: explicación del fallo en la reproducción del medio"
+  },
+  "actionConfirmation.openMedia": {
+    "message": "Abrir archivo original",
+    "description": "Confirmación previa a la acción: abrir enlace del medio"
+  },
+  "actionConfirmation.tiktok.reviewBadge": {
+    "message": "Confirmar antes de publicar",
+    "description": "Etiqueta de estado de tarjeta de confirmación de TikTok"
+  },
   "actionConfirmation.tiktok.postingTo": {
     "message": "Publicar en",
     "description": "Confirmación de publicación de TikTok: etiqueta de cuenta"
+  },
+  "actionConfirmation.tiktok.connected": {
+    "message": "Conectado",
+    "description": "Confirmación de publicación de TikTok: estado de conexión de la cuenta"
+  },
+  "actionConfirmation.tiktok.unknownAccount": {
+    "message": "Información de la cuenta no disponible",
+    "description": "Confirmación de publicación de TikTok: texto de marcador de posición cuando falta el apodo de la cuenta"
+  },
+  "actionConfirmation.tiktok.detailsUnavailable": {
+    "message": "La configuración de publicación no está lista",
+    "description": "Confirmación de publicación de TikTok: título de falta de información del creador"
+  },
+  "actionConfirmation.tiktok.detailsUnavailableHint": {
+    "message": "No se pudo leer el alcance visible soportado por esta cuenta. Por favor, cancela y permite que el asistente vuelva a obtener la configuración de publicación de TikTok.",
+    "description": "Confirmación de publicación de TikTok: explicación de falta de información del creador"
+  },
+  "actionConfirmation.tiktok.videoTooLongTitle": {
+    "message": "La duración del video no cumple con el límite de la cuenta",
+    "description": "Confirmación de publicación en TikTok: título para video demasiado largo"
+  },
+  "actionConfirmation.tiktok.postDetails": {
+    "message": "Contenido de publicación",
+    "description": "Confirmación de publicación de TikTok: título de grupo de configuración de contenido"
+  },
+  "actionConfirmation.tiktok.requiredNote": {
+    "message": "* Requerido",
+    "description": "Confirmación de publicación de TikTok: explicación de campos obligatorios"
   },
   "actionConfirmation.tiktok.caption": {
     "message": "Texto",
@@ -1390,6 +1438,10 @@
   "actionConfirmation.tiktok.privacyPlaceholder": {
     "message": "Por favor selecciona…",
     "description": "Confirmación de publicación de TikTok: marcador de posición de visibilidad, no puede tener un valor predeterminado según los requisitos de TikTok"
+  },
+  "actionConfirmation.tiktok.noPrivacyOptions": {
+    "message": "No se obtuvo un alcance visible disponible, no se puede publicar por el momento",
+    "description": "Confirmación de publicación de TikTok: alcance visible vacío"
   },
   "actionConfirmation.tiktok.privacyPublic": {
     "message": "Todos",
@@ -1411,6 +1463,14 @@
     "message": "Permitir interacciones",
     "description": "Confirmación de publicación de TikTok: etiqueta de grupo para el interruptor de interacciones"
   },
+  "actionConfirmation.tiktok.interactionsHint": {
+    "message": "Solo se pueden activar los métodos de interacción actualmente permitidos por esta cuenta; por defecto, todos están desactivados.",
+    "description": "Confirmación de publicación de TikTok: explicación del interruptor de interacción"
+  },
+  "actionConfirmation.tiktok.disabledByAccount": {
+    "message": "Esta cuenta ha sido desactivada: {list}",
+    "description": "Confirmación de publicación de TikTok: capacidades de interacción deshabilitadas de la cuenta"
+  },
   "actionConfirmation.tiktok.allowComment": {
     "message": "Comentarios",
     "description": "Interruptor de interacción de TikTok: permite comentarios"
@@ -1423,17 +1483,33 @@
     "message": "Combinar",
     "description": "Interruptor de interacción de TikTok: permite stitching"
   },
+  "actionConfirmation.tiktok.disclosure": {
+    "message": "Divulgación de contenido",
+    "description": "Confirmación de publicación de TikTok: título de grupo de contenido comercial"
+  },
   "actionConfirmation.tiktok.commercial": {
     "message": "Este es contenido comercial",
     "description": "Confirmación de publicación de TikTok: interruptor de divulgación de contenido comercial"
+  },
+  "actionConfirmation.tiktok.commercialHint": {
+    "message": "Si el contenido promociona una marca, producto o servicio, por favor, divulga según corresponda.",
+    "description": "Confirmación de publicación de TikTok: explicación de divulgación de contenido comercial"
   },
   "actionConfirmation.tiktok.yourBrand": {
     "message": "tu marca",
     "description": "Contenido comercial de TikTok: promociona tu propio negocio"
   },
+  "actionConfirmation.tiktok.yourBrandHint": {
+    "message": "Promocione su propio negocio o el que usted gestiona",
+    "description": "Contenido comercial de TikTok: explicación sobre la promoción de negocios propios"
+  },
   "actionConfirmation.tiktok.brandedContent": {
     "message": "Contenido de marca",
     "description": "Contenido comercial de TikTok: colaboración pagada"
+  },
+  "actionConfirmation.tiktok.brandedContentHint": {
+    "message": "Promocionar a terceros por pago, regalos u otros beneficios",
+    "description": "Contenido comercial de TikTok: explicación de colaboraciones pagadas"
   },
   "actionConfirmation.tiktok.labelPromotional": {
     "message": "El video será etiquetado como 'contenido promocional'",
@@ -1450,6 +1526,42 @@
   "actionConfirmation.tiktok.tooLong": {
     "message": "El video excede el límite de duración de esta cuenta ({max} segundos)",
     "description": "Confirmación de publicación de TikTok: error de duración excesiva del video"
+  },
+  "actionConfirmation.tiktok.beforePublishing": {
+    "message": "Por favor, confirma antes de publicar",
+    "description": "Confirmación de publicación de TikTok: título de explicación de políticas"
+  },
+  "actionConfirmation.tiktok.policyIntro": {
+    "message": "Al hacer clic en 'Publicar', confirmas que tienes derechos sobre el contenido y la música, y aceptas los términos de uso de música de TikTok.",
+    "description": "Confirmación de publicación de TikTok: explicación de políticas de contenido general"
+  },
+  "actionConfirmation.tiktok.policyIntroBranded": {
+    "message": "Al hacer clic en 'Publicar', confirmas que la información de divulgación es precisa y aceptas las políticas de contenido de marca y los términos de uso de música de TikTok.",
+    "description": "Confirmación de publicación de TikTok: explicación de políticas de contenido de marca"
+  },
+  "actionConfirmation.tiktok.musicUsageLink": {
+    "message": "Ver Confirmación de Uso de Música",
+    "description": "Confirmación de publicación de TikTok: enlace a la confirmación de uso de música"
+  },
+  "actionConfirmation.tiktok.brandedPolicyLink": {
+    "message": "Ver Política de Contenido de Marca",
+    "description": "Confirmación de publicación de TikTok: enlace a la política de contenido de marca"
+  },
+  "actionConfirmation.tiktok.fixDetailsFirst": {
+    "message": "La información de publicación está incompleta, por favor cancela y vuelve a generar la tarjeta de confirmación",
+    "description": "Confirmación de publicación de TikTok: razón para deshabilitar el botón cuando faltan detalles"
+  },
+  "actionConfirmation.tiktok.useShorterVideo": {
+    "message": "Por favor, use un video que cumpla con la duración permitida para esta cuenta",
+    "description": "Confirmación de publicación en TikTok: razón por la que el botón está deshabilitado debido a que el video es demasiado largo"
+  },
+  "actionConfirmation.tiktok.selectPrivacyFirst": {
+    "message": "Por favor, selecciona quién puede ver este video",
+    "description": "Confirmación de publicación de TikTok: razón para deshabilitar el botón cuando no se selecciona el alcance visible"
+  },
+  "actionConfirmation.tiktok.selectDisclosureType": {
+    "message": "Por favor, selecciona el tipo de contenido comercial",
+    "description": "Confirmación de publicación de TikTok: razón para deshabilitar el botón cuando no se selecciona el tipo de divulgación comercial"
   },
   "actionConfirmation.tiktok.music": {
     "message": "Publicar significa que aceptas el 'Acuerdo de uso de música' de TikTok",

--- a/src/i18n/fi/chat.json
+++ b/src/i18n/fi/chat.json
@@ -898,7 +898,7 @@
   },
   "scheduledTasks.humanize.cronRaw": {
     "message": "Cron: {cron}",
-    "description": "Ihmisten luettavissa oleva muoto: alkuperäinen Cron"
+    "description": "Ihmisluettava: alkuperäinen Cron"
   },
   "scheduledTasks.humanize.once": {
     "message": "kerran klo {time}",
@@ -1086,7 +1086,7 @@
   },
   "artifacts.kind.video": {
     "message": "Video",
-    "description": "Tuotetyyppi - video"
+    "description": "Tuotetyyppi – video"
   },
   "artifacts.kind.audio": {
     "message": "Ääni",
@@ -1331,9 +1331,57 @@
     "message": "Peruttu",
     "description": "Vahvistuskortti: käyttäjän peruutuksen jälkeen näkyvä viesti"
   },
+  "actionConfirmation.mediaLoading": {
+    "message": "Ladataan mediasisältöä…",
+    "description": "Vahvistuskortti ennen toimintoa: median lataustila"
+  },
+  "actionConfirmation.mediaUnavailable": {
+    "message": "Esikatselua ei voi toistaa täällä",
+    "description": "Vahvistuskortti ennen toimintoa: median toistamisen epäonnistumisen otsikko"
+  },
+  "actionConfirmation.mediaUnavailableHint": {
+    "message": "Median linkki saattaa olla vanhentunut tai nykyinen selain ei tue tätä formaattia. Tarkista alkuperäinen tiedosto ennen julkaisua.",
+    "description": "Vahvistuskortti ennen toimintoa: median toistamisen epäonnistumisen selitys"
+  },
+  "actionConfirmation.openMedia": {
+    "message": "Avaa alkuperäinen tiedosto",
+    "description": "Vahvistuskortti ennen toimintoa: avaa median linkki"
+  },
+  "actionConfirmation.tiktok.reviewBadge": {
+    "message": "Vahvista ennen julkaisua",
+    "description": "TikTok julkaisuvahvistuskortin tila"
+  },
   "actionConfirmation.tiktok.postingTo": {
     "message": "Julkaise",
     "description": "TikTok julkaisu vahvistus: tilin etiketti"
+  },
+  "actionConfirmation.tiktok.connected": {
+    "message": "Yhdistetty",
+    "description": "TikTok julkaisuvahvistus: tilin yhdistämisen tila"
+  },
+  "actionConfirmation.tiktok.unknownAccount": {
+    "message": "Tilin tiedot eivät ole saatavilla",
+    "description": "TikTok julkaisuvahvistus: paikkamerkki, kun tilin lempinimi puuttuu"
+  },
+  "actionConfirmation.tiktok.detailsUnavailable": {
+    "message": "Julkaisun asetukset eivät ole valmiit",
+    "description": "TikTok julkaisuvahvistus: luojan tietojen puuttumisen otsikko"
+  },
+  "actionConfirmation.tiktok.detailsUnavailableHint": {
+    "message": "Tilin tukemaa näkyvyyttä ei voitu lukea. Peruuta ja anna avustajan hankkia TikTok julkaisuasetukset uudelleen.",
+    "description": "TikTok julkaisuvahvistus: luojan tietojen puuttumisen selitys"
+  },
+  "actionConfirmation.tiktok.videoTooLongTitle": {
+    "message": "Videon pituus ei täytä tilin rajoituksia",
+    "description": "TikTok-julkaisun vahvistuksen otsikko: video on liian pitkä"
+  },
+  "actionConfirmation.tiktok.postDetails": {
+    "message": "Julkaisusisältö",
+    "description": "TikTok julkaisuvahvistus: sisällön asetusten ryhmittelyotsikko"
+  },
+  "actionConfirmation.tiktok.requiredNote": {
+    "message": "* Pakollinen",
+    "description": "TikTok julkaisuvahvistus: pakollisten kenttien selitys"
   },
   "actionConfirmation.tiktok.caption": {
     "message": "Kuvateksti",
@@ -1350,6 +1398,10 @@
   "actionConfirmation.tiktok.privacyPlaceholder": {
     "message": "Valitse…",
     "description": "TikTok julkaisu vahvistus: näkyvyys paikkamerkki, TikTokin vaatimusten mukaan ei voi olla oletusarvoa"
+  },
+  "actionConfirmation.tiktok.noPrivacyOptions": {
+    "message": "Saatavilla olevia näkyvyysvaihtoehtoja ei saatu, julkaisu ei ole mahdollinen",
+    "description": "TikTok julkaisuvahvistus: näkyvyyden puuttuminen"
   },
   "actionConfirmation.tiktok.privacyPublic": {
     "message": "Kaikki",
@@ -1371,6 +1423,14 @@
     "message": "Salli vuorovaikutus",
     "description": "TikTok julkaisu vahvistus: vuorovaikutuskytkimen ryhmäetiketti"
   },
+  "actionConfirmation.tiktok.interactionsHint": {
+    "message": "Voit vain avata tilin tällä hetkellä sallitut vuorovaikutustavat; oletuksena kaikki on suljettu.",
+    "description": "TikTok julkaisuvahvistus: vuorovaikutuksen kytkentäselitys"
+  },
+  "actionConfirmation.tiktok.disabledByAccount": {
+    "message": "Tämä tili on suljettu: {list}",
+    "description": "TikTok julkaisuvahvistus: tilin käytön rajoitukset"
+  },
   "actionConfirmation.tiktok.allowComment": {
     "message": "Kommentit",
     "description": "TikTok vuorovaikutuksen kytkin: salli kommentit"
@@ -1383,17 +1443,33 @@
     "message": "Leikkaus",
     "description": "TikTok vuorovaikutuksen kytkin: salli leikkaus"
   },
+  "actionConfirmation.tiktok.disclosure": {
+    "message": "Sisällön paljastaminen",
+    "description": "TikTok julkaisuvahvistus: kaupallisen sisällön ryhmittelyotsikko"
+  },
   "actionConfirmation.tiktok.commercial": {
     "message": "Tämä on kaupallinen sisältö",
     "description": "TikTok julkaisu vahvistus: kaupallisen sisällön ilmoitus"
+  },
+  "actionConfirmation.tiktok.commercialHint": {
+    "message": "Jos sisältö mainostaa brändiä, tuotetta tai palvelua, paljasta se tosiasioiden mukaan.",
+    "description": "TikTok julkaisuvahvistus: kaupallisen sisällön paljastamisen selitys"
   },
   "actionConfirmation.tiktok.yourBrand": {
     "message": "Brändisi",
     "description": "TikTok liiketoimintasisältö: oman liiketoiminnan mainostaminen"
   },
+  "actionConfirmation.tiktok.yourBrandHint": {
+    "message": "Mainosta omaa tai yrityksesi toimintaa",
+    "description": "TikTok-liiketoimintasisältö: omaa liiketoimintaa koskeva mainosohje"
+  },
   "actionConfirmation.tiktok.brandedContent": {
     "message": "Brändisisältö",
     "description": "TikTok kaupallinen sisältö: maksullinen yhteistyö"
+  },
+  "actionConfirmation.tiktok.brandedContentHint": {
+    "message": "Kolmannen osapuolen mainostaminen maksua, lahjoja tai muita etuja vastaan",
+    "description": "TikTok kaupallinen sisältö: maksetun yhteistyön selitys"
   },
   "actionConfirmation.tiktok.labelPromotional": {
     "message": "Video merkitään 'mainos sisällöksi'",
@@ -1410,6 +1486,42 @@
   "actionConfirmation.tiktok.tooLong": {
     "message": "Video ylittää tämän tilin aikarajan ({max} sekuntia)",
     "description": "TikTok julkaisu vahvistus: videon pituusvirhe"
+  },
+  "actionConfirmation.tiktok.beforePublishing": {
+    "message": "Vahvista ennen julkaisua",
+    "description": "TikTok julkaisuvahvistus: käytäntöjen selitysotsikko"
+  },
+  "actionConfirmation.tiktok.policyIntro": {
+    "message": "Klikkaamalla 'Julkaise' vahvistat, että sinulla on oikeus käyttää sisältöä ja musiikkia sekä hyväksyt TikTokin musiikin käyttöehdot.",
+    "description": "TikTok julkaisuvahvistus: yleisten sisältöpolitiikkojen selitys"
+  },
+  "actionConfirmation.tiktok.policyIntroBranded": {
+    "message": "Klikkaamalla 'Julkaise' vahvistat, että paljastamasi tiedot ovat tarkkoja ja hyväksyt TikTokin brändisisältöpolitiikan ja musiikin käyttöehdot.",
+    "description": "TikTok julkaisuvahvistus: brändisisältöpolitiikan selitys"
+  },
+  "actionConfirmation.tiktok.musicUsageLink": {
+    "message": "Katso 'Musiikin käyttövahvistus'",
+    "description": "TikTok julkaisuvahvistus: musiikin käyttövahvistuksen linkki"
+  },
+  "actionConfirmation.tiktok.brandedPolicyLink": {
+    "message": "Katso 'Brändisisältöpolitiikka'",
+    "description": "TikTok julkaisuvahvistus: brändisisältöpolitiikan linkki"
+  },
+  "actionConfirmation.tiktok.fixDetailsFirst": {
+    "message": "Julkaisutiedot ovat puutteelliset, peruuta ja luo vahvistuskortti uudelleen",
+    "description": "TikTok julkaisuvahvistus: syiden selitys, miksi tiedot puuttuvat"
+  },
+  "actionConfirmation.tiktok.useShorterVideo": {
+    "message": "Käytä videota, joka täyttää tilin pituusrajoituksen",
+    "description": "TikTok-julkaisun vahvistus: painikkeen poiskytkentä syynä videon liian pitkä kesto"
+  },
+  "actionConfirmation.tiktok.selectPrivacyFirst": {
+    "message": "Valitse, kuka voi nähdä tämän videon",
+    "description": "TikTok julkaisuvahvistus: syiden selitys, miksi näkyvyys ei ole valittu"
+  },
+  "actionConfirmation.tiktok.selectDisclosureType": {
+    "message": "Valitse kaupallisen sisällön tyyppi",
+    "description": "TikTok julkaisuvahvistus: syiden selitys, miksi kaupallista paljastustyyppiä ei ole valittu"
   },
   "actionConfirmation.tiktok.music": {
     "message": "Julkaisemalla hyväksyt TikTokin 'Musiikin käyttö vahvistus'",

--- a/src/i18n/fr/chat.json
+++ b/src/i18n/fr/chat.json
@@ -417,7 +417,7 @@
   },
   "title.limitations": {
     "message": "Limitations",
-    "description": "Titre sur la page web indiquant que cette section concerne les limitations techniques du service"
+    "description": "Titre dans la page web, indiquant que cette section concerne les limitations techniques du service"
   },
   "title.complexQuestion": {
     "message": "Répondre à des questions complexes",
@@ -1117,11 +1117,11 @@
   },
   "artifacts.kind.article": {
     "message": "Article",
-    "description": "Type de production - Article"
+    "description": "Type de produit - Article"
   },
   "artifacts.kind.image": {
     "message": "Image",
-    "description": "Type de production - Image"
+    "description": "Type de produit - Image"
   },
   "artifacts.kind.video": {
     "message": "Vidéo",
@@ -1129,11 +1129,11 @@
   },
   "artifacts.kind.audio": {
     "message": "Audio",
-    "description": "Type de production - Audio"
+    "description": "Type de produit - Audio"
   },
   "artifacts.kind.document": {
     "message": "Document",
-    "description": "Type de production - Document"
+    "description": "Type de produit - Document"
   },
   "artifacts.kind.email": {
     "message": "E-mail",
@@ -1141,7 +1141,7 @@
   },
   "artifacts.kind.message": {
     "message": "Message",
-    "description": "Type de production - Message"
+    "description": "Type de produit - Message"
   },
   "artifacts.kind.dataset": {
     "message": "Données",
@@ -1370,9 +1370,57 @@
     "message": "Annulé",
     "description": "Alerte repliée après que l'utilisateur a annulé sur la carte de confirmation avant exécution."
   },
+  "actionConfirmation.mediaLoading": {
+    "message": "Chargement de l'aperçu des médias…",
+    "description": "Carte de confirmation avant exécution : état de chargement des médias"
+  },
+  "actionConfirmation.mediaUnavailable": {
+    "message": "Impossible de lire l'aperçu ici",
+    "description": "Carte de confirmation avant exécution : titre de l'échec de lecture des médias"
+  },
+  "actionConfirmation.mediaUnavailableHint": {
+    "message": "Le lien du média peut avoir expiré ou le navigateur actuel ne prend pas en charge ce format. Veuillez ouvrir le fichier original pour vérification avant publication.",
+    "description": "Carte de confirmation avant exécution : explication de l'échec de lecture des médias"
+  },
+  "actionConfirmation.openMedia": {
+    "message": "Ouvrir le fichier original",
+    "description": "Carte de confirmation avant exécution : ouvrir le lien des médias"
+  },
+  "actionConfirmation.tiktok.reviewBadge": {
+    "message": "Confirmation avant publication",
+    "description": "Étiquette d'état de la carte de confirmation de publication TikTok"
+  },
   "actionConfirmation.tiktok.postingTo": {
     "message": "Publier sur",
     "description": "Étiquette de compte dans la confirmation de publication TikTok."
+  },
+  "actionConfirmation.tiktok.connected": {
+    "message": "Connecté",
+    "description": "Confirmation de publication TikTok : état de connexion du compte"
+  },
+  "actionConfirmation.tiktok.unknownAccount": {
+    "message": "Informations sur le compte non disponibles",
+    "description": "Confirmation de publication TikTok : texte d'espace réservé lorsque le nom du compte est manquant"
+  },
+  "actionConfirmation.tiktok.detailsUnavailable": {
+    "message": "Les paramètres de publication ne sont pas encore prêts",
+    "description": "Confirmation de publication TikTok : titre manquant d'informations sur le créateur"
+  },
+  "actionConfirmation.tiktok.detailsUnavailableHint": {
+    "message": "Impossible de lire la portée visible prise en charge par ce compte. Veuillez annuler et laisser l'assistant récupérer à nouveau les paramètres de publication TikTok.",
+    "description": "Confirmation de publication TikTok : explication du manque d'informations sur le créateur"
+  },
+  "actionConfirmation.tiktok.videoTooLongTitle": {
+    "message": "La durée de la vidéo ne respecte pas la limite du compte",
+    "description": "Confirmation de publication TikTok : titre pour vidéo trop longue"
+  },
+  "actionConfirmation.tiktok.postDetails": {
+    "message": "Contenu à publier",
+    "description": "Confirmation de publication TikTok : titre de la section des paramètres de contenu"
+  },
+  "actionConfirmation.tiktok.requiredNote": {
+    "message": "* Champ requis",
+    "description": "Confirmation de publication TikTok : explication des champs obligatoires"
   },
   "actionConfirmation.tiktok.caption": {
     "message": "Légende",
@@ -1389,6 +1437,10 @@
   "actionConfirmation.tiktok.privacyPlaceholder": {
     "message": "Veuillez sélectionner…",
     "description": "Espace réservé pour la visibilité dans la confirmation de publication TikTok, ne peut pas avoir de valeur par défaut selon les exigences de TikTok."
+  },
+  "actionConfirmation.tiktok.noPrivacyOptions": {
+    "message": "Aucune portée visible disponible, publication impossible pour le moment",
+    "description": "Confirmation de publication TikTok : portée visible vide"
   },
   "actionConfirmation.tiktok.privacyPublic": {
     "message": "Tout le monde",
@@ -1410,6 +1462,14 @@
     "message": "Autoriser les interactions",
     "description": "Étiquette de groupe pour le commutateur d'interaction dans la confirmation de publication TikTok."
   },
+  "actionConfirmation.tiktok.interactionsHint": {
+    "message": "Seules les méthodes d'interaction actuellement autorisées pour ce compte peuvent être activées ; par défaut, toutes sont désactivées.",
+    "description": "Confirmation de publication TikTok : explication de l'activation des interactions"
+  },
+  "actionConfirmation.tiktok.disabledByAccount": {
+    "message": "Ce compte est désactivé : {list}",
+    "description": "Confirmation de publication TikTok : capacités d'interaction désactivées du compte"
+  },
   "actionConfirmation.tiktok.allowComment": {
     "message": "Commentaires",
     "description": "Commutateur d'interaction TikTok : autoriser les commentaires."
@@ -1422,17 +1482,33 @@
     "message": "Assemblage",
     "description": "Commutateur d'interaction TikTok : autoriser les stitches."
   },
+  "actionConfirmation.tiktok.disclosure": {
+    "message": "Divulgation de contenu",
+    "description": "Confirmation de publication TikTok : titre de la section de contenu commercial"
+  },
   "actionConfirmation.tiktok.commercial": {
     "message": "Ceci est un contenu commercial",
     "description": "Confirmation de publication TikTok : commutateur de divulgation de contenu commercial."
+  },
+  "actionConfirmation.tiktok.commercialHint": {
+    "message": "Si le contenu promeut une marque, un produit ou un service, veuillez divulguer en conséquence.",
+    "description": "Confirmation de publication TikTok : explication de la divulgation de contenu commercial"
   },
   "actionConfirmation.tiktok.yourBrand": {
     "message": "votre marque",
     "description": "Contenu commercial TikTok : promotion de votre propre entreprise"
   },
+  "actionConfirmation.tiktok.yourBrandHint": {
+    "message": "Faites la promotion de vous-même ou de votre entreprise",
+    "description": "Contenu commercial TikTok : explication sur la promotion de son propre entreprise"
+  },
   "actionConfirmation.tiktok.brandedContent": {
     "message": "Contenu de marque",
     "description": "Contenu commercial TikTok : collaboration payante."
+  },
+  "actionConfirmation.tiktok.brandedContentHint": {
+    "message": "Promotion d'un tiers en raison d'un paiement, d'un cadeau ou d'autres avantages",
+    "description": "Contenu commercial TikTok : explication de la collaboration payante"
   },
   "actionConfirmation.tiktok.labelPromotional": {
     "message": "La vidéo sera marquée comme « contenu promotionnel »",
@@ -1449,6 +1525,42 @@
   "actionConfirmation.tiktok.tooLong": {
     "message": "La vidéo dépasse la limite de durée de ce compte ({max} secondes)",
     "description": "Confirmation de publication TikTok : erreur de durée excessive de la vidéo."
+  },
+  "actionConfirmation.tiktok.beforePublishing": {
+    "message": "Veuillez confirmer avant la publication",
+    "description": "Confirmation de publication TikTok : titre de l'explication de la politique"
+  },
+  "actionConfirmation.tiktok.policyIntro": {
+    "message": "En cliquant sur « Publier », vous confirmez que vous avez les droits d'utilisation du contenu et de la musique, et que vous acceptez les conditions d'utilisation de la musique de TikTok.",
+    "description": "Confirmation de publication TikTok : explication de la politique de contenu général"
+  },
+  "actionConfirmation.tiktok.policyIntroBranded": {
+    "message": "En cliquant sur « Publier », vous confirmez que les informations divulguées sont exactes et que vous acceptez la politique de contenu de marque et les conditions d'utilisation de la musique de TikTok.",
+    "description": "Confirmation de publication TikTok : explication de la politique de contenu de marque"
+  },
+  "actionConfirmation.tiktok.musicUsageLink": {
+    "message": "Voir la « Confirmation d'utilisation de la musique »",
+    "description": "Confirmation de publication TikTok : lien vers la confirmation d'utilisation de la musique"
+  },
+  "actionConfirmation.tiktok.brandedPolicyLink": {
+    "message": "Voir la « Politique de contenu de marque »",
+    "description": "Confirmation de publication TikTok : lien vers la politique de contenu de marque"
+  },
+  "actionConfirmation.tiktok.fixDetailsFirst": {
+    "message": "Les informations de publication sont incomplètes, veuillez annuler puis régénérer la carte de confirmation",
+    "description": "Confirmation de publication TikTok : raison de la désactivation du bouton en cas de détails manquants"
+  },
+  "actionConfirmation.tiktok.useShorterVideo": {
+    "message": "Veuillez utiliser une vidéo conforme à la limite de durée de ce compte",
+    "description": "Confirmation de publication TikTok : raison pour laquelle le bouton est désactivé lorsque la vidéo est trop longue"
+  },
+  "actionConfirmation.tiktok.selectPrivacyFirst": {
+    "message": "Veuillez sélectionner qui peut voir cette vidéo",
+    "description": "Confirmation de publication TikTok : raison de la désactivation du bouton lorsque la portée visible n'est pas sélectionnée"
+  },
+  "actionConfirmation.tiktok.selectDisclosureType": {
+    "message": "Veuillez sélectionner le type de contenu commercial",
+    "description": "Confirmation de publication TikTok : raison de la désactivation du bouton lorsque le type de divulgation commerciale n'est pas sélectionné"
   },
   "actionConfirmation.tiktok.music": {
     "message": "La publication signifie que vous acceptez la « confirmation d'utilisation de la musique » de TikTok",

--- a/src/i18n/it/chat.json
+++ b/src/i18n/it/chat.json
@@ -926,7 +926,7 @@
   },
   "scheduledTasks.humanize.cronRaw": {
     "message": "Cron: {cron}",
-    "description": "Formato leggibile dall'uomo: Cron originale"
+    "description": "Leggibile dall'uomo: Cron originale"
   },
   "scheduledTasks.humanize.once": {
     "message": "Una sola volta {time}",
@@ -1125,11 +1125,11 @@
   },
   "artifacts.kind.video": {
     "message": "Video",
-    "description": "Tipo di output - Video"
+    "description": "Tipo di output - video"
   },
   "artifacts.kind.audio": {
     "message": "Audio",
-    "description": "Tipo di output - Audio"
+    "description": "Tipo di output - audio"
   },
   "artifacts.kind.document": {
     "message": "Documento",
@@ -1137,7 +1137,7 @@
   },
   "artifacts.kind.email": {
     "message": "Email",
-    "description": "Tipo di output - Email"
+    "description": "Tipo di output - email"
   },
   "artifacts.kind.message": {
     "message": "Messaggio",
@@ -1149,7 +1149,7 @@
   },
   "artifacts.kind.link": {
     "message": "Link",
-    "description": "Tipo di output - Link"
+    "description": "Tipo di output - link"
   },
   "artifacts.kind.other": {
     "message": "Altro",
@@ -1370,9 +1370,57 @@
     "message": "Annullato",
     "description": "Scheda di conferma prima dell'esecuzione: messaggio di avviso dopo che l'utente ha annullato"
   },
+  "actionConfirmation.mediaLoading": {
+    "message": "Caricamento anteprima media in corso...",
+    "description": "Conferma prima dell'azione: stato di caricamento del media"
+  },
+  "actionConfirmation.mediaUnavailable": {
+    "message": "Impossibile riprodurre l'anteprima qui",
+    "description": "Conferma prima dell'azione: titolo di errore di riproduzione del media"
+  },
+  "actionConfirmation.mediaUnavailableHint": {
+    "message": "Il link del media potrebbe essere scaduto o il browser attuale non supporta questo formato. Controlla il file originale prima della pubblicazione.",
+    "description": "Conferma prima dell'azione: spiegazione dell'errore di riproduzione del media"
+  },
+  "actionConfirmation.openMedia": {
+    "message": "Apri file originale",
+    "description": "Conferma prima dell'azione: apri il link del media"
+  },
+  "actionConfirmation.tiktok.reviewBadge": {
+    "message": "Conferma prima della pubblicazione",
+    "description": "Etichetta di stato della scheda di conferma TikTok"
+  },
   "actionConfirmation.tiktok.postingTo": {
     "message": "Pubblica su",
     "description": "Conferma di pubblicazione TikTok: etichetta dell'account"
+  },
+  "actionConfirmation.tiktok.connected": {
+    "message": "Connesso",
+    "description": "Conferma di pubblicazione TikTok: stato di connessione dell'account"
+  },
+  "actionConfirmation.tiktok.unknownAccount": {
+    "message": "Informazioni sull'account non disponibili",
+    "description": "Conferma di pubblicazione TikTok: testo segnaposto quando manca il soprannome dell'account"
+  },
+  "actionConfirmation.tiktok.detailsUnavailable": {
+    "message": "Le impostazioni di pubblicazione non sono pronte",
+    "description": "Conferma di pubblicazione TikTok: titolo per mancanza di informazioni sul creatore"
+  },
+  "actionConfirmation.tiktok.detailsUnavailableHint": {
+    "message": "Impossibile leggere l'ambito di visibilità supportato da questo account. Annulla e fai in modo che l'assistente recuperi nuovamente le impostazioni di pubblicazione di TikTok.",
+    "description": "Conferma di pubblicazione TikTok: spiegazione per mancanza di informazioni sul creatore"
+  },
+  "actionConfirmation.tiktok.videoTooLongTitle": {
+    "message": "La durata del video non rispetta il limite dell'account",
+    "description": "Conferma di pubblicazione TikTok: titolo per video troppo lungo"
+  },
+  "actionConfirmation.tiktok.postDetails": {
+    "message": "Contenuto da pubblicare",
+    "description": "Conferma di pubblicazione TikTok: titolo per gruppo di impostazioni del contenuto"
+  },
+  "actionConfirmation.tiktok.requiredNote": {
+    "message": "* Obbligatorio",
+    "description": "Conferma di pubblicazione TikTok: spiegazione dei campi obbligatori"
   },
   "actionConfirmation.tiktok.caption": {
     "message": "Didascalia",
@@ -1389,6 +1437,10 @@
   "actionConfirmation.tiktok.privacyPlaceholder": {
     "message": "Seleziona…",
     "description": "Conferma di pubblicazione TikTok: segnaposto per la visibilità, non può avere un valore predefinito secondo i requisiti di TikTok"
+  },
+  "actionConfirmation.tiktok.noPrivacyOptions": {
+    "message": "Non sono state ottenute opzioni di visibilità disponibili, non è possibile pubblicare per il momento",
+    "description": "Conferma di pubblicazione TikTok: visibilità vuota"
   },
   "actionConfirmation.tiktok.privacyPublic": {
     "message": "Tutti",
@@ -1410,6 +1462,14 @@
     "message": "Consenti interazioni",
     "description": "Conferma di pubblicazione TikTok: etichetta di gruppo per l'interruttore di interazione"
   },
+  "actionConfirmation.tiktok.interactionsHint": {
+    "message": "È possibile attivare solo i metodi di interazione attualmente consentiti per questo account; di default sono tutti disabilitati.",
+    "description": "Conferma di pubblicazione TikTok: spiegazione dell'interruttore di interazione"
+  },
+  "actionConfirmation.tiktok.disabledByAccount": {
+    "message": "Questo account è disabilitato: {list}",
+    "description": "Conferma di pubblicazione TikTok: capacità di interazione disabilitata dell'account"
+  },
   "actionConfirmation.tiktok.allowComment": {
     "message": "Commenti",
     "description": "Interruttore di interazione TikTok: consenti commenti"
@@ -1422,17 +1482,33 @@
     "message": "Unione",
     "description": "Interruttore di interazione TikTok: consenti stitch"
   },
+  "actionConfirmation.tiktok.disclosure": {
+    "message": "Divulgazione dei contenuti",
+    "description": "Conferma di pubblicazione TikTok: titolo per gruppo di contenuti commerciali"
+  },
   "actionConfirmation.tiktok.commercial": {
     "message": "Questo è contenuto commerciale",
     "description": "Conferma di pubblicazione TikTok: interruttore di divulgazione del contenuto commerciale"
+  },
+  "actionConfirmation.tiktok.commercialHint": {
+    "message": "Se il contenuto promuove un marchio, prodotto o servizio, si prega di divulgare in base alla situazione reale.",
+    "description": "Conferma di pubblicazione TikTok: spiegazione della divulgazione dei contenuti commerciali"
   },
   "actionConfirmation.tiktok.yourBrand": {
     "message": "il tuo marchio",
     "description": "Contenuto commerciale di TikTok: promuovi la tua attività"
   },
+  "actionConfirmation.tiktok.yourBrandHint": {
+    "message": "Promuovi te stesso o l'attività che gestisci",
+    "description": "Contenuti commerciali TikTok: spiegazione per la promozione della propria attività"
+  },
   "actionConfirmation.tiktok.brandedContent": {
     "message": "Contenuto sponsorizzato",
     "description": "Contenuto commerciale TikTok: collaborazione a pagamento"
+  },
+  "actionConfirmation.tiktok.brandedContentHint": {
+    "message": "Promuovere un terzo per pagamento, omaggi o altri benefici",
+    "description": "Contenuto commerciale TikTok: spiegazione della collaborazione a pagamento"
   },
   "actionConfirmation.tiktok.labelPromotional": {
     "message": "Il video sarà contrassegnato come 'contenuto promozionale'",
@@ -1449,6 +1525,42 @@
   "actionConfirmation.tiktok.tooLong": {
     "message": "Il video supera il limite di durata per questo account ({max} secondi)",
     "description": "Conferma di pubblicazione TikTok: errore di video troppo lungo"
+  },
+  "actionConfirmation.tiktok.beforePublishing": {
+    "message": "Si prega di confermare prima della pubblicazione",
+    "description": "Conferma di pubblicazione TikTok: titolo della spiegazione delle politiche"
+  },
+  "actionConfirmation.tiktok.policyIntro": {
+    "message": "Cliccando su \"Pubblica\" confermi di avere i diritti d'uso sui contenuti e sulla musica e accetti i termini di utilizzo della musica di TikTok.",
+    "description": "Conferma di pubblicazione TikTok: spiegazione della politica sui contenuti generali"
+  },
+  "actionConfirmation.tiktok.policyIntroBranded": {
+    "message": "Cliccando su \"Pubblica\" confermi che le informazioni di divulgazione sono accurate e accetti la politica sui contenuti di marca e i termini di utilizzo della musica di TikTok.",
+    "description": "Conferma di pubblicazione TikTok: spiegazione della politica sui contenuti di marca"
+  },
+  "actionConfirmation.tiktok.musicUsageLink": {
+    "message": "Visualizza la \"Conferma dell'uso della musica\"",
+    "description": "Conferma di pubblicazione TikTok: link alla conferma dell'uso della musica"
+  },
+  "actionConfirmation.tiktok.brandedPolicyLink": {
+    "message": "Visualizza la \"Politica sui contenuti di marca\"",
+    "description": "Conferma di pubblicazione TikTok: link alla politica sui contenuti di marca"
+  },
+  "actionConfirmation.tiktok.fixDetailsFirst": {
+    "message": "Informazioni di pubblicazione incomplete, si prega di annullare e rigenerare la scheda di conferma",
+    "description": "Conferma di pubblicazione TikTok: motivo per cui il pulsante è disabilitato quando mancano i dettagli"
+  },
+  "actionConfirmation.tiktok.useShorterVideo": {
+    "message": "Si prega di utilizzare un video che rispetti il limite di durata di questo account",
+    "description": "Conferma di pubblicazione TikTok: motivo per cui il pulsante è disabilitato quando il video è troppo lungo"
+  },
+  "actionConfirmation.tiktok.selectPrivacyFirst": {
+    "message": "Seleziona chi può vedere questo video",
+    "description": "Conferma di pubblicazione TikTok: motivo per cui il pulsante è disabilitato quando non è selezionata la visibilità"
+  },
+  "actionConfirmation.tiktok.selectDisclosureType": {
+    "message": "Seleziona il tipo di contenuto commerciale",
+    "description": "Conferma di pubblicazione TikTok: motivo per cui il pulsante è disabilitato quando non è selezionato il tipo di divulgazione commerciale"
   },
   "actionConfirmation.tiktok.music": {
     "message": "Pubblicando, accetti la 'Conferma di utilizzo della musica' di TikTok",

--- a/src/i18n/ja/chat.json
+++ b/src/i18n/ja/chat.json
@@ -1315,14 +1315,6 @@
     "message": "このタスクは実行中です",
     "description": "タスクはすでに実行されています"
   },
-  "model.claudeOpus47": {
-    "message": "claude-opus-4.7",
-    "description": "サービスのモデル名、すなわち Claude Opus 4.7"
-  },
-  "model.claudeOpus47Description": {
-    "message": "現在最も先進的なモデル",
-    "description": "Claude Opus 4.7モデルの説明"
-  },
   "actionConfirmation.confirm": {
     "message": "確認",
     "description": "执行前确认卡片的确认按钮"
@@ -1339,9 +1331,57 @@
     "message": "キャンセルしました",
     "description": "执行前确认卡片：用户取消后的折叠提示"
   },
+  "actionConfirmation.mediaLoading": {
+    "message": "メディアプレビューを読み込んでいます…",
+    "description": "実行前確認カード：メディアの読み込み状態"
+  },
+  "actionConfirmation.mediaUnavailable": {
+    "message": "ここでプレビューを再生できません",
+    "description": "実行前確認カード：メディア再生失敗のタイトル"
+  },
+  "actionConfirmation.mediaUnavailableHint": {
+    "message": "メディアリンクが期限切れの可能性があります。または、現在のブラウザがその形式をサポートしていません。公開前に元のファイルを開いて確認してください。",
+    "description": "実行前確認カード：メディア再生失敗の説明"
+  },
+  "actionConfirmation.openMedia": {
+    "message": "元のファイルを開く",
+    "description": "実行前確認カード：メディアリンクを開く"
+  },
+  "actionConfirmation.tiktok.reviewBadge": {
+    "message": "公開前に確認",
+    "description": "TikTok 公開確認カードの状態ラベル"
+  },
   "actionConfirmation.tiktok.postingTo": {
     "message": "投稿先",
     "description": "TikTok 发布确认：账号标签"
+  },
+  "actionConfirmation.tiktok.connected": {
+    "message": "接続済み",
+    "description": "TikTok 公開確認：アカウント接続状態"
+  },
+  "actionConfirmation.tiktok.unknownAccount": {
+    "message": "アカウント情報が利用できません",
+    "description": "TikTok 公開確認：アカウントのニックネームが欠けている時のプレースホルダ文"
+  },
+  "actionConfirmation.tiktok.detailsUnavailable": {
+    "message": "公開設定がまだ準備できていません",
+    "description": "TikTok 公開確認：クリエイター情報が欠けているタイトル"
+  },
+  "actionConfirmation.tiktok.detailsUnavailableHint": {
+    "message": "そのアカウントがサポートする可視範囲を読み取れませんでした。キャンセルして、アシスタントにTikTok公開設定を再取得させてください。",
+    "description": "TikTok 公開確認：クリエイター情報が欠けている説明"
+  },
+  "actionConfirmation.tiktok.videoTooLongTitle": {
+    "message": "動画の長さがアカウントの制限に合っていません",
+    "description": "TikTok 発表確認：動画が長すぎるタイトル"
+  },
+  "actionConfirmation.tiktok.postDetails": {
+    "message": "公開コンテンツ",
+    "description": "TikTok 公開確認：コンテンツ設定のグループタイトル"
+  },
+  "actionConfirmation.tiktok.requiredNote": {
+    "message": "* 必須",
+    "description": "TikTok 公開確認：必須の説明"
   },
   "actionConfirmation.tiktok.caption": {
     "message": "キャプション",
@@ -1358,6 +1398,10 @@
   "actionConfirmation.tiktok.privacyPlaceholder": {
     "message": "選択してください…",
     "description": "TikTok 发布确认：可见范围占位符，按 TikTok 要求不能有默认值"
+  },
+  "actionConfirmation.tiktok.noPrivacyOptions": {
+    "message": "利用可能な可視範囲が取得できず、現在公開できません",
+    "description": "TikTok 公開確認：可視範囲が空"
   },
   "actionConfirmation.tiktok.privacyPublic": {
     "message": "全員",
@@ -1379,6 +1423,14 @@
     "message": "インタラクションを許可",
     "description": "TikTok 发布确认：互动开关分组标签"
   },
+  "actionConfirmation.tiktok.interactionsHint": {
+    "message": "このアカウントで現在許可されているインタラクション方法のみを有効にできます。デフォルトではすべて無効です。",
+    "description": "TikTok 公開確認：インタラクションスイッチの説明"
+  },
+  "actionConfirmation.tiktok.disabledByAccount": {
+    "message": "このアカウントは無効です：{list}",
+    "description": "TikTok 公開確認：アカウントの無効なインタラクション機能"
+  },
   "actionConfirmation.tiktok.allowComment": {
     "message": "コメント",
     "description": "TikTok 互动开关：允许评论"
@@ -1391,17 +1443,33 @@
     "message": "リミックス",
     "description": "TikTok 互动开关：允许拼接"
   },
+  "actionConfirmation.tiktok.disclosure": {
+    "message": "コンテンツの開示",
+    "description": "TikTok 公開確認：商業コンテンツのグループタイトル"
+  },
   "actionConfirmation.tiktok.commercial": {
     "message": "これは商用コンテンツです",
     "description": "TikTok 发布确认：商业内容披露开关"
+  },
+  "actionConfirmation.tiktok.commercialHint": {
+    "message": "コンテンツがブランド、製品、またはサービスを宣伝する場合は、実際の状況を開示してください。",
+    "description": "TikTok 公開確認：商業コンテンツの開示説明"
   },
   "actionConfirmation.tiktok.yourBrand": {
     "message": "自分のブランド",
     "description": "TikTok 商业内容：推广自有业务"
   },
+  "actionConfirmation.tiktok.yourBrandHint": {
+    "message": "あなた自身またはあなたのビジネスを宣伝する",
+    "description": "TikTok 商業コンテンツ：自社ビジネスの宣伝に関する説明"
+  },
   "actionConfirmation.tiktok.brandedContent": {
     "message": "ブランドコンテンツ",
     "description": "TikTok 商业内容：付费合作"
+  },
+  "actionConfirmation.tiktok.brandedContentHint": {
+    "message": "支払い、贈り物、またはその他の利益のために第三者を宣伝する",
+    "description": "TikTok 商業コンテンツ：有料コラボレーションの説明"
   },
   "actionConfirmation.tiktok.labelPromotional": {
     "message": "動画は「プロモーションコンテンツ」として表示されます",
@@ -1418,6 +1486,50 @@
   "actionConfirmation.tiktok.tooLong": {
     "message": "動画がアカウントの上限（{max} 秒）を超えています",
     "description": "TikTok 发布确认：视频超长错误"
+  },
+  "actionConfirmation.tiktok.beforePublishing": {
+    "message": "公開前に確認してください",
+    "description": "TikTok 公開確認：ポリシー説明のタイトル"
+  },
+  "actionConfirmation.tiktok.policyIntro": {
+    "message": "「公開」をクリックすることで、コンテンツと音楽の使用権を確認し、TikTokの音楽使用規約に同意したことになります。",
+    "description": "TikTok 公開確認：一般的なコンテンツポリシーの説明"
+  },
+  "actionConfirmation.tiktok.policyIntroBranded": {
+    "message": "「公開」をクリックすることで、開示情報が正確であることを確認し、TikTokのブランドコンテンツポリシーと音楽使用規約に同意したことになります。",
+    "description": "TikTok 公開確認：ブランドコンテンツポリシーの説明"
+  },
+  "actionConfirmation.tiktok.musicUsageLink": {
+    "message": "「音楽使用確認」を確認する",
+    "description": "TikTok 公開確認：音楽使用確認のリンク"
+  },
+  "actionConfirmation.tiktok.brandedPolicyLink": {
+    "message": "「ブランドコンテンツポリシー」を確認する",
+    "description": "TikTok 公開確認：ブランドコンテンツポリシーのリンク"
+  },
+  "actionConfirmation.tiktok.fixDetailsFirst": {
+    "message": "公開情報が不完全です。キャンセルしてから確認カードを再生成してください。",
+    "description": "TikTok 公開確認：詳細が欠けている時のボタン無効の理由"
+  },
+  "actionConfirmation.tiktok.useShorterVideo": {
+    "message": "このアカウントの時間制限に合った短い動画を使用してください",
+    "description": "TikTok 発表確認：動画が長すぎるためボタンが無効になっています"
+  },
+  "actionConfirmation.tiktok.selectPrivacyFirst": {
+    "message": "この動画を誰が見ることができるかを選択してください",
+    "description": "TikTok 公開確認：可視範囲が選択されていない時のボタン無効の理由"
+  },
+  "actionConfirmation.tiktok.selectDisclosureType": {
+    "message": "商業コンテンツの種類を選択してください",
+    "description": "TikTok 公開確認：商業開示タイプが選択されていない時のボタン無効の理由"
+  },
+  "model.claudeOpus47": {
+    "message": "claude-opus-4.7",
+    "description": "サービスのモデル名、すなわち Claude Opus 4.7"
+  },
+  "model.claudeOpus47Description": {
+    "message": "現在最も先進的なモデル",
+    "description": "Claude Opus 4.7モデルの説明"
   },
   "actionConfirmation.tiktok.music": {
     "message": "投稿すると、TikTok の音楽利用確認に同意したことになります",

--- a/src/i18n/ko/chat.json
+++ b/src/i18n/ko/chat.json
@@ -1370,9 +1370,57 @@
     "message": "취소됨",
     "description": "실행 전 확인 카드: 사용자가 취소한 후의 접기 알림"
   },
+  "actionConfirmation.mediaLoading": {
+    "message": "미디어 미리보기를 로딩 중입니다…",
+    "description": "실행 전 확인 카드: 미디어 로딩 상태"
+  },
+  "actionConfirmation.mediaUnavailable": {
+    "message": "여기서 미리보기를 재생할 수 없습니다",
+    "description": "실행 전 확인 카드: 미디어 재생 실패 제목"
+  },
+  "actionConfirmation.mediaUnavailableHint": {
+    "message": "미디어 링크가 만료되었거나 현재 브라우저가 해당 형식을 지원하지 않을 수 있습니다. 게시 전에 원본 파일을 열어 확인하세요.",
+    "description": "실행 전 확인 카드: 미디어 재생 실패 설명"
+  },
+  "actionConfirmation.openMedia": {
+    "message": "원본 파일 열기",
+    "description": "실행 전 확인 카드: 미디어 링크 열기"
+  },
+  "actionConfirmation.tiktok.reviewBadge": {
+    "message": "게시 전 확인",
+    "description": "TikTok 게시 확인 카드 상태 태그"
+  },
   "actionConfirmation.tiktok.postingTo": {
     "message": "게시 대상",
     "description": "TikTok 게시 확인: 계정 레이블"
+  },
+  "actionConfirmation.tiktok.connected": {
+    "message": "연결됨",
+    "description": "TikTok 게시 확인: 계정 연결 상태"
+  },
+  "actionConfirmation.tiktok.unknownAccount": {
+    "message": "계정 정보가 사용할 수 없습니다",
+    "description": "TikTok 게시 확인: 계정 닉네임이 누락되었을 때의 자리 표시자 문구"
+  },
+  "actionConfirmation.tiktok.detailsUnavailable": {
+    "message": "게시 설정이 준비되지 않았습니다",
+    "description": "TikTok 게시 확인: 크리에이터 정보 누락 제목"
+  },
+  "actionConfirmation.tiktok.detailsUnavailableHint": {
+    "message": "해당 계정이 지원하는 가시 범위를 읽을 수 없습니다. 취소하고 도우미에게 TikTok 게시 설정을 다시 가져오도록 하세요.",
+    "description": "TikTok 게시 확인: 크리에이터 정보 누락 설명"
+  },
+  "actionConfirmation.tiktok.videoTooLongTitle": {
+    "message": "비디오 길이가 계정 제한에 맞지 않습니다.",
+    "description": "TikTok 게시 확인: 비디오가 너무 긴 제목"
+  },
+  "actionConfirmation.tiktok.postDetails": {
+    "message": "게시 내용",
+    "description": "TikTok 게시 확인: 내용 설정 그룹 제목"
+  },
+  "actionConfirmation.tiktok.requiredNote": {
+    "message": "* 필수",
+    "description": "TikTok 게시 확인: 필수 설명"
   },
   "actionConfirmation.tiktok.caption": {
     "message": "캡션",
@@ -1389,6 +1437,10 @@
   "actionConfirmation.tiktok.privacyPlaceholder": {
     "message": "선택하세요…",
     "description": "TikTok 게시 확인: 가시 범위 자리 표시자, TikTok 요구 사항에 따라 기본값이 없어야 함"
+  },
+  "actionConfirmation.tiktok.noPrivacyOptions": {
+    "message": "사용 가능한 가시 범위를 가져오지 못했습니다. 현재 게시할 수 없습니다",
+    "description": "TikTok 게시 확인: 가시 범위 없음"
   },
   "actionConfirmation.tiktok.privacyPublic": {
     "message": "모두",
@@ -1410,6 +1462,14 @@
     "message": "상호작용 허용",
     "description": "TikTok 게시 확인: 상호작용 스위치 그룹 레이블"
   },
+  "actionConfirmation.tiktok.interactionsHint": {
+    "message": "현재 계정에서 허용된 상호작용 방식만 활성화할 수 있습니다; 기본적으로 모두 비활성화되어 있습니다.",
+    "description": "TikTok 게시 확인: 상호작용 스위치 설명"
+  },
+  "actionConfirmation.tiktok.disabledByAccount": {
+    "message": "이 계정은 비활성화되었습니다: {list}",
+    "description": "TikTok 게시 확인: 계정 비활성화된 상호작용 기능"
+  },
   "actionConfirmation.tiktok.allowComment": {
     "message": "댓글 허용",
     "description": "TikTok 상호작용 스위치: 댓글 허용"
@@ -1422,17 +1482,33 @@
     "message": "스티치 허용",
     "description": "TikTok 상호작용 스위치: 스티치 허용"
   },
+  "actionConfirmation.tiktok.disclosure": {
+    "message": "내용 공개",
+    "description": "TikTok 게시 확인: 상업 콘텐츠 그룹 제목"
+  },
   "actionConfirmation.tiktok.commercial": {
     "message": "이것은 상업적 콘텐츠입니다.",
     "description": "TikTok 게시 확인: 상업적 콘텐츠 공개 스위치"
+  },
+  "actionConfirmation.tiktok.commercialHint": {
+    "message": "내용이 브랜드, 제품 또는 서비스를 홍보하는 경우 실제 상황을 공개하세요.",
+    "description": "TikTok 게시 확인: 상업 콘텐츠 공개 설명"
   },
   "actionConfirmation.tiktok.yourBrand": {
     "message": "당신의 브랜드",
     "description": "TikTok 비즈니스 콘텐츠: 자사 비즈니스를 홍보"
   },
+  "actionConfirmation.tiktok.yourBrandHint": {
+    "message": "본인 또는 운영하는 비즈니스를 홍보하세요.",
+    "description": "TikTok 상업 콘텐츠: 자사 비즈니스 홍보 설명"
+  },
   "actionConfirmation.tiktok.brandedContent": {
     "message": "브랜드 콘텐츠",
     "description": "TikTok 상업적 콘텐츠: 유료 협력"
+  },
+  "actionConfirmation.tiktok.brandedContentHint": {
+    "message": "지불, 선물 또는 기타 이익을 위해 제3자를 홍보합니다",
+    "description": "TikTok 상업 콘텐츠: 유료 협력 설명"
   },
   "actionConfirmation.tiktok.labelPromotional": {
     "message": "비디오는 '프로모션 콘텐츠'로 표시됩니다.",
@@ -1449,6 +1525,42 @@
   "actionConfirmation.tiktok.tooLong": {
     "message": "비디오가 해당 계정의 길이 제한({max}초)을 초과했습니다.",
     "description": "TikTok 게시 확인: 비디오 길이 초과 오류"
+  },
+  "actionConfirmation.tiktok.beforePublishing": {
+    "message": "게시 전에 확인하세요",
+    "description": "TikTok 게시 확인: 정책 설명 제목"
+  },
+  "actionConfirmation.tiktok.policyIntro": {
+    "message": "‘게시’ 버튼을 클릭하면 콘텐츠와 음악 사용 권한이 있음을 확인하고 TikTok의 음악 사용 약관에 동의하는 것입니다.",
+    "description": "TikTok 게시 확인: 일반 콘텐츠 정책 설명"
+  },
+  "actionConfirmation.tiktok.policyIntroBranded": {
+    "message": "‘게시’ 버튼을 클릭하면 공개 정보가 정확함을 확인하고 TikTok의 브랜드 콘텐츠 정책 및 음악 사용 약관에 동의하는 것입니다.",
+    "description": "TikTok 게시 확인: 브랜드 콘텐츠 정책 설명"
+  },
+  "actionConfirmation.tiktok.musicUsageLink": {
+    "message": "《음악 사용 확인》 보기",
+    "description": "TikTok 게시 확인: 음악 사용 확인 링크"
+  },
+  "actionConfirmation.tiktok.brandedPolicyLink": {
+    "message": "《브랜드 콘텐츠 정책》 보기",
+    "description": "TikTok 게시 확인: 브랜드 콘텐츠 정책 링크"
+  },
+  "actionConfirmation.tiktok.fixDetailsFirst": {
+    "message": "게시 정보가 불완전합니다. 취소 후 확인 카드를 다시 생성하세요.",
+    "description": "TikTok 게시 확인: 세부 정보 누락 시 버튼 비활성화 이유"
+  },
+  "actionConfirmation.tiktok.useShorterVideo": {
+    "message": "해당 계정의 시간 제한에 맞는 비디오로 변경하세요.",
+    "description": "TikTok 게시 확인: 비디오가 너무 길 때 버튼 비활성화 이유"
+  },
+  "actionConfirmation.tiktok.selectPrivacyFirst": {
+    "message": "누가 이 비디오를 볼 수 있는지 선택하세요",
+    "description": "TikTok 게시 확인: 가시 범위가 선택되지 않았을 때 버튼 비활성화 이유"
+  },
+  "actionConfirmation.tiktok.selectDisclosureType": {
+    "message": "상업 콘텐츠 유형을 선택하세요",
+    "description": "TikTok 게시 확인: 상업 공개 유형이 선택되지 않았을 때 버튼 비활성화 이유"
   },
   "actionConfirmation.tiktok.music": {
     "message": "게시함으로써 TikTok의 '음악 사용 확인'에 동의합니다.",

--- a/src/i18n/pl/chat.json
+++ b/src/i18n/pl/chat.json
@@ -926,7 +926,7 @@
   },
   "scheduledTasks.humanize.cronRaw": {
     "message": "Cron: {cron}",
-    "description": "Czytelna dla ludzi: oryginalny Cron"
+    "description": "Czytelne dla ludzi: surowy Cron"
   },
   "scheduledTasks.humanize.once": {
     "message": "Jednorazowo {time}",
@@ -1129,7 +1129,7 @@
   },
   "artifacts.kind.audio": {
     "message": "Audio",
-    "description": "Typ artefaktu - audio"
+    "description": "Typ zasobu - audio"
   },
   "artifacts.kind.document": {
     "message": "Dokument",
@@ -1149,7 +1149,7 @@
   },
   "artifacts.kind.link": {
     "message": "Link",
-    "description": "Typ artefaktu - link"
+    "description": "Typ zasobu - link"
   },
   "artifacts.kind.other": {
     "message": "Inne",
@@ -1370,9 +1370,57 @@
     "message": "Anulowano",
     "description": "Karta potwierdzenia przed wykonaniem: komunikat po anulowaniu przez użytkownika."
   },
+  "actionConfirmation.mediaLoading": {
+    "message": "Ładowanie podglądu mediów...",
+    "description": "Potwierdzenie przed wykonaniem: stan ładowania mediów"
+  },
+  "actionConfirmation.mediaUnavailable": {
+    "message": "Nie można odtworzyć podglądu tutaj",
+    "description": "Potwierdzenie przed wykonaniem: tytuł błędu odtwarzania mediów"
+  },
+  "actionConfirmation.mediaUnavailableHint": {
+    "message": "Link do mediów może być nieaktualny lub bieżąca przeglądarka nie obsługuje tego formatu. Proszę otworzyć oryginalny plik przed publikacją, aby potwierdzić.",
+    "description": "Potwierdzenie przed wykonaniem: opis błędu odtwarzania mediów"
+  },
+  "actionConfirmation.openMedia": {
+    "message": "Otwórz oryginalny plik",
+    "description": "Potwierdzenie przed wykonaniem: otwórz link do mediów"
+  },
+  "actionConfirmation.tiktok.reviewBadge": {
+    "message": "Potwierdź przed publikacją",
+    "description": "Etykieta stanu karty potwierdzenia TikTok"
+  },
   "actionConfirmation.tiktok.postingTo": {
     "message": "Publikuj do",
     "description": "Etykieta konta w potwierdzeniu publikacji TikTok."
+  },
+  "actionConfirmation.tiktok.connected": {
+    "message": "Połączono",
+    "description": "Potwierdzenie publikacji TikTok: status połączenia konta"
+  },
+  "actionConfirmation.tiktok.unknownAccount": {
+    "message": "Informacje o koncie niedostępne",
+    "description": "Potwierdzenie publikacji TikTok: tekst zastępczy przy braku nazwy użytkownika konta"
+  },
+  "actionConfirmation.tiktok.detailsUnavailable": {
+    "message": "Ustawienia publikacji nie są jeszcze gotowe",
+    "description": "Potwierdzenie publikacji TikTok: brak informacji o twórcy"
+  },
+  "actionConfirmation.tiktok.detailsUnavailableHint": {
+    "message": "Nie udało się odczytać dostępnego zasięgu tego konta. Proszę anulować i pozwolić asystentowi ponownie uzyskać ustawienia publikacji TikTok.",
+    "description": "Potwierdzenie publikacji TikTok: opis braku informacji o twórcy"
+  },
+  "actionConfirmation.tiktok.videoTooLongTitle": {
+    "message": "Czas trwania wideo nie spełnia ograniczeń konta",
+    "description": "Potwierdzenie publikacji TikTok: tytuł zbyt długiego wideo"
+  },
+  "actionConfirmation.tiktok.postDetails": {
+    "message": "Treść publikacji",
+    "description": "Potwierdzenie publikacji TikTok: tytuł grupy ustawień treści"
+  },
+  "actionConfirmation.tiktok.requiredNote": {
+    "message": "* Wymagane",
+    "description": "Potwierdzenie publikacji TikTok: wytyczne dotyczące pól obowiązkowych"
   },
   "actionConfirmation.tiktok.caption": {
     "message": "Opis",
@@ -1389,6 +1437,10 @@
   "actionConfirmation.tiktok.privacyPlaceholder": {
     "message": "Wybierz…",
     "description": "Znak zastępczy w potwierdzeniu publikacji TikTok dla widoczności, nie może mieć wartości domyślnej zgodnie z wymaganiami TikTok."
+  },
+  "actionConfirmation.tiktok.noPrivacyOptions": {
+    "message": "Nie uzyskano dostępnych opcji widoczności, publikacja jest obecnie niemożliwa",
+    "description": "Potwierdzenie publikacji TikTok: brak dostępnych opcji widoczności"
   },
   "actionConfirmation.tiktok.privacyPublic": {
     "message": "Wszyscy",
@@ -1410,6 +1462,14 @@
     "message": "Zezwól na interakcje",
     "description": "Etykieta grupy przełączników interakcji w potwierdzeniu publikacji TikTok."
   },
+  "actionConfirmation.tiktok.interactionsHint": {
+    "message": "Można włączyć tylko te interakcje, które są aktualnie dozwolone dla tego konta; domyślnie wszystkie są wyłączone.",
+    "description": "Potwierdzenie publikacji TikTok: wytyczne dotyczące przełączników interakcji"
+  },
+  "actionConfirmation.tiktok.disabledByAccount": {
+    "message": "To konto zostało wyłączone: {list}",
+    "description": "Potwierdzenie publikacji TikTok: interaktywne możliwości konta wyłączone"
+  },
   "actionConfirmation.tiktok.allowComment": {
     "message": "Komentarze",
     "description": "Przełącznik interakcji TikTok: zezwól na komentarze."
@@ -1422,17 +1482,33 @@
     "message": "Szycie",
     "description": "Przełącznik interakcji TikTok: zezwól na szycie."
   },
+  "actionConfirmation.tiktok.disclosure": {
+    "message": "Ujawnienie treści",
+    "description": "Potwierdzenie publikacji TikTok: tytuł grupy treści komercyjnych"
+  },
   "actionConfirmation.tiktok.commercial": {
     "message": "To jest treść komercyjna",
     "description": "Potwierdzenie publikacji TikTok: przełącznik ujawnienia treści komercyjnej."
+  },
+  "actionConfirmation.tiktok.commercialHint": {
+    "message": "Jeśli treść promuje markę, produkt lub usługę, należy ujawnić to zgodnie z rzeczywistością.",
+    "description": "Potwierdzenie publikacji TikTok: wytyczne dotyczące ujawniania treści komercyjnych"
   },
   "actionConfirmation.tiktok.yourBrand": {
     "message": "Twoja marka",
     "description": "Treść biznesowa TikTok: promowanie własnej działalności"
   },
+  "actionConfirmation.tiktok.yourBrandHint": {
+    "message": "Promuj siebie lub swoją działalność",
+    "description": "Treści komercyjne TikTok: informacja o promowaniu własnej działalności"
+  },
   "actionConfirmation.tiktok.brandedContent": {
     "message": "Treść markowa",
     "description": "Treść komercyjna TikTok: płatna współpraca."
+  },
+  "actionConfirmation.tiktok.brandedContentHint": {
+    "message": "Promowanie osób trzecich za opłatą, w zamian za prezenty lub inne korzyści",
+    "description": "Treść komercyjna TikTok: wytyczne dotyczące płatnych współprac"
   },
   "actionConfirmation.tiktok.labelPromotional": {
     "message": "Film zostanie oznaczony jako „treść promocyjna”",
@@ -1449,6 +1525,42 @@
   "actionConfirmation.tiktok.tooLong": {
     "message": "Film przekracza maksymalny czas trwania konta ({max} sekund)",
     "description": "Potwierdzenie publikacji TikTok: błąd z powodu zbyt długiego filmu."
+  },
+  "actionConfirmation.tiktok.beforePublishing": {
+    "message": "Proszę potwierdzić przed publikacją",
+    "description": "Potwierdzenie publikacji TikTok: tytuł wytycznych"
+  },
+  "actionConfirmation.tiktok.policyIntro": {
+    "message": "Klikając „Publikuj”, potwierdzasz, że masz prawo do korzystania z treści i muzyki oraz zgadzasz się na warunki korzystania z muzyki TikTok.",
+    "description": "Potwierdzenie publikacji TikTok: wytyczne dotyczące standardowej polityki treści"
+  },
+  "actionConfirmation.tiktok.policyIntroBranded": {
+    "message": "Klikając „Publikuj”, potwierdzasz, że informacje ujawnione są dokładne oraz zgadzasz się na politykę treści markowych TikTok i warunki korzystania z muzyki.",
+    "description": "Potwierdzenie publikacji TikTok: wytyczne dotyczące polityki treści markowych"
+  },
+  "actionConfirmation.tiktok.musicUsageLink": {
+    "message": "Zobacz „Potwierdzenie użycia muzyki”",
+    "description": "Potwierdzenie publikacji TikTok: link do potwierdzenia użycia muzyki"
+  },
+  "actionConfirmation.tiktok.brandedPolicyLink": {
+    "message": "Zobacz „Politykę treści markowych”",
+    "description": "Potwierdzenie publikacji TikTok: link do polityki treści markowych"
+  },
+  "actionConfirmation.tiktok.fixDetailsFirst": {
+    "message": "Informacje o publikacji są niekompletne, proszę anulować i ponownie wygenerować kartę potwierdzenia",
+    "description": "Potwierdzenie publikacji TikTok: powód wyłączenia przy braku szczegółów"
+  },
+  "actionConfirmation.tiktok.useShorterVideo": {
+    "message": "Proszę użyć wideo zgodnego z ograniczeniami czasowymi tego konta",
+    "description": "Potwierdzenie publikacji TikTok: powód dezaktywacji przycisku z powodu zbyt długiego wideo"
+  },
+  "actionConfirmation.tiktok.selectPrivacyFirst": {
+    "message": "Proszę wybrać, kto może zobaczyć to wideo",
+    "description": "Potwierdzenie publikacji TikTok: powód wyłączenia przy braku wybranej opcji widoczności"
+  },
+  "actionConfirmation.tiktok.selectDisclosureType": {
+    "message": "Proszę wybrać typ treści komercyjnej",
+    "description": "Potwierdzenie publikacji TikTok: powód wyłączenia przy braku wybranego typu ujawnienia"
   },
   "actionConfirmation.tiktok.music": {
     "message": "Publikując, zgadzasz się na „Potwierdzenie użycia muzyki” TikTok",

--- a/src/i18n/pt/chat.json
+++ b/src/i18n/pt/chat.json
@@ -926,7 +926,7 @@
   },
   "scheduledTasks.humanize.cronRaw": {
     "message": "Cron: {cron}",
-    "description": "Formato legível para humanos: Cron original"
+    "description": "Legível por humanos: Cron original"
   },
   "scheduledTasks.humanize.once": {
     "message": "Uma vez {time}",
@@ -1370,9 +1370,57 @@
     "message": "Cancelado",
     "description": "Dica de colapso após o usuário cancelar na confirmação antes da execução."
   },
+  "actionConfirmation.mediaLoading": {
+    "message": "Carregando pré-visualização de mídia…",
+    "description": "Confirmação antes da execução: estado de carregamento da mídia"
+  },
+  "actionConfirmation.mediaUnavailable": {
+    "message": "Não é possível reproduzir a pré-visualização aqui",
+    "description": "Confirmação antes da execução: título de falha na reprodução da mídia"
+  },
+  "actionConfirmation.mediaUnavailableHint": {
+    "message": "O link da mídia pode ter expirado ou o navegador atual não suporta este formato. Por favor, abra o arquivo original para confirmação antes de publicar.",
+    "description": "Confirmação antes da execução: descrição da falha na reprodução da mídia"
+  },
+  "actionConfirmation.openMedia": {
+    "message": "Abrir arquivo original",
+    "description": "Confirmação antes da execução: abrir link da mídia"
+  },
+  "actionConfirmation.tiktok.reviewBadge": {
+    "message": "Confirmação antes da publicação",
+    "description": "Etiqueta de status do cartão de confirmação do TikTok"
+  },
   "actionConfirmation.tiktok.postingTo": {
     "message": "Publicar em",
     "description": "Confirmação de publicação do TikTok: rótulo da conta."
+  },
+  "actionConfirmation.tiktok.connected": {
+    "message": "Conectado",
+    "description": "Confirmação de publicação do TikTok: estado de conexão da conta"
+  },
+  "actionConfirmation.tiktok.unknownAccount": {
+    "message": "Informações da conta não disponíveis",
+    "description": "Confirmação de publicação do TikTok: texto de espaço reservado quando o nome de usuário da conta está ausente"
+  },
+  "actionConfirmation.tiktok.detailsUnavailable": {
+    "message": "Configurações de publicação ainda não estão prontas",
+    "description": "Confirmação de publicação do TikTok: título de falta de informações do criador"
+  },
+  "actionConfirmation.tiktok.detailsUnavailableHint": {
+    "message": "Não foi possível ler o alcance visível suportado por esta conta. Por favor, cancele e permita que o assistente recupere as configurações de publicação do TikTok novamente.",
+    "description": "Confirmação de publicação do TikTok: descrição da falta de informações do criador"
+  },
+  "actionConfirmation.tiktok.videoTooLongTitle": {
+    "message": "Duração do vídeo não atende ao limite da conta",
+    "description": "Confirmação de publicação do TikTok: título para vídeo muito longo."
+  },
+  "actionConfirmation.tiktok.postDetails": {
+    "message": "Conteúdo da publicação",
+    "description": "Confirmação de publicação do TikTok: título do grupo de configurações de conteúdo"
+  },
+  "actionConfirmation.tiktok.requiredNote": {
+    "message": "* Obrigatório",
+    "description": "Confirmação de publicação do TikTok: descrição de campos obrigatórios"
   },
   "actionConfirmation.tiktok.caption": {
     "message": "Texto",
@@ -1389,6 +1437,10 @@
   "actionConfirmation.tiktok.privacyPlaceholder": {
     "message": "Selecione…",
     "description": "Confirmação de publicação do TikTok: espaço reservado para visibilidade, não pode ter valor padrão conforme exigido pelo TikTok."
+  },
+  "actionConfirmation.tiktok.noPrivacyOptions": {
+    "message": "Não foi possível obter um alcance visível disponível, não é possível publicar no momento",
+    "description": "Confirmação de publicação do TikTok: alcance visível vazio"
   },
   "actionConfirmation.tiktok.privacyPublic": {
     "message": "Todos",
@@ -1410,6 +1462,14 @@
     "message": "Permitir interações",
     "description": "Confirmação de publicação do TikTok: rótulo do grupo de interruptores de interação."
   },
+  "actionConfirmation.tiktok.interactionsHint": {
+    "message": "Somente as formas de interação atualmente permitidas para esta conta podem ser ativadas; todas estão desativadas por padrão.",
+    "description": "Confirmação de publicação do TikTok: descrição do interruptor de interação"
+  },
+  "actionConfirmation.tiktok.disabledByAccount": {
+    "message": "Esta conta foi desativada: {list}",
+    "description": "Confirmação de publicação do TikTok: capacidade de interação desativada da conta"
+  },
   "actionConfirmation.tiktok.allowComment": {
     "message": "Comentários",
     "description": "Interruptor de interação do TikTok: permite comentários."
@@ -1422,17 +1482,33 @@
     "message": "Costura",
     "description": "Interruptor de interação do TikTok: permite costuras."
   },
+  "actionConfirmation.tiktok.disclosure": {
+    "message": "Divulgação de conteúdo",
+    "description": "Confirmação de publicação do TikTok: título do grupo de conteúdo comercial"
+  },
   "actionConfirmation.tiktok.commercial": {
     "message": "Este é um conteúdo comercial",
     "description": "Confirmação de publicação do TikTok: interruptor de divulgação de conteúdo comercial."
+  },
+  "actionConfirmation.tiktok.commercialHint": {
+    "message": "Se o conteúdo promover uma marca, produto ou serviço, divulgue conforme necessário.",
+    "description": "Confirmação de publicação do TikTok: descrição da divulgação de conteúdo comercial"
   },
   "actionConfirmation.tiktok.yourBrand": {
     "message": "sua marca",
     "description": "Conteúdo comercial do TikTok: promover seu próprio negócio"
   },
+  "actionConfirmation.tiktok.yourBrandHint": {
+    "message": "Promova você mesmo ou o seu negócio",
+    "description": "Conteúdo comercial do TikTok: explicação sobre como promover seu próprio negócio."
+  },
   "actionConfirmation.tiktok.brandedContent": {
     "message": "Conteúdo de marca",
     "description": "Conteúdo comercial do TikTok: colaboração paga."
+  },
+  "actionConfirmation.tiktok.brandedContentHint": {
+    "message": "Promoção de terceiros por pagamento, brindes ou outros benefícios",
+    "description": "Conteúdo comercial do TikTok: descrição da colaboração paga"
   },
   "actionConfirmation.tiktok.labelPromotional": {
     "message": "O vídeo será marcado como 'conteúdo promocional'",
@@ -1449,6 +1525,42 @@
   "actionConfirmation.tiktok.tooLong": {
     "message": "O vídeo excede o limite de duração para esta conta ({max} segundos)",
     "description": "Confirmação de publicação do TikTok: erro de vídeo muito longo."
+  },
+  "actionConfirmation.tiktok.beforePublishing": {
+    "message": "Por favor, confirme antes de publicar",
+    "description": "Confirmação de publicação do TikTok: título da explicação da política"
+  },
+  "actionConfirmation.tiktok.policyIntro": {
+    "message": "Ao clicar em 'Publicar', você confirma que possui os direitos de uso do conteúdo e da música, e concorda com os termos de uso de música do TikTok.",
+    "description": "Confirmação de publicação do TikTok: explicação da política de conteúdo padrão"
+  },
+  "actionConfirmation.tiktok.policyIntroBranded": {
+    "message": "Ao clicar em 'Publicar', você confirma que as informações de divulgação estão corretas e concorda com a política de conteúdo de marca e os termos de uso de música do TikTok.",
+    "description": "Confirmação de publicação do TikTok: explicação da política de conteúdo de marca"
+  },
+  "actionConfirmation.tiktok.musicUsageLink": {
+    "message": "Ver Confirmação de Uso de Música",
+    "description": "Confirmação de publicação do TikTok: link para confirmação de uso de música"
+  },
+  "actionConfirmation.tiktok.brandedPolicyLink": {
+    "message": "Ver Política de Conteúdo de Marca",
+    "description": "Confirmação de publicação do TikTok: link para a política de conteúdo de marca"
+  },
+  "actionConfirmation.tiktok.fixDetailsFirst": {
+    "message": "Informações de publicação incompletas, por favor, cancele e gere novamente o cartão de confirmação",
+    "description": "Confirmação de publicação do TikTok: razão para desativação do botão quando detalhes estão faltando"
+  },
+  "actionConfirmation.tiktok.useShorterVideo": {
+    "message": "Por favor, use um vídeo que atenda ao limite de duração da conta",
+    "description": "Confirmação de publicação do TikTok: motivo pelo qual o botão está desativado devido ao vídeo ser muito longo."
+  },
+  "actionConfirmation.tiktok.selectPrivacyFirst": {
+    "message": "Por favor, selecione quem pode ver este vídeo",
+    "description": "Confirmação de publicação do TikTok: razão para desativação do botão quando o alcance visível não é selecionado"
+  },
+  "actionConfirmation.tiktok.selectDisclosureType": {
+    "message": "Por favor, selecione o tipo de conteúdo comercial",
+    "description": "Confirmação de publicação do TikTok: razão para desativação do botão quando o tipo de divulgação comercial não é selecionado"
   },
   "actionConfirmation.tiktok.music": {
     "message": "Publicar significa que você concorda com a 'Confirmação de uso de música' do TikTok",

--- a/src/i18n/ru/chat.json
+++ b/src/i18n/ru/chat.json
@@ -926,7 +926,7 @@
   },
   "scheduledTasks.humanize.cronRaw": {
     "message": "Cron: {cron}",
-    "description": "Читаемая человеком версия: оригинальный Cron"
+    "description": "Читаемый человеком: оригинальный Cron"
   },
   "scheduledTasks.humanize.once": {
     "message": "один раз в {time}",
@@ -1370,9 +1370,57 @@
     "message": "Отменено",
     "description": "Подсказка о сворачивании после отмены пользователем в карточке подтверждения перед выполнением"
   },
+  "actionConfirmation.mediaLoading": {
+    "message": "Загрузка медиа-превью...",
+    "description": "Подтверждение перед выполнением: статус загрузки медиа"
+  },
+  "actionConfirmation.mediaUnavailable": {
+    "message": "Невозможно воспроизвести превью здесь",
+    "description": "Подтверждение перед выполнением: заголовок ошибки воспроизведения медиа"
+  },
+  "actionConfirmation.mediaUnavailableHint": {
+    "message": "Ссылка на медиа могла устареть, или текущий браузер не поддерживает этот формат. Пожалуйста, откройте оригинальный файл для проверки перед публикацией.",
+    "description": "Подтверждение перед выполнением: объяснение ошибки воспроизведения медиа"
+  },
+  "actionConfirmation.openMedia": {
+    "message": "Открыть оригинальный файл",
+    "description": "Подтверждение перед выполнением: открыть ссылку на медиа"
+  },
+  "actionConfirmation.tiktok.reviewBadge": {
+    "message": "Подтверждение перед публикацией",
+    "description": "Статус карточки подтверждения публикации в TikTok"
+  },
   "actionConfirmation.tiktok.postingTo": {
     "message": "Публикация в",
     "description": "Метка аккаунта в подтверждении публикации TikTok"
+  },
+  "actionConfirmation.tiktok.connected": {
+    "message": "Подключено",
+    "description": "Подтверждение публикации в TikTok: статус подключения аккаунта"
+  },
+  "actionConfirmation.tiktok.unknownAccount": {
+    "message": "Информация об аккаунте недоступна",
+    "description": "Подтверждение публикации в TikTok: текст-заполнитель при отсутствии ника аккаунта"
+  },
+  "actionConfirmation.tiktok.detailsUnavailable": {
+    "message": "Настройки публикации еще не готовы",
+    "description": "Подтверждение публикации в TikTok: заголовок отсутствующей информации о создателе"
+  },
+  "actionConfirmation.tiktok.detailsUnavailableHint": {
+    "message": "Не удалось получить доступ к видимости, поддерживаемой этим аккаунтом. Пожалуйста, отмените и позвольте помощнику заново получить настройки публикации TikTok.",
+    "description": "Подтверждение публикации в TikTok: объяснение отсутствующей информации о создателе"
+  },
+  "actionConfirmation.tiktok.videoTooLongTitle": {
+    "message": "Длительность видео не соответствует ограничению аккаунта",
+    "description": "Подтверждение публикации TikTok: заголовок для слишком длинного видео"
+  },
+  "actionConfirmation.tiktok.postDetails": {
+    "message": "Содержимое публикации",
+    "description": "Подтверждение публикации в TikTok: заголовок группы настроек контента"
+  },
+  "actionConfirmation.tiktok.requiredNote": {
+    "message": "* Обязательно",
+    "description": "Подтверждение публикации в TikTok: объяснение обязательных полей"
   },
   "actionConfirmation.tiktok.caption": {
     "message": "Подпись",
@@ -1389,6 +1437,10 @@
   "actionConfirmation.tiktok.privacyPlaceholder": {
     "message": "Пожалуйста, выберите…",
     "description": "Заполнитель области видимости в подтверждении публикации TikTok, не может иметь значения по умолчанию согласно требованиям TikTok"
+  },
+  "actionConfirmation.tiktok.noPrivacyOptions": {
+    "message": "Не удалось получить доступные параметры видимости, публикация временно невозможна",
+    "description": "Подтверждение публикации в TikTok: отсутствие видимости"
   },
   "actionConfirmation.tiktok.privacyPublic": {
     "message": "Все",
@@ -1410,6 +1462,14 @@
     "message": "Разрешить взаимодействие",
     "description": "Метка группы переключателей взаимодействия в подтверждении публикации TikTok"
   },
+  "actionConfirmation.tiktok.interactionsHint": {
+    "message": "Можно включить только те способы взаимодействия, которые в данный момент разрешены для этого аккаунта; по умолчанию все отключены.",
+    "description": "Подтверждение публикации в TikTok: объяснение переключателя взаимодействия"
+  },
+  "actionConfirmation.tiktok.disabledByAccount": {
+    "message": "Этот аккаунт отключен: {list}",
+    "description": "Подтверждение публикации в TikTok: отключенные возможности взаимодействия аккаунта"
+  },
   "actionConfirmation.tiktok.allowComment": {
     "message": "Комментарии",
     "description": "Переключатель взаимодействия TikTok: разрешить комментарии"
@@ -1422,17 +1482,33 @@
     "message": "Сшивание",
     "description": "Переключатель взаимодействия TikTok: разрешить сшивание"
   },
+  "actionConfirmation.tiktok.disclosure": {
+    "message": "Раскрытие контента",
+    "description": "Подтверждение публикации в TikTok: заголовок группы коммерческого контента"
+  },
   "actionConfirmation.tiktok.commercial": {
     "message": "Это коммерческий контент",
     "description": "Переключатель раскрытия коммерческого контента в подтверждении публикации TikTok"
+  },
+  "actionConfirmation.tiktok.commercialHint": {
+    "message": "Если контент продвигает бренд, продукт или услугу, пожалуйста, раскройте информацию в соответствии с фактической ситуацией.",
+    "description": "Подтверждение публикации в TikTok: объяснение раскрытия коммерческого контента"
   },
   "actionConfirmation.tiktok.yourBrand": {
     "message": "Ваш бренд",
     "description": "Коммерческий контент TikTok: продвижение собственного бизнеса"
   },
+  "actionConfirmation.tiktok.yourBrandHint": {
+    "message": "Продвигайте себя или свой бизнес",
+    "description": "Коммерческий контент TikTok: объяснение продвижения собственного бизнеса"
+  },
   "actionConfirmation.tiktok.brandedContent": {
     "message": "Брендированный контент",
     "description": "Коммерческий контент TikTok: платное сотрудничество"
+  },
+  "actionConfirmation.tiktok.brandedContentHint": {
+    "message": "Продвижение третьей стороны за счет оплаты, подарков или других выгод",
+    "description": "Коммерческое содержание TikTok: объяснение платного сотрудничества"
   },
   "actionConfirmation.tiktok.labelPromotional": {
     "message": "Видео будет помечено как «рекламный контент»",
@@ -1449,6 +1525,42 @@
   "actionConfirmation.tiktok.tooLong": {
     "message": "Видео превышает лимит времени для этого аккаунта ({max} секунд)",
     "description": "Ошибка превышения длины видео в подтверждении публикации TikTok"
+  },
+  "actionConfirmation.tiktok.beforePublishing": {
+    "message": "Пожалуйста, подтвердите перед публикацией",
+    "description": "Подтверждение публикации в TikTok: заголовок политики"
+  },
+  "actionConfirmation.tiktok.policyIntro": {
+    "message": "Нажимая «Опубликовать», вы подтверждаете, что обладаете правами на использование контента и музыки, и соглашаетесь с условиями использования музыки TikTok.",
+    "description": "Подтверждение публикации в TikTok: объяснение политики обычного контента"
+  },
+  "actionConfirmation.tiktok.policyIntroBranded": {
+    "message": "Нажимая «Опубликовать», вы подтверждаете, что информация о раскрытии точна, и соглашаетесь с политикой брендированного контента и условиями использования музыки TikTok.",
+    "description": "Подтверждение публикации в TikTok: объяснение политики брендированного контента"
+  },
+  "actionConfirmation.tiktok.musicUsageLink": {
+    "message": "Посмотреть «Подтверждение использования музыки»",
+    "description": "Подтверждение публикации в TikTok: ссылка на подтверждение использования музыки"
+  },
+  "actionConfirmation.tiktok.brandedPolicyLink": {
+    "message": "Посмотреть «Политику брендированного контента»",
+    "description": "Подтверждение публикации в TikTok: ссылка на политику брендированного контента"
+  },
+  "actionConfirmation.tiktok.fixDetailsFirst": {
+    "message": "Информация о публикации неполная, пожалуйста, отмените и создайте подтверждение заново",
+    "description": "Подтверждение публикации в TikTok: причина отключения кнопки при отсутствии деталей"
+  },
+  "actionConfirmation.tiktok.useShorterVideo": {
+    "message": "Пожалуйста, используйте видео, соответствующее ограничению по времени для этого аккаунта",
+    "description": "Подтверждение публикации TikTok: причина отключения кнопки из-за слишком длинного видео"
+  },
+  "actionConfirmation.tiktok.selectPrivacyFirst": {
+    "message": "Пожалуйста, выберите, кто может видеть это видео",
+    "description": "Подтверждение публикации в TikTok: причина отключения кнопки при отсутствии выбора видимости"
+  },
+  "actionConfirmation.tiktok.selectDisclosureType": {
+    "message": "Пожалуйста, выберите тип коммерческого контента",
+    "description": "Подтверждение публикации в TikTok: причина отключения кнопки при отсутствии выбора типа раскрытия"
   },
   "actionConfirmation.tiktok.music": {
     "message": "Публикация означает, что вы соглашаетесь с «Подтверждением использования музыки» TikTok",

--- a/src/i18n/sr/chat.json
+++ b/src/i18n/sr/chat.json
@@ -898,7 +898,7 @@
   },
   "scheduledTasks.humanize.cronRaw": {
     "message": "Cron: {cron}",
-    "description": "Читљиво за људе: оригинални Cron"
+    "description": "Лако читљиво: оригинални Cron"
   },
   "scheduledTasks.humanize.once": {
     "message": "једном у {time}",
@@ -1331,9 +1331,57 @@
     "message": "Отказано",
     "description": "Картица за потврду пре извршења: обавештење након отказа од стране корисника"
   },
+  "actionConfirmation.mediaLoading": {
+    "message": "Učitavanje medijske pregleda…",
+    "description": "Potvrda pre akcije: Status učitavanja medija"
+  },
+  "actionConfirmation.mediaUnavailable": {
+    "message": "Nije moguće reprodukovati pregled ovde",
+    "description": "Potvrda pre akcije: Naslov greške pri reprodukciji medija"
+  },
+  "actionConfirmation.mediaUnavailableHint": {
+    "message": "Veza do medija možda je istekao, ili trenutni pregledač ne podržava ovaj format. Molimo vas da prvo otvorite izvorni fajl za potvrdu.",
+    "description": "Potvrda pre akcije: Objašnjenje greške pri reprodukciji medija"
+  },
+  "actionConfirmation.openMedia": {
+    "message": "Otvorite izvorni fajl",
+    "description": "Potvrda pre akcije: Otvorite vezu do medija"
+  },
+  "actionConfirmation.tiktok.reviewBadge": {
+    "message": "Potvrda pre objavljivanja",
+    "description": "TikTok potvrda pre objavljivanja: Status oznake potvrde"
+  },
   "actionConfirmation.tiktok.postingTo": {
     "message": "Објављује се на",
     "description": "TikTok потврда објављивања: ознака налога"
+  },
+  "actionConfirmation.tiktok.connected": {
+    "message": "Povezano",
+    "description": "TikTok potvrda pre objavljivanja: Status povezivanja naloga"
+  },
+  "actionConfirmation.tiktok.unknownAccount": {
+    "message": "Informacije o nalogu nisu dostupne",
+    "description": "TikTok potvrda pre objavljivanja: Tekst za zauzeto mesto kada nedostaje nadimak naloga"
+  },
+  "actionConfirmation.tiktok.detailsUnavailable": {
+    "message": "Podešavanja za objavljivanje još nisu spremna",
+    "description": "TikTok potvrda pre objavljivanja: Naslov nedostajućih informacija o kreatoru"
+  },
+  "actionConfirmation.tiktok.detailsUnavailableHint": {
+    "message": "Nije moguće pročitati dostupne opsege za ovaj nalog. Molimo vas da otkažete i ponovo zatražite TikTok podešavanja za objavljivanje.",
+    "description": "TikTok potvrda pre objavljivanja: Objašnjenje nedostajućih informacija o kreatoru"
+  },
+  "actionConfirmation.tiktok.videoTooLongTitle": {
+    "message": "Дужина видеа не испуњава ограничење налога",
+    "description": "TikTok потврда акције: наслов за видео који је превише дуг"
+  },
+  "actionConfirmation.tiktok.postDetails": {
+    "message": "Objavi sadržaj",
+    "description": "TikTok potvrda pre objavljivanja: Naslov grupe podešavanja sadržaja"
+  },
+  "actionConfirmation.tiktok.requiredNote": {
+    "message": "* Obavezno",
+    "description": "TikTok potvrda pre objavljivanja: Objašnjenje obaveznih informacija"
   },
   "actionConfirmation.tiktok.caption": {
     "message": "Наслов",
@@ -1350,6 +1398,10 @@
   "actionConfirmation.tiktok.privacyPlaceholder": {
     "message": "Изаберите…",
     "description": "TikTok потврда објављивања: место за унос видљивости, према захтевима TikTok не може имати подразумевану вредност"
+  },
+  "actionConfirmation.tiktok.noPrivacyOptions": {
+    "message": "Nije dostupna vidljivost, trenutno ne može da se objavi",
+    "description": "TikTok potvrda pre objavljivanja: Vidljivost je prazna"
   },
   "actionConfirmation.tiktok.privacyPublic": {
     "message": "Сви",
@@ -1371,6 +1423,14 @@
     "message": "Дозволи интеракције",
     "description": "TikTok потврда објављивања: ознака групе за прекидач интеракција"
   },
+  "actionConfirmation.tiktok.interactionsHint": {
+    "message": "Možete omogućiti samo načine interakcije koje trenutni nalog dozvoljava; podrazumevano su svi isključeni.",
+    "description": "TikTok potvrda pre objavljivanja: Objašnjenje prekidača za interakciju"
+  },
+  "actionConfirmation.tiktok.disabledByAccount": {
+    "message": "Ovaj nalog je onemogućen: {list}",
+    "description": "TikTok potvrda pre objavljivanja: Interaktivne mogućnosti onemogućenog naloga"
+  },
   "actionConfirmation.tiktok.allowComment": {
     "message": "Коментари",
     "description": "TikTok интеракција: дозвољава коментаре"
@@ -1383,17 +1443,33 @@
     "message": "Спој",
     "description": "TikTok интеракција: дозвољава спајање"
   },
+  "actionConfirmation.tiktok.disclosure": {
+    "message": "Otkrivanje sadržaja",
+    "description": "TikTok potvrda pre objavljivanja: Naslov grupe komercijalnog sadržaja"
+  },
   "actionConfirmation.tiktok.commercial": {
     "message": "Ово је комерцијални садржај",
     "description": "TikTok потврда објављивања: прекидач за откривање комерцијалног садржаја"
+  },
+  "actionConfirmation.tiktok.commercialHint": {
+    "message": "Ako sadržaj promoviše brend, proizvod ili uslugu, molimo vas da to otkrijete prema stvarnoj situaciji.",
+    "description": "TikTok potvrda pre objavljivanja: Objašnjenje otkrivanja komercijalnog sadržaja"
   },
   "actionConfirmation.tiktok.yourBrand": {
     "message": "Vaš brend",
     "description": "TikTok poslovni sadržaj: promocija vlastitog biznisa"
   },
+  "actionConfirmation.tiktok.yourBrandHint": {
+    "message": "Промовишите себе или свој посао",
+    "description": "TikTok комерцијални садржај: објашњење за промоцију сопственог посла"
+  },
   "actionConfirmation.tiktok.brandedContent": {
     "message": "Брендирани садржај",
     "description": "TikTok комерцијални садржај: плаћена сарадња"
+  },
+  "actionConfirmation.tiktok.brandedContentHint": {
+    "message": "Promocija treće strane zbog plaćanja, poklona ili drugih koristi",
+    "description": "TikTok komercijalni sadržaj: Objašnjenje plaćenih saradnji"
   },
   "actionConfirmation.tiktok.labelPromotional": {
     "message": "Видео ће бити обележен као „промотивни садржај“",
@@ -1410,6 +1486,42 @@
   "actionConfirmation.tiktok.tooLong": {
     "message": "Видео прелази максимално време налога ({max} секунди)",
     "description": "TikTok потврда објављивања: грешка због превеликог трајања видеа"
+  },
+  "actionConfirmation.tiktok.beforePublishing": {
+    "message": "Molimo vas da potvrdite pre objavljivanja",
+    "description": "TikTok potvrda pre objavljivanja: Naslov objašnjenja politike"
+  },
+  "actionConfirmation.tiktok.policyIntro": {
+    "message": "Klikom na 'Objavi' potvrđujete da imate prava na korišćenje sadržaja i muzike, i slažete se sa uslovima korišćenja muzike TikTok-a.",
+    "description": "TikTok potvrda pre objavljivanja: Objašnjenje politike za običan sadržaj"
+  },
+  "actionConfirmation.tiktok.policyIntroBranded": {
+    "message": "Klikom na 'Objavi' potvrđujete da su informacije o otkrivanju tačne i slažete se sa politikom brendiranog sadržaja i uslovima korišćenja muzike TikTok-a.",
+    "description": "TikTok potvrda pre objavljivanja: Objašnjenje politike za brendirani sadržaj"
+  },
+  "actionConfirmation.tiktok.musicUsageLink": {
+    "message": "Pogledajte 'Potvrdu o korišćenju muzike'",
+    "description": "TikTok potvrda pre objavljivanja: Link ka potvrdi o korišćenju muzike"
+  },
+  "actionConfirmation.tiktok.brandedPolicyLink": {
+    "message": "Pogledajte 'Politiku brendiranog sadržaja'",
+    "description": "TikTok potvrda pre objavljivanja: Link ka politici brendiranog sadržaja"
+  },
+  "actionConfirmation.tiktok.fixDetailsFirst": {
+    "message": "Informacije o objavljivanju nisu potpune, molimo vas da otkažete i ponovo generišete potvrdu",
+    "description": "TikTok potvrda pre objavljivanja: Razlog onemogućavanja dugmeta kada nedostaju detalji"
+  },
+  "actionConfirmation.tiktok.useShorterVideo": {
+    "message": "Молимо вас да користите видео које испуњава ограничење трајања за овај налог",
+    "description": "TikTok потврда акције: разлог за онемогућавање дугмета када је видео превише дуг"
+  },
+  "actionConfirmation.tiktok.selectPrivacyFirst": {
+    "message": "Molimo vas da odaberete ko može da vidi ovaj video",
+    "description": "TikTok potvrda pre objavljivanja: Razlog onemogućavanja dugmeta kada nije odabran opseg vidljivosti"
+  },
+  "actionConfirmation.tiktok.selectDisclosureType": {
+    "message": "Molimo vas da odaberete tip komercijalnog sadržaja",
+    "description": "TikTok potvrda pre objavljivanja: Razlog onemogućavanja dugmeta kada nije odabran tip otkrivanja"
   },
   "actionConfirmation.tiktok.music": {
     "message": "Објављивањем потврђујете да се слажете са TikTok-овом „Потврдом о коришћењу музике“",

--- a/src/i18n/sv/chat.json
+++ b/src/i18n/sv/chat.json
@@ -926,7 +926,7 @@
   },
   "scheduledTasks.humanize.cronRaw": {
     "message": "Cron: {cron}",
-    "description": "Mänskligt läsbart: Ursprunglig Cron"
+    "description": "Mänskligt läsbart: Original Cron"
   },
   "scheduledTasks.humanize.once": {
     "message": "Engångs {time}",
@@ -945,8 +945,8 @@
     "description": "Val av modell"
   },
   "scheduledTasks.form.prompt": {
-    "message": "Prompt",
-    "description": "Prompt fält"
+    "message": "Promptord",
+    "description": "Fält för promptord"
   },
   "scheduledTasks.form.promptPlaceholder": {
     "message": "Ange frågan eller kommandot som ska köras schemalagt, stöder {'{{date}}'}, {'{{run_count}}'}, {'{{last_output}}'} variabler",
@@ -1125,7 +1125,7 @@
   },
   "artifacts.kind.video": {
     "message": "Video",
-    "description": "Utdata typ - Video"
+    "description": "Typ av utdata - video"
   },
   "artifacts.kind.audio": {
     "message": "Ljud",
@@ -1370,9 +1370,57 @@
     "message": "Avbruten",
     "description": "Bekräftelsekort: Meddelande efter att användaren har avbrutit"
   },
+  "actionConfirmation.mediaLoading": {
+    "message": "Laddar mediavisning...",
+    "description": "Bekräftelsekort före åtgärd: Medialaddningsstatus"
+  },
+  "actionConfirmation.mediaUnavailable": {
+    "message": "Kan inte spela förhandsvisning här",
+    "description": "Bekräftelsekort före åtgärd: Titel för misslyckad medieuppspelning"
+  },
+  "actionConfirmation.mediaUnavailableHint": {
+    "message": "Medielänken kan ha gått ut, eller så stöder den aktuella webbläsaren inte detta format. Vänligen öppna originalfilen för att bekräfta innan publicering.",
+    "description": "Bekräftelsekort före åtgärd: Förklaring till misslyckad medieuppspelning"
+  },
+  "actionConfirmation.openMedia": {
+    "message": "Öppna originalfil",
+    "description": "Bekräftelsekort före åtgärd: Öppna medielänk"
+  },
+  "actionConfirmation.tiktok.reviewBadge": {
+    "message": "Bekräfta före publicering",
+    "description": "TikTok publiceringsbekräftelsekortets statusetikett"
+  },
   "actionConfirmation.tiktok.postingTo": {
     "message": "Publicera till",
     "description": "TikTok publiceringsbekräftelse: Kontot etikett"
+  },
+  "actionConfirmation.tiktok.connected": {
+    "message": "Ansluten",
+    "description": "TikTok publiceringsbekräftelse: Kontoinformation om anslutningsstatus"
+  },
+  "actionConfirmation.tiktok.unknownAccount": {
+    "message": "Kontoinformation är inte tillgänglig",
+    "description": "TikTok publiceringsbekräftelse: Platshållartext vid saknad kontonamn"
+  },
+  "actionConfirmation.tiktok.detailsUnavailable": {
+    "message": "Publiceringsinställningar är inte klara",
+    "description": "TikTok publiceringsbekräftelse: Titel för saknad skaparinformation"
+  },
+  "actionConfirmation.tiktok.detailsUnavailableHint": {
+    "message": "Det gick inte att läsa den synlighet som kontot stöder. Vänligen avbryt och låt assistenten hämta TikTok publiceringsinställningar på nytt.",
+    "description": "TikTok publiceringsbekräftelse: Förklaring till saknad skaparinformation"
+  },
+  "actionConfirmation.tiktok.videoTooLongTitle": {
+    "message": "Videons längd uppfyller inte kontots begränsning",
+    "description": "TikTok publiceringsbekräftelse: Titel för videor som är för långa"
+  },
+  "actionConfirmation.tiktok.postDetails": {
+    "message": "Publicera innehåll",
+    "description": "TikTok publiceringsbekräftelse: Titel för innehållsinställningar"
+  },
+  "actionConfirmation.tiktok.requiredNote": {
+    "message": "* Obligatoriskt fält",
+    "description": "TikTok publiceringsbekräftelse: Förklaring till obligatoriska fält"
   },
   "actionConfirmation.tiktok.caption": {
     "message": "Text",
@@ -1389,6 +1437,10 @@
   "actionConfirmation.tiktok.privacyPlaceholder": {
     "message": "Vänligen välj…",
     "description": "TikTok publiceringsbekräftelse: Platshållare för synlighetsinställningar, enligt TikToks krav får det inte finnas något standardvärde"
+  },
+  "actionConfirmation.tiktok.noPrivacyOptions": {
+    "message": "Ingen tillgänglig synlighet har erhållits, publicering kan för närvarande inte göras",
+    "description": "TikTok publiceringsbekräftelse: Ingen synlighet tillgänglig"
   },
   "actionConfirmation.tiktok.privacyPublic": {
     "message": "Alla",
@@ -1410,6 +1462,14 @@
     "message": "Tillåt interaktioner",
     "description": "TikTok publiceringsbekräftelse: Gruppetikett för interaktionsinställningar"
   },
+  "actionConfirmation.tiktok.interactionsHint": {
+    "message": "Endast de interaktionssätt som kontot för närvarande tillåter kan aktiveras; som standard är alla avstängda.",
+    "description": "TikTok publiceringsbekräftelse: Förklaring till interaktionsinställningar"
+  },
+  "actionConfirmation.tiktok.disabledByAccount": {
+    "message": "Detta konto har stängts av: {list}",
+    "description": "TikTok publiceringsbekräftelse: Interaktionsmöjligheter för ett avstängt konto"
+  },
   "actionConfirmation.tiktok.allowComment": {
     "message": "Kommentarer",
     "description": "TikTok interaktionsinställning: Tillåt kommentarer"
@@ -1422,17 +1482,33 @@
     "message": "Sammanfogning",
     "description": "TikTok interaktionsinställning: Tillåt stitch"
   },
+  "actionConfirmation.tiktok.disclosure": {
+    "message": "Innehållsavslöjande",
+    "description": "TikTok publiceringsbekräftelse: Titel för kommersiellt innehåll"
+  },
   "actionConfirmation.tiktok.commercial": {
     "message": "Detta är kommersiellt innehåll",
     "description": "TikTok publiceringsbekräftelse: Avslöjande för kommersiellt innehåll"
+  },
+  "actionConfirmation.tiktok.commercialHint": {
+    "message": "Om innehållet främjar ett varumärke, produkt eller tjänst, vänligen avslöja det korrekt.",
+    "description": "TikTok publiceringsbekräftelse: Beskrivning av kommersiell innehållsavslöjande"
   },
   "actionConfirmation.tiktok.yourBrand": {
     "message": "ditt varumärke",
     "description": "TikTok kommersiellt innehåll: marknadsför ditt eget företag"
   },
+  "actionConfirmation.tiktok.yourBrandHint": {
+    "message": "Marknadsför dig själv eller ditt företag",
+    "description": "TikTok kommersiellt innehåll: Förklaring för att marknadsföra eget företag"
+  },
   "actionConfirmation.tiktok.brandedContent": {
     "message": "Märkesinnehåll",
     "description": "TikTok kommersiellt innehåll: Betald samarbeten"
+  },
+  "actionConfirmation.tiktok.brandedContentHint": {
+    "message": "Främja en tredje part för betalning, gåvor eller andra fördelar",
+    "description": "TikTok kommersiellt innehåll: Beskrivning av betald samverkan"
   },
   "actionConfirmation.tiktok.labelPromotional": {
     "message": "Videon kommer att märkas som 'Reklaminnehåll'",
@@ -1449,6 +1525,42 @@
   "actionConfirmation.tiktok.tooLong": {
     "message": "Videon överskrider kontots tidsgräns ({max} sekunder)",
     "description": "TikTok publiceringsbekräftelse: Felmeddelande för för lång video"
+  },
+  "actionConfirmation.tiktok.beforePublishing": {
+    "message": "Vänligen bekräfta före publicering",
+    "description": "TikTok publiceringsbekräftelse: Policybeskrivningstext"
+  },
+  "actionConfirmation.tiktok.policyIntro": {
+    "message": "Genom att klicka på \"Publicera\" bekräftar du att du har rätt att använda innehållet och musiken samt godkänner TikToks villkor för musikbruk.",
+    "description": "TikTok publiceringsbekräftelse: Beskrivning av allmänna innehållspolicy"
+  },
+  "actionConfirmation.tiktok.policyIntroBranded": {
+    "message": "Genom att klicka på \"Publicera\" bekräftar du att informationen om avslöjande är korrekt och godkänner TikToks policy för varumärkesinnehåll och villkor för musikbruk.",
+    "description": "TikTok publiceringsbekräftelse: Beskrivning av policy för varumärkesinnehåll"
+  },
+  "actionConfirmation.tiktok.musicUsageLink": {
+    "message": "Se \"Bekräftelse av musikbruk\"",
+    "description": "TikTok publiceringsbekräftelse: Länk till bekräftelse av musikbruk"
+  },
+  "actionConfirmation.tiktok.brandedPolicyLink": {
+    "message": "Se \"Policy för varumärkesinnehåll\"",
+    "description": "TikTok publiceringsbekräftelse: Länk till policy för varumärkesinnehåll"
+  },
+  "actionConfirmation.tiktok.fixDetailsFirst": {
+    "message": "Publiceringsinformation är ofullständig, vänligen avbryt och generera bekräftelsekortet igen",
+    "description": "TikTok publiceringsbekräftelse: Orsak till inaktivering av knapp vid saknade detaljer"
+  },
+  "actionConfirmation.tiktok.useShorterVideo": {
+    "message": "Vänligen använd en video som uppfyller kontots tidsbegränsning",
+    "description": "TikTok publiceringsbekräftelse: Anledningen till att knappen är inaktiverad för videor som är för långa"
+  },
+  "actionConfirmation.tiktok.selectPrivacyFirst": {
+    "message": "Vänligen välj vem som kan se denna video",
+    "description": "TikTok publiceringsbekräftelse: Orsak till inaktivering av knapp vid ej vald synlighet"
+  },
+  "actionConfirmation.tiktok.selectDisclosureType": {
+    "message": "Vänligen välj typ av kommersiellt innehåll",
+    "description": "TikTok publiceringsbekräftelse: Orsak till inaktivering av knapp vid ej vald typ av avslöjande"
   },
   "actionConfirmation.tiktok.music": {
     "message": "Publicering innebär att du godkänner TikToks 'Musikanvändningsbekräftelse'",

--- a/src/i18n/uk/chat.json
+++ b/src/i18n/uk/chat.json
@@ -926,7 +926,7 @@
   },
   "scheduledTasks.humanize.cronRaw": {
     "message": "Cron: {cron}",
-    "description": "Людською мовою: оригінальний Cron"
+    "description": "Людське читання: оригінальний Cron"
   },
   "scheduledTasks.humanize.once": {
     "message": "Одноразово {time}",
@@ -1370,9 +1370,57 @@
     "message": "Скасовано",
     "description": "Картка підтвердження перед виконанням: повідомлення після скасування користувачем"
   },
+  "actionConfirmation.mediaLoading": {
+    "message": "Завантаження медіа-прев'ю...",
+    "description": "Підтвердження перед виконанням: статус завантаження медіа"
+  },
+  "actionConfirmation.mediaUnavailable": {
+    "message": "Неможливо відтворити прев'ю тут",
+    "description": "Підтвердження перед виконанням: заголовок помилки відтворення медіа"
+  },
+  "actionConfirmation.mediaUnavailableHint": {
+    "message": "Посилання на медіа могло втратити актуальність, або поточний браузер не підтримує цей формат. Будь ласка, відкрийте оригінальний файл для підтвердження перед публікацією.",
+    "description": "Підтвердження перед виконанням: пояснення помилки відтворення медіа"
+  },
+  "actionConfirmation.openMedia": {
+    "message": "Відкрити оригінальний файл",
+    "description": "Підтвердження перед виконанням: відкриття медіа-посилання"
+  },
+  "actionConfirmation.tiktok.reviewBadge": {
+    "message": "Підтвердження перед публікацією",
+    "description": "Статус картки підтвердження публікації TikTok"
+  },
   "actionConfirmation.tiktok.postingTo": {
     "message": "Публікація до",
     "description": "Підтвердження публікації TikTok: мітка облікового запису"
+  },
+  "actionConfirmation.tiktok.connected": {
+    "message": "Підключено",
+    "description": "Підтвердження публікації TikTok: статус підключення аккаунта"
+  },
+  "actionConfirmation.tiktok.unknownAccount": {
+    "message": "Інформація про аккаунт недоступна",
+    "description": "Підтвердження публікації TikTok: заповнювальний текст при відсутності ніку аккаунта"
+  },
+  "actionConfirmation.tiktok.detailsUnavailable": {
+    "message": "Налаштування публікації ще не готові",
+    "description": "Підтвердження публікації TikTok: заголовок відсутньої інформації про творця"
+  },
+  "actionConfirmation.tiktok.detailsUnavailableHint": {
+    "message": "Не вдалося отримати видимість, підтримувану цим аккаунтом. Будь ласка, скасуйте та дайте помічнику повторно отримати налаштування публікації TikTok.",
+    "description": "Підтвердження публікації TikTok: пояснення відсутньої інформації про творця"
+  },
+  "actionConfirmation.tiktok.videoTooLongTitle": {
+    "message": "Тривалість відео не відповідає обмеженням акаунта",
+    "description": "TikTok підтвердження дії: заголовок для надто довгого відео"
+  },
+  "actionConfirmation.tiktok.postDetails": {
+    "message": "Контент публікації",
+    "description": "Підтвердження публікації TikTok: заголовок налаштувань контенту"
+  },
+  "actionConfirmation.tiktok.requiredNote": {
+    "message": "* Обов'язково",
+    "description": "Підтвердження публікації TikTok: пояснення обов'язкових полів"
   },
   "actionConfirmation.tiktok.caption": {
     "message": "Опис",
@@ -1389,6 +1437,10 @@
   "actionConfirmation.tiktok.privacyPlaceholder": {
     "message": "Будь ласка, виберіть…",
     "description": "Підтвердження публікації TikTok: заповнювач для видимості, не може мати значення за замовчуванням згідно з вимогами TikTok"
+  },
+  "actionConfirmation.tiktok.noPrivacyOptions": {
+    "message": "Не вдалося отримати доступні параметри видимості, наразі публікацію не можна здійснити",
+    "description": "Підтвердження публікації TikTok: відсутність видимості"
   },
   "actionConfirmation.tiktok.privacyPublic": {
     "message": "Усі",
@@ -1410,6 +1462,14 @@
     "message": "Дозволити взаємодію",
     "description": "Підтвердження публікації TikTok: мітка групи перемикачів взаємодії"
   },
+  "actionConfirmation.tiktok.interactionsHint": {
+    "message": "Можна активувати лише ті способи взаємодії, які наразі дозволені для цього аккаунта; за замовчуванням всі вимкнені.",
+    "description": "Підтвердження публікації TikTok: пояснення перемикача взаємодії"
+  },
+  "actionConfirmation.tiktok.disabledByAccount": {
+    "message": "Цей аккаунт вимкнено: {list}",
+    "description": "Підтвердження публікації TikTok: взаємодії, які заборонені для вимкненого аккаунта"
+  },
   "actionConfirmation.tiktok.allowComment": {
     "message": "Коментарі",
     "description": "Перемикач взаємодії TikTok: дозволити коментарі"
@@ -1422,17 +1482,33 @@
     "message": "Склеювання",
     "description": "Перемикач взаємодії TikTok: дозволити склеювання"
   },
+  "actionConfirmation.tiktok.disclosure": {
+    "message": "Розкриття контенту",
+    "description": "Підтвердження публікації TikTok: заголовок групи комерційного контенту"
+  },
   "actionConfirmation.tiktok.commercial": {
     "message": "Це комерційний контент",
     "description": "Підтвердження публікації TikTok: перемикач розкриття комерційного контенту"
+  },
+  "actionConfirmation.tiktok.commercialHint": {
+    "message": "Якщо контент просуває бренд, продукт або послугу, будь ласка, розкрийте інформацію відповідно до реальності.",
+    "description": "Підтвердження публікації TikTok: пояснення розкриття комерційного контенту"
   },
   "actionConfirmation.tiktok.yourBrand": {
     "message": "Ваш бренд",
     "description": "TikTok комерційний контент: просування власного бізнесу"
   },
+  "actionConfirmation.tiktok.yourBrandHint": {
+    "message": "Рекламуйте себе або свій бізнес",
+    "description": "TikTok комерційний контент: пояснення щодо реклами власного бізнесу"
+  },
   "actionConfirmation.tiktok.brandedContent": {
     "message": "Брендований контент",
     "description": "Комерційний контент TikTok: платне співробітництво"
+  },
+  "actionConfirmation.tiktok.brandedContentHint": {
+    "message": "Просування третьої сторони за рахунок оплати, подарунків або інших вигод",
+    "description": "TikTok комерційний контент: пояснення платного співробітництва"
   },
   "actionConfirmation.tiktok.labelPromotional": {
     "message": "Відео буде позначено як «рекламний контент»",
@@ -1449,6 +1525,42 @@
   "actionConfirmation.tiktok.tooLong": {
     "message": "Відео перевищує максимальний ліміт тривалості для цього облікового запису ({max} секунд)",
     "description": "Підтвердження публікації TikTok: помилка перевищення тривалості відео"
+  },
+  "actionConfirmation.tiktok.beforePublishing": {
+    "message": "Будь ласка, підтверджте перед публікацією",
+    "description": "Підтвердження публікації TikTok: заголовок пояснення політики"
+  },
+  "actionConfirmation.tiktok.policyIntro": {
+    "message": "Натискаючи «Опублікувати», ви підтверджуєте, що маєте право на використання контенту та музики, і погоджуєтеся з умовами використання музики TikTok.",
+    "description": "Підтвердження публікації TikTok: пояснення загальної політики контенту"
+  },
+  "actionConfirmation.tiktok.policyIntroBranded": {
+    "message": "Натискаючи «Опублікувати», ви підтверджуєте, що інформація про розкриття є точною, і погоджуєтеся з політикою брендового контенту та умовами використання музики TikTok.",
+    "description": "Підтвердження публікації TikTok: пояснення політики брендових контентів"
+  },
+  "actionConfirmation.tiktok.musicUsageLink": {
+    "message": "Переглянути «Підтвердження використання музики»",
+    "description": "Підтвердження публікації TikTok: посилання на підтвердження використання музики"
+  },
+  "actionConfirmation.tiktok.brandedPolicyLink": {
+    "message": "Переглянути «Політику брендового контенту»",
+    "description": "Підтвердження публікації TikTok: посилання на політику брендових контентів"
+  },
+  "actionConfirmation.tiktok.fixDetailsFirst": {
+    "message": "Інформація про публікацію неповна, будь ласка, скасуйте та згенеруйте підтверджувальну картку знову",
+    "description": "Підтвердження публікації TikTok: причина відключення кнопки при відсутності деталей"
+  },
+  "actionConfirmation.tiktok.useShorterVideo": {
+    "message": "Будь ласка, використайте відео, що відповідає обмеженням по тривалості для цього акаунта",
+    "description": "TikTok підтвердження дії: причина, чому кнопка вимкнена через надто довге відео"
+  },
+  "actionConfirmation.tiktok.selectPrivacyFirst": {
+    "message": "Будь ласка, виберіть, хто може бачити це відео",
+    "description": "Підтвердження публікації TikTok: причина відключення кнопки при відсутності вибору видимості"
+  },
+  "actionConfirmation.tiktok.selectDisclosureType": {
+    "message": "Будь ласка, виберіть тип комерційного контенту",
+    "description": "Підтвердження публікації TikTok: причина відключення кнопки при відсутності вибору типу розкриття"
   },
   "actionConfirmation.tiktok.music": {
     "message": "Публікація означає, що ви погоджуєтеся з «Підтвердженням використання музики» TikTok",

--- a/src/i18n/zh-CN/chat.json
+++ b/src/i18n/zh-CN/chat.json
@@ -1364,9 +1364,57 @@
     "message": "已取消",
     "description": "执行前确认卡片：用户取消后的折叠提示"
   },
+  "actionConfirmation.mediaLoading": {
+    "message": "正在加载媒体预览…",
+    "description": "执行前确认卡片：媒体加载状态"
+  },
+  "actionConfirmation.mediaUnavailable": {
+    "message": "无法在此处播放预览",
+    "description": "执行前确认卡片：媒体播放失败标题"
+  },
+  "actionConfirmation.mediaUnavailableHint": {
+    "message": "媒体链接可能已过期，或当前浏览器不支持该格式。发布前请先打开原文件确认。",
+    "description": "执行前确认卡片：媒体播放失败说明"
+  },
+  "actionConfirmation.openMedia": {
+    "message": "打开原文件",
+    "description": "执行前确认卡片：打开媒体链接"
+  },
+  "actionConfirmation.tiktok.reviewBadge": {
+    "message": "发布前确认",
+    "description": "TikTok 发布确认卡片状态标签"
+  },
   "actionConfirmation.tiktok.postingTo": {
-    "message": "发布至",
+    "message": "发布到此账号",
     "description": "TikTok 发布确认：账号标签"
+  },
+  "actionConfirmation.tiktok.connected": {
+    "message": "已连接",
+    "description": "TikTok 发布确认：账号连接状态"
+  },
+  "actionConfirmation.tiktok.unknownAccount": {
+    "message": "账号信息不可用",
+    "description": "TikTok 发布确认：缺少账号昵称时的占位文案"
+  },
+  "actionConfirmation.tiktok.detailsUnavailable": {
+    "message": "发布设置尚未准备好",
+    "description": "TikTok 发布确认：创作者信息缺失标题"
+  },
+  "actionConfirmation.tiktok.detailsUnavailableHint": {
+    "message": "未能读取该账号支持的可见范围。请取消并让助手重新获取 TikTok 发布设置。",
+    "description": "TikTok 发布确认：创作者信息缺失说明"
+  },
+  "actionConfirmation.tiktok.videoTooLongTitle": {
+    "message": "视频时长不符合账号限制",
+    "description": "TikTok 发布确认：视频超长标题"
+  },
+  "actionConfirmation.tiktok.postDetails": {
+    "message": "发布内容",
+    "description": "TikTok 发布确认：内容设置分组标题"
+  },
+  "actionConfirmation.tiktok.requiredNote": {
+    "message": "* 必填",
+    "description": "TikTok 发布确认：必填说明"
   },
   "actionConfirmation.tiktok.caption": {
     "message": "文案",
@@ -1381,8 +1429,12 @@
     "description": "TikTok 发布确认：可见范围下拉标签"
   },
   "actionConfirmation.tiktok.privacyPlaceholder": {
-    "message": "请选择…",
+    "message": "请选择可见范围",
     "description": "TikTok 发布确认：可见范围占位符，按 TikTok 要求不能有默认值"
+  },
+  "actionConfirmation.tiktok.noPrivacyOptions": {
+    "message": "未获取到可用的可见范围，暂不能发布",
+    "description": "TikTok 发布确认：可见范围为空"
   },
   "actionConfirmation.tiktok.privacyPublic": {
     "message": "所有人",
@@ -1401,8 +1453,16 @@
     "description": "TikTok 可见范围：仅自己可见"
   },
   "actionConfirmation.tiktok.interactions": {
-    "message": "允许互动",
+    "message": "互动权限",
     "description": "TikTok 发布确认：互动开关分组标签"
+  },
+  "actionConfirmation.tiktok.interactionsHint": {
+    "message": "仅可开启该账号当前允许的互动方式；默认全部关闭。",
+    "description": "TikTok 发布确认：互动开关说明"
+  },
+  "actionConfirmation.tiktok.disabledByAccount": {
+    "message": "此账号已关闭：{list}",
+    "description": "TikTok 发布确认：账号禁用的互动能力"
   },
   "actionConfirmation.tiktok.allowComment": {
     "message": "评论",
@@ -1416,17 +1476,33 @@
     "message": "拼接",
     "description": "TikTok 互动开关：允许拼接"
   },
+  "actionConfirmation.tiktok.disclosure": {
+    "message": "内容披露",
+    "description": "TikTok 发布确认：商业内容分组标题"
+  },
   "actionConfirmation.tiktok.commercial": {
     "message": "这是商业内容",
     "description": "TikTok 发布确认：商业内容披露开关"
   },
+  "actionConfirmation.tiktok.commercialHint": {
+    "message": "如果内容推广品牌、产品或服务，请按实际情况披露。",
+    "description": "TikTok 发布确认：商业内容披露说明"
+  },
   "actionConfirmation.tiktok.yourBrand": {
-    "message": "你的品牌",
+    "message": "推广自己的品牌",
     "description": "TikTok 商业内容：推广自有业务"
   },
+  "actionConfirmation.tiktok.yourBrandHint": {
+    "message": "推广您本人或您经营的业务",
+    "description": "TikTok 商业内容：推广自有业务说明"
+  },
   "actionConfirmation.tiktok.brandedContent": {
-    "message": "品牌内容",
+    "message": "品牌合作内容",
     "description": "TikTok 商业内容：付费合作"
+  },
+  "actionConfirmation.tiktok.brandedContentHint": {
+    "message": "因付款、赠品或其他利益而推广第三方",
+    "description": "TikTok 商业内容：付费合作说明"
   },
   "actionConfirmation.tiktok.labelPromotional": {
     "message": "视频将被标记为「推广内容」",
@@ -1444,12 +1520,40 @@
     "message": "视频超过该账号的时长上限（{max} 秒）",
     "description": "TikTok 发布确认：视频超长错误"
   },
-  "actionConfirmation.tiktok.music": {
-    "message": "发布即表示您同意 TikTok 的《音乐使用确认》",
-    "description": "TikTok 发布确认：音乐使用声明"
+  "actionConfirmation.tiktok.beforePublishing": {
+    "message": "发布前请确认",
+    "description": "TikTok 发布确认：政策说明标题"
   },
-  "actionConfirmation.tiktok.musicBranded": {
-    "message": "发布即表示您同意 TikTok 的《品牌内容政策》和《音乐使用确认》",
-    "description": "TikTok 发布确认：勾选品牌内容后的声明"
+  "actionConfirmation.tiktok.policyIntro": {
+    "message": "点击“发布”即表示您确认拥有内容与音乐的使用权，并同意 TikTok 的音乐使用条款。",
+    "description": "TikTok 发布确认：普通内容政策说明"
+  },
+  "actionConfirmation.tiktok.policyIntroBranded": {
+    "message": "点击“发布”即表示您确认披露信息准确，并同意 TikTok 的品牌内容政策与音乐使用条款。",
+    "description": "TikTok 发布确认：品牌内容政策说明"
+  },
+  "actionConfirmation.tiktok.musicUsageLink": {
+    "message": "查看《音乐使用确认》",
+    "description": "TikTok 发布确认：音乐使用确认链接"
+  },
+  "actionConfirmation.tiktok.brandedPolicyLink": {
+    "message": "查看《品牌内容政策》",
+    "description": "TikTok 发布确认：品牌内容政策链接"
+  },
+  "actionConfirmation.tiktok.fixDetailsFirst": {
+    "message": "发布信息不完整，请取消后重新生成确认卡",
+    "description": "TikTok 发布确认：详情缺失时的按钮禁用原因"
+  },
+  "actionConfirmation.tiktok.useShorterVideo": {
+    "message": "请换用符合该账号时长限制的视频",
+    "description": "TikTok 发布确认：视频超长时的按钮禁用原因"
+  },
+  "actionConfirmation.tiktok.selectPrivacyFirst": {
+    "message": "请选择谁可以看此视频",
+    "description": "TikTok 发布确认：未选可见范围时的按钮禁用原因"
+  },
+  "actionConfirmation.tiktok.selectDisclosureType": {
+    "message": "请选择商业内容类型",
+    "description": "TikTok 发布确认：未选商业披露类型时的按钮禁用原因"
   }
 }

--- a/src/i18n/zh-TW/chat.json
+++ b/src/i18n/zh-TW/chat.json
@@ -1331,9 +1331,57 @@
     "message": "已取消",
     "description": "執行前確認卡片：用戶取消後的折疊提示"
   },
+  "actionConfirmation.mediaLoading": {
+    "message": "正在加載媒體預覽…",
+    "description": "執行前確認卡片：媒體加載狀態"
+  },
+  "actionConfirmation.mediaUnavailable": {
+    "message": "無法在此處播放預覽",
+    "description": "執行前確認卡片：媒體播放失敗標題"
+  },
+  "actionConfirmation.mediaUnavailableHint": {
+    "message": "媒體鏈接可能已過期，或當前瀏覽器不支持該格式。發布前請先打開原文件確認。",
+    "description": "執行前確認卡片：媒體播放失敗說明"
+  },
+  "actionConfirmation.openMedia": {
+    "message": "打開原文件",
+    "description": "執行前確認卡片：打開媒體鏈接"
+  },
+  "actionConfirmation.tiktok.reviewBadge": {
+    "message": "發布前確認",
+    "description": "TikTok 發布確認卡片狀態標籤"
+  },
   "actionConfirmation.tiktok.postingTo": {
     "message": "發布至",
     "description": "TikTok 發布確認：帳號標籤"
+  },
+  "actionConfirmation.tiktok.connected": {
+    "message": "已連接",
+    "description": "TikTok 發布確認：帳號連接狀態"
+  },
+  "actionConfirmation.tiktok.unknownAccount": {
+    "message": "帳號信息不可用",
+    "description": "TikTok 發布確認：缺少帳號暱稱時的佔位文案"
+  },
+  "actionConfirmation.tiktok.detailsUnavailable": {
+    "message": "發布設置尚未準備好",
+    "description": "TikTok 發布確認：創作者信息缺失標題"
+  },
+  "actionConfirmation.tiktok.detailsUnavailableHint": {
+    "message": "未能讀取該帳號支持的可見範圍。請取消並讓助手重新獲取 TikTok 發布設置。",
+    "description": "TikTok 發布確認：創作者信息缺失說明"
+  },
+  "actionConfirmation.tiktok.videoTooLongTitle": {
+    "message": "影片時長不符合帳號限制",
+    "description": "TikTok 發布確認：影片超長標題"
+  },
+  "actionConfirmation.tiktok.postDetails": {
+    "message": "發布內容",
+    "description": "TikTok 發布確認：內容設置分組標題"
+  },
+  "actionConfirmation.tiktok.requiredNote": {
+    "message": "* 必填",
+    "description": "TikTok 發布確認：必填說明"
   },
   "actionConfirmation.tiktok.caption": {
     "message": "文案",
@@ -1350,6 +1398,10 @@
   "actionConfirmation.tiktok.privacyPlaceholder": {
     "message": "請選擇…",
     "description": "TikTok 發布確認：可見範圍占位符，按 TikTok 要求不能有默認值"
+  },
+  "actionConfirmation.tiktok.noPrivacyOptions": {
+    "message": "未獲取到可用的可見範圍，暫不能發布",
+    "description": "TikTok 發布確認：可見範圍為空"
   },
   "actionConfirmation.tiktok.privacyPublic": {
     "message": "所有人",
@@ -1371,6 +1423,14 @@
     "message": "允許互動",
     "description": "TikTok 發布確認：互動開關分組標籤"
   },
+  "actionConfirmation.tiktok.interactionsHint": {
+    "message": "僅可開啟該帳號當前允許的互動方式；默認全部關閉。",
+    "description": "TikTok 發布確認：互動開關說明"
+  },
+  "actionConfirmation.tiktok.disabledByAccount": {
+    "message": "此帳號已關閉：{list}",
+    "description": "TikTok 發布確認：帳號禁用的互動能力"
+  },
   "actionConfirmation.tiktok.allowComment": {
     "message": "評論",
     "description": "TikTok 互動開關：允許評論"
@@ -1383,17 +1443,33 @@
     "message": "拼接",
     "description": "TikTok 互動開關：允許拼接"
   },
+  "actionConfirmation.tiktok.disclosure": {
+    "message": "內容披露",
+    "description": "TikTok 發布確認：商業內容分組標題"
+  },
   "actionConfirmation.tiktok.commercial": {
     "message": "這是商業內容",
     "description": "TikTok 發布確認：商業內容披露開關"
+  },
+  "actionConfirmation.tiktok.commercialHint": {
+    "message": "如果內容推廣品牌、產品或服務，請按實際情況披露。",
+    "description": "TikTok 發布確認：商業內容披露說明"
   },
   "actionConfirmation.tiktok.yourBrand": {
     "message": "你的品牌",
     "description": "TikTok 商業內容：推廣自有業務"
   },
+  "actionConfirmation.tiktok.yourBrandHint": {
+    "message": "推廣您本人或您經營的業務",
+    "description": "TikTok 商業內容：推廣自有業務說明"
+  },
   "actionConfirmation.tiktok.brandedContent": {
     "message": "品牌內容",
     "description": "TikTok 商業內容：付費合作"
+  },
+  "actionConfirmation.tiktok.brandedContentHint": {
+    "message": "因付款、贈品或其他利益而推廣第三方",
+    "description": "TikTok 商業內容：付費合作說明"
   },
   "actionConfirmation.tiktok.labelPromotional": {
     "message": "視頻將被標記為「推廣內容」",
@@ -1410,6 +1486,42 @@
   "actionConfirmation.tiktok.tooLong": {
     "message": "視頻超過該帳號的時長上限（{max} 秒）",
     "description": "TikTok 發布確認：視頻超長錯誤"
+  },
+  "actionConfirmation.tiktok.beforePublishing": {
+    "message": "發布前請確認",
+    "description": "TikTok 發布確認：政策說明標題"
+  },
+  "actionConfirmation.tiktok.policyIntro": {
+    "message": "點擊“發布”即表示您確認擁有內容與音樂的使用權，並同意 TikTok 的音樂使用條款。",
+    "description": "TikTok 發布確認：普通內容政策說明"
+  },
+  "actionConfirmation.tiktok.policyIntroBranded": {
+    "message": "點擊“發布”即表示您確認披露信息準確，並同意 TikTok 的品牌內容政策與音樂使用條款。",
+    "description": "TikTok 發布確認：品牌內容政策說明"
+  },
+  "actionConfirmation.tiktok.musicUsageLink": {
+    "message": "查看《音樂使用確認》",
+    "description": "TikTok 發布確認：音樂使用確認鏈接"
+  },
+  "actionConfirmation.tiktok.brandedPolicyLink": {
+    "message": "查看《品牌內容政策》",
+    "description": "TikTok 發布確認：品牌內容政策鏈接"
+  },
+  "actionConfirmation.tiktok.fixDetailsFirst": {
+    "message": "發布信息不完整，請取消後重新生成確認卡",
+    "description": "TikTok 發布確認：詳情缺失時的按鈕禁用原因"
+  },
+  "actionConfirmation.tiktok.useShorterVideo": {
+    "message": "請換用符合該帳號時長限制的影片",
+    "description": "TikTok 發布確認：影片超長時的按鈕禁用原因"
+  },
+  "actionConfirmation.tiktok.selectPrivacyFirst": {
+    "message": "請選擇誰可以看此視頻",
+    "description": "TikTok 發布確認：未選可見範圍時的按鈕禁用原因"
+  },
+  "actionConfirmation.tiktok.selectDisclosureType": {
+    "message": "請選擇商業內容類型",
+    "description": "TikTok 發布確認：未選商業披露類型時的按鈕禁用原因"
   },
   "actionConfirmation.tiktok.music": {
     "message": "發布即表示您同意 TikTok 的《音樂使用確認》",

--- a/src/models/chat.ts
+++ b/src/models/chat.ts
@@ -321,12 +321,14 @@ export interface IActionConfirmationResult {
  *  guideline violation, not just a bug. */
 export interface ITikTokPublishDetail {
   creator_nickname: string;
+  creator_avatar_url?: string;
   /** Exact options to offer. Never render a value outside this list. */
   privacy_level_options: string[];
   comment_disabled: boolean;
   duet_disabled: boolean;
   stitch_disabled: boolean;
   max_video_post_duration_sec: number;
+  suggested_title?: string;
   /** Photo posts have no duet/stitch — show only "allow comment". */
   is_photo_post?: boolean;
 }


### PR DESCRIPTION
## Summary
- redesign TikTok confirmation as a responsive media-and-settings review screen
- add media loading/error fallback, explicit validation reasons, account metadata fallback, and policy links
- block incomplete creator-info payloads instead of showing an empty privacy dropdown
- localize the new UX across every supported locale

## Verification
- targeted component tests: 29 passed
- full suite: 140 files/1171 tests passed; one unrelated shell-session timeout passed on isolated rerun (24/24)
- `npm run lint:check` (0 errors; 2 pre-existing warnings)
- `npx vue-tsc -b`
- `npm run build:web`
- `python3 scripts/check_i18n_coverage.py`
- Playwright desktop/mobile visual render; real sample video reached readyState 4 and no horizontal overflow
- both official TikTok policy URLs return 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)