### PR TITLE
feat(suno): send excluded styles as negative_tags

### DIFF
--- a/change/@acedatacloud-nexior-suno-negative-tags.json
+++ b/change/@acedatacloud-nexior-suno-negative-tags.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "send Suno excluded styles through the canonical negative_tags API field while preserving prompt reuse from older tasks",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/suno/config/AdvancedParams.vue
+++ b/src/components/suno/config/AdvancedParams.vue
@@ -144,12 +144,12 @@ export default defineComponent({
     },
     styleNegative: {
       get() {
-        return this.$store.state.suno?.config?.style_negative || '';
+        return this.$store.state.suno?.config?.negative_tags || '';
       },
       set(val: string) {
         this.$store.commit('suno/setConfig', {
           ...this.$store.state.suno?.config,
-          style_negative: val || undefined
+          negative_tags: val || undefined
         });
       }
     },

--- a/src/components/suno/task/Preview.vue
+++ b/src/components/suno/task/Preview.vue
@@ -710,7 +710,14 @@ export default defineComponent({
     onReusePrompt(audio: ISunoAudio) {
       const req = (this.modelValue?.request ?? {}) as ISunoAudioRequest;
       const hasContent =
-        req.prompt || req.lyric || req.style || req.title || req.lyric_prompt || req.style_negative || req.persona_id;
+        req.prompt ||
+        req.lyric ||
+        req.style ||
+        req.title ||
+        req.lyric_prompt ||
+        req.negative_tags ||
+        req.style_negative ||
+        req.persona_id;
       if (!hasContent) {
         ElMessage.warning(this.$t('suno.message.reusePromptEmpty'));
         return;
@@ -726,7 +733,7 @@ export default defineComponent({
         lyrics_mode: req.lyrics_mode ?? 'manual',
         title: req.title ?? '',
         style: req.style ?? '',
-        style_negative: req.style_negative ?? '',
+        negative_tags: req.negative_tags ?? req.style_negative ?? '',
         vocal_gender: req.vocal_gender,
         weirdness: req.weirdness,
         style_influence: req.style_influence,

--- a/src/models/suno.ts
+++ b/src/models/suno.ts
@@ -64,7 +64,7 @@ export interface ISunoConfig {
   instrumental?: boolean;
   title?: string;
   style?: string;
-  style_negative?: string;
+  negative_tags?: string;
   action?: string;
   audio?: ISunoAudio | undefined;
   audio_id?: string;
@@ -97,6 +97,8 @@ export interface ISunoAudioRequest {
   custom?: boolean;
   title?: string;
   style?: string;
+  negative_tags?: string;
+  /** @deprecated Read only for reusing tasks created before negative_tags. */
   style_negative?: string;
   vocal_gender?: string;
   weirdness?: number;


### PR DESCRIPTION
## Contract
Send Suno excluded styles with the canonical `negative_tags` field. Historical task reuse still reads legacy `style_negative` and migrates it into the new config field.

## Dependency graph
PlatformService runtime -> PlatformBackend contract/docs -> Nexior client.

Depends on https://github.com/AceDataCloud/PlatformBackend/pull/1301.

## Validation
- ESLint: 0 errors (2 unrelated existing warnings).
- `npx vue-tsc -b --pretty false` passed.
- Beachball patch change file added.

## Review
Adversarial review not requested.

## Rollout / rollback
Deploy through the existing Nexior release workflow. Runtime compatibility allows rollback without breaking existing requests.
