### PR TITLE
ci: aggregate complete daily releases

### DIFF
--- a/.github/workflows/auto-release-mobile.yaml
+++ b/.github/workflows/auto-release-mobile.yaml
@@ -1,10 +1,8 @@
 name: Auto Release Mobile (Testing)
 
-# Runs ONCE PER DAY (not per merge) to keep macOS/iOS Actions minutes down —
-# iOS builds on the 10x-billed macOS runner, so per-merge fan-out was the single
-# largest Actions cost. The daily build uses main's HEAD (the latest released
-# version via beachball). build-ios.yaml's TestFlight dedup preflight auto-skips
-# the macOS job on days with no new version, so a quiet day costs ~nothing.
+# Runs once per day after the aggregated Beachball/GitHub Release window.
+# iOS builds on the 10x-billed macOS runner, so per-merge fan-out would dominate
+# Actions cost. Duplicate-version preflights make a quiet day nearly free.
 #
 # This orchestrator dispatches the existing build-android.yaml / build-ios.yaml
 # with PRODUCTION EXPLICITLY DISABLED:
@@ -19,9 +17,8 @@ name: Auto Release Mobile (Testing)
 
 on:
   schedule:
-    # 04:07 Beijing time (UTC 20:07). Off the top of the hour to dodge GitHub's
-    # cron congestion. Cadence is intentionally daily, not per-merge.
-    - cron: '7 20 * * *'
+    # 05:47 Beijing time (UTC 21:47), after the daily package/desktop/APK release.
+    - cron: '47 21 * * *'
   # Allow re-running the auto test-publish by hand for the current ref.
   workflow_dispatch: {}
 

--- a/.github/workflows/build-android.yaml
+++ b/.github/workflows/build-android.yaml
@@ -4,6 +4,17 @@ on:
   push:
     tags:
       - 'android-v*'
+  workflow_call:
+    inputs:
+      release_tag:
+        description: 'Existing draft Release to receive the sideload APK.'
+        required: true
+        type: string
+      upload_to_play:
+        description: 'Upload the AAB to Google Play.'
+        required: false
+        default: false
+        type: boolean
   workflow_dispatch:
     inputs:
       track:
@@ -51,7 +62,7 @@ jobs:
     name: Preflight (skip if Play already has this versionCode)
     runs-on: ubuntu-latest
     outputs:
-      should-build: ${{ steps.check.outputs.should-build }}
+      should-build: ${{ steps.package_only.outputs.should-build || steps.check.outputs.should-build }}
       version-name: ${{ steps.version.outputs.name }}
       version-code: ${{ steps.version.outputs.code }}
       track: ${{ steps.track.outputs.track }}
@@ -75,7 +86,7 @@ jobs:
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "track=${{ inputs.track }}" >> "$GITHUB_OUTPUT"
           else
-            # Tag push (android-v*) defaults to Open testing (beta) and then promotes to production.
+            # Tag and reusable release builds use beta metadata by default.
             echo "track=beta" >> "$GITHUB_OUTPUT"
           fi
 
@@ -84,8 +95,14 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Build without Play preflight
+        if: github.event_name == 'workflow_call' && !inputs.upload_to_play
+        run: echo "should-build=true" >> "$GITHUB_OUTPUT"
+        id: package_only
+
       - name: Check Play Console for existing AAB/APK
         id: check
+        if: github.event_name != 'workflow_call' || inputs.upload_to_play
         env:
           FORCE: ${{ inputs.force }}
           SA_JSON: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
@@ -207,12 +224,14 @@ jobs:
           mv android/app/src/main/assets/public android/app/src/full/assets/public
 
       - name: Build web assets (play flavor, Computer Use OFF, tree-shaken)
+        if: github.event_name != 'workflow_call' || inputs.upload_to_play
         env:
           VITE_STRIPE_PUBLISHABLE_KEY: ${{ secrets.VITE_STRIPE_PUBLISHABLE_KEY }}
           VITE_COMPUTER_USE: 'false'
         run: npm run build:android
 
       - name: Stage play-flavor web assets
