### PR TITLE
feat(scheduled-tasks): add explicit time zones

### DIFF
--- a/change/@acedatacloud-nexior-scheduled-timezone.json
+++ b/change/@acedatacloud-nexior-scheduled-timezone.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Let scheduled tasks select and display an IANA time zone, and make desktop-local schedules honor the saved zone across daylight-saving changes.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/electron/scheduler/schedule.test.ts
+++ b/electron/scheduler/schedule.test.ts
@@ -1,32 +1,31 @@
 import { describe, it, expect } from 'vitest';
 import { nextTick, missedTicks, parseCron, type ScheduleSpec } from './schedule';
 
-// Fixed reference points, so no test depends on the wall clock.
-// 2026-03-10T08:30:00 local time.
-const BASE = Math.floor(new Date(2026, 2, 10, 8, 30, 0).getTime() / 1000);
+// Fixed UTC reference points, so tests do not depend on the host time zone.
+const BASE = Math.floor(Date.UTC(2026, 2, 10, 8, 30, 0) / 1000);
 const at = (y: number, mo: number, d: number, h: number, mi: number): number =>
-  Math.floor(new Date(y, mo, d, h, mi, 0).getTime() / 1000);
+  Math.floor(Date.UTC(y, mo, d, h, mi, 0) / 1000);
 
 describe('parseCron', () => {
   it('accepts the shapes the task form produces', () => {
-    expect(parseCron('0 9 * * *')).not.toBeNull();
-    expect(parseCron('*/15 * * * *')).not.toBeNull();
-    expect(parseCron('30 8 * * 1-5')).not.toBeNull();
-    expect(parseCron('0 0,12 * * *')).not.toBeNull();
+    expect(parseCron('0 9 * * *')).toBe(true);
+    expect(parseCron('*/15 * * * *')).toBe(true);
+    expect(parseCron('30 8 * * 1-5')).toBe(true);
+    expect(parseCron('0 0,12 * * *')).toBe(true);
   });
 
   it('rejects malformed expressions rather than guessing', () => {
     // A misparsed cron that silently "works" would fire at the wrong time
     // forever; null makes the task visibly never fire instead.
-    expect(parseCron('0 9 * *')).toBeNull();
-    expect(parseCron('61 9 * * *')).toBeNull();
-    expect(parseCron('0 25 * * *')).toBeNull();
-    expect(parseCron('a b c d e')).toBeNull();
-    expect(parseCron('*/0 * * * *')).toBeNull();
+    expect(parseCron('0 9 * *')).toBe(false);
+    expect(parseCron('61 9 * * *')).toBe(false);
+    expect(parseCron('0 25 * * *')).toBe(false);
+    expect(parseCron('a b c d e')).toBe(false);
+    expect(parseCron('*/0 * * * *')).toBe(false);
   });
 
-  it('folds cron day-of-week 7 onto Sunday', () => {
-    expect(parseCron('0 9 * * 7')?.dayOfWeek.has(0)).toBe(true);
+  it('accepts cron day-of-week 7 as Sunday', () => {
+    expect(parseCron('0 9 * * 7')).toBe(true);
   });
 });
 
@@ -71,32 +70,62 @@ describe('nextTick — interval', () => {
 describe('nextTick — cron', () => {
   it('finds the next daily tick', () => {
     // 08:30 → today 09:00
-    expect(nextTick({ type: 'cron', cron: '0 9 * * *' }, BASE)).toBe(at(2026, 2, 10, 9, 0));
+    expect(nextTick({ type: 'cron', tz: 'UTC', cron: '0 9 * * *' }, BASE)).toBe(at(2026, 2, 10, 9, 0));
   });
 
   it('rolls to tomorrow once today is past', () => {
     const afterNine = at(2026, 2, 10, 9, 30);
-    expect(nextTick({ type: 'cron', cron: '0 9 * * *' }, afterNine)).toBe(at(2026, 2, 11, 9, 0));
+    expect(nextTick({ type: 'cron', tz: 'UTC', cron: '0 9 * * *' }, afterNine)).toBe(at(2026, 2, 11, 9, 0));
   });
 
   it('honours weekday restrictions', () => {
     // 2026-03-10 is a Tuesday; a Fri-only task should land on the 13th.
-    expect(nextTick({ type: 'cron', cron: '0 9 * * 5' }, BASE)).toBe(at(2026, 2, 13, 9, 0));
+    expect(nextTick({ type: 'cron', tz: 'UTC', cron: '0 9 * * 5' }, BASE)).toBe(at(2026, 2, 13, 9, 0));
   });
 
   it('ORs the two day fields when both are restricted (POSIX rule)', () => {
     // "the 1st OR a Monday" — from Tue the 10th, next Monday is the 16th,
     // which is sooner than the 1st of April.
-    expect(nextTick({ type: 'cron', cron: '0 9 1 * 1' }, BASE)).toBe(at(2026, 2, 16, 9, 0));
+    expect(nextTick({ type: 'cron', tz: 'UTC', cron: '0 9 1 * 1' }, BASE)).toBe(at(2026, 2, 16, 9, 0));
   });
 
   it('returns null for an unparseable cron instead of firing arbitrarily', () => {
-    expect(nextTick({ type: 'cron', cron: 'not a cron' }, BASE)).toBeNull();
+    expect(nextTick({ type: 'cron', tz: 'UTC', cron: 'not a cron' }, BASE)).toBeNull();
   });
 
   it('returns null for a date that never occurs', () => {
-    // Feb 30th: the search runs its full year bound and gives up.
-    expect(nextTick({ type: 'cron', cron: '0 9 30 2 *' }, BASE)).toBeNull();
+    expect(nextTick({ type: 'cron', tz: 'UTC', cron: '0 9 30 2 *' }, BASE)).toBeNull();
+  });
+
+  it('uses the task time zone rather than the device time zone', () => {
+    const after = Math.floor(Date.parse('2026-03-10T00:30:00Z') / 1000);
+    expect(nextTick({ type: 'cron', cron: '0 9 * * *', tz: 'Asia/Shanghai' }, after)).toBe(
+      Math.floor(Date.parse('2026-03-10T01:00:00Z') / 1000)
+    );
+    expect(nextTick({ type: 'cron', cron: '0 9 * * *', tz: 'America/Los_Angeles' }, after)).toBe(
+      Math.floor(Date.parse('2026-03-10T16:00:00Z') / 1000)
+    );
+  });
+
+  it('advances through the spring DST gap using the IANA rule', () => {
+    const after = Math.floor(Date.parse('2026-03-08T09:00:00Z') / 1000);
+    expect(nextTick({ type: 'cron', cron: '30 2 * * *', tz: 'America/Los_Angeles' }, after)).toBe(
+      Math.floor(Date.parse('2026-03-08T10:30:00Z') / 1000)
+    );
+  });
+
+  it('does not fire the repeated fall-back wall-clock minute twice', () => {
+    const beforeFirst = Math.floor(Date.parse('2026-11-01T08:00:00Z') / 1000);
+    const first = nextTick({ type: 'cron', cron: '30 1 * * *', tz: 'America/Los_Angeles' }, beforeFirst)!;
+    expect(first).toBe(Math.floor(Date.parse('2026-11-01T08:30:00Z') / 1000));
+    expect(nextTick({ type: 'cron', cron: '30 1 * * *', tz: 'America/Los_Angeles' }, first)).toBe(
+      Math.floor(Date.parse('2026-11-02T09:30:00Z') / 1000)
+    );
+  });
+
+  it('fails closed for a missing or invalid time zone', () => {
+    expect(nextTick({ type: 'cron', cron: '0 9 * * *' }, BASE)).toBeNull();
+    expect(nextTick({ type: 'cron', cron: '0 9 * * *', tz: 'Mars/Olympus_Mons' }, BASE)).toBeNull();
   });
 });
 
@@ -109,7 +138,7 @@ describe('nextTick — once', () => {
 });
 
 describe('missedTicks', () => {
-  const daily: ScheduleSpec = { type: 'cron', cron: '0 9 * * *' };
+  const daily: ScheduleSpec = { type: 'cron', cron: '0 9 * * *', tz: 'UTC' };
 
   it('lists every tick in the gap, oldest first', () => {
     const from = at(2026, 2, 10, 10, 0); // after the 10th's run

--- a/electron/scheduler/schedule.ts
+++ b/electron/scheduler/schedule.ts
@@ -1,3 +1,5 @@
+import cronParser from 'cron-parser';
+
 /**
  * When a locally-executed scheduled task should next fire.
  *
@@ -16,8 +18,6 @@ export type ScheduleSpec =
 
 /** Seconds, matching the wire format (the backend speaks epoch seconds). */
 export type Epoch = number;
-
-const MINUTE = 60;
 
 /**
  * Parse one field of a 5-field cron expression into the set of values it
@@ -54,57 +54,17 @@ function parseField(field: string, min: number, max: number): Set<number> | null
   return values.size ? values : null;
 }
 
-interface CronFields {
-  minute: Set<number>;
-  hour: Set<number>;
-  dayOfMonth: Set<number>;
-  month: Set<number>;
-  dayOfWeek: Set<number>;
-  /** Cron's day fields are OR'd when both are restricted — the POSIX rule. */
-  dayOfMonthRestricted: boolean;
-  dayOfWeekRestricted: boolean;
-}
-
-export function parseCron(expr: string): CronFields | null {
+export function parseCron(expr: string): boolean {
   const parts = expr.trim().split(/\s+/);
-  if (parts.length !== 5) return null;
-  const minute = parseField(parts[0], 0, 59);
-  const hour = parseField(parts[1], 0, 23);
-  const dayOfMonth = parseField(parts[2], 1, 31);
-  const month = parseField(parts[3], 1, 12);
-  // Accept 7 as Sunday (crontab convention) and fold it onto 0.
-  const dayOfWeekRaw = parseField(parts[4], 0, 7);
-  if (!minute || !hour || !dayOfMonth || !month || !dayOfWeekRaw) return null;
-  const dayOfWeek = new Set([...dayOfWeekRaw].map((d) => (d === 7 ? 0 : d)));
-  return {
-    minute,
-    hour,
-    dayOfMonth,
-    month,
-    dayOfWeek,
-    dayOfMonthRestricted: parts[2] !== '*',
-    dayOfWeekRestricted: parts[4] !== '*'
-  };
+  if (parts.length !== 5) return false;
+  return (
+    parseField(parts[0], 0, 59) !== null &&
+    parseField(parts[1], 0, 23) !== null &&
+    parseField(parts[2], 1, 31) !== null &&
+    parseField(parts[3], 1, 12) !== null &&
+    parseField(parts[4], 0, 7) !== null
+  );
 }
-
-function matchesCron(fields: CronFields, date: Date): boolean {
-  if (!fields.minute.has(date.getMinutes())) return false;
-  if (!fields.hour.has(date.getHours())) return false;
-  if (!fields.month.has(date.getMonth() + 1)) return false;
-  const domMatch = fields.dayOfMonth.has(date.getDate());
-  const dowMatch = fields.dayOfWeek.has(date.getDay());
-  // POSIX: when BOTH day fields are restricted, a match on either one fires.
-  // When only one is, that one must match.
-  if (fields.dayOfMonthRestricted && fields.dayOfWeekRestricted) return domMatch || dowMatch;
-  if (fields.dayOfMonthRestricted) return domMatch;
-  if (fields.dayOfWeekRestricted) return dowMatch;
-  return true;
-}
-
-/** A year of minutes — the search bound for a cron that may never match (e.g.
- *  Feb 30). Cheap: the loop is integer maths over at most ~525k steps, and only
- *  a pathological expression ever runs it to completion. */
-const CRON_SEARCH_LIMIT_MINUTES = 366 * 24 * 60;
 
 /**
  * The first tick strictly after `after`.
@@ -113,10 +73,8 @@ const CRON_SEARCH_LIMIT_MINUTES = 366 * 24 * 60;
  * expired `ends_at`, an unparseable or impossible cron). Callers treat null as
  * "this task is done", never as "fire now".
  *
- * All cron maths runs in the host's LOCAL time. The task's `tz` is deliberately
- * ignored here: a local task fires on the machine the user is sitting at, and
- * "9am" means 9am where that machine is. A cloud task keeps using the
- * scheduler's tz handling.
+ * Cron uses the task's saved IANA time zone, matching platform-scheduler. The
+ * binding to a device controls where it fires, not what "9am" means.
  */
 export function nextTick(schedule: ScheduleSpec, after: Epoch): Epoch | null {
   const endsAt = schedule.type === 'once' ? undefined : schedule.ends_at;
@@ -143,16 +101,17 @@ function computeRawNext(schedule: ScheduleSpec, after: Epoch): Epoch | null {
     return anchor + (Math.floor(elapsed / period) + 1) * period;
   }
 
-  const fields = parseCron(schedule.cron);
-  if (!fields) return null;
+  if (!parseCron(schedule.cron) || !schedule.tz) return null;
   const start = schedule.starts_at !== undefined && schedule.starts_at > after ? schedule.starts_at : after;
-  // Cron has minute resolution: begin at the next whole minute after `start`.
-  const cursor = new Date((Math.floor(start / MINUTE) + 1) * MINUTE * 1000);
-  for (let i = 0; i < CRON_SEARCH_LIMIT_MINUTES; i += 1) {
-    if (matchesCron(fields, cursor)) return Math.floor(cursor.getTime() / 1000);
-    cursor.setMinutes(cursor.getMinutes() + 1);
+  try {
+    const iter = cronParser.parseExpression(schedule.cron, {
+      currentDate: new Date(start * 1000),
+      tz: schedule.tz
+    });
+    return Math.floor(iter.next().toDate().getTime() / 1000);
+  } catch {
+    return null;
   }
-  return null;
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "codemirror": "^6.0.1",
         "copy-to-clipboard": "^4.0.2",
         "cordova-plugin-purchase": "^13.11.0",
+        "cron-parser": "^4.9.0",
         "dayjs": "^1.11.21",
         "electron-updater": "^6.8.9",
         "element-plus": "2.10.4",
@@ -9918,6 +9919,18 @@
       "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
       "license": "MIT"
     },
+    "node_modules/cron-parser": {
+      "version": "4.9.0",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cron-parser/-/cron-parser-4.9.0.tgz",
+      "integrity": "sha1-A0BpSvPkagiUl4xvUqbbtcDxGtU=",
+      "license": "MIT",
+      "dependencies": {
+        "luxon": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/cross-env": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
@@ -14468,6 +14481,15 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.7.2",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha1-1pfkj0eFU8yhh6D4Q2r/Ro47oLo=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/mac-scrollbar": {

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "codemirror": "^6.0.1",
     "copy-to-clipboard": "^4.0.2",
     "cordova-plugin-purchase": "^13.11.0",
+    "cron-parser": "^4.9.0",
     "dayjs": "^1.11.21",
     "electron-updater": "^6.8.9",
     "element-plus": "2.10.4",

--- a/src/i18n/ar/chat.json
+++ b/src/i18n/ar/chat.json
@@ -1589,5 +1589,15 @@
   "model.claudeOpus47Description": {
     "message": "النموذج الأكثر تقدمًا حاليًا",
     "description": "وصف نموذج Claude Opus 4.7"
+  },
+  "scheduledTasks.form.timezone": {
+    "message": "المنطقة الزمنية"
+  },
+  "scheduledTasks.form.timezoneHint": {
+    "message": "تستخدم المهام الجديدة المنطقة الزمنية لهذا الجهاز افتراضيًا: {timezone}. وبعد الحفظ تبقى ثابتة للمهمة."
+  },
+  "scheduledTasks.form.timezoneInvalid": {
+    "message": "اختر منطقة زمنية صالحة وفق IANA"
   }
+
 }

--- a/src/i18n/de/chat.json
+++ b/src/i18n/de/chat.json
@@ -1589,5 +1589,15 @@
   "model.claudeOpus47Description": {
     "message": "Aktuell das fortschrittlichste Modell",
     "description": "Beschreibung des Claude Opus 4.7-Modells"
+  },
+  "scheduledTasks.form.timezone": {
+    "message": "Zeitzone"
+  },
+  "scheduledTasks.form.timezoneHint": {
+    "message": "Neue Aufgaben verwenden standardmäßig die Zeitzone dieses Geräts: {timezone}. Nach dem Speichern bleibt sie für die Aufgabe fest."
+  },
+  "scheduledTasks.form.timezoneInvalid": {
+    "message": "Wähle eine gültige IANA-Zeitzone aus"
   }
+
 }

--- a/src/i18n/el/chat.json
+++ b/src/i18n/el/chat.json
@@ -1589,5 +1589,15 @@
   "model.claudeOpus47Description": {
     "message": "Το πιο προηγμένο μοντέλο αυτή τη στιγμή",
     "description": "Περιγραφή του μοντέλου Claude Opus 4.7"
+  },
+  "scheduledTasks.form.timezone": {
+    "message": "Ζώνη ώρας"
+  },
+  "scheduledTasks.form.timezoneHint": {
+    "message": "Οι νέες εργασίες χρησιμοποιούν από προεπιλογή τη ζώνη ώρας αυτής της συσκευής: {timezone}. Μετά την αποθήκευση παραμένει σταθερή για την εργασία."
+  },
+  "scheduledTasks.form.timezoneInvalid": {
+    "message": "Επιλέξτε έγκυρη ζώνη ώρας IANA"
   }
+
 }

--- a/src/i18n/en/chat.json
+++ b/src/i18n/en/chat.json
@@ -910,6 +910,18 @@
   "scheduledTasks.form.time": {
     "message": "Time"
   },
+  "scheduledTasks.form.timezone": {
+    "message": "Time zone",
+    "description": "Scheduled task time zone field"
+  },
+  "scheduledTasks.form.timezoneHint": {
+    "message": "New tasks default to this device's time zone: {timezone}. Once saved, it stays fixed to the task.",
+    "description": "Scheduled task time zone guidance"
+  },
+  "scheduledTasks.form.timezoneInvalid": {
+    "message": "Select a valid IANA time zone",
+    "description": "Invalid time zone warning"
+  },
   "scheduledTasks.form.weekday": {
     "message": "Weekday"
   },

--- a/src/i18n/es/chat.json
+++ b/src/i18n/es/chat.json
@@ -1590,5 +1590,15 @@
   "model.claudeOpus47Description": {
     "message": "Modelo más avanzado actualmente",
     "description": "Descripción del modelo Claude Opus 4.7"
+  },
+  "scheduledTasks.form.timezone": {
+    "message": "Zona horaria"
+  },
+  "scheduledTasks.form.timezoneHint": {
+    "message": "Las tareas nuevas usan de forma predeterminada la zona horaria de este dispositivo: {timezone}. Una vez guardada, queda fija para la tarea."
+  },
+  "scheduledTasks.form.timezoneInvalid": {
+    "message": "Selecciona una zona horaria IANA válida"
   }
+
 }

--- a/src/i18n/fi/chat.json
+++ b/src/i18n/fi/chat.json
@@ -1550,5 +1550,15 @@
   "model.claudeOpus47Description": {
     "message": "Tällä hetkellä edistyksellisin malli",
     "description": "Claude Opus 4.7 -mallin kuvaus"
+  },
+  "scheduledTasks.form.timezone": {
+    "message": "Aikavyöhyke"
+  },
+  "scheduledTasks.form.timezoneHint": {
+    "message": "Uudet tehtävät käyttävät oletuksena tämän laitteen aikavyöhykettä: {timezone}. Tallennuksen jälkeen se pysyy tehtäväkohtaisena."
+  },
+  "scheduledTasks.form.timezoneInvalid": {
+    "message": "Valitse kelvollinen IANA-aikavyöhyke"
   }
+
 }

--- a/src/i18n/fr/chat.json
+++ b/src/i18n/fr/chat.json
@@ -1589,5 +1589,15 @@
   "model.claudeOpus47Description": {
     "message": "Modèle le plus avancé actuellement",
     "description": "Description du modèle Claude Opus 4.7"
+  },
+  "scheduledTasks.form.timezone": {
+    "message": "Fuseau horaire"
+  },
+  "scheduledTasks.form.timezoneHint": {
+    "message": "Les nouvelles tâches utilisent par défaut le fuseau horaire de cet appareil : {timezone}. Une fois enregistré, il reste associé à la tâche."
+  },
+  "scheduledTasks.form.timezoneInvalid": {
+    "message": "Sélectionnez un fuseau horaire IANA valide"
   }
+
 }

--- a/src/i18n/it/chat.json
+++ b/src/i18n/it/chat.json
@@ -1589,5 +1589,15 @@
   "model.claudeOpus47Description": {
     "message": "Modello più avanzato attualmente disponibile",
     "description": "Descrizione del modello Claude Opus 4.7"
+  },
+  "scheduledTasks.form.timezone": {
+    "message": "Fuso orario"
+  },
+  "scheduledTasks.form.timezoneHint": {
+    "message": "Le nuove attività usano per impostazione predefinita il fuso orario di questo dispositivo: {timezone}. Dopo il salvataggio resta fisso per l’attività."
+  },
+  "scheduledTasks.form.timezoneInvalid": {
+    "message": "Seleziona un fuso orario IANA valido"
   }
+
 }

--- a/src/i18n/ja/chat.json
+++ b/src/i18n/ja/chat.json
@@ -1550,5 +1550,15 @@
   "actionConfirmation.tiktok.musicBranded": {
     "message": "投稿すると、TikTok のブランドコンテンツポリシーおよび音楽利用確認に同意したことになります",
     "description": "TikTok 发布确认：勾选品牌内容后的声明"
+  },
+  "scheduledTasks.form.timezone": {
+    "message": "タイムゾーン"
+  },
+  "scheduledTasks.form.timezoneHint": {
+    "message": "新しいタスクでは、このデバイスのタイムゾーン（{timezone}）が既定で使用されます。保存後はタスクに固定されます。"
+  },
+  "scheduledTasks.form.timezoneInvalid": {
+    "message": "有効な IANA タイムゾーンを選択してください"
   }
+
 }

--- a/src/i18n/ko/chat.json
+++ b/src/i18n/ko/chat.json
@@ -1589,5 +1589,15 @@
   "model.claudeOpus47Description": {
     "message": "현재 가장 진보된 모델",
     "description": "Claude Opus 4.7 모델의 설명"
+  },
+  "scheduledTasks.form.timezone": {
+    "message": "시간대"
+  },
+  "scheduledTasks.form.timezoneHint": {
+    "message": "새 작업은 기본적으로 이 기기의 시간대({timezone})를 사용합니다. 저장한 뒤에는 작업에 고정됩니다."
+  },
+  "scheduledTasks.form.timezoneInvalid": {
+    "message": "유효한 IANA 시간대를 선택하세요"
   }
+
 }

--- a/src/i18n/pl/chat.json
+++ b/src/i18n/pl/chat.json
@@ -1589,5 +1589,15 @@
   "model.claudeOpus47Description": {
     "message": "Obecnie najnowocześniejszy model",
     "description": "Opis modelu Claude Opus 4.7"
+  },
+  "scheduledTasks.form.timezone": {
+    "message": "Strefa czasowa"
+  },
+  "scheduledTasks.form.timezoneHint": {
+    "message": "Nowe zadania domyślnie używają strefy czasowej tego urządzenia: {timezone}. Po zapisaniu pozostaje ona przypisana do zadania."
+  },
+  "scheduledTasks.form.timezoneInvalid": {
+    "message": "Wybierz prawidłową strefę czasową IANA"
   }
+
 }

--- a/src/i18n/pt/chat.json
+++ b/src/i18n/pt/chat.json
@@ -1589,5 +1589,15 @@
   "model.claudeOpus47Description": {
     "message": "Modelo mais avançado atualmente",
     "description": "Descrição do modelo Claude Opus 4.7"
+  },
+  "scheduledTasks.form.timezone": {
+    "message": "Fuso horário"
+  },
+  "scheduledTasks.form.timezoneHint": {
+    "message": "Novas tarefas usam por padrão o fuso horário deste dispositivo: {timezone}. Depois de salvo, ele permanece fixo para a tarefa."
+  },
+  "scheduledTasks.form.timezoneInvalid": {
+    "message": "Selecione um fuso horário IANA válido"
   }
+
 }

--- a/src/i18n/ru/chat.json
+++ b/src/i18n/ru/chat.json
@@ -1589,5 +1589,15 @@
   "model.claudeOpus47Description": {
     "message": "На данный момент самая продвинутая модель",
     "description": "Описание модели Claude Opus 4.7"
+  },
+  "scheduledTasks.form.timezone": {
+    "message": "Часовой пояс"
+  },
+  "scheduledTasks.form.timezoneHint": {
+    "message": "Новые задачи по умолчанию используют часовой пояс этого устройства: {timezone}. После сохранения он закрепляется за задачей."
+  },
+  "scheduledTasks.form.timezoneInvalid": {
+    "message": "Выберите допустимый часовой пояс IANA"
   }
+
 }

