### PR TITLE
fix(footer): use tenant brand copyright

### DIFF
--- a/change/@acedatacloud-nexior-turboclaw-footer.json
+++ b/change/@acedatacloud-nexior-turboclaw-footer.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Use each site's own brand and copyright in the public footer.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/common/BottomFooter.test.ts
+++ b/src/components/common/BottomFooter.test.ts
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+import { shallowMount } from '@vue/test-utils';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import BottomFooter from './BottomFooter.vue';
+
+const mountFooter = (site: Record<string, unknown>, host = 'tenant.example.com') => {
+  vi.stubGlobal('location', { host });
+  return shallowMount(BottomFooter, {
+    global: {
+      stubs: {
+        ElContainer: { template: '<footer><slot /></footer>' },
+        ElRow: { template: '<div><slot /></div>' },
+        ElCol: { template: '<div><slot /></div>' },
+        FontAwesomeIcon: { template: '<span class="github-icon" />' }
+      },
+      mocks: {
+        $t: (key: string) => (key === 'common.entity.copyright' ? '版权所有' : key),
+        $store: { state: { site } }
+      }
+    }
+  });
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('BottomFooter site branding', () => {
+  it('uses the tenant title with the current year', () => {
+    const wrapper = mountFooter({ title: 'turboclaw', branding: {} });
+
+    expect(wrapper.text()).toContain(`turboclaw © ${new Date().getFullYear()} 版权所有`);
+    expect(wrapper.text()).not.toContain('Ace Data Cloud');
+    expect(wrapper.find('a[href="/"]').text()).toBe('turboclaw');
+    expect(wrapper.find('.github-icon').exists()).toBe(false);
+  });
+
+  it('prefers the complete custom copyright', () => {
+    const wrapper = mountFooter({ title: 'turboclaw', branding: { copyright: '© 2026 TurboClaw Ltd.' } });
+
+    expect(wrapper.text()).toContain('© 2026 TurboClaw Ltd.');
+    expect(wrapper.text()).not.toContain('版权所有');
+  });
+
+  it('keeps the first-party GitHub link on the official host', () => {
+    const wrapper = mountFooter({ title: 'Ace Data Cloud' }, 'studio.acedata.cloud');
+
+    expect(wrapper.find('a[href="https://github.com/AceDataCloud/Nexior"]').exists()).toBe(true);
+  });
+});

--- a/src/components/common/BottomFooter.vue
+++ b/src/components/common/BottomFooter.vue
@@ -9,19 +9,24 @@
                 <a href="/download">{{ $t('common.nav.mobileApp') }}</a>
                 ·
               </template>
-              <a href="https://platform.acedata.cloud">{{ $t('common.entity.website') }}</a> ©
-              {{ new Date().getFullYear() }}
-              {{ $t('common.entity.copyright') }}
-              ·
-              <a
-                href="https://github.com/AceDataCloud/Nexior"
-                target="_blank"
-                rel="noopener noreferrer"
-                class="github-link"
-                :title="$t('common.nav.github')"
-              >
-                <font-awesome-icon :icon="faGithub" />
-              </a>
+              <template v-if="customCopyright">{{ customCopyright }}</template>
+              <template v-else>
+                <a href="/">{{ brandName }}</a> ©
+                {{ new Date().getFullYear() }}
+                {{ $t('common.entity.copyright') }}
+              </template>
+              <template v-if="isMainOfficialHost">
+                ·
+                <a
+                  href="https://github.com/AceDataCloud/Nexior"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="github-link"
+                  :title="$t('common.nav.github')"
+                >
+                  <font-awesome-icon :icon="faGithub" />
+                </a>
+              </template>
             </p>
           </el-col>
         </el-row>
@@ -35,7 +40,7 @@ import { defineComponent } from 'vue';
 import { ElContainer, ElRow, ElCol } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { faGithub } from '@fortawesome/free-brands-svg-icons';
-import { isMainOfficial } from '@/utils';
+import { getBrandCopyright, getBrandName, isMainOfficial } from '@/utils';
 
 export default defineComponent({
   name: 'BottomFooter',
@@ -51,6 +56,12 @@ export default defineComponent({
     };
   },
   computed: {
+    brandName(): string {
+      return getBrandName(this.$store.state.site);
+    },
+    customCopyright(): string | undefined {
+      return getBrandCopyright(this.$store.state.site);
+    },
     // The mobile-app download page only exists on the official main host.
     isMainOfficialHost() {
       return isMainOfficial();

--- a/src/utils/site.test.ts
+++ b/src/utils/site.test.ts
@@ -7,6 +7,8 @@ import {
   getApplicationCallerOrderDiscountRate,
   applyMarkup,
   isBrandingHidden,
+  getBrandName,
+  getBrandCopyright,
   getBrandSupportUrl,
   getBrandContacts,
   hasBrandContacts
@@ -145,6 +147,20 @@ describe('isBrandingHidden', () => {
     expect(isBrandingHidden({ branding: { hide_powered_by: true } } as never, 'powered_by')).toBe(true);
     expect(isBrandingHidden({ branding: { hide_powered_by: false } } as never, 'powered_by')).toBe(false);
     expect(isBrandingHidden({ branding: { hide_powered_by: 1 } } as never, 'powered_by')).toBe(false);
+  });
+});
+
+describe('brand footer values', () => {
+  it('uses the site title and falls back to the platform brand', () => {
+    expect(getBrandName({ title: '  turboclaw  ' } as never)).toBe('turboclaw');
+    expect(getBrandName({ title: '   ' } as never)).toBe('Ace Data Cloud');
+    expect(getBrandName(null)).toBe('Ace Data Cloud');
+  });
+
+  it('returns only a non-empty custom copyright', () => {
+    expect(getBrandCopyright({ branding: { copyright: '  © TurboClaw  ' } } as never)).toBe('© TurboClaw');
+    expect(getBrandCopyright({ branding: { copyright: '   ' } } as never)).toBeUndefined();
+    expect(getBrandCopyright(null)).toBeUndefined();
   });
 });
 

--- a/src/utils/site.ts
+++ b/src/utils/site.ts
@@ -86,6 +86,14 @@ export const isBrandingHidden = (site: ISite | null | undefined, key: 'powered_b
   return false;
 };
 
+export const getBrandName = (site?: ISite | null): string => {
+  return site?.title?.trim() || 'Ace Data Cloud';
+};
+
+export const getBrandCopyright = (site?: ISite | null): string | undefined => {
+  return site?.branding?.copyright?.trim() || undefined;
+};
+
 /**
  * Resolve the reseller's support URL: `branding.links.support` first, then
  * the legacy `metadata.support_url`. Returns '' when neither is set so


### PR DESCRIPTION
## Summary
- render each tenant Site title in the public footer instead of the Ace Data Cloud translation constant
- honor `Site.branding.copyright` when a complete custom statement is configured
- keep the AceDataCloud GitHub link limited to the official Studio host
- add helper and component regression coverage plus a beachball patch entry

## Root cause
`ai.turboclaw.cloud` loaded the correct Site (`title: turboclaw`) but Nexior `BottomFooter.vue` ignored it and always rendered `common.entity.website`, which is Ace Data Cloud.

## Verification
- `vitest run --root <worktree> src/utils/site.test.ts src/components/common/BottomFooter.test.ts` — 30/30 passed
- ESLint on changed source/test files — passed
- `vue-tsc -b --pretty false` — passed
- `npm run build:web` — passed
- full Vitest: 154 files / 1206 tests passed; 2 unrelated pre-existing suites failed because `cron-parser` is absent from the shared local node_modules and `x402ScenarioContract.test.ts` hardcodes the primary checkout path

🤖 Generated with [Claude Code](https://claude.com/claude-code)