+        if: github.event_name != 'workflow_call' || inputs.upload_to_play
         # The Play web bundle is compiled with no Local Tools entry and no
         # Computer Use / AccessibilityService adapter code; it lives only in the
         # `play` flavor. cap copy re-processes dist into the main source set the
@@ -238,6 +257,7 @@ jobs:
         shell: bash
 
       - name: Build Play AAB (play flavor, no Computer Use)
+        if: github.event_name != 'workflow_call' || inputs.upload_to_play
         working-directory: android
         run: |
           chmod +x gradlew
@@ -263,44 +283,38 @@ jobs:
           path: android/app/build/outputs/apk/full/release/app-full-release.apk
 
       - name: Upload AAB artifact
+        if: github.event_name != 'workflow_call' || inputs.upload_to_play
         uses: actions/upload-artifact@v7
         with:
           name: nexior-${{ needs.preflight.outputs.version-name }}.aab
           path: android/app/build/outputs/bundle/playRelease/app-play-release.aab
 
-      # Attach the sideloadable APK to the matching GitHub Release
-      # (@acedatacloud/nexior_v<version>, created by github-release.yaml). Only
-      # attach when that release ALREADY EXISTS, so a manual `android-v*` /
-      # workflow_dispatch run can never create a spurious release. action-gh-
-      # release is idempotent: it updates the existing release and adds the asset.
-      - name: Check release exists
-        id: rel
+      - name: Verify draft Release exists
+        if: github.event_name == 'workflow_call'
         env:
           GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN || github.token }}
-          REL_TAG: '@acedatacloud/nexior_v${{ needs.preflight.outputs.version-name }}'
+          REL_TAG: ${{ inputs.release_tag }}
         run: |
-          if gh release view "$REL_TAG" -R "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "::warning::release $REL_TAG not found — skipping APK attach."
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-          fi
+          IS_DRAFT=$(gh release view "$REL_TAG" -R "$GITHUB_REPOSITORY" --json isDraft --jq .isDraft)
+          test "$IS_DRAFT" = "true" || { echo "::error::$REL_TAG is missing or is not a draft"; exit 1; }
 
       - name: Stage versioned APK
-        if: steps.rel.outputs.exists == 'true'
+        if: github.event_name == 'workflow_call'
         run: cp android/app/build/outputs/apk/full/release/app-full-release.apk "nexior-${{ needs.preflight.outputs.version-name }}.apk"
 
-      - name: Attach APK to GitHub Release
-        if: steps.rel.outputs.exists == 'true'
+      - name: Attach APK to draft GitHub Release
+        if: github.event_name == 'workflow_call'
         uses: softprops/action-gh-release@v3
         env:
           GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN || github.token }}
         with:
-          tag_name: '@acedatacloud/nexior_v${{ needs.preflight.outputs.version-name }}'
+          tag_name: ${{ inputs.release_tag }}
+          draft: true
           files: nexior-${{ needs.preflight.outputs.version-name }}.apk
           fail_on_unmatched_files: true
 
       - name: Upload to Play Store
+        if: github.event_name != 'workflow_call' || inputs.upload_to_play
         uses: r0adkll/upload-google-play@v1
         with:
           serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
@@ -325,6 +339,7 @@ jobs:
       always()
       && needs.preflight.result == 'success'
       && (needs.build.result == 'success' || needs.build.result == 'skipped')
+      && github.event_name != 'workflow_call'
       && needs.preflight.outputs.track != 'production'
       && (github.event_name != 'workflow_dispatch' || inputs.promote_to_production)
     runs-on: ubuntu-latest

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -5,17 +5,12 @@ name: Desktop
 #
 # Triggers:
 #   - pull_request (desktop paths)        → E2E smoke only
-#   - schedule (daily 04:07 Beijing)      → E2E + build .exe/.dmg beta artifacts
-#                                           (30-day retention; NO release attach,
-#                                            NO COS publish). Daily — not per merge —
-#                                            because the macOS leg bills at 10x.
+#   - workflow_call (daily release)       → E2E + build + attach installers
 #   - push tag `desktop-v*`               → E2E + build + PUBLISH to `latest`
 #   - workflow_dispatch (channel/dry_run) → E2E + build + (optional) PUBLISH
 #
