### PR TITLE
fix(branding): use Site title and description in hero copy

### DIFF
--- a/change/@acedatacloud-nexior-35bac597-9511-4747-87ca-53ef34319eb3.json
+++ b/change/@acedatacloud-nexior-35bac597-9511-4747-87ca-53ef34319eb3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "use each initialized Site's title and description as the /home and /intro hero copy, with default marketing text only as a fallback",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/pages/index/Index.test.ts
+++ b/src/pages/index/Index.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import Index from './Index.vue';
+
+const heroHeadline = (site: Record<string, unknown>, fallback = 'Default marketing headline') =>
+  (Index as any).computed.heroHeadline.call({
+    site,
+    $t: () => fallback
+  });
+
+describe('/home Site subtitle', () => {
+  it('uses the configured Site description', () => {
+    expect(
+      heroHeadline({
+        description: 'Create cinematic AI videos with Seedance 2.0.'
+      })
+    ).toBe('Create cinematic AI videos with Seedance 2.0.');
+  });
+
+  it('falls back to the default marketing headline when the description is empty', () => {
+    expect(heroHeadline({ description: '   ' })).toBe('Default marketing headline');
+    expect(heroHeadline({})).toBe('Default marketing headline');
+  });
+});

--- a/src/pages/index/Index.vue
+++ b/src/pages/index/Index.vue
@@ -6,7 +6,7 @@
         <div class="hero__copy">
           <span class="eyebrow">{{ $t('index.badge.hero') }}</span>
           <h1>{{ site?.title }}</h1>
-          <p class="hero__headline">{{ $t('index.subtitle.banner') }}</p>
+          <p class="hero__headline">{{ heroHeadline }}</p>
           <p class="hero__summary">{{ $t('index.subtitle.hero') }}</p>
           <div class="hero__actions">
             <el-button type="primary" size="large" @click="onStart">
@@ -375,6 +375,9 @@ export default defineComponent({
   computed: {
     site() {
       return this.$store.state.site;
+    },
+    heroHeadline(): string {
+      return this.site?.description?.trim() || this.$t('index.subtitle.banner');
     },
     enabledFeatures(): Record<string, { enabled?: boolean } | undefined> {
       return (this.site?.features ?? {}) as Record<string, { enabled?: boolean } | undefined>;

--- a/src/pages/intro/Index.test.ts
+++ b/src/pages/intro/Index.test.ts
@@ -121,6 +121,28 @@ describe('/intro site capability filtering', () => {
     expect(wrapper.find('.model-grid').attributes('style')).toContain('--model-grid-columns: 5');
   });
 
+  it('uses Site title and description as the presentation hero copy', () => {
+    const wrapper = mountIntro({
+      id: 'studio',
+      origin: 'brand.studio.acedata.cloud',
+      title: 'Seedance AI Video Generator',
+      description: 'Create cinematic AI videos from text, images, and reference clips.',
+      features: studioFeatures
+    });
+
+    expect(wrapper.get('h1').text()).toBe('Seedance AI Video Generator');
+    expect(wrapper.get('.hero__summary').text()).toBe(
+      'Create cinematic AI videos from text, images, and reference clips.'
+    );
+  });
+
+  it('falls back to default hero copy when Site branding text is empty', () => {
+    const wrapper = mountIntro({ id: 'studio', title: '  ', description: '', features: studioFeatures });
+
+    expect(wrapper.get('h1').text()).toBe('intro.title.hero');
+    expect(wrapper.get('.hero__summary').text()).toBe('intro.subtitle.hero');
+  });
+
   it('uses outward-facing campaign headlines instead of configuration labels', () => {
     const copy = Object.values(zhIntro)
       .map((entry) => entry.message)

--- a/src/pages/intro/Index.vue
+++ b/src/pages/intro/Index.vue
@@ -221,10 +221,10 @@ export default defineComponent({
       return CAPABILITY_KEYS.filter((key) => this.enabledFeatures[key]?.enabled);
     },
     heroTitle(): string {
-      return this.siteLoaded ? this.$t('intro.title.site') : this.$t('intro.title.hero');
+      return this.site?.title?.trim() || this.$t('intro.title.hero');
     },
     heroSubtitle(): string {
-      return this.siteLoaded ? this.$t('intro.subtitle.site') : this.$t('intro.subtitle.hero');
+      return this.site?.description?.trim() || this.$t('intro.subtitle.hero');
     },
     heroStats() {
       return [


### PR DESCRIPTION
## Root cause

The Site API already provides brand-specific copy through `Site.title` and `Site.description`, but the public pages still rendered fixed global marketing strings:

- `/home`: `index.subtitle.banner` (for example “An all-in-one AI creation and business platform”)
- `/intro`: `intro.title.site` / `intro.subtitle.site` (for example “Frontier AI, ready for every idea”)

That made a branded Seedance site display generic Ace Data Cloud copy even though its Site record already had a precise product subtitle.

## Fix

Use the initialized Site as the source of truth:

### `/home`

- H1: existing `Site.title`
- headline: `Site.description`
- empty description fallback: existing localized `index.subtitle.banner`

### `/intro`

- H1: `Site.title`
- summary: `Site.description`
- empty field fallbacks: existing localized `intro.title.hero` / `intro.subtitle.hero`

The fixed campaign strings remain only as safe defaults for unconfigured sites.

## Verified with Seedance branding

Test values match the live Seedance Site:

- title: `Seedance AI Video Generator`
- description: `Create cinematic AI videos with Seedance 2.0. Turn text, images, or reference clips into high-quality videos.`

Playwright results:

- `/home`: dynamic title + dynamic description, generic banner absent
- `/intro`: dynamic title + dynamic description, “Frontier AI…” absent
- page errors: 0 on both routes

Additional verification:

- unit/regression tests: **9/9 passed**
- `vue-tsc -b`: passed
- focused ESLint: passed
- blank title/description fallback behavior covered