### PR TITLE
fix(scheduled-tasks): open categorized template links

### DIFF
--- a/change/@acedatacloud-nexior-3cb69036-c64c-499d-80d7-c585e6713a24.json
+++ b/change/@acedatacloud-nexior-3cb69036-c64c-499d-80d7-c585e6713a24.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Open scheduled template deep links in the requested category.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/pages/chat/ScheduledTasks.test.ts
+++ b/src/pages/chat/ScheduledTasks.test.ts
@@ -245,6 +245,25 @@ describe('chat/ScheduledTasks — local execution', () => {
 
 describe('chat/ScheduledTasks', () => {
   afterEach(() => vi.restoreAllMocks());
+
+  it('opens the template wizard automatically for a categorized deep link', async () => {
+    vi.spyOn(scheduledTasksOperator, 'listTasks').mockResolvedValue([]);
+    const wrapper = shallowMount(ScheduledTasks, {
+      global: {
+        stubs: { ScheduledTemplateWizard: true },
+        mocks: {
+          $t: (key: string) => key,
+          $te: () => false,
+          $route: { query: { template_category: 'marketing' } },
+          $store: { state: { chat: { credential: { token: 'tok' } }, site: { features: {} } } }
+        }
+      }
+    });
+    await flushPromises();
+    const vm = wrapper.vm as unknown as { showTemplateWizard: boolean; templateInitialCategory: string };
+    expect(vm.showTemplateWizard).toBe(true);
+    expect(vm.templateInitialCategory).toBe('marketing');
+  });
   const browserSkill: IAuthorizableSkill = {
     slug: 'xiaohongshu',
     name: 'Xiaohongshu',

--- a/src/pages/chat/ScheduledTasks.vue
+++ b/src/pages/chat/ScheduledTasks.vue
@@ -927,6 +927,7 @@ export default defineComponent({
   async mounted() {
     document.addEventListener('visibilitychange', this.onVisibilityChange);
     await this.loadTasks();
+    if (this.$route?.query?.template_category) this.openTemplateGallery();
   },
   unmounted() {
     document.removeEventListener('visibilitychange', this.onVisibilityChange);


### PR DESCRIPTION
## Summary
- automatically open the template wizard when `/chatgpt/scheduled` carries `template_category`
- preserve the marketing category sent by the referral-center CTA
- keep direct visits unchanged

## Validation
- 74 scheduled-task/template component tests passed
- `npm run lint:check` (0 errors; 2 pre-existing warnings)
- `npm run build:web`
- `python3 scripts/check_i18n_coverage.py`
- `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)