-# The macOS/Windows build used to fire on every beachball release tag
-# (@acedatacloud/nexior_v*), i.e. almost every merge — the single biggest
-# desktop Actions cost. It's now a once-daily beta build; the live auto-update
-# feed (COS) is still an admin-gated `desktop-v*` release, untouched.
+# Product releases call this workflow once after the day's Beachball aggregation.
+# The live auto-update feed (COS) remains an independent, admin-gated release.
 #
 # Required repo secrets:
 #   TENCENT_CLOUD_SECRET_ID / TENCENT_CLOUD_SECRET_KEY        COS upload
@@ -45,10 +40,17 @@ on:
       - 'scripts/gen-tray-icon.py'
       - 'scripts/publish_desktop_release.py'
       - '.github/workflows/desktop.yml'
-  schedule:
-    # 04:07 Beijing time (UTC 20:07), off the top of the hour to dodge cron
-    # congestion. Daily beta build of the desktop installers.
-    - cron: '7 20 * * *'
+  workflow_call:
+    inputs:
+      release_tag:
+        description: 'Existing draft Release to receive the installers.'
+        required: true
+        type: string
+      channel:
+        description: 'electron-builder channel for the packaged metadata.'
+        required: false
+        default: 'beta'
+        type: string
   push:
     tags:
       - 'desktop-v*'
@@ -72,7 +74,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.release_tag || inputs.channel || 'smoke' }}
   cancel-in-progress: true
 
 env:
@@ -108,7 +110,7 @@ jobs:
   # Resolve the channel and whether this run publishes to the live feed.
   #   tag desktop-v*  → latest, publish
   #   workflow_dispatch → chosen channel, publish unless dry_run
-  #   push to main    → beta, build artifacts only (no publish)
+  #   workflow_call   → beta, attach to the aggregate draft (no COS publish)
   # --------------------------------------------------------------------------
   resolve:
     name: Resolve channel
@@ -119,19 +121,26 @@ jobs:
       publish: ${{ steps.c.outputs.publish }}
     steps:
       - id: c
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          INPUT_CHANNEL: ${{ inputs.channel }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          GIT_REF: ${{ github.ref }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "channel=${{ inputs.channel }}" >> "$GITHUB_OUTPUT"
-            if [ "${{ inputs.dry_run }}" = "true" ]; then
+          if [ -n "$RELEASE_TAG" ]; then
+            echo "channel=$INPUT_CHANNEL" >> "$GITHUB_OUTPUT"
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+          elif [ -n "$INPUT_CHANNEL" ]; then
+            echo "channel=$INPUT_CHANNEL" >> "$GITHUB_OUTPUT"
+            if [ "$DRY_RUN" = "true" ]; then
               echo "publish=false" >> "$GITHUB_OUTPUT"
             else
               echo "publish=true" >> "$GITHUB_OUTPUT"
             fi
-          elif [[ "${{ github.ref }}" == refs/tags/desktop-v* ]]; then
+          elif [[ "$GIT_REF" == refs/tags/desktop-v* ]]; then
             echo "channel=latest" >> "$GITHUB_OUTPUT"
             echo "publish=true" >> "$GITHUB_OUTPUT"
           else
-            # push to main → auto-build beta installers as artifacts, no publish
             echo "channel=beta" >> "$GITHUB_OUTPUT"
             echo "publish=false" >> "$GITHUB_OUTPUT"
           fi
@@ -253,36 +262,24 @@ jobs:
           retention-days: 30
           if-no-files-found: error
 
-      # Attach this OS's installer to the GitHub Release for the version
-      # currently on main (@acedatacloud/nexior_v<package.json version>, created
-      # by github-release.yaml on the beachball tag). We gate on the release
-      # ALREADY EXISTING (mirroring build-android.yaml) rather than on a tag ref,
-      # so the daily scheduled build still attaches to the day's release. A
-      # manual desktop-v* / workflow_dispatch run never creates a bare release.
-      - name: Resolve release tag from package.json
-        id: rel
-        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-        shell: bash
+      - name: Verify draft Release exists
+        if: github.event_name == 'workflow_call'
         env:
           GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN || github.token }}
