### PR TITLE
design: use Tabler Face ID for digital human

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,29 @@
+# Third-Party Notices
+
+## Tabler Icons — `face-id`
+
+The digital human icon in `public/digitalhuman-logo.svg` is adapted from the
+[`face-id`](https://tabler.io/icons/icon/face-id) icon in
+[Tabler Icons](https://github.com/tabler/tabler-icons).
+
+MIT License
+
+Copyright (c) 2020-2026 Paweł Kuna
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/change/@acedatacloud-nexior-digitalhuman-logo.json
+++ b/change/@acedatacloud-nexior-digitalhuman-logo.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "replace the digital human service badge with the clear, small-size Tabler Face ID icon",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/public/digitalhuman-logo.svg
+++ b/public/digitalhuman-logo.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-labelledby="title desc">
+  <title id="title">Digital Human</title>
+  <desc id="desc">A face framed by four focus corners</desc>
+  <path
+    d="M4 8V6a2 2 0 0 1 2-2h2M4 16v2a2 2 0 0 0 2 2h2m8-16h2a2 2 0 0 1 2 2v2m-4 12h2a2 2 0 0 0 2-2v-2M9 10h.01M15 10h.01M9.5 15a3.5 3.5 0 0 0 5 0"
+    fill="none"
+    stroke="#7C5CFC"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    stroke-width="2"
+  />
+</svg>

--- a/src/constants/digitalhuman.ts
+++ b/src/constants/digitalhuman.ts
@@ -1,6 +1,6 @@
 export const DIGITALHUMAN_SERVICE_ID = '5b132265-40e8-4a79-9582-589f8eea4733';
 
-export const DIGITALHUMAN_LOGO = 'https://cdn.acedata.cloud/uploads/b47b3899-d41a-4295-93b9-20686ac98598';
+export const DIGITALHUMAN_LOGO = '/digitalhuman-logo.svg';
 
 export const DIGITALHUMAN_DEFAULT_LANG = 'zh';
 export const DIGITALHUMAN_ALLOWED_LANGS = ['zh', 'en'];


### PR DESCRIPTION
## Summary
- replace the generic digital-human badge with Tabler Icons' established `face-id` glyph
- preserve the official Tabler geometry and only apply Nexior's product accent color
- serve the SVG locally across navigation, settings, homepage, and task cards
- include the upstream MIT copyright and license in `THIRD_PARTY_NOTICES.md`

## Source and license
- Source: https://tabler.io/icons/icon/face-id
- Project: https://github.com/tabler/tabler-icons
- License: MIT, copyright 2020-2026 Paweł Kuna

## Verification
- `npm run lint:check` (passes with 2 pre-existing warnings)
- `npx vue-tsc -b`
- `npm run test:run -- src/components/common/CapabilityPresentation.test.ts src/components/setting/CapabilitiesMetadata.test.ts`
- `npm run verify`
- rendered and reviewed at 28px and 128px

🤖 Generated with [Claude Code](https://claude.com/claude-code)