### PR TITLE
Fix MiniMax aspect ratio wrapping

### DIFF
--- a/change/@acedatacloud-nexior-minimax-aspect-wrap.json
+++ b/change/@acedatacloud-nexior-minimax-aspect-wrap.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Wrap MiniMax aspect ratio options into a balanced two-row layout.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/minimax/ConfigPanel.vue
+++ b/src/components/minimax/ConfigPanel.vue
@@ -227,6 +227,7 @@ export default defineComponent({
 
 .ratio-options {
   display: flex;
+  flex-wrap: wrap;
   gap: 10px;
 }
 


### PR DESCRIPTION
## Summary
- allow MiniMax aspect-ratio tiles to wrap within the configuration sidebar
- preserve the existing 48px tile sizing while arranging the seven options as 4 + 3 on the current narrow panel
- add the required Beachball patch change file

## Validation
- `./node_modules/.bin/eslint src/components/minimax/ConfigPanel.vue`
- `npm run build:web`
- `npm run verify`
- Playwright at a 768 x 1224 viewport: ratio container width and scroll width both 279px, `flex-wrap: wrap`, row counts `[4, 3]`, and each tile remains 48px wide

## Visual evidence
Verified locally on `/minimax`: the second row moves below the first without horizontal overflow, and the duration and watermark controls remain unobstructed.