+          REL_TAG: ${{ inputs.release_tag }}
+        shell: bash
         run: |
-          VERSION=$(node -p "require('./package.json').version")
-          REL_TAG="@acedatacloud/nexior_v${VERSION}"
-          echo "tag=$REL_TAG" >> "$GITHUB_OUTPUT"
-          if gh release view "$REL_TAG" -R "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "::warning::release $REL_TAG not found — skipping installer attach (artifacts still uploaded)."
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-          fi
+          IS_DRAFT=$(gh release view "$REL_TAG" -R "$GITHUB_REPOSITORY" --json isDraft --jq .isDraft)
+          test "$IS_DRAFT" = "true" || { echo "::error::$REL_TAG is missing or is not a draft"; exit 1; }
 
-      - name: Attach installer to GitHub Release
-        if: steps.rel.outputs.exists == 'true'
+      - name: Attach installer to draft GitHub Release
+        if: github.event_name == 'workflow_call'
         uses: softprops/action-gh-release@v3
         env:
           GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN || github.token }}
         with:
-          tag_name: ${{ steps.rel.outputs.tag }}
+          tag_name: ${{ inputs.release_tag }}
+          draft: true
           files: ${{ runner.os == 'Windows' && 'release/*.exe' || 'release/*.dmg' }}
           fail_on_unmatched_files: true
 

--- a/.github/workflows/github-release.yaml
+++ b/.github/workflows/github-release.yaml
@@ -1,21 +1,33 @@
 name: github-release
 
-"on":
-  push:
-    tags:
-      - '@acedatacloud/nexior_v*'
-      - 'v*'
+# Assemble one complete, public Release from the daily Beachball version. The
+# Release stays draft until every downloadable platform asset is present.
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Beachball tag to assemble (for example @acedatacloud/nexior_v3.356.14).'
+        required: true
+        type: string
 
 permissions:
   contents: write
 
+concurrency:
+  group: github-release-${{ inputs.release_tag }}
+  cancel-in-progress: false
+
 jobs:
-  release:
+  prepare:
+    name: Build web dist and create draft
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
     steps:
-      - name: Checkout
+      - name: Checkout release tag
         uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.release_tag }}
           fetch-depth: 0
 
       - name: Set up Node.js
@@ -27,66 +39,131 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build
+      - name: Validate release metadata
+        id: meta
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          VERSION=$(node -p "require('./package.json').version")
+          EXPECTED="@acedatacloud/nexior_v${VERSION}"
+          test "$RELEASE_TAG" = "$EXPECTED" || {
+            echo "::error::release tag $RELEASE_TAG does not match package version $EXPECTED"
+            exit 1
+          }
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Build web dist
         run: npm run build
 
-      - name: Prepare metadata
-        id: meta
-        shell: bash
+      - name: Package web dist
         env:
-          # Optional override; falls back to the canonical URL shipped in the app.
-          IOS_APP_STORE_URL_OVERRIDE: ${{ vars.IOS_APP_STORE_URL }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
         run: |
-          TAG="${GITHUB_REF_NAME}"
-          SAFE_TAG="${TAG//\//-}"
-          if [[ "$TAG" == *"_v"* ]]; then
-            VERSION="${TAG##*_v}"
-          else
-            VERSION="${TAG#v}"
-          fi
-          # iOS store link: prefer the repo-variable override, else the canonical
-          # URL the app already ships with (single source of truth in mobile.ts).
-          IOS_URL="${IOS_APP_STORE_URL_OVERRIDE:-}"
-          if [ -z "$IOS_URL" ]; then
-            IOS_URL=$(sed -nE "s/.*MOBILE_IOS_APP_STORE_URL *= *'([^']+)'.*/\1/p" src/constants/mobile.ts | head -n1)
-          fi
-          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
-          echo "safe_tag=${SAFE_TAG}" >> "$GITHUB_OUTPUT"
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "ios_url=${IOS_URL}" >> "$GITHUB_OUTPUT"
-
-      - name: Package dist
-        shell: bash
-        run: |
-          ASSET="nexior-dist-${{ steps.meta.outputs.safe_tag }}.tar.gz"
+          SAFE_TAG=${RELEASE_TAG//\//-}
+          ASSET="nexior-dist-${SAFE_TAG}.tar.gz"
           tar -czf "$ASSET" dist
           sha256sum "$ASSET" > "${ASSET}.sha256"
 
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
+      - name: Create draft Release with web assets
         env:
-          GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN || github.token }}
+          GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN || github.token }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          set -euo pipefail
+          if gh release view "$RELEASE_TAG" -R "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            IS_DRAFT=$(gh release view "$RELEASE_TAG" -R "$GITHUB_REPOSITORY" --json isDraft --jq .isDraft)
+            test "$IS_DRAFT" = "true" || {
+              echo "::error::$RELEASE_TAG is already public; refusing to replace it"
+              exit 1
+            }
+          else
+            gh release create "$RELEASE_TAG" -R "$GITHUB_REPOSITORY" \
+              --verify-tag --draft --generate-notes --title "v$VERSION"
+          fi
+          gh release upload "$RELEASE_TAG" -R "$GITHUB_REPOSITORY" \
+            nexior-dist-*.tar.gz nexior-dist-*.tar.gz.sha256 --clobber
+
+  desktop:
+    name: Build desktop installers
+    needs: prepare
+    uses: ./.github/workflows/desktop.yml
+    with:
+      release_tag: ${{ inputs.release_tag }}
+      channel: beta
+    secrets: inherit
+
+  android:
+    name: Build Android sideload package
+    needs: prepare
+    uses: ./.github/workflows/build-android.yaml
+    with:
+      release_tag: ${{ inputs.release_tag }}
+      upload_to_play: false
+    secrets: inherit
+
+  publish:
+    name: Verify assets and publish Release
+    needs: [prepare, desktop, android]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@v4
         with:
-          tag_name: ${{ steps.meta.outputs.tag }}
-          name: v${{ steps.meta.outputs.version }}
-          generate_release_notes: true
-          # The platform installers themselves are attached by the per-platform
-          # workflows (build-android.yaml / desktop.yml) which finish on their own
-          # runners; this block just documents where each lives. append_body keeps
-          # the auto-generated changelog above this table.
-          append_body: true
-          body: |
-            ## 📦 Downloads
+          ref: ${{ inputs.release_tag }}
 
-            | Platform | How to get it |
-            |----------|---------------|
-            | 🍎 **macOS** | The `.dmg` in Assets below (`x64` for Intel, `arm64` for Apple Silicon) |
-            | 🪟 **Windows** | The `.exe` installer in Assets below |
-            | 🤖 **Android** | The `.apk` in Assets below (sideload), or [Google Play](https://play.google.com/store/apps/details?id=com.acedatacloud.nexior) |
-            | 📱 **iOS** | ${{ steps.meta.outputs.ios_url != '' && format('[App Store]({0})', steps.meta.outputs.ios_url) || 'TestFlight beta (coming soon)' }} |
-            | 🌐 **Web** | The `nexior-dist-*.tar.gz` below (self-host) |
+      - name: Verify complete asset set
+        env:
+          GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN || github.token }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          ASSETS=$(gh release view "$RELEASE_TAG" -R "$GITHUB_REPOSITORY" --json assets --jq '.assets[].name')
+          printf '%s\n' "$ASSETS"
 
