### PR TITLE
fix(theme): preserve chat contrast for custom colors

### DIFF
--- a/change/@acedatacloud-nexior-chat-theme-contrast.json
+++ b/change/@acedatacloud-nexior-chat-theme-contrast.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Keep chat and accent-tinted surfaces readable with custom site colours in dark mode.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/assets/scss/_common.scss
+++ b/src/assets/scss/_common.scss
@@ -33,7 +33,9 @@ html:root {
   --el-color-primary-light-5: #93b8c3;
   --el-color-primary-light-7: #bed4db;
   --el-color-primary-light-8: #d4e3e7;
-  --el-color-primary-light-9: #e9f1f3;
+  --app-brand-bg-light: #e9f1f3;
+  --app-brand-bg-dark: #0e2a33;
+  --el-color-primary-light-9: var(--app-brand-bg-light);
   --el-color-primary-dark-2: #1f5a6b;
   // Channel + hex form of the brand colour. Use `rgba(var(--app-brand-rgb), …)`
   // for translucent fills / glows so they automatically follow the picked
@@ -130,12 +132,9 @@ html.dark {
   // a slight cool undertone, but the canvas itself is GitHub-style cool-gray
   // (#0d1117 / #161b22) and the brand stays as accent only (`primary-light-9`,
   // hero gradient, glows).
-  // NOTE: in dark mode we override `--el-color-primary-light-9` to a darker
-  // teal so it works as a code-block / inline-token background. This is
-  // intentionally NOT runtime-driven from the picked accent colour, because
-  // the dark-mode tinted background relies on the relative-luminance contrast
-  // with #0d1117 which an unconstrained user-picked hex would break.
-  --el-color-primary-light-9: #0e2a33;
+  // Keep light-9 semantic: runtime accent colours provide a dark-surface tint
+  // separately from their near-white light-mode derivative.
+  --el-color-primary-light-9: var(--app-brand-bg-dark);
   --el-bg-color: #0d1117;
   --el-bg-color-page: #08090c;
   --el-card-bg-color: #161b22;

--- a/src/utils/theme.test.ts
+++ b/src/utils/theme.test.ts
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { applyAccentColor, parseHex } from './theme';
+
+const managedProperties = [
+  '--el-color-primary',
+  '--el-color-primary-light-9',
+  '--app-brand-bg-light',
+  '--app-brand-bg-dark'
+];
+
+const channel = (hex: string, offset: number) => parseInt(hex.slice(offset, offset + 2), 16);
+
+const luminance = (hex: string): number => {
+  const linear = [1, 3, 5].map((offset) => {
+    const value = channel(hex, offset) / 255;
+    return value <= 0.04045 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * linear[0] + 0.7152 * linear[1] + 0.0722 * linear[2];
+};
+
+const contrast = (foreground: string, background: string): number => {
+  const lighter = Math.max(luminance(foreground), luminance(background));
+  const darker = Math.min(luminance(foreground), luminance(background));
+  return (lighter + 0.05) / (darker + 0.05);
+};
+
+afterEach(() => {
+  for (const property of managedProperties) document.documentElement.style.removeProperty(property);
+});
+
+describe('applyAccentColor', () => {
+  it('keeps theme-aware backgrounds separate from Element Plus light-9', () => {
+    document.documentElement.style.setProperty('--el-color-primary-light-9', '#ffffff');
+
+    applyAccentColor('#277186');
+
+    const style = document.documentElement.style;
+    expect(style.getPropertyValue('--el-color-primary')).toBe('#277186');
+    expect(style.getPropertyValue('--app-brand-bg-light')).toBe('#e9f1f3');
+    expect(style.getPropertyValue('--app-brand-bg-dark')).toBe('#12222b');
+    expect(style.getPropertyValue('--el-color-primary-light-9')).toBe('');
+  });
+
+  it.each([
+    ['pale pink', '#fbe8e1'],
+    ['white', '#ffffff'],
+    ['black', '#000000'],
+    ['saturated yellow', '#ffff00'],
+    ['short hex', '#f0a']
+  ])('keeps %s readable against dark-theme text', (_name, accent) => {
+    applyAccentColor(accent);
+
+    const background = document.documentElement.style.getPropertyValue('--app-brand-bg-dark');
+    expect(contrast('#e5e7eb', background)).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it('removes every theme background override for invalid colours', () => {
+    applyAccentColor('#fff');
+    applyAccentColor('not-a-colour');
+
+    const style = document.documentElement.style;
+    expect(style.getPropertyValue('--el-color-primary')).toBe('');
+    expect(style.getPropertyValue('--app-brand-bg-light')).toBe('');
+    expect(style.getPropertyValue('--app-brand-bg-dark')).toBe('');
+    expect(style.getPropertyValue('--el-color-primary-light-9')).toBe('');
+  });
+});
+
+describe('theme background tokens', () => {
+  it('maps light-9 to the theme-specific brand background', () => {
+    const commonScss = readFileSync(resolve(process.cwd(), 'src/assets/scss/_common.scss'), 'utf8');
+
+    expect(commonScss).toMatch(/--app-brand-bg-light: #e9f1f3;/);
+    expect(commonScss).toMatch(/--app-brand-bg-dark: #0e2a33;/);
+    expect(commonScss).toMatch(/html:root[\s\S]*--el-color-primary-light-9: var\(--app-brand-bg-light\);/);
+    expect(commonScss).toMatch(/html\.dark[\s\S]*--el-color-primary-light-9: var\(--app-brand-bg-dark\);/);
+  });
+});
+
+describe('parseHex', () => {
+  it('accepts short and long hex colours', () => {
+    expect(parseHex('#abc')).toEqual({ r: 170, g: 187, b: 204 });
+    expect(parseHex('277186')).toEqual({ r: 39, g: 113, b: 134 });
+  });
+});

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -75,6 +75,8 @@ const PRIMARY_VAR_KEYS = [
   '--el-color-primary-light-8',
   '--el-color-primary-light-9',
   '--el-color-primary-dark-2',
+  '--app-brand-bg-light',
+  '--app-brand-bg-dark',
   '--app-brand-rgb',
   '--app-brand-hex',
   '--app-brand-hex-dark-2',
@@ -128,6 +130,7 @@ function mix(base: RGB, mixin: RGB, weight: number): RGB {
 
 const WHITE: RGB = { r: 255, g: 255, b: 255 };
 const BLACK: RGB = { r: 0, g: 0, b: 0 };
+const DARK_SURFACE: RGB = { r: 13, g: 17, b: 23 };
 
 /**
  * Apply an accent colour at runtime. Pass `null` / `undefined` /
@@ -153,14 +156,18 @@ export function applyAccentColor(hex?: string | null): void {
   const l9 = mix(rgb, WHITE, 0.9);
   // Dark derivative — mix with black at 20 %.
   const d2 = mix(rgb, BLACK, 0.2);
+  // Dark surfaces need a brand tint, not a near-white Element Plus light-N.
+  const darkBg = mix(DARK_SURFACE, rgb, 0.18);
 
   root.setProperty('--el-color-primary', rgbToHex(rgb));
   root.setProperty('--el-color-primary-light-3', rgbToHex(l3));
   root.setProperty('--el-color-primary-light-5', rgbToHex(l5));
   root.setProperty('--el-color-primary-light-7', rgbToHex(l7));
   root.setProperty('--el-color-primary-light-8', rgbToHex(l8));
-  root.setProperty('--el-color-primary-light-9', rgbToHex(l9));
+  root.removeProperty('--el-color-primary-light-9');
   root.setProperty('--el-color-primary-dark-2', rgbToHex(d2));
+  root.setProperty('--app-brand-bg-light', rgbToHex(l9));
+  root.setProperty('--app-brand-bg-dark', rgbToHex(darkBg));
 
   // Channel-only form for `rgba(var(--app-brand-rgb), 0.x)` consumers in
   // _common.scss + various pages' scoped styles.


### PR DESCRIPTION
## Summary

- separate light and dark brand-tinted surface tokens from the runtime primary palette
- keep dark chat bubbles and other `primary-light-9` surfaces readable for arbitrary site colors
- add WCAG contrast and CSS mapping regression coverage

## Verification

- `npm run test:run -- src/utils/theme.test.ts src/assets/tailwindConfig.test.ts src/components/chat/Message.browserTool.test.ts` (12 passed)
- `npm run lint:check` (0 errors; 2 existing warnings)
- `npm run build:web`
- `npm run verify`
- Browser computed-style audit: dark custom colors ranged from 9.17:1 to 16.01:1 contrast

🤖 Generated with [Claude Code](https://claude.com/claude-code)