--- a/src/i18n/sr/chat.json
+++ b/src/i18n/sr/chat.json
@@ -1550,5 +1550,15 @@
   "model.claudeOpus47Description": {
     "message": "Trenutno najnapredniji model",
     "description": "Opis Claude Opus 4.7 modela"
+  },
+  "scheduledTasks.form.timezone": {
+    "message": "Временска зона"
+  },
+  "scheduledTasks.form.timezoneHint": {
+    "message": "Нови задаци подразумевано користе временску зону овог уређаја: {timezone}. Након чувања она остаје везана за задатак."
+  },
+  "scheduledTasks.form.timezoneInvalid": {
+    "message": "Изаберите важећу IANA временску зону"
   }
+
 }

--- a/src/i18n/sv/chat.json
+++ b/src/i18n/sv/chat.json
@@ -1589,5 +1589,15 @@
   "model.claudeOpus47Description": {
     "message": "Den mest avancerade modellen hittills",
     "description": "Beskrivning av Claude Opus 4.7-modellen"
+  },
+  "scheduledTasks.form.timezone": {
+    "message": "Tidszon"
+  },
+  "scheduledTasks.form.timezoneHint": {
+    "message": "Nya uppgifter använder som standard den här enhetens tidszon: {timezone}. När den har sparats förblir den knuten till uppgiften."
+  },
+  "scheduledTasks.form.timezoneInvalid": {
+    "message": "Välj en giltig IANA-tidszon"
   }