-            > ⚠️ The desktop apps are currently an **unsigned beta**: on macOS, right-click → Open to bypass Gatekeeper; on Windows, click "Run anyway" on the SmartScreen prompt. They switch to signed builds automatically once the signing certificates are configured.
-          files: |
-            nexior-dist-${{ steps.meta.outputs.safe_tag }}.tar.gz
-            nexior-dist-${{ steps.meta.outputs.safe_tag }}.tar.gz.sha256
+          require_count() {
+            PATTERN=$1
+            EXPECTED=$2
+            COUNT=$(printf '%s\n' "$ASSETS" | grep -Ec "$PATTERN" || true)
+            if [ "$COUNT" -ne "$EXPECTED" ]; then
+              echo "::error::expected $EXPECTED asset(s) matching $PATTERN, found $COUNT"
+              exit 1
+            fi
+          }
+
+          require_count '^nexior-dist-.*\.tar\.gz$' 1
+          require_count '^nexior-dist-.*\.tar\.gz\.sha256$' 1
+          require_count '^nexior-[0-9]+\.[0-9]+\.[0-9]+\.apk$' 1
+          require_count '^AceData\.Setup\..*\.exe$' 1
+          require_count '^AceData-[0-9]+\.[0-9]+\.[0-9]+\.dmg$' 1
+          require_count '^AceData-[0-9]+\.[0-9]+\.[0-9]+-arm64\.dmg$' 1
+
+      - name: Publish completed Release
+        env:
+          GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN || github.token }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          IOS_APP_STORE_URL_OVERRIDE: ${{ vars.IOS_APP_STORE_URL }}
+        run: |
+          set -euo pipefail
+          IOS_URL=${IOS_APP_STORE_URL_OVERRIDE:-}
+          if [ -z "$IOS_URL" ]; then
+            IOS_URL=$(sed -nE "s/.*MOBILE_IOS_APP_STORE_URL *= *'([^']+)'.*/\1/p" src/constants/mobile.ts | head -n1)
+          fi
+          gh release view "$RELEASE_TAG" -R "$GITHUB_REPOSITORY" --json body --jq .body > release-notes.md
+          cat >> release-notes.md <<EOF
+
+          ## 📦 Downloads
+
+          | Platform | How to get it |
+          |----------|---------------|
+          | 🍎 **macOS** | The \`.dmg\` in Assets below (plain name for Intel, \`arm64\` for Apple Silicon) |
+          | 🪟 **Windows** | The \`.exe\` installer in Assets below |
+          | 🤖 **Android** | The \`.apk\` in Assets below (sideload), or [Google Play](https://play.google.com/store/apps/details?id=com.acedatacloud.nexior) |
+          | 📱 **iOS** | [App Store](${IOS_URL}) |
+          | 🌐 **Web** | The \`nexior-dist-*.tar.gz\` below (self-host) |
+
+          > ⚠️ Desktop signing depends on the configured platform certificates. If an OS warns about an unsigned beta, use macOS right-click → Open or Windows "Run anyway".
+          EOF
+          gh release edit "$RELEASE_TAG" -R "$GITHUB_REPOSITORY" \
+            --notes-file release-notes.md --draft=false --latest

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,25 +1,30 @@
 name: publish
+
+# Aggregate all merged change files into one product version per day. Web deploys
+# remain independent and still run on every push to main via deploy.yaml.
 on:
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - .gitignore
-      - README.md
-      - SECURITY.md
-      - LICENSE
-      - CHANGELOG.md
-      - CHANGELOG.json
-      - 'docs/**'
-      - '.vscode/**'
-      - '.github/ISSUE_TEMPLATE/**'
+  schedule:
+    # 04:07 Beijing time (UTC 20:07), after the day's changes have accumulated.
+    - cron: '7 20 * * *'
+  workflow_dispatch: {}
+
+permissions:
+  actions: write
+  contents: write
+
+concurrency:
+  group: daily-product-release
+  cancel-in-progress: false
+
 jobs:
   run:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout latest main
         uses: actions/checkout@v4
         with:
+          ref: main
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Set up Node.js
@@ -35,8 +40,7 @@ jobs:
         run: npm run build
 
       - name: Setup .npmrc
-        run: |
-          echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > ~/.npmrc
+        run: echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > ~/.npmrc
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -46,11 +50,8 @@ jobs:
           git config --global user.email 'actions@github.com'
           git remote set-url origin "https://${{ secrets.BOT_GITHUB_TOKEN }}@github.com/AceDataCloud/Nexior"
 
-      # Auto-recover from "version already exists" errors caused by partial
-      # publishes (npm push succeeded, git push failed). If the local
-      # package.json baseline is behind the npm registry's latest version,
-      # bump the baseline so beachball computes a fresh next version instead
-      # of trying to re-publish an already-taken one.
+      # Recover from a partial publish where npm succeeded but the version commit
+      # or tag did not reach GitHub.
       - name: Sync package.json baseline to npm latest
         run: |
           set -e
@@ -63,15 +64,36 @@ jobs:
           fi
           HIGHER=$(node -e "const s=require('semver'); console.log(s.gt(process.argv[1], process.argv[2]) ? '1' : '0')" "$NPM_LATEST" "$LOCAL")
           if [ "$HIGHER" = "1" ]; then
-            echo "::warning::Local package.json version ($LOCAL) is behind npm registry ($NPM_LATEST). Syncing baseline so beachball can publish."
-            sed -i.bak -E "s/(\"version\": \")[^\"]+(\")/\\1${NPM_LATEST}\\2/" package.json
+            echo "::warning::Local package.json version ($LOCAL) is behind npm registry ($NPM_LATEST)."
+            npm pkg set "version=$NPM_LATEST"
             rm -f package.json.bak
-            echo "package.json baseline now at $NPM_LATEST"
-          else
-            echo "Local version ($LOCAL) >= npm registry ($NPM_LATEST). No sync needed."
           fi
 
-      - name: Publish
-        run: npm run release
+      - name: Publish aggregated package version
+        id: publish
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+          BEFORE=$(node -p "require('./package.json').version")
+          npm run release
+          AFTER=$(node -p "require('./package.json').version")
+          echo "before=$BEFORE" >> "$GITHUB_OUTPUT"
+          echo "after=$AFTER" >> "$GITHUB_OUTPUT"
+          if [ "$AFTER" = "$BEFORE" ]; then
+            echo "published=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No versioned change files are pending; nothing to release."
+            exit 0
+          fi
+
+          TAG="@acedatacloud/nexior_v${AFTER}"
+          git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null
+          echo "published=true" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Assemble complete GitHub Release
+        if: steps.publish.outputs.published == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+          TAG: ${{ steps.publish.outputs.tag }}
+        run: gh workflow run github-release.yaml --ref "$TAG" -f release_tag="$TAG"

--- a/change/@acedatacloud-nexior-78ff6e4a-cdc9-4a6d-bb77-c6272bb8c142.json
+++ b/change/@acedatacloud-nexior-78ff6e4a-cdc9-4a6d-bb77-c6272bb8c142.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "ci: aggregate product releases daily with complete desktop and Android assets",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "none"
+}

--- a/docs/DESKTOP_RELEASE.md
+++ b/docs/DESKTOP_RELEASE.md
@@ -46,16 +46,22 @@ manifest** (artifacts are immutable, never deleted).
 
 ## Cutting a release
 
-- **Beta (works today, signed or not):** Actions → **Desktop** → _Run workflow_ → channel `beta`.
-- **Stable (requires the signing certs above):** push a `desktop-v*` tag
-  (e.g. `desktop-v3.282.4`) **or** run the workflow with channel `latest`.
+The normal product release is aggregated once per day. Actions → **publish**
+runs Beachball against the accumulated change files, publishes npm, creates a
+draft GitHub Release, and calls this workflow to attach Windows and both macOS
+installers. The Release becomes public only after Web dist, APK, EXE, x64 DMG,
+and arm64 DMG all exist. Run **publish** manually for an urgent full release.
 
-Flow: `e2e` smoke (Linux/xvfb) → wait for **admin approval** → `build` matrix
-(Windows + macOS): `build:electron` → `compile:electron` → `copy-renderer` →
-`electron-builder` (signs when a cert is present; macOS notarizes via the API
-key + staples, verified by `stapler validate`) → upload artifacts → publish to COS.
+Desktop auto-update feeds remain separate:
 
-`workflow_dispatch` has a `dry_run` toggle (build + sign, skip the COS upload).
+- **Beta (signed or unsigned):** Actions → **Desktop** → _Run workflow_ → channel `beta`.
+- **Stable (requires signing certs):** push a `desktop-v*` tag or run **Desktop**
+  with channel `latest`.
+
+Flow: `e2e` smoke → `build` matrix → `electron-builder` → workflow artifacts.
+A daily product release attaches installers to its draft GitHub Release without
+changing the COS feed. A direct Desktop release publishes to COS behind the
+`desktop-release` approval gate. `dry_run` skips that COS publish.
 
 ## Cross-repo prerequisites for desktop login
 

--- a/docs/MOBILE_RELEASE.md
+++ b/docs/MOBILE_RELEASE.md
@@ -5,18 +5,21 @@ Android (Google Play Store) 和 iOS (App Store) 的 CI/CD 构建与发布指南�
 ## 架构概览
 
 ```
