### PR TITLE
fix(chat): localize TikTok confirmation branding

### DIFF
--- a/change/@acedatacloud-nexior-tiktok-confirm-followup.json
+++ b/change/@acedatacloud-nexior-tiktok-confirm-followup.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Use the official TikTok brand icon and localize the publish confirmation title, summary, and action label from the active Studio locale.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/chat/ActionConfirmationCard.test.ts
+++ b/src/components/chat/ActionConfirmationCard.test.ts
@@ -132,6 +132,32 @@ describe('ActionConfirmationCard', () => {
     expect(link.attributes('rel')).toBe('noopener noreferrer');
   });
 
+  it('uses the TikTok brand icon and localizes fixed publish copy', () => {
+    const wrapper = mountCard({
+      action_confirmation_id: 'actconf_tiktok',
+      kind: 'tiktok.publish',
+      title: '模型生成的标题',
+      summary: '模型生成的摘要',
+      confirm_label: '模型生成的按钮',
+      preview: { type: 'video', url: 'https://cdn.example.com/video.mp4' },
+      detail: {
+        creator_nickname: 'Creator',
+        privacy_level_options: ['SELF_ONLY'],
+        comment_disabled: false,
+        duet_disabled: false,
+        stitch_disabled: false,
+        max_video_post_duration_sec: 600
+      }
+    });
+
+    expect(wrapper.find('.acc-brand-mark i').exists()).toBe(true);
+    expect(wrapper.text()).toContain('chat.actionConfirmation.tiktok.publishTitle');
+    expect(wrapper.text()).toContain('chat.actionConfirmation.tiktok.publishSummary');
+    expect(wrapper.findAll('button')[1].text()).toBe('chat.actionConfirmation.tiktok.publishButton');
+    expect(wrapper.text()).not.toContain('模型生成的标题');
+    expect(wrapper.text()).not.toContain('模型生成的摘要');
+  });
+
   it('renders malformed TikTok history as a blocked TikTok form instead of a generic blank card', () => {
     const wrapper = mountCard({
       action_confirmation_id: 'actconf_tiktok',

--- a/src/components/chat/ActionConfirmationCard.vue
+++ b/src/components/chat/ActionConfirmationCard.vue
@@ -9,7 +9,9 @@
   >
     <div class="acc-header">
       <div class="acc-heading">
-        <span v-if="isTikTokPublish" class="acc-brand-mark" aria-hidden="true">♪</span>
+        <span v-if="isTikTokPublish" class="acc-brand-mark" aria-hidden="true">
+          <font-awesome-icon :icon="faTiktok" />
+        </span>
         <component
           :is="headerIcon"
           v-else
@@ -20,7 +22,7 @@
         />
         <div class="acc-heading-copy">
           <span v-if="isTikTokPublish" class="acc-eyebrow">TikTok</span>
-          <span class="header-title">{{ payload.title }}</span>
+          <span class="header-title">{{ headerTitle }}</span>
         </div>
       </div>
       <span v-if="isTikTokPublish && !resolved" class="acc-review-badge">
@@ -28,7 +30,7 @@
       </span>
     </div>
 
-    <p v-if="payload.summary" class="acc-summary">{{ payload.summary }}</p>
+    <p v-if="summary" class="acc-summary">{{ summary }}</p>
 
     <div class="acc-content" :class="{ 'has-tiktok-layout': isTikTokPublish }">
       <div v-if="payload.preview" class="acc-preview" :class="{ 'has-error': mediaFailed }">
@@ -113,6 +115,8 @@
 
 <script lang="ts">
 import { ConfirmIcon, ExternalLinkIcon, WarningIcon } from '@acedatacloud/core/icons/components';
+import { faTiktok } from '@fortawesome/free-brands-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { ElButton } from 'element-plus';
 import { defineComponent, type PropType } from 'vue';
 import GenericFieldList from './GenericFieldList.vue';
@@ -130,7 +134,15 @@ interface IData {
 
 export default defineComponent({
   name: 'ActionConfirmationCard',
-  components: { GenericFieldList, TikTokPublishForm, ConfirmIcon, ExternalLinkIcon, WarningIcon, ElButton },
+  components: {
+    GenericFieldList,
+    TikTokPublishForm,
+    ConfirmIcon,
+    ExternalLinkIcon,
+    WarningIcon,
+    FontAwesomeIcon,
+    ElButton
+  },
   props: {
     payload: {
       type: Object as PropType<IActionConfirmationPayload>,
@@ -157,8 +169,21 @@ export default defineComponent({
     };
   },
   computed: {
+    faTiktok() {
+      return faTiktok;
+    },
     isTikTokPublish(): boolean {
       return this.payload?.kind === 'tiktok.publish';
+    },
+    headerTitle(): string {
+      return this.isTikTokPublish
+        ? (this.$t('chat.actionConfirmation.tiktok.publishTitle') as string)
+        : this.payload.title;
+    },
+    summary(): string {
+      return this.isTikTokPublish
+        ? (this.$t('chat.actionConfirmation.tiktok.publishSummary') as string)
+        : this.payload.summary || '';
     },
     initialTitle(): string {
       const detail = this.payload?.detail as Record<string, unknown> | undefined;
@@ -180,6 +205,7 @@ export default defineComponent({
       return this.isDestructive ? WarningIcon : ConfirmIcon;
     },
     confirmLabel(): string {
+      if (this.isTikTokPublish) return this.$t('chat.actionConfirmation.tiktok.publishButton') as string;
       return this.payload?.confirm_label || (this.$t('chat.actionConfirmation.confirm') as string);
     },
     formattedDuration(): string {

--- a/src/i18n/ar/chat.json
+++ b/src/i18n/ar/chat.json
@@ -1390,6 +1390,18 @@
     "message": "تأكيد قبل النشر",
     "description": "تأكيد نشر TikTok: علامة حالة بطاقة التأكيد"
   },
+    "actionConfirmation.tiktok.publishTitle": {
+      "message": "نشر على TikTok",
+      "description": "عنوان بطاقة تأكيد النشر على TikTok"
+    },
+    "actionConfirmation.tiktok.publishSummary": {
+      "message": "بعد التأكيد، سيتم نشر هذا الفيديو على حسابك في TikTok.",
+      "description": "ملخص بطاقة تأكيد النشر على TikTok"
+    },
+    "actionConfirmation.tiktok.publishButton": {
+      "message": "نشر",
+      "description": "زر تقديم تأكيد النشر على بطاقة تأكيد TikTok"
+    },
   "actionConfirmation.tiktok.postingTo": {
     "message": "نشر إلى",
     "description": "تأكيد نشر TikTok: علامة الحساب"

--- a/src/i18n/de/chat.json
+++ b/src/i18n/de/chat.json
@@ -1390,6 +1390,18 @@
     "message": "Bestätigung vor der Veröffentlichung",
     "description": "TikTok Veröffentlichungsbestätigung: Statuslabel der Karte"
   },
+    "actionConfirmation.tiktok.publishTitle": {
+      "message": "Auf TikTok veröffentlichen",
+      "description": "Titel der TikTok Veröffentlichungsbestätigung"
+    },
+    "actionConfirmation.tiktok.publishSummary": {
+      "message": "Nach Bestätigung wird dieses Video auf deinem TikTok-Konto veröffentlicht.",
+      "description": "Zusammenfassung der TikTok Veröffentlichungsbestätigung"
+    },
+    "actionConfirmation.tiktok.publishButton": {
+      "message": "Veröffentlichen",
+      "description": "Schaltfläche zum Bestätigen der Veröffentlichung auf TikTok"
+    },
   "actionConfirmation.tiktok.postingTo": {
     "message": "Veröffentlichen an",
     "description": "Bestätigungsfeld für TikTok: Kontolabel"

--- a/src/i18n/el/chat.json
+++ b/src/i18n/el/chat.json
@@ -1390,6 +1390,18 @@
     "message": "Επιβεβαίωση πριν από την δημοσίευση",
     "description": "Επιβεβαίωση δημοσίευσης TikTok: ετικέτα κατάστασης κάρτας"
   },
+    "actionConfirmation.tiktok.publishTitle": {
+      "message": "Δημοσίευση στο TikTok",
+      "description": "Τίτλος της κάρτας επιβεβαίωσης δημοσίευσης TikTok"
+    },
+    "actionConfirmation.tiktok.publishSummary": {
+      "message": "Μετά την επιβεβαίωση, αυτό το βίντεο θα δημοσιευτεί στον λογαριασμό σας TikTok.",
+      "description": "Περίληψη της κάρτας επιβεβαίωσης δημοσίευσης TikTok"
+    },
+    "actionConfirmation.tiktok.publishButton": {
+      "message": "Δημοσίευση",
+      "description": "Το κουμπί υποβολής της κάρτας επιβεβαίωσης δημοσίευσης TikTok"
+    },
   "actionConfirmation.tiktok.postingTo": {
     "message": "Δημοσίευση σε",
     "description": "Επιβεβαίωση δημοσίευσης TikTok: Ετικέτα λογαριασμού"

--- a/src/i18n/en/chat.json
+++ b/src/i18n/en/chat.json
@@ -1316,6 +1316,18 @@
     "message": "Review before posting",
     "description": "TikTok confirmation card status badge"
   },
+  "actionConfirmation.tiktok.publishTitle": {
+    "message": "Publish to TikTok",
+    "description": "TikTok publish confirmation card title"
+  },
+  "actionConfirmation.tiktok.publishSummary": {
+    "message": "Confirm to publish this video to your TikTok account.",
+    "description": "TikTok publish confirmation card summary"
+  },
+  "actionConfirmation.tiktok.publishButton": {
+    "message": "Publish",
+    "description": "TikTok publish confirmation card submit button"
+  },
   "actionConfirmation.tiktok.postingTo": {
     "message": "Posting to this account",
     "description": "TikTok publish confirmation: account label"

--- a/src/i18n/es/chat.json
+++ b/src/i18n/es/chat.json
@@ -1391,6 +1391,18 @@
     "message": "Confirmar antes de publicar",
     "description": "Etiqueta de estado de tarjeta de confirmación de TikTok"
   },
+    "actionConfirmation.tiktok.publishTitle": {
+      "message": "Publicar en TikTok",
+      "description": "Título de la tarjeta de confirmación de publicación de TikTok"
+    },
+    "actionConfirmation.tiktok.publishSummary": {
+      "message": "Al confirmar, este video se publicará en tu cuenta de TikTok.",
+      "description": "Resumen de la tarjeta de confirmación de publicación de TikTok"
+    },
+    "actionConfirmation.tiktok.publishButton": {
+      "message": "Publicar",
+      "description": "Botón de envío de la tarjeta de confirmación de publicación de TikTok"
+    },
   "actionConfirmation.tiktok.postingTo": {
     "message": "Publicar en",
     "description": "Confirmación de publicación de TikTok: etiqueta de cuenta"

--- a/src/i18n/fi/chat.json
+++ b/src/i18n/fi/chat.json
@@ -1351,6 +1351,18 @@
     "message": "Vahvista ennen julkaisua",
     "description": "TikTok julkaisuvahvistuskortin tila"
   },
+    "actionConfirmation.tiktok.publishTitle": {
+      "message": "Julkaise TikTokiin",
+      "description": "TikTok julkaisu vahvistusikkunan otsikko"
+    },
+    "actionConfirmation.tiktok.publishSummary": {
+      "message": "Vahvistuksen jälkeen tämä video julkaistaan TikTok-tilillesi.",
+      "description": "TikTok julkaisu vahvistusikkunan yhteenveto"
+    },
+    "actionConfirmation.tiktok.publishButton": {
+      "message": "Julkaise",
+      "description": "TikTok julkaisu vahvistusikkunan lähetyspainike"
+    },
   "actionConfirmation.tiktok.postingTo": {
     "message": "Julkaise",
     "description": "TikTok julkaisu vahvistus: tilin etiketti"

--- a/src/i18n/fr/chat.json
+++ b/src/i18n/fr/chat.json
@@ -1390,6 +1390,18 @@
     "message": "Confirmation avant publication",
     "description": "Étiquette d'état de la carte de confirmation de publication TikTok"
   },
+    "actionConfirmation.tiktok.publishTitle": {
+      "message": "Publier sur TikTok",
+      "description": "Titre de la carte de confirmation de publication TikTok"
+    },
+    "actionConfirmation.tiktok.publishSummary": {
+      "message": "Après confirmation, cette vidéo sera publiée sur votre compte TikTok.",
+      "description": "Résumé de la carte de confirmation de publication TikTok"
+    },
+    "actionConfirmation.tiktok.publishButton": {
+      "message": "Publier",
+      "description": "Bouton de soumission de la carte de confirmation de publication TikTok"
+    },
   "actionConfirmation.tiktok.postingTo": {
     "message": "Publier sur",
     "description": "Étiquette de compte dans la confirmation de publication TikTok."

--- a/src/i18n/it/chat.json
+++ b/src/i18n/it/chat.json
@@ -1390,6 +1390,18 @@
     "message": "Conferma prima della pubblicazione",
     "description": "Etichetta di stato della scheda di conferma TikTok"
   },
+    "actionConfirmation.tiktok.publishTitle": {
+      "message": "Pubblica su TikTok",
+      "description": "Titolo della scheda di conferma pubblicazione di TikTok"
+    },
+    "actionConfirmation.tiktok.publishSummary": {
+      "message": "Dopo la conferma, questo video sarà pubblicato sul tuo account TikTok.",
+      "description": "Sommario della scheda di conferma pubblicazione di TikTok"
+    },
+    "actionConfirmation.tiktok.publishButton": {
+      "message": "Pubblica",
+      "description": "Pulsante di invio per la scheda di conferma pubblicazione di TikTok"
+    },
   "actionConfirmation.tiktok.postingTo": {
     "message": "Pubblica su",
     "description": "Conferma di pubblicazione TikTok: etichetta dell'account"

--- a/src/i18n/ja/chat.json
+++ b/src/i18n/ja/chat.json
@@ -1351,6 +1351,18 @@
     "message": "公開前に確認",
     "description": "TikTok 公開確認カードの状態ラベル"
   },
+    "actionConfirmation.tiktok.publishTitle": {
+      "message": "TikTok に公開",
+      "description": "TikTok 公開確認カードのタイトル"
+    },
+    "actionConfirmation.tiktok.publishSummary": {
+      "message": "確認後、この動画をあなたの TikTok アカウントに公開します。",
+      "description": "TikTok 公開確認カードの概要"
+    },
+    "actionConfirmation.tiktok.publishButton": {
+      "message": "公開",
+      "description": "TikTok 公開確認カードの送信ボタン"
+    },
   "actionConfirmation.tiktok.postingTo": {
     "message": "投稿先",
     "description": "TikTok 发布确认：账号标签"

--- a/src/i18n/ko/chat.json
+++ b/src/i18n/ko/chat.json
@@ -1390,6 +1390,18 @@
     "message": "게시 전 확인",
     "description": "TikTok 게시 확인 카드 상태 태그"
   },
+    "actionConfirmation.tiktok.publishTitle": {
+      "message": "TikTok에 게시",
+      "description": "TikTok 게시 확인 카드 제목"
+    },
+    "actionConfirmation.tiktok.publishSummary": {
+      "message": "확인하면 이 동영상이 귀하의 TikTok 계정에 게시됩니다.",
+      "description": "TikTok 게시 확인 카드 요약"
+    },
+    "actionConfirmation.tiktok.publishButton": {
+      "message": "게시",
+      "description": "TikTok 게시 확인 카드의 제출 버튼"
+    },
   "actionConfirmation.tiktok.postingTo": {
     "message": "게시 대상",
     "description": "TikTok 게시 확인: 계정 레이블"

--- a/src/i18n/pl/chat.json
+++ b/src/i18n/pl/chat.json
@@ -1390,6 +1390,18 @@
     "message": "Potwierdź przed publikacją",
     "description": "Etykieta stanu karty potwierdzenia TikTok"
   },
+    "actionConfirmation.tiktok.publishTitle": {
+      "message": "Opublikuj na TikTok",
+      "description": "Tytuł potwierdzenia publikacji na TikTok."
+    },
+    "actionConfirmation.tiktok.publishSummary": {
+      "message": "Po potwierdzeniu ten film zostanie opublikowany na Twoim koncie TikTok.",
+      "description": "Podsumowanie potwierdzenia publikacji na TikTok."
+    },
+    "actionConfirmation.tiktok.publishButton": {
+      "message": "Opublikuj",
+      "description": "Przycisk do potwierdzenia publikacji na TikTok."
+    },
   "actionConfirmation.tiktok.postingTo": {
     "message": "Publikuj do",
     "description": "Etykieta konta w potwierdzeniu publikacji TikTok."

--- a/src/i18n/pt/chat.json
+++ b/src/i18n/pt/chat.json
@@ -1390,6 +1390,18 @@
     "message": "Confirmação antes da publicação",
     "description": "Etiqueta de status do cartão de confirmação do TikTok"
   },
+    "actionConfirmation.tiktok.publishTitle": {
+      "message": "Publicar no TikTok",
+      "description": "Título da confirmação de publicação no TikTok."
+    },
+    "actionConfirmation.tiktok.publishSummary": {
+      "message": "Após a confirmação, este vídeo será publicado na sua conta do TikTok.",
+      "description": "Resumo da confirmação de publicação no TikTok."
+    },
+    "actionConfirmation.tiktok.publishButton": {
+      "message": "Publicar",
+      "description": "Botão de confirmação para enviar a publicação no TikTok."
+    },
   "actionConfirmation.tiktok.postingTo": {
     "message": "Publicar em",
     "description": "Confirmação de publicação do TikTok: rótulo da conta."

--- a/src/i18n/ru/chat.json
+++ b/src/i18n/ru/chat.json
@@ -1390,6 +1390,18 @@
     "message": "Подтверждение перед публикацией",
     "description": "Статус карточки подтверждения публикации в TikTok"
   },
+    "actionConfirmation.tiktok.publishTitle": {
+      "message": "Публикация в TikTok",
+      "description": "Заголовок подтверждения публикации на TikTok"
+    },
+    "actionConfirmation.tiktok.publishSummary": {
+      "message": "После подтверждения это видео будет опубликовано в вашем аккаунте TikTok.",
+      "description": "Сводка подтверждения публикации на TikTok"
+    },
+    "actionConfirmation.tiktok.publishButton": {
+      "message": "Опубликовать",
+      "description": "Кнопка подтверждения публикации на TikTok"
+    },
   "actionConfirmation.tiktok.postingTo": {
     "message": "Публикация в",
     "description": "Метка аккаунта в подтверждении публикации TikTok"

--- a/src/i18n/sr/chat.json
+++ b/src/i18n/sr/chat.json
@@ -1351,6 +1351,18 @@
     "message": "Potvrda pre objavljivanja",
     "description": "TikTok potvrda pre objavljivanja: Status oznake potvrde"
   },
+    "actionConfirmation.tiktok.publishTitle": {
+      "message": "Objavi na TikTok",
+      "description": "Naslov potvrde za objavljivanje na TikTok-u."
+    },
+    "actionConfirmation.tiktok.publishSummary": {
+      "message": "Potvrdom će se ovaj video objaviti na tvom TikTok nalogu.",
+      "description": "Sažetak potvrde za objavljivanje na TikTok-u."
+    },
+    "actionConfirmation.tiktok.publishButton": {
+      "message": "Objavi",
+      "description": "Dugme za potvrdu objavljivanja na TikTok-u."
+    },
   "actionConfirmation.tiktok.postingTo": {
     "message": "Објављује се на",
     "description": "TikTok потврда објављивања: ознака налога"

--- a/src/i18n/sv/chat.json
+++ b/src/i18n/sv/chat.json
@@ -1390,6 +1390,18 @@
     "message": "Bekräfta före publicering",
     "description": "TikTok publiceringsbekräftelsekortets statusetikett"
   },
+    "actionConfirmation.tiktok.publishTitle": {
+      "message": "Publicera på TikTok",
+      "description": "Titel för TikTok publiceringsbekräftelsekort"
+    },
+    "actionConfirmation.tiktok.publishSummary": {
+      "message": "Bekräfta för att publicera denna video på ditt TikTok-konto.",
+      "description": "Sammanfattning av TikTok publiceringsbekräftelsekort"
+    },
+    "actionConfirmation.tiktok.publishButton": {
+      "message": "Publicera",
+      "description": "TikTok publiceringsbekräftelsekortets inlämningsknapp"
+    },
   "actionConfirmation.tiktok.postingTo": {
     "message": "Publicera till",
     "description": "TikTok publiceringsbekräftelse: Kontot etikett"

--- a/src/i18n/uk/chat.json
+++ b/src/i18n/uk/chat.json
@@ -1390,6 +1390,18 @@
     "message": "Підтвердження перед публікацією",
     "description": "Статус картки підтвердження публікації TikTok"
   },
+    "actionConfirmation.tiktok.publishTitle": {
+      "message": "Опублікувати на TikTok",
+      "description": "Заголовок підтвердження публікації на TikTok"
+    },
+    "actionConfirmation.tiktok.publishSummary": {
+      "message": "Після підтвердження це відео буде опубліковано у вашому акаунті TikTok.",
+      "description": "Резюме підтвердження публікації на TikTok"
+    },
+    "actionConfirmation.tiktok.publishButton": {
+      "message": "Опублікувати",
+      "description": "Кнопка підтвердження публікації на TikTok"
+    },
   "actionConfirmation.tiktok.postingTo": {
     "message": "Публікація до",
     "description": "Підтвердження публікації TikTok: мітка облікового запису"

--- a/src/i18n/zh-CN/chat.json
+++ b/src/i18n/zh-CN/chat.json
@@ -1384,6 +1384,18 @@
     "message": "发布前确认",
     "description": "TikTok 发布确认卡片状态标签"
   },
+  "actionConfirmation.tiktok.publishTitle": {
+    "message": "发布到 TikTok",
+    "description": "TikTok 发布确认卡片标题"
+  },
+  "actionConfirmation.tiktok.publishSummary": {
+    "message": "确认后将把此视频发布到你的 TikTok 账号。",
+    "description": "TikTok 发布确认卡片摘要"
+  },
+  "actionConfirmation.tiktok.publishButton": {
+    "message": "发布",
+    "description": "TikTok 发布确认卡片的提交按钮"
+  },
   "actionConfirmation.tiktok.postingTo": {
     "message": "发布到此账号",
     "description": "TikTok 发布确认：账号标签"

--- a/src/i18n/zh-TW/chat.json
+++ b/src/i18n/zh-TW/chat.json
@@ -1351,6 +1351,18 @@
     "message": "發布前確認",
     "description": "TikTok 發布確認卡片狀態標籤"
   },
+    "actionConfirmation.tiktok.publishTitle": {
+      "message": "發佈到 TikTok",
+      "description": "TikTok 發佈確認卡片標題"
+    },
+    "actionConfirmation.tiktok.publishSummary": {
+      "message": "確認後將把此影片發佈到你的 TikTok 帳號。",
+      "description": "TikTok 發佈確認卡片摘要"
+    },
+    "actionConfirmation.tiktok.publishButton": {
+      "message": "發佈",
+      "description": "TikTok 發佈確認卡片的提交按鈕"
+    },
   "actionConfirmation.tiktok.postingTo": {
     "message": "發布至",
     "description": "TikTok 發布確認：帳號標籤"


### PR DESCRIPTION
## Summary
- replace the simulated music-note badge with the official TikTok brand glyph already used by Nexior
- localize the known TikTok confirmation title, summary, and Publish action from the active Studio locale instead of rendering model-authored strings verbatim
- add translated copy across every supported locale and regression coverage

## Investigation context
The production conversation `6661c75a-e1bb-42bf-b233-4323afa7e003` mixed Chinese dynamic payload strings with English fixed UI because Studio was using the English locale. Known TikTok chrome now comes entirely from frontend i18n; only editable user content remains dynamic.

The reported publish failure was investigated separately: the original prompt explicitly requested “只展示确认卡，不要执行发布”, so the resumed model made no TikTok tool call. No TikTok post was submitted. A duplicate resume then received HTTP 400 because the conversation was no longer paused.

## Verification
- ActionConfirmationCard + TikTokPublishForm: 30/30 tests passed
- vue-tsc passed
- ESLint: 0 errors (2 unrelated existing warnings)
- i18n coverage: 17 locales × 48 namespaces passed
- beachball check passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)