+
 }

--- a/src/i18n/uk/chat.json
+++ b/src/i18n/uk/chat.json
@@ -1589,5 +1589,15 @@
   "model.claudeOpus47Description": {
     "message": "Найсучасніша модель на сьогодні",
     "description": "Опис моделі Claude Opus 4.7"
+  },
+  "scheduledTasks.form.timezone": {
+    "message": "Часовий пояс"
+  },
+  "scheduledTasks.form.timezoneHint": {
+    "message": "Нові завдання типово використовують часовий пояс цього пристрою: {timezone}. Після збереження він закріплюється за завданням."
+  },
+  "scheduledTasks.form.timezoneInvalid": {
+    "message": "Виберіть дійсний часовий пояс IANA"
   }
+
 }

--- a/src/i18n/zh-CN/chat.json
+++ b/src/i18n/zh-CN/chat.json
@@ -963,6 +963,18 @@
     "message": "执行时间",
     "description": "时间字段"
   },
+  "scheduledTasks.form.timezone": {
+    "message": "时区",
+    "description": "定时任务时区字段"
+  },
+  "scheduledTasks.form.timezoneHint": {
+    "message": "新任务默认使用当前设备时区：{timezone}。保存后固定到任务，不会随设备位置自动改变。",
+    "description": "定时任务时区说明"
+  },
+  "scheduledTasks.form.timezoneInvalid": {
+    "message": "请选择有效的 IANA 时区",
+    "description": "无效时区提示"
+  },
   "scheduledTasks.form.weekday": {
     "message": "星期",
     "description": "星期字段"

--- a/src/i18n/zh-TW/chat.json
+++ b/src/i18n/zh-TW/chat.json
@@ -1550,5 +1550,15 @@
   "model.claudeOpus47Description": {
     "message": "目前最先進的模型",
     "description": "Claude Opus 4.7 模型的描述"
+  },
+  "scheduledTasks.form.timezone": {
+    "message": "時區"
+  },
+  "scheduledTasks.form.timezoneHint": {
+    "message": "新任務預設使用目前裝置的時區：{timezone}。儲存後會固定於任務，不會隨裝置位置自動變更。"
+  },
+  "scheduledTasks.form.timezoneInvalid": {
+    "message": "請選擇有效的 IANA 時區"
   }
+
 }