-package.json (版本源)
-    ↓  npm run sync-version
-android/app/build.gradle  +  ios/App/App.xcodeproj/project.pbxproj
-    ↓  git tag android-v* / ios-v*
-GitHub Actions
-    ↓
-Google Play Store (AAB)  /  TestFlight (IPA)
+PR merge → main ──→ Web 自动部署
+                 └→ 每日 publish 聚合 Beachball 版本
+                      ├→ GitHub Release：Web dist + APK + EXE + DMG
+                      └→ npm package
+
+独立移动渠道工作流 → Google Play (AAB) / TestFlight (IPA)
 ```
 
+- **聚合版本 workflow**: `.github/workflows/publish.yaml`
+- **完整 GitHub Release workflow**: `.github/workflows/github-release.yaml`
 - **Android workflow**: `.github/workflows/build-android.yaml`
 - **iOS workflow**: `.github/workflows/build-ios.yaml`
 - **版本同步脚本**: `scripts/sync-native-version.js`
+
+GitHub Release 出包不会上传 Play 或提交 App Store；测试渠道与正式商店仍由独立工作流和 review-state gate 控制。
 
 ---
 
@@ -171,21 +174,13 @@ git tag ios-v3.29.5 && git push origin ios-v3.29.5
 
 ## 三、日常发版流程
 
-```bash
-# 1. 更新 package.json 版本号（通过 beachball 或手动修改）
+1. PR 必须带 Beachball change 文件；合并到 `main` 后 Web 仍立即自动部署。
+2. 每天北京时间 04:07，`publish` 把当天 change 文件聚合成一个版本，发布 npm，并组装完整 GitHub Release。
+3. 需要提前出包时，在 Actions 手动运行 **publish**；它与定时任务共享 concurrency，不会并发发两个版本。
+4. 需要手动重新部署 Web 时，运行 **deploy**。部署不会创建产品 Release。
+5. GitHub Release 只构建可下载 APK，不上传 Play。Android/iOS 测试渠道在聚合发布后独立运行，正式商店继续由 **Auto Production Mobile** 或 **Release Mobile** 的门禁控制。
 