--- a/src/pages/chat/ScheduledTasks.test.ts
+++ b/src/pages/chat/ScheduledTasks.test.ts
@@ -348,6 +348,7 @@ describe('chat/ScheduledTasks', () => {
       dailyTime: '09:00',
       weekday: 1,
       cronExpr: '0 9 * * *',
+      timezone: expect.any(String),
       authorizedSkills: [],
       authorizedMcpServers: [],
       browserConnectionId: '',
@@ -357,6 +358,26 @@ describe('chat/ScheduledTasks', () => {
       authorizationExpiresAt: expect.any(Number),
       maxTurns: 50
     });
+  });
+
+  it('keeps the saved time zone when editing instead of replacing it with this device zone', () => {
+    const wrapper = mountComponent();
+    const vm = wrapper.vm as unknown as {
+      openEdit: (task: IScheduledTask) => void;
+      form: { timezone: string };
+      buildSchedule: () => IScheduledTask['schedule'];
+      scheduleLabel: (schedule: IScheduledTask['schedule']) => string;
+    };
+    const losAngeles = {
+      ...editedTask,
+      schedule: { type: 'cron', cron: '0 22 * * *', tz: 'America/Los_Angeles' } as const
+    };
+
+    vm.openEdit(losAngeles);
+
+    expect(vm.form.timezone).toBe('America/Los_Angeles');
+    expect(vm.buildSchedule()).toMatchObject({ type: 'cron', tz: 'America/Los_Angeles' });
+    expect(vm.scheduleLabel(losAngeles.schedule)).toContain('America/Los_Angeles');
   });
 
   it('prefills the create form from an existing task, with a numbered name', async () => {
@@ -381,6 +402,7 @@ describe('chat/ScheduledTasks', () => {
       scheduleType: 'interval',
       intervalValue: 6,
       intervalUnit: 'hour',
+      timezone: 'Asia/Shanghai',
       authorizedSkills: ['hashnode'],
       authorizedMcpServers: ['publishing'],
       maxTurns: 12

--- a/src/pages/chat/ScheduledTasks.vue
+++ b/src/pages/chat/ScheduledTasks.vue
@@ -394,6 +394,15 @@
           </div>
         </el-form-item>
 
+        <el-form-item :label="$t('chat.scheduledTasks.form.timezone')" required>
+          <el-select v-model="form.timezone" filterable style="width: 100%">
+            <el-option v-for="tz in timezoneOptions" :key="tz" :label="timeZoneLabel(tz)" :value="tz" />
+          </el-select>
+          <div class="hint">
+            {{ $t('chat.scheduledTasks.form.timezoneHint', { timezone: detectedTimezoneLabel }) }}
+          </div>
+        </el-form-item>
+
         <el-form-item v-if="form.scheduleType === 'interval'" :label="$t('chat.scheduledTasks.scheduleType.interval')">
           <el-input-number
             v-model="form.intervalValue"
@@ -614,8 +623,9 @@ import { CHAT_MODEL_GROUPS, CHAT_MODEL_NAME_GPT_5_6_SOL } from '@/constants';
 import { getSurface, isDesktop } from '@/utils/surface';
 import { desktopBridge, localExec, type LocalToolSpec } from '@/utils/desktop';
 import { IChatModelGroup } from '@/models';
+import { detectedTimeZone, isValidTimeZone, listTimeZones, timeZoneLabel } from '@/utils/timezones';
 
-const USER_TZ = Intl.DateTimeFormat().resolvedOptions().timeZone || 'Asia/Shanghai';
+const USER_TZ = detectedTimeZone();
 
 type ScheduledTab = 'tasks' | 'runs';
 type RunStatusFilter = 'all' | IScheduledRunStatus;
@@ -645,6 +655,7 @@ interface TaskForm {
   dailyTime: string;
   weekday: number;
   cronExpr: string;
+  timezone: string;
   authorizedSkills: string[];
   authorizedMcpServers: string[];
   browserConnectionId: string;
@@ -798,10 +809,16 @@ export default defineComponent({
     // Live human-readable summary of the schedule the form currently builds.
     schedulePreview(): string {
       try {
-        return this.humanizeSchedule(this.buildSchedule());
+        return this.scheduleLabel(this.buildSchedule());
       } catch {
         return '';
       }
+    },
+    timezoneOptions(): string[] {
+      return listTimeZones(USER_TZ, this.form.timezone);
+    },
+    detectedTimezoneLabel(): string {
+      return timeZoneLabel(USER_TZ);
     },
     selectedBrowserConnections(): IAuthorizableBrowserConnection[] {
       const selected = new Set(this.form.authorizedSkills);
@@ -883,6 +900,7 @@ export default defineComponent({
         dailyTime: '09:00',
         weekday: 1,
         cronExpr: '0 9 * * *',
+        timezone: USER_TZ,
         authorizedSkills: [],
         authorizedMcpServers: [],
         browserConnectionId: '',
@@ -1164,6 +1182,7 @@ export default defineComponent({
         dailyTime,
         weekday,
         cronExpr,
+        timezone: s.tz || USER_TZ,
         authorizedSkills: task.unattended_policy?.allowed_skills || [],
         authorizedMcpServers: task.unattended_policy?.allowed_mcp_servers || [],
         browserConnectionId: task.unattended_policy?.browser_connections?.[0]?.connection_id ?? '',
@@ -1234,30 +1253,35 @@ export default defineComponent({
       return build(n);
     },
     buildSchedule(): IScheduleSpec {
-      const { scheduleType, intervalValue, intervalUnit, hourlyMinute, dailyTime, weekday, cronExpr } = this.form;
+      const { scheduleType, intervalValue, intervalUnit, hourlyMinute, dailyTime, weekday, cronExpr, timezone } =
+        this.form;
       if (scheduleType === 'interval') {
         const unitSeconds = intervalUnit === 'day' ? 86400 : intervalUnit === 'hour' ? 3600 : 60;
         // Scheduler's finest cadence is 60s; guard against sub-minute intervals.
         const seconds = Math.max(60, Math.round(intervalValue) * unitSeconds);
-        return { type: 'interval', interval_seconds: seconds, tz: USER_TZ };
+        return { type: 'interval', interval_seconds: seconds, tz: timezone };
       }
       if (scheduleType === 'hourly') {
         const m = Math.min(59, Math.max(0, Math.round(hourlyMinute)));
-        return { type: 'cron', cron: `${m} * * * *`, tz: USER_TZ };
+        return { type: 'cron', cron: `${m} * * * *`, tz: timezone };
       }
       if (scheduleType === 'daily') {
         const [h, m] = dailyTime.split(':');
-        return { type: 'cron', cron: `${m} ${h} * * *`, tz: USER_TZ };
+        return { type: 'cron', cron: `${m} ${h} * * *`, tz: timezone };
       }
       if (scheduleType === 'weekly') {
         const [h, m] = dailyTime.split(':');
-        return { type: 'cron', cron: `${m} ${h} * * ${weekday}`, tz: USER_TZ };
+        return { type: 'cron', cron: `${m} ${h} * * ${weekday}`, tz: timezone };
       }
-      return { type: 'cron', cron: cronExpr, tz: USER_TZ };
+      return { type: 'cron', cron: cronExpr, tz: timezone };
     },
     async saveTask() {
       if (!this.form.question.trim()) {
         ElMessage.warning(this.$t('chat.scheduledTasks.form.required') as string);
+        return;
+      }
+      if (!isValidTimeZone(this.form.timezone)) {
+        ElMessage.warning(this.$t('chat.scheduledTasks.form.timezoneInvalid') as string);
         return;
       }
       // Connection/browser bindings below are rebuilt from authorizableSkills;
@@ -1650,7 +1674,10 @@ export default defineComponent({
       return t('once', { time: new Date(s.at * 1000).toLocaleString() });
     },
     scheduleLabel(s: IScheduleSpec) {
-      return this.humanizeSchedule(s);
+      return `${this.humanizeSchedule(s)} · ${timeZoneLabel(s.tz)}`;
+    },
+    timeZoneLabel(timeZone: string) {
+      return timeZoneLabel(timeZone);
     },
     formatTime(ts: number) {
       return new Date(ts * 1000).toLocaleString();

--- a/src/utils/timezones.test.ts
+++ b/src/utils/timezones.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { isValidTimeZone, listTimeZones, timeZoneLabel, timeZoneOffset } from './timezones';
+
+describe('time zone helpers', () => {
+  it('validates IANA zones rather than fixed-offset labels', () => {
+    expect(isValidTimeZone('Asia/Shanghai')).toBe(true);
+    expect(isValidTimeZone('UTC')).toBe(true);
+    expect(isValidTimeZone('UTC+8')).toBe(false);
+    expect(isValidTimeZone('Mars/Olympus_Mons')).toBe(false);
+  });
+
+  it('includes the saved zone even when building the fallback list', () => {
+    expect(listTimeZones('America/Los_Angeles')).toContain('America/Los_Angeles');
+    expect(listTimeZones()).toContain('UTC');
+  });
+
+  it('formats the current offset without replacing the IANA identity', () => {
+    const winter = new Date('2026-01-15T12:00:00Z');
+    const summer = new Date('2026-07-15T12:00:00Z');
+    expect(timeZoneOffset('America/Los_Angeles', winter)).toBe('UTC-8');
+    expect(timeZoneOffset('America/Los_Angeles', summer)).toBe('UTC-7');
+    expect(timeZoneLabel('Asia/Shanghai', winter)).toBe('Asia/Shanghai (UTC+8)');
+  });
+});

--- a/src/utils/timezones.ts
+++ b/src/utils/timezones.ts
@@ -1,0 +1,74 @@
+const FALLBACK_TIMEZONES = [
+  'UTC',
+  'Asia/Shanghai',
+  'Asia/Hong_Kong',
+  'Asia/Tokyo',
+  'Asia/Seoul',
+  'Asia/Singapore',
+  'Asia/Kolkata',
+  'Europe/London',
+  'Europe/Paris',
+  'Europe/Berlin',
+  'Europe/Moscow',
+  'America/New_York',
+  'America/Chicago',
+  'America/Denver',
+  'America/Los_Angeles',
+  'America/Toronto',
+  'America/Sao_Paulo',
+  'Australia/Sydney',
+  'Pacific/Auckland'
+];
+
+export function detectedTimeZone(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || 'Asia/Shanghai';
+  } catch {
+    return 'Asia/Shanghai';
+  }
+}
+
+export function isValidTimeZone(timeZone: string): boolean {
+  if (!timeZone?.trim()) return false;
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone }).format(0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function timeZoneOffset(timeZone: string, date = new Date()): string {
+  try {
+    const part = new Intl.DateTimeFormat('en-US', {
+      timeZone,
+      timeZoneName: 'shortOffset'
+    })
+      .formatToParts(date)
+      .find(({ type }) => type === 'timeZoneName')?.value;
+    if (!part || part === 'GMT') return 'UTC';
+    return part.replace('GMT', 'UTC');
+  } catch {
+    return '';
+  }
+}
+
+export function timeZoneLabel(timeZone: string, date = new Date()): string {
+  const offset = timeZoneOffset(timeZone, date);
+  return offset ? `${timeZone} (${offset})` : timeZone;
+}
+
+export function listTimeZones(...include: Array<string | undefined>): string[] {
+  let supported: string[] = [];
+  try {
+    const values = (Intl as typeof Intl & { supportedValuesOf?: (key: 'timeZone') => string[] }).supportedValuesOf;
+    supported = values?.('timeZone') ?? [];
+  } catch {
+    supported = [];
+  }
+  return [
+    ...new Set(['UTC', ...include.filter((value): value is string => !!value), ...supported, ...FALLBACK_TIMEZONES])
+  ]
+    .filter(isValidTimeZone)
+    .sort((a, b) => a.localeCompare(b));
+}


### PR DESCRIPTION
## Summary
- add an explicit searchable IANA time-zone picker to scheduled tasks
- preserve and display each task’s saved zone when editing, duplicating, and listing tasks
- make desktop-local cron scheduling honor the saved zone, including DST transitions
- validate locale coverage and add focused UI/time-zone/desktop scheduler tests

## Verification
- `npm run lint:check` (passes with two pre-existing warnings)
- `npx vue-tsc -b --force`
- `npm test -- --run src/utils/timezones.test.ts electron/scheduler/schedule.test.ts src/pages/chat/ScheduledTasks.test.ts`
- `npm run compile:electron`
- `python3 scripts/check_i18n_coverage.py`
- `npm run verify`

🤖 Generated with [Claude Code](https://claude.com/claude-code)