-# 2. 同步版本到 Android + iOS native 项目
-npm run sync-version
-
-# 3. 提交版本变更
-git add -A && git commit -m "chore: bump version to x.y.z"
-
-# 4. 打 tag 触发 CI
-git tag android-vX.Y.Z && git tag ios-vX.Y.Z
-git push origin android-vX.Y.Z ios-vX.Y.Z
-```
-
-Android 可通过 GitHub Actions 手动选择 track 逐步放量：`internal → alpha → beta → production`。
+Android 可通过 GitHub Actions 手动选择 track 逐步放量：`internal → alpha → beta → production`。旧的 `android-v*` / `ios-v*` 触发方式仍保留用于明确的商店构建。
 
 ---
 


### PR DESCRIPTION
## Summary

- aggregate Beachball/npm/GitHub releases once per day instead of once per PR merge
- keep Web deployment automatic on every merge and retain manual deploy/release controls
- hold GitHub Releases as drafts until Web dist, Android APK, Windows EXE, Intel DMG, and Apple Silicon DMG are all attached
- reuse desktop and Android workflows without touching COS auto-update feeds or app stores
- move the independent mobile testing schedule after the aggregate release window

## Verification

- `actionlint` on all modified workflows
- YAML parse for all workflows
- `npm run lint:check` (0 errors, 2 existing warnings)
- `python3 scripts/check_i18n_coverage.py`
- `npm run test:run` (146 files, 1194 tests passed)
- `npm run build`
- `npm run verify` (run directly; shared Husky hook resolves a worktree change path twice)

🤖 Generated with [Claude Code](https://claude.com/claude-code)