### PR TITLE
feat(usage): show x402 USDC settlements

### DIFF
--- a/change/@acedatacloud-nexior-x402-usage-display.json
+++ b/change/@acedatacloud-nexior-x402-usage-display.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Show settled USDC amounts and transaction links in API usage history.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.358.0",
       "license": "MIT",
       "dependencies": {
-        "@acedatacloud/core": "^0.18.0",
+        "@acedatacloud/core": "^0.19.1",
         "@acedatacloud/x402-client": "^2026.726.1",
         "@capacitor-community/apple-sign-in": "^7.1.0",
         "@capacitor-community/stripe": "^8.1.1",
@@ -128,9 +128,9 @@
       }
     },
     "node_modules/@acedatacloud/core": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@acedatacloud/core/-/core-0.18.0.tgz",
-      "integrity": "sha512-0WW81RJvcxZgIWsIek5sNKpPHVqis5gtD18AD2eVCHvXmTLkp4YQ/qPUd4L+2bVBwf1CxzpbRR5CuaRjpdjvVw==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@acedatacloud/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-ucJMqJMnCrsLWTnmOMogiZ6RLxBWv6hDJptgKIfs+t9fqbn7vvdUJFCnMkq/Q7ggJkm2dY3NvpWAatefnZHjQw==",
       "license": "UNLICENSED",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "build:ssg": "cross-env VITE_SURFACE=web vite-ssg build"
   },
   "dependencies": {
-    "@acedatacloud/core": "^0.18.0",
+    "@acedatacloud/core": "^0.19.1",
     "@acedatacloud/x402-client": "^2026.726.1",
     "@capacitor-community/apple-sign-in": "^7.1.0",
     "@capacitor-community/stripe": "^8.1.1",

--- a/src/i18n/ar/usage.json
+++ b/src/i18n/ar/usage.json
@@ -162,5 +162,53 @@
   "message.exportFailed": {
     "message": "فشل التصدير. يرجى تضييق النطاق الزمني والمحاولة مرة أخرى.",
     "description": "Error toast shown when the CSV export request fails (network or server error)."
+  },
+  "field.paidAmount": {
+    "message": "المبلغ المدفوع",
+    "description": "المبلغ الذي تم تسويته فعليًا على السلسلة."
+  },
+  "field.network": {
+    "message": "شبكة الدفع",
+    "description": "الشبكة المستخدمة للدفع على السلسلة."
+  },
+  "field.transaction": {
+    "message": "معرّف المعاملة",
+    "description": "هاش المعاملة أو التوقيع للدفع على السلسلة."
+  },
+  "field.payer": {
+    "message": "عنوان الدفع",
+    "description": "عنوان المحفظة الذي بدأ الدفع على السلسلة."
+  },
+  "button.viewTransaction": {
+    "message": "عرض المعاملة",
+    "description": "عرض المعاملة في مستعرض الكتل الموثوق."
+  },
+  "dialog.payment": {
+    "message": "الدفع",
+    "description": "استخدم علامة تبويب معلومات الدفع في نافذة التفاصيل."
+  },
+  "value.balanceNotApplicable": {
+    "message": "غير قابل للتطبيق (الدفع على السلسلة)",
+    "description": "يظهر عندما لا يتم استخدام رصيد نقاط المنصة للدفع على السلسلة."
+  },
+  "value.paymentUnavailable": {
+    "message": "معلومات الدفع غير متاحة",
+    "description": "يظهر عندما تفتقر السجلات أو التسويات غير المؤكدة إلى معلومات دفع موثوقة."
+  },
+  "value.paymentSettled": {
+    "message": "تم التسوية",
+    "description": "تم تأكيد تسوية الدفع على السلسلة."
+  },
+  "value.paymentUnconfirmed": {
+    "message": "في انتظار التأكيد",
+    "description": "تم إرجاع الدفع على السلسلة بنجاح ولكن لا يزال يتعين تسوية الحقائق."
+  },
+  "value.paymentFailed": {
+    "message": "فشل الدفع",
+    "description": "فشل تسوية الدفع على السلسلة أو تم تخطيها."
+  },
+  "value.attemptTransaction": {
+    "message": "محاولة المعاملة",
+    "description": "محاولة معاملة لم يتم تأكيد نجاحها بعد."
   }
 }

--- a/src/i18n/de/usage.json
+++ b/src/i18n/de/usage.json
@@ -149,7 +149,7 @@
   },
   "view.trend": {
     "message": "Trend",
-    "description": "Der Ansichtsschalter für die Analysekarte: Zeigt die gestapelten Säulendiagramme des API-Verbrauchs über die Zeit."
+    "description": "Der Ansichtsschalter für die Analyse-Karten: zeigt gestapelte Säulendiagramme des API-Verbrauchs über die Zeit."
   },
   "view.distribution": {
     "message": "Anteil",
@@ -162,5 +162,53 @@
   "message.exportFailed": {
     "message": "Export fehlgeschlagen. Bitte grenzen Sie den Zeitraum ein und versuchen Sie es erneut.",
     "description": "Fehlerhinweis, wenn die Anfrage zum CSV-Export fehlschlägt (Netzwerk- oder Serverfehler)."
+  },
+  "field.paidAmount": {
+    "message": "Bezahlt Betrag",
+    "description": "Der Betrag, der tatsächlich für die On-Chain-Zahlung abgerechnet wurde."
+  },
+  "field.network": {
+    "message": "Zahlungsnetzwerk",
+    "description": "Das Netzwerk, das für die On-Chain-Zahlung verwendet wird."
+  },
+  "field.transaction": {
+    "message": "Transaktions-ID",
+    "description": "Der Transaktions-Hash oder die Signatur der On-Chain-Zahlung."
+  },
+  "field.payer": {
+    "message": "Zahlungsadresse",
+    "description": "Die Wallet-Adresse, die die On-Chain-Zahlung initiiert."
+  },
+  "button.viewTransaction": {
+    "message": "Transaktion anzeigen",
+    "description": "Zeigt die Transaktion in einem vertrauenswürdigen Block-Explorer an."
+  },
+  "dialog.payment": {
+    "message": "Zahlung",
+    "description": "Verwendet den Zahlungsinformationen-Tab im Detail-Popup."
+  },
+  "value.balanceNotApplicable": {
+    "message": "Nicht anwendbar (On-Chain-Zahlung)",
+    "description": "Wird angezeigt, wenn bei der On-Chain-Zahlung kein Plattform-Punkte-Guthaben verwendet wird."
+  },
+  "value.paymentUnavailable": {
+    "message": "Zahlungsinformationen nicht verfügbar",
+    "description": "Wird angezeigt, wenn vertrauenswürdige Zahlungsinformationen in der Historie oder bei unbestätigten Abrechnungen fehlen."
+  },
+  "value.paymentSettled": {
+    "message": "Abgeschlossen",
+    "description": "Die Zahlung auf der Blockchain wurde erfolgreich abgeschlossen."
+  },
+  "value.paymentUnconfirmed": {
+    "message": "Ausstehende Bestätigung",
+    "description": "Die Zahlung auf der Blockchain wurde als erfolgreich zurückgegeben, aber die Abrechnung muss noch abgeglichen werden."
+  },
+  "value.paymentFailed": {
+    "message": "Zahlung fehlgeschlagen",
+    "description": "Die Zahlung auf der Blockchain ist fehlgeschlagen oder wurde übersprungen."
+  },
+  "value.attemptTransaction": {
+    "message": "Transaktion versuchen",
+    "description": "Versuche einer Transaktion, die noch nicht erfolgreich bestätigt wurden."
   }
 }

--- a/src/i18n/el/usage.json
+++ b/src/i18n/el/usage.json
@@ -162,5 +162,53 @@
   "message.exportFailed": {
     "message": "Η εξαγωγή απέτυχε. Περιορίστε το εύρος ημερομηνιών και δοκιμάστε ξανά.",
     "description": "Error toast shown when the CSV export request fails (network or server error)."
+  },
+  "field.paidAmount": {
+    "message": "Ποσό που έχει πληρωθεί",
+    "description": "Το ποσό που έχει διακανονιστεί στην πληρωμή στο blockchain."
+  },
+  "field.network": {
+    "message": "Δίκτυο πληρωμής",
+    "description": "Το δίκτυο που χρησιμοποιείται για την πληρωμή στο blockchain."
+  },
+  "field.transaction": {
+    "message": "ID συναλλαγής",
+    "description": "Το hash ή η υπογραφή της συναλλαγής πληρωμής στο blockchain."
+  },
+  "field.payer": {
+    "message": "Διεύθυνση πληρωμής",
+    "description": "Η διεύθυνση πορτοφολιού που ξεκινά την πληρωμή στο blockchain."
+  },
+  "button.viewTransaction": {
+    "message": "Δείτε τη συναλλαγή",
+    "description": "Δείτε τη συναλλαγή σε έναν αξιόπιστο μπλοκ εξερευνητή."
+  },
+  "dialog.payment": {
+    "message": "Πληρωμή",
+    "description": "Χρησιμοποιήστε την καρτέλα πληροφοριών πληρωμής στο αναδυόμενο παράθυρο."
+  },
+  "value.balanceNotApplicable": {
+    "message": "Μη εφαρμόσιμο (πληρωμή στο blockchain)",
+    "description": "Εμφανίζεται όταν η πληρωμή στο blockchain δεν χρησιμοποιεί το υπόλοιπο πόντων της πλατφόρμας."
+  },
+  "value.paymentUnavailable": {
+    "message": "Πληροφορίες πληρωμής μη διαθέσιμες",
+    "description": "Εμφανίζεται όταν οι πληροφορίες πληρωμής δεν είναι αξιόπιστες λόγω ιστορικού ή μη επιβεβαιωμένου διακανονισμού."
+  },
+  "value.paymentSettled": {
+    "message": "Επιβεβαιωμένο",
+    "description": "Η πληρωμή μέσω blockchain έχει επιβεβαιωθεί."
+  },
+  "value.paymentUnconfirmed": {
+    "message": "Σε Αναμονή Επιβεβαίωσης",
+    "description": "Η πληρωμή μέσω blockchain έχει επιστραφεί ως επιτυχής, αλλά η πραγματική εκκαθάριση χρειάζεται έλεγχο."
+  },
+  "value.paymentFailed": {
+    "message": "Αποτυχία Πληρωμής",
+    "description": "Η πληρωμή μέσω blockchain απέτυχε ή παραλείφθηκε."
+  },
+  "value.attemptTransaction": {
+    "message": "Προσπάθεια Συναλλαγής",
+    "description": "Μια προσπάθεια συναλλαγής που δεν έχει επιβεβαιωθεί ως επιτυχής."
   }
 }

--- a/src/i18n/en/usage.json
+++ b/src/i18n/en/usage.json
@@ -162,5 +162,53 @@
   "message.exportFailed": {
     "message": "Export failed. Please narrow the date range and try again.",
     "description": "Error toast shown when the CSV export request fails (network or server error)."
+  },
+  "field.paidAmount": {
+    "message": "Amount Paid",
+    "description": "The amount actually settled by the on-chain payment."
+  },
+  "field.network": {
+    "message": "Payment Network",
+    "description": "The network used for the on-chain payment."
+  },
+  "field.transaction": {
+    "message": "Transaction ID",
+    "description": "The transaction hash or signature for the on-chain payment."
+  },
+  "field.payer": {
+    "message": "Payer Address",
+    "description": "The wallet address that made the on-chain payment."
+  },
+  "button.viewTransaction": {
+    "message": "View Transaction",
+    "description": "Open the transaction in a trusted block explorer."
+  },
+  "dialog.payment": {
+    "message": "Payment",
+    "description": "Payment information tab in the usage detail dialog."
+  },
+  "value.balanceNotApplicable": {
+    "message": "Not applicable (on-chain payment)",
+    "description": "Shown when an on-chain payment does not use the platform credit balance."
+  },
+  "value.paymentUnavailable": {
+    "message": "Payment details unavailable",
+    "description": "Shown when a legacy or unconfirmed record lacks trusted payment details."
+  },
+  "value.paymentSettled": {
+    "message": "Settled",
+    "description": "The on-chain payment settlement is confirmed."
+  },
+  "value.paymentUnconfirmed": {
+    "message": "Unconfirmed",
+    "description": "The payment returned success but its settlement facts still require reconciliation."
+  },
+  "value.paymentFailed": {
+    "message": "Payment failed",
+    "description": "The on-chain payment settlement failed or was skipped."
+  },
+  "value.attemptTransaction": {
+    "message": "Attempt transaction",
+    "description": "A settlement attempt transaction that is not confirmed as successful."
   }
 }

--- a/src/i18n/es/usage.json
+++ b/src/i18n/es/usage.json
@@ -162,5 +162,53 @@
   "message.exportFailed": {
     "message": "Error al exportar. Reduzca el rango de fechas e inténtelo de nuevo.",
     "description": "Notificación de error cuando la solicitud de exportación CSV falla (error de red o servidor)."
+  },
+  "field.paidAmount": {
+    "message": "Cantidad pagada",
+    "description": "La cantidad efectivamente liquidada en el pago en cadena."
+  },
+  "field.network": {
+    "message": "Red de pago",
+    "description": "La red utilizada para el pago en cadena."
+  },
+  "field.transaction": {
+    "message": "ID de transacción",
+    "description": "El hash o firma de la transacción del pago en cadena."
+  },
+  "field.payer": {
+    "message": "Dirección de pago",
+    "description": "La dirección de la billetera que inicia el pago en cadena."
+  },
+  "button.viewTransaction": {
+    "message": "Ver transacción",
+    "description": "Ver transacción en un explorador de bloques de confianza."
+  },
+  "dialog.payment": {
+    "message": "Pagar",
+    "description": "Usar la pestaña de información de pago en el cuadro de diálogo."
+  },
+  "value.balanceNotApplicable": {
+    "message": "No aplicable (pago en cadena)",
+    "description": "Se muestra cuando el pago en cadena no utiliza el saldo de puntos de la plataforma."
+  },
+  "value.paymentUnavailable": {
+    "message": "Información de pago no disponible",
+    "description": "Se muestra cuando faltan datos de pago confiables en el historial o en liquidaciones no confirmadas."
+  },
+  "value.paymentSettled": {
+    "message": "Pagado",
+    "description": "El pago en la cadena ha sido confirmado como liquidado."
+  },
+  "value.paymentUnconfirmed": {
+    "message": "Pendiente de confirmación",
+    "description": "El pago en la cadena ha sido devuelto como exitoso, pero los hechos de la liquidación aún necesitan ser conciliados."
+  },
+  "value.paymentFailed": {
+    "message": "Pago fallido",
+    "description": "El pago en la cadena ha fallado o ha sido omitido."
+  },
+  "value.attemptTransaction": {
+    "message": "Intentar transacción",
+    "description": "Intento de transacción que aún no ha sido confirmado como exitoso."
   }
 }

--- a/src/i18n/fi/usage.json
+++ b/src/i18n/fi/usage.json
@@ -162,5 +162,53 @@
   "message.exportFailed": {
     "message": "Vienti epäonnistui. Rajaa aikaväliä ja yritä uudelleen.",
     "description": "Error toast shown when the CSV export request fails (network or server error)."
+  },
+  "field.paidAmount": {
+    "message": "Maksettu summa",
+    "description": "Lohkoketjussa todellisuudessa maksettu summa."
+  },
+  "field.network": {
+    "message": "Maksuverkko",
+    "description": "Verkko, jota käytetään lohkoketjussa maksamiseen."
+  },
+  "field.transaction": {
+    "message": "Tapahtuma ID",
+    "description": "Lohkoketjussa maksun tapahtuman hash tai allekirjoitus."
+  },
+  "field.payer": {
+    "message": "Maksajan osoite",
+    "description": "Lohkoketjussa maksun aloittaneen lompakon osoite."
+  },
+  "button.viewTransaction": {
+    "message": "Näytä tapahtuma",
+    "description": "Näyttää tapahtuman luotettavassa lohkoketjun selaimessa."
+  },
+  "dialog.payment": {
+    "message": "Maksaa",
+    "description": "Käytä maksutietojen välilehteä yksityiskohtien pop-upissa."
+  },
+  "value.balanceNotApplicable": {
+    "message": "Ei sovellettavissa (lohkoketjumaksu)",
+    "description": "Näytetään, kun lohkoketjumaksu ei käytä alustan pisteiden saldoa."
+  },
+  "value.paymentUnavailable": {
+    "message": "Maksutiedot eivät ole saatavilla",
+    "description": "Näytetään, kun historiatiedoista tai vahvistamattomasta maksusta puuttuu luotettavat maksutiedot."
+  },
+  "value.paymentSettled": {
+    "message": "Maksu on vahvistettu",
+    "description": "Ketjussa maksutapahtuma on vahvistettu."
+  },
+  "value.paymentUnconfirmed": {
+    "message": "Vahvistusta odotetaan",
+    "description": "Ketjussa maksu on palautettu onnistuneena, mutta maksutapahtuma tarvitsee vielä tarkistuksen."
+  },
+  "value.paymentFailed": {
+    "message": "Maksu epäonnistui",
+    "description": "Ketjussa maksutapahtuma epäonnistui tai ohitettiin."
+  },
+  "value.attemptTransaction": {
+    "message": "Yritä tapahtumaa",
+    "description": "Vielä vahvistamaton onnistunut maksuyritys."
   }
 }

--- a/src/i18n/fr/usage.json
+++ b/src/i18n/fr/usage.json
@@ -162,5 +162,53 @@
   "message.exportFailed": {
     "message": "Échec de l'exportation. Veuillez réduire la plage de dates et réessayer.",
     "description": "Error toast shown when the CSV export request fails (network or server error)."
+  },
+  "field.paidAmount": {
+    "message": "Montant payé",
+    "description": "Le montant effectivement réglé pour le paiement sur la chaîne."
+  },
+  "field.network": {
+    "message": "Réseau de paiement",
+    "description": "Le réseau utilisé pour le paiement sur la chaîne."
+  },
+  "field.transaction": {
+    "message": "ID de transaction",
+    "description": "Le hachage ou la signature de la transaction pour le paiement sur la chaîne."
+  },
+  "field.payer": {
+    "message": "Adresse de paiement",
+    "description": "L'adresse du portefeuille qui initie le paiement sur la chaîne."
+  },
+  "button.viewTransaction": {
+    "message": "Voir la transaction",
+    "description": "Afficher la transaction dans un explorateur de blocs de confiance."
+  },
+  "dialog.payment": {
+    "message": "Paiement",
+    "description": "Utilisez l'onglet des informations de paiement dans la fenêtre contextuelle."
+  },
+  "value.balanceNotApplicable": {
+    "message": "Non applicable (paiement sur la chaîne)",
+    "description": "Affiché lorsque le paiement sur la chaîne n'utilise pas le solde de points de la plateforme."
+  },
+  "value.paymentUnavailable": {
+    "message": "Informations de paiement indisponibles",
+    "description": "Affiché lorsque les informations de paiement fiables manquent dans l'historique ou pour les règlements non confirmés."
+  },
+  "value.paymentSettled": {
+    "message": "Règlement effectué",
+    "description": "Le paiement sur la chaîne a été confirmé comme réglé."
+  },
+  "value.paymentUnconfirmed": {
+    "message": "En attente de confirmation",
+    "description": "Le paiement sur la chaîne a été retourné comme réussi, mais le fait du règlement doit encore être vérifié."
+  },
+  "value.paymentFailed": {
+    "message": "Paiement échoué",
+    "description": "Échec du règlement du paiement sur la chaîne ou contourné."
+  },
+  "value.attemptTransaction": {
+    "message": "Essayer la transaction",
+    "description": "Tentative de transaction de règlement qui n'a pas encore été confirmée comme réussie."
   }
 }

--- a/src/i18n/it/usage.json
+++ b/src/i18n/it/usage.json
@@ -162,5 +162,53 @@
   "message.exportFailed": {
     "message": "Esportazione non riuscita. Riduci l'intervallo di date e riprova.",
     "description": "Error toast shown when the CSV export request fails (network or server error)."
+  },
+  "field.paidAmount": {
+    "message": "Importo pagato",
+    "description": "L'importo effettivamente regolato per il pagamento sulla blockchain."
+  },
+  "field.network": {
+    "message": "Rete di pagamento",
+    "description": "La rete utilizzata per il pagamento sulla blockchain."
+  },
+  "field.transaction": {
+    "message": "ID transazione",
+    "description": "L'hash o la firma della transazione per il pagamento sulla blockchain."
+  },
+  "field.payer": {
+    "message": "Indirizzo del pagatore",
+    "description": "L'indirizzo del portafoglio che avvia il pagamento sulla blockchain."
+  },
+  "button.viewTransaction": {
+    "message": "Visualizza transazione",
+    "description": "Visualizza la transazione in un esploratore di blocchi affidabile."
+  },
+  "dialog.payment": {
+    "message": "Pagamento",
+    "description": "Utilizza la scheda delle informazioni di pagamento nella finestra di dialogo."
+  },
+  "value.balanceNotApplicable": {
+    "message": "Non applicabile (pagamento sulla blockchain)",
+    "description": "Visualizzato quando il pagamento sulla blockchain non utilizza il saldo dei punti della piattaforma."
+  },
+  "value.paymentUnavailable": {
+    "message": "Informazioni sul pagamento non disponibili",
+    "description": "Visualizzato quando le informazioni di pagamento affidabili mancano nella cronologia o in una regolazione non confermata."
+  },
+  "value.paymentSettled": {
+    "message": "Pagamento regolato e confermato",
+    "description": "Il pagamento sulla blockchain è stato confermato e regolato."
+  },
+  "value.paymentUnconfirmed": {
+    "message": "In attesa di conferma",
+    "description": "Il pagamento sulla blockchain è stato restituito come riuscito, ma il fatto della transazione deve ancora essere riconciliato."
+  },
+  "value.paymentFailed": {
+    "message": "Pagamento fallito",
+    "description": "Il pagamento sulla blockchain è fallito o è stato saltato."
+  },
+  "value.attemptTransaction": {
+    "message": "Tentativo di transazione",
+    "description": "Tentativo di transazione non ancora confermato come riuscito."
   }
 }

--- a/src/i18n/ja/usage.json
+++ b/src/i18n/ja/usage.json
@@ -162,5 +162,53 @@
   "message.exportFailed": {
     "message": "エクスポートに失敗しました。期間を絞って再試行してください。",
     "description": "CSVエクスポートリクエストが失敗した場合のエラートースト"
+  },
+  "field.paidAmount": {
+    "message": "支払済み金額",
+    "description": "オンチェーン支払いで実際に決済された金額です。"
+  },
+  "field.network": {
+    "message": "支払いネットワーク",
+    "description": "オンチェーン支払いに使用されるネットワークです。"
+  },
+  "field.transaction": {
+    "message": "取引 ID",
+    "description": "オンチェーン支払いの取引ハッシュまたは署名です。"
+  },
+  "field.payer": {
+    "message": "支払いアドレス",
+    "description": "オンチェーン支払いを開始するウォレットアドレスです。"
+  },
+  "button.viewTransaction": {
+    "message": "取引を表示",
+    "description": "信頼できるブロックエクスプローラーで取引を表示します。"
+  },
+  "dialog.payment": {
+    "message": "支払い",
+    "description": "詳細ポップアップの支払い情報タブを使用します。"
+  },
+  "value.balanceNotApplicable": {
+    "message": "該当なし（オンチェーン支払い）",
+    "description": "オンチェーン支払いでプラットフォームのポイント残高が使用されない場合に表示されます。"
+  },
+  "value.paymentUnavailable": {
+    "message": "支払い情報が利用できません",
+    "description": "履歴または未確認の決済に信頼できる支払い情報が欠けている場合に表示されます。"
+  },
+  "value.paymentSettled": {
+    "message": "決済済み",
+    "description": "ブロックチェーン上の支払いが確認されました。"
+  },
+  "value.paymentUnconfirmed": {
+    "message": "未確認",
+    "description": "ブロックチェーン上の支払いが成功として返されましたが、決済の事実はまだ照合が必要です。"
+  },
+  "value.paymentFailed": {
+    "message": "支払いに失敗しました",
+    "description": "ブロックチェーン上の支払い決済が失敗したか、スキップされました。"
+  },
+  "value.attemptTransaction": {
+    "message": "取引を試みる",
+    "description": "まだ成功が確認されていない決済の試みです。"
   }
 }

--- a/src/i18n/ko/usage.json
+++ b/src/i18n/ko/usage.json
@@ -162,5 +162,53 @@
   "message.exportFailed": {
     "message": "내보내기에 실패했습니다. 기간을 좁혀 다시 시도하세요.",
     "description": "CSV 내보내기 실패 시 표시되는 오류 토스트"
+  },
+  "field.paidAmount": {
+    "message": "지불 금액",
+    "description": "체인 상에서 실제로 정산된 금액입니다."
+  },
+  "field.network": {
+    "message": "지불 네트워크",
+    "description": "체인 상에서 지불에 사용되는 네트워크입니다."
+  },
+  "field.transaction": {
+    "message": "거래 ID",
+    "description": "체인 상 지불의 거래 해시 또는 서명입니다."
+  },
+  "field.payer": {
+    "message": "지불 주소",
+    "description": "체인 상 지불을 시작한 지갑 주소입니다."
+  },
+  "button.viewTransaction": {
+    "message": "거래 보기",
+    "description": "신뢰할 수 있는 블록 탐색기에서 거래를 확인합니다."
+  },
+  "dialog.payment": {
+    "message": "지불",
+    "description": "세부 정보 팝업의 지불 정보 탭을 사용합니다."
+  },
+  "value.balanceNotApplicable": {
+    "message": "해당 없음 (체인 상 지불)",
+    "description": "체인 상 지불에 플랫폼 포인트 잔액이 사용되지 않을 때 표시됩니다."
+  },
+  "value.paymentUnavailable": {
+    "message": "지불 정보 사용 불가",
+    "description": "기록 또는 미확인 정산에 신뢰할 수 있는 지불 정보가 없을 때 표시됩니다."
+  },
+  "value.paymentSettled": {
+    "message": "결제 완료",
+    "description": "체인 상에서 결제가 확인되었습니다."
+  },
+  "value.paymentUnconfirmed": {
+    "message": "확인 대기",
+    "description": "체인 상에서 결제가 성공적으로 반환되었지만 결제 사실은 여전히 조정이 필요합니다."
+  },
+  "value.paymentFailed": {
+    "message": "결제 실패",
+    "description": "체인 상에서 결제가 실패했거나 건너뛰어졌습니다."
+  },
+  "value.attemptTransaction": {
+    "message": "거래 시도",
+    "description": "아직 성공적으로 확인되지 않은 결제 시도 거래."
   }
 }

--- a/src/i18n/pl/usage.json
+++ b/src/i18n/pl/usage.json
@@ -13,7 +13,7 @@
   },
   "field.status": {
     "message": "Status",
-    "description": "Status procesu aplikacji."
+    "description": "Status aplikacji."
   },
   "field.api": {
     "message": "API",
@@ -149,7 +149,7 @@
   },
   "view.trend": {
     "message": "Trend",
-    "description": "Przycisk przełączania widoku analizy: pokazuje skumulowany wykres słupkowy zużycia API w czasie."
+    "description": "Przycisk przełączania widoku analizy: wyświetla skumulowany wykres słupkowy zużycia API w czasie."
   },
   "view.distribution": {
     "message": "Udział",
@@ -162,5 +162,53 @@
   "message.exportFailed": {
     "message": "Eksport nie powiódł się. Zawęź zakres dat i spróbuj ponownie.",
     "description": "Komunikat błędu wyświetlany, gdy eksport CSV się nie powiedzie (błąd sieci lub serwera)."
+  },
+  "field.paidAmount": {
+    "message": "Kwota zapłacona",
+    "description": "Kwota, która została rzeczywiście rozliczona w płatności na łańcuchu."
+  },
+  "field.network": {
+    "message": "Sieć płatności",
+    "description": "Sieć używana do płatności na łańcuchu."
+  },
+  "field.transaction": {
+    "message": "ID transakcji",
+    "description": "Hash lub podpis transakcji płatności na łańcuchu."
+  },
+  "field.payer": {
+    "message": "Adres płatnika",
+    "description": "Adres portfela, który inicjuje płatność na łańcuchu."
+  },
+  "button.viewTransaction": {
+    "message": "Zobacz transakcję",
+    "description": "Wyświetl transakcję w zaufanym eksploratorze bloków."
+  },
+  "dialog.payment": {
+    "message": "Płatność",
+    "description": "Użyj zakładki z informacjami o płatności w oknie dialogowym."
+  },
+  "value.balanceNotApplicable": {
+    "message": "Nie dotyczy (płatność na łańcuchu)",
+    "description": "Wyświetlane, gdy płatność na łańcuchu nie wykorzystuje salda punktów platformy."
+  },
+  "value.paymentUnavailable": {
+    "message": "Informacje o płatności niedostępne",
+    "description": "Wyświetlane, gdy brakuje wiarygodnych informacji o płatności w historii lub w przypadku niepotwierdzonego rozliczenia."
+  },
+  "value.paymentSettled": {
+    "message": "Zrealizowane",
+    "description": "Płatność na blockchainie została potwierdzona jako zrealizowana."
+  },
+  "value.paymentUnconfirmed": {
+    "message": "Do potwierdzenia",
+    "description": "Płatność na blockchainie została zwrócona jako udana, ale faktyczna realizacja wymaga jeszcze uzgodnienia."
+  },
+  "value.paymentFailed": {
+    "message": "Płatność nieudana",
+    "description": "Płatność na blockchainie nie powiodła się lub została pominięta."
+  },
+  "value.attemptTransaction": {
+    "message": "Próba transakcji",
+    "description": "Próba transakcji, która nie została jeszcze potwierdzona jako udana."
   }
 }

--- a/src/i18n/pt/usage.json
+++ b/src/i18n/pt/usage.json
@@ -162,5 +162,53 @@
   "message.exportFailed": {
     "message": "Falha na exportação. Reduza o intervalo de datas e tente novamente.",
     "description": "Error toast shown when the CSV export request fails (network or server error)."
+  },
+  "field.paidAmount": {
+    "message": "Valor Pago",
+    "description": "O valor efetivamente liquidado no pagamento na blockchain."
+  },
+  "field.network": {
+    "message": "Rede de Pagamento",
+    "description": "A rede utilizada para pagamentos na blockchain."
+  },
+  "field.transaction": {
+    "message": "ID da Transação",
+    "description": "O hash ou assinatura da transação do pagamento na blockchain."
+  },
+  "field.payer": {
+    "message": "Endereço do Pagador",
+    "description": "O endereço da carteira que iniciou o pagamento na blockchain."
+  },
+  "button.viewTransaction": {
+    "message": "Ver Transação",
+    "description": "Visualizar a transação em um explorador de blocos confiável."
+  },
+  "dialog.payment": {
+    "message": "Pagamento",
+    "description": "Usar a aba de informações de pagamento na janela de detalhes."
+  },
+  "value.balanceNotApplicable": {
+    "message": "Não Aplicável (Pagamento na Blockchain)",
+    "description": "Exibido quando o pagamento na blockchain não utiliza o saldo de pontos da plataforma."
+  },
+  "value.paymentUnavailable": {
+    "message": "Informações de Pagamento Indisponíveis",
+    "description": "Exibido quando informações de pagamento confiáveis estão ausentes em registros históricos ou liquidações não confirmadas."
+  },
+  "value.paymentSettled": {
+    "message": "Liquidado",
+    "description": "O pagamento na blockchain foi confirmado como liquidado."
+  },
+  "value.paymentUnconfirmed": {
+    "message": "Aguardando confirmação",
+    "description": "O pagamento na blockchain foi retornado como bem-sucedido, mas a liquidação ainda precisa ser reconciliada."
+  },
+  "value.paymentFailed": {
+    "message": "Pagamento falhou",
+    "description": "O pagamento na blockchain falhou ou foi pulado."
+  },
+  "value.attemptTransaction": {
+    "message": "Tentar transação",
+    "description": "Tentativa de transação de liquidação que ainda não foi confirmada como bem-sucedida."
   }
 }

--- a/src/i18n/ru/usage.json
+++ b/src/i18n/ru/usage.json
@@ -162,5 +162,53 @@
   "message.exportFailed": {
     "message": "Не удалось экспортировать. Сузьте диапазон дат и повторите попытку.",
     "description": "Error toast shown when the CSV export request fails (network or server error)."
+  },
+  "field.paidAmount": {
+    "message": "Сумма оплаты",
+    "description": "Фактическая сумма, урегулированная при онлайновой оплате."
+  },
+  "field.network": {
+    "message": "Сетевая оплата",
+    "description": "Сеть, используемая для онлайновой оплаты."
+  },
+  "field.transaction": {
+    "message": "ID транзакции",
+    "description": "Хэш или подпись транзакции для онлайновой оплаты."
+  },
+  "field.payer": {
+    "message": "Адрес плательщика",
+    "description": "Адрес кошелька, инициировавшего онлайновую оплату."
+  },
+  "button.viewTransaction": {
+    "message": "Просмотреть транзакцию",
+    "description": "Просмотр транзакции в доверенном блокчейн-обозревателе."
+  },
+  "dialog.payment": {
+    "message": "Оплата",
+    "description": "Используйте вкладку информации о платеже в всплывающем окне."
+  },
+  "value.balanceNotApplicable": {
+    "message": "Не применимо (онлайновая оплата)",
+    "description": "Отображается, когда для онлайновой оплаты не используется баланс платформенных очков."
+  },
+  "value.paymentUnavailable": {
+    "message": "Информация о платеже недоступна",
+    "description": "Отображается, когда отсутствует достоверная информация о платеже в истории или при неподтвержденном урегулировании."
+  },
+  "value.paymentSettled": {
+    "message": "Расчет завершен",
+    "description": "Расчет на блокчейне подтвержден."
+  },
+  "value.paymentUnconfirmed": {
+    "message": "Ожидает подтверждения",
+    "description": "Оплата на блокчейне возвращена как успешная, но фактический расчет все еще требует сверки."
+  },
+  "value.paymentFailed": {
+    "message": "Оплата не удалась",
+    "description": "Неудача или пропуск расчета на блокчейне."
+  },
+  "value.attemptTransaction": {
+    "message": "Попробовать транзакцию",
+    "description": "Попытка транзакции, которая еще не подтверждена как успешная."
   }
 }

--- a/src/i18n/sr/usage.json
+++ b/src/i18n/sr/usage.json
@@ -162,5 +162,53 @@
   "message.exportFailed": {
     "message": "Извоз није успео. Сузите опсег датума и покушајте поново.",
     "description": "Порука о грешци када захтев за извоз CSV-а не успе (мрежна или серверска грешка)."
+  },
+  "field.paidAmount": {
+    "message": "Iznos plaćen",
+    "description": "Iznos koji je stvarno obračunat za onlajn plaćanje."
+  },
+  "field.network": {
+    "message": "Mreža plaćanja",
+    "description": "Mreža koja se koristi za onlajn plaćanje."
+  },
+  "field.transaction": {
+    "message": "ID transakcije",
+    "description": "Hash ili potpis transakcije za onlajn plaćanje."
+  },
+  "field.payer": {
+    "message": "Adresa platioca",
+    "description": "Novčanik adresa koja inicira onlajn plaćanje."
+  },
+  "button.viewTransaction": {
+    "message": "Pogledaj transakciju",
+    "description": "Pogledajte transakciju u pouzdanom blok pregledniku."
+  },
+  "dialog.payment": {
+    "message": "Plaćanje",
+    "description": "Koristite karticu sa informacijama o plaćanju u dijalogu."
+  },
+  "value.balanceNotApplicable": {
+    "message": "Nije primenljivo (onlajn plaćanje)",
+    "description": "Prikazuje se kada onlajn plaćanje ne koristi saldo platforme."
+  },
+  "value.paymentUnavailable": {
+    "message": "Informacije o plaćanju nisu dostupne",
+    "description": "Prikazuje se kada nedostaju pouzdane informacije o plaćanju u istoriji ili nepotvrđenim obračunima."
+  },
+  "value.paymentSettled": {
+    "message": "Plaćeno",
+    "description": "Onlajn uplata je potvrđena kao završena."
+  },
+  "value.paymentUnconfirmed": {
+    "message": "Na čekanju",
+    "description": "Onlajn uplata je vraćena kao uspešna, ali se još uvek mora uskladiti."
+  },
+  "value.paymentFailed": {
+    "message": "Plaćanje nije uspelo",
+    "description": "Neuspešna ili preskočena onlajn uplata."
+  },
+  "value.attemptTransaction": {
+    "message": "Pokušaj transakcije",
+    "description": "Pokušaj transakcije koji još nije potvrđen kao uspešan."
   }
 }

--- a/src/i18n/sv/usage.json
+++ b/src/i18n/sv/usage.json
@@ -37,7 +37,7 @@
   },
   "field.metadata": {
     "message": "Metadata",
-    "description": "Använd metadata för registreringen."
+    "description": "Använd metadata för registrerade data."
   },
   "title.totalUsed": {
     "message": "Total användning (poäng)",
@@ -162,5 +162,53 @@
   "message.exportFailed": {
     "message": "Exporten misslyckades. Begränsa datumintervallet och försök igen.",
     "description": "Error toast shown when the CSV export request fails (network or server error)."
+  },
+  "field.paidAmount": {
+    "message": "Betalt belopp",
+    "description": "Det belopp som faktiskt har avräknats för on-chain betalningar."
+  },
+  "field.network": {
+    "message": "Betalningsnätverk",
+    "description": "Nätverket som används för on-chain betalningar."
+  },
+  "field.transaction": {
+    "message": "Transaktions-ID",
+    "description": "Transaktionshash eller signatur för den on-chain betalningen."
+  },
+  "field.payer": {
+    "message": "Betalaradress",
+    "description": "Plånboksadressen som initierade den on-chain betalningen."
+  },
+  "button.viewTransaction": {
+    "message": "Visa transaktion",
+    "description": "Visa transaktionen i en betrodd blockutforskare."
+  },
+  "dialog.payment": {
+    "message": "Betala",
+    "description": "Använd betalningsinformationen i detaljdialogens flik."
+  },
+  "value.balanceNotApplicable": {
+    "message": "Ej tillämpligt (on-chain betalning)",
+    "description": "Visas när plattformens poängsaldo inte används för on-chain betalningar."
+  },
+  "value.paymentUnavailable": {
+    "message": "Betalningsinformation inte tillgänglig",
+    "description": "Visas när historik eller obekräftad avräkning saknar pålitlig betalningsinformation."
+  },
+  "value.paymentSettled": {
+    "message": "Avslutad",
+    "description": "Betalning på kedjan har bekräftats som avslutad."
+  },
+  "value.paymentUnconfirmed": {
+    "message": "Väntar på bekräftelse",
+    "description": "Betalning på kedjan har returnerat som lyckad men avstämning krävs fortfarande."
+  },
+  "value.paymentFailed": {
+    "message": "Betalning misslyckades",
+    "description": "Betalning på kedjan misslyckades eller hoppades över."
+  },
+  "value.attemptTransaction": {
+    "message": "Försök transaktion",
+    "description": "Försök till transaktion som ännu inte bekräftats som lyckad."
   }
 }

--- a/src/i18n/uk/usage.json
+++ b/src/i18n/uk/usage.json
@@ -162,5 +162,53 @@
   "message.exportFailed": {
     "message": "Не вдалося експортувати. Звузьте діапазон дат і повторіть спробу.",
     "description": "Error toast shown when the CSV export request fails (network or server error)."
+  },
+  "field.paidAmount": {
+    "message": "Сума платежу",
+    "description": "Сума, фактично зафіксована під час онлайнового платежу."
+  },
+  "field.network": {
+    "message": "Платіжна мережа",
+    "description": "Мережа, що використовується для онлайнових платежів."
+  },
+  "field.transaction": {
+    "message": "ID транзакції",
+    "description": "Хеш або підпис транзакції для онлайнового платежу."
+  },
+  "field.payer": {
+    "message": "Адреса платника",
+    "description": "Адреса гаманця, з якої ініціюється онлайновий платіж."
+  },
+  "button.viewTransaction": {
+    "message": "Переглянути транзакцію",
+    "description": "Перегляньте транзакцію у надійному блокчейн-браузері."
+  },
+  "dialog.payment": {
+    "message": "Оплата",
+    "description": "Використовуйте вкладку інформації про оплату у спливаючому вікні деталей."
+  },
+  "value.balanceNotApplicable": {
+    "message": "Не застосовується (онлайновий платіж)",
+    "description": "Відображається, коли онлайновий платіж не використовує залишок балів платформи."
+  },
+  "value.paymentUnavailable": {
+    "message": "Інформація про оплату недоступна",
+    "description": "Відображається, коли в історії або при непідтвердженій угоді відсутня надійна інформація про оплату."
+  },
+  "value.paymentSettled": {
+    "message": "Вирішено",
+    "description": "Платіж на ланцюзі підтверджено як завершений."
+  },
+  "value.paymentUnconfirmed": {
+    "message": "Очікує підтвердження",
+    "description": "Платіж на ланцюзі повернувся успішно, але фактичне завершення ще потребує звірки."
+  },
+  "value.paymentFailed": {
+    "message": "Платіж не вдався",
+    "description": "Не вдалося завершити платіж на ланцюзі або він був пропущений."
+  },
+  "value.attemptTransaction": {
+    "message": "Спробувати транзакцію",
+    "description": "Спроба транзакції, яка ще не підтверджена як успішна."
   }
 }

--- a/src/i18n/zh-CN/usage.json
+++ b/src/i18n/zh-CN/usage.json
@@ -162,5 +162,53 @@
   "message.exportFailed": {
     "message": "导出失败，请缩小时间范围后重试。",
     "description": "CSV 导出请求失败（网络或服务端错误）时的错误提示"
+  },
+  "field.paidAmount": {
+    "message": "已支付金额",
+    "description": "链上支付实际结算的金额。"
+  },
+  "field.network": {
+    "message": "支付网络",
+    "description": "链上支付所使用的网络。"
+  },
+  "field.transaction": {
+    "message": "交易 ID",
+    "description": "链上支付的交易哈希或签名。"
+  },
+  "field.payer": {
+    "message": "付款地址",
+    "description": "发起链上支付的钱包地址。"
+  },
+  "button.viewTransaction": {
+    "message": "查看交易",
+    "description": "在受信任的区块浏览器中查看交易。"
+  },
+  "dialog.payment": {
+    "message": "支付",
+    "description": "使用详情弹窗中的支付信息标签页。"
+  },
+  "value.balanceNotApplicable": {
+    "message": "不适用（链上支付）",
+    "description": "链上支付不使用平台积分余额时显示。"
+  },
+  "value.paymentUnavailable": {
+    "message": "支付信息不可用",
+    "description": "历史记录或未确认结算缺少可信支付信息时显示。"
+  },
+  "value.paymentSettled": {
+    "message": "已结算",
+    "description": "链上支付已确认结算。"
+  },
+  "value.paymentUnconfirmed": {
+    "message": "待确认",
+    "description": "链上支付已返回成功但结算事实仍需对账。"
+  },
+  "value.paymentFailed": {
+    "message": "支付失败",
+    "description": "链上支付结算失败或被跳过。"
+  },
+  "value.attemptTransaction": {
+    "message": "尝试交易",
+    "description": "尚未确认成功的结算尝试交易。"
   }
 }

--- a/src/i18n/zh-TW/usage.json
+++ b/src/i18n/zh-TW/usage.json
@@ -162,5 +162,53 @@
   "message.exportFailed": {
     "message": "匯出失敗，請縮小時間範圍後重試。",
     "description": "CSV 匯出請求失敗（網路或服務端錯誤）時的錯誤提示"
+  },
+  "field.paidAmount": {
+    "message": "已支付金額",
+    "description": "鏈上支付實際結算的金額。"
+  },
+  "field.network": {
+    "message": "支付網絡",
+    "description": "鏈上支付所使用的網絡。"
+  },
+  "field.transaction": {
+    "message": "交易 ID",
+    "description": "鏈上支付的交易哈希或簽名。"
+  },
+  "field.payer": {
+    "message": "付款地址",
+    "description": "發起鏈上支付的錢包地址。"
+  },
+  "button.viewTransaction": {
+    "message": "查看交易",
+    "description": "在受信任的區塊瀏覽器中查看交易。"
+  },
+  "dialog.payment": {
+    "message": "支付",
+    "description": "使用詳情彈窗中的支付資訊標籤頁。"
+  },
+  "value.balanceNotApplicable": {
+    "message": "不適用（鏈上支付）",
+    "description": "鏈上支付不使用平台積分餘額時顯示。"
+  },
+  "value.paymentUnavailable": {
+    "message": "支付資訊不可用",
+    "description": "歷史記錄或未確認結算缺少可信支付資訊時顯示。"
+  },
+  "value.paymentSettled": {
+    "message": "已結算",
+    "description": "鏈上支付已確認結算。"
+  },
+  "value.paymentUnconfirmed": {
+    "message": "待確認",
+    "description": "鏈上支付已返回成功但結算事實仍需對賬。"
+  },
+  "value.paymentFailed": {
+    "message": "支付失敗",
+    "description": "鏈上支付結算失敗或被跳過。"
+  },
+  "value.attemptTransaction": {
+    "message": "嘗試交易",
+    "description": "尚未確認成功的結算嘗試交易。"
   }
 }

--- a/src/models/usage.ts
+++ b/src/models/usage.ts
@@ -5,6 +5,20 @@ export interface IUsageCredential {
   name?: string;
 }
 
+export interface IX402UsageMetadata extends Record<string, unknown> {
+  x402?: boolean;
+  x402_settlement_status?: 'settled' | 'unconfirmed';
+  x402_amount_atomic?: string;
+  x402_decimals?: number;
+  x402_currency?: string;
+  x402_network?: string;
+  x402_tx?: string;
+  x402_payer?: string;
+  x402_settle_error?: string;
+  x402_settle_attempt_tx?: string;
+  x402_skipped?: boolean;
+}
+
 export interface IApiUsage {
   id?: string;
   api_id?: string;
@@ -18,7 +32,7 @@ export interface IApiUsage {
   used_amount?: number;
   deducted_amount?: number;
   original_amount?: number;
-  metadata?: Record<string, any>;
+  metadata?: IX402UsageMetadata;
   service?: IService;
 }
 

--- a/src/pages/console/usage/List.vue
+++ b/src/pages/console/usage/List.vue
@@ -211,7 +211,13 @@
                 class-name="text-center"
               >
                 <template #default="scope">
-                  <div v-if="getDeductedAmount(scope.row) === getOriginalAmount(scope.row)">
+                  <div v-if="isX402Usage(scope.row)" class="space-y-1">
+                    <strong v-if="getX402Payment(scope.row)">
+                      {{ getX402Payment(scope.row)?.amount }} {{ getX402Payment(scope.row)?.currency }}
+                    </strong>
+                    <span v-else class="text-gray-400">{{ $t('usage.value.paymentUnavailable') }}</span>
+                  </div>
+                  <div v-else-if="getDeductedAmount(scope.row) === getOriginalAmount(scope.row)">
                     <span>{{ getDeductedAmount(scope.row) }}</span>
                   </div>
                   <div v-else>
@@ -232,7 +238,8 @@
                 class-name="text-center"
               >
                 <template #default="scope">
-                  <span>{{ getRemainingAmount(scope.row) }}</span>
+                  <span v-if="isX402Usage(scope.row)">{{ $t('usage.value.balanceNotApplicable') }}</span>
+                  <span v-else>{{ getRemainingAmount(scope.row) }}</span>
                 </template>
               </el-table-column>
               <el-table-column
@@ -244,7 +251,11 @@
                 <template #default="scope">
                   <div class="flex flex-wrap gap-2">
                     <el-tag
-                      v-if="scope.row.original_amount > scope.row.deducted_amount && scope.row.original_amount > 0"
+                      v-if="
+                        !isX402Usage(scope.row) &&
+                        scope.row.original_amount > scope.row.deducted_amount &&
+                        scope.row.original_amount > 0
+                      "
                       type="success"
                       :style="{
                         textWrap: 'wrap',
@@ -260,6 +271,29 @@
                         ).toFixed(0) + '% OFF'
                       }}
                     </el-tag>
+                    <div v-if="isX402Usage(scope.row)" class="flex min-w-0 items-center gap-1">
+                      <el-tag :type="getX402StatusType(scope.row)">{{ $t(getX402StatusKey(scope.row)) }}</el-tag>
+                      <a
+                        v-if="getX402Payment(scope.row)?.explorerUrl"
+                        :href="getX402Payment(scope.row)?.explorerUrl"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="truncate text-primary"
+                      >
+                        {{ $t('usage.button.viewTransaction') }}
+                        <external-link-icon class="ml-1 inline-block h-3.5 w-3.5" />
+                      </a>
+                      <span v-else-if="getX402Transaction(scope.row)" class="key truncate">
+                        {{
+                          scope.row.metadata?.x402_settle_attempt_tx ? `${$t('usage.value.attemptTransaction')}: ` : ''
+                        }}{{ shortTransaction(getX402Transaction(scope.row)) }}
+                      </span>
+                      <copy-to-clipboard
+                        v-if="getX402Transaction(scope.row)"
+                        :content="getX402Transaction(scope.row)"
+                        class="inline-block shrink-0"
+                      />
+                    </div>
                     <el-tag
                       v-for="(name, key) in getSimpleMetadata(scope.row.metadata)"
                       :key="key"
@@ -409,6 +443,52 @@
         destroy-on-close
       >
         <el-tabs v-model="detailActiveTab">
+          <el-tab-pane v-if="detailRow && isX402Usage(detailRow)" :label="$t('usage.dialog.payment')" name="payment">
+            <el-skeleton v-if="detailLoading" :rows="6" animated />
+            <dl v-else class="payment-details">
+              <dt>{{ $t('usage.field.status') }}</dt>
+              <dd>
+                <el-tag :type="getX402StatusType(detailRow)">{{ $t(getX402StatusKey(detailRow)) }}</el-tag>
+                <span v-if="detailRow.metadata?.x402_settle_error" class="ml-2 text-danger">
+                  {{ detailRow.metadata.x402_settle_error }}
+                </span>
+              </dd>
+              <dt>{{ $t('usage.field.paidAmount') }}</dt>
+              <dd v-if="getX402Payment(detailRow)">
+                {{ getX402Payment(detailRow)?.amount }} {{ getX402Payment(detailRow)?.currency }}
+              </dd>
+              <dd v-else>{{ $t('usage.value.paymentUnavailable') }}</dd>
+              <dt>{{ $t('usage.field.network') }}</dt>
+              <dd>{{ detailRow.metadata?.x402_network || '-' }}</dd>
+              <dt>{{ $t('usage.field.payer') }}</dt>
+              <dd class="break-all">{{ detailRow.metadata?.x402_payer || '-' }}</dd>
+              <dt>
+                {{
+                  detailRow.metadata?.x402_settle_attempt_tx
+                    ? $t('usage.value.attemptTransaction')
+                    : $t('usage.field.transaction')
+                }}
+              </dt>
+              <dd class="break-all">
+                {{ getX402Transaction(detailRow) || '-' }}
+                <copy-to-clipboard
+                  v-if="getX402Transaction(detailRow)"
+                  :content="getX402Transaction(detailRow)"
+                  class="inline-block"
+                />
+                <a
+                  v-if="getX402Payment(detailRow)?.explorerUrl"
+                  :href="getX402Payment(detailRow)?.explorerUrl"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="ml-2 text-primary"
+                >
+                  {{ $t('usage.button.viewTransaction') }}
+                  <external-link-icon class="ml-1 inline-block h-3.5 w-3.5" />
+                </a>
+              </dd>
+            </dl>
+          </el-tab-pane>
           <el-tab-pane :label="$t('usage.dialog.request')" name="request">
             <el-skeleton v-if="detailLoading" :rows="6" animated />
             <pre v-else-if="detailRow?.metadata?.request" class="detail-json">{{
@@ -437,7 +517,7 @@
 </template>
 
 <script lang="ts">
-import { ApplicationsIcon, ExportIcon } from '@acedatacloud/core/icons/components';
+import { ApplicationsIcon, ExportIcon, ExternalLinkIcon } from '@acedatacloud/core/icons/components';
 import { defineComponent } from 'vue';
 import {
   IApi,
@@ -479,6 +559,7 @@ import {
 import qs from 'qs';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 import { getBaseUrlPlatform } from '@/utils';
+import { getX402CopyableTransaction, getX402UsagePayment, isX402Usage, omitX402Metadata } from '@/utils/usagePayment';
 import { Bar as BarChart, Doughnut as DoughnutChart } from 'vue-chartjs';
 import {
   Chart as ChartJS,
@@ -576,6 +657,7 @@ export default defineComponent({
   components: {
     ApplicationsIcon,
     ExportIcon,
+    ExternalLinkIcon,
     Pagination,
     ElTag,
     ElDatePicker,
@@ -1038,15 +1120,27 @@ export default defineComponent({
       }
       return `${elapsed.toFixed(2)} s`;
     },
-    getSimpleMetadata(metadata: Record<string, any> | undefined) {
-      if (!metadata) return {};
-      const result: Record<string, any> = {};
-      for (const [key, value] of Object.entries(metadata)) {
-        if (key === 'request' || key === 'response') continue;
-        if (typeof value === 'object' && value !== null) continue;
-        result[key] = value;
-      }
-      return result;
+    isX402Usage,
+    getX402Payment: getX402UsagePayment,
+    getX402Transaction: getX402CopyableTransaction,
+    getX402StatusType(usage: IApiUsage) {
+      if (getX402UsagePayment(usage)) return 'success';
+      if (usage.metadata?.x402_settlement_status === 'unconfirmed') return 'warning';
+      if (usage.metadata?.x402_settle_error || usage.metadata?.x402_skipped) return 'danger';
+      return 'info';
+    },
+    getX402StatusKey(usage: IApiUsage) {
+      if (getX402UsagePayment(usage)) return 'usage.value.paymentSettled';
+      if (usage.metadata?.x402_settlement_status === 'unconfirmed') return 'usage.value.paymentUnconfirmed';
+      if (usage.metadata?.x402_settle_error || usage.metadata?.x402_skipped) return 'usage.value.paymentFailed';
+      return 'usage.value.paymentUnavailable';
+    },
+    shortTransaction(transaction?: string) {
+      if (!transaction || transaction.length <= 16) return transaction || '';
+      return `${transaction.slice(0, 8)}…${transaction.slice(-6)}`;
+    },
+    getSimpleMetadata(metadata: IApiUsage['metadata']) {
+      return omitX402Metadata(metadata);
     },
     getCredentialLabel(usage: IApiUsage | IProxyUsage) {
       const name = usage.credential?.name?.trim();
@@ -1055,18 +1149,19 @@ export default defineComponent({
       return usage.credential?.id || usage.credential_id || '-';
     },
     onShowDetail(row: IApiUsage) {
-      this.detailRow = { ...row, metadata: undefined };
-      this.detailActiveTab = 'request';
+      this.detailRow = { ...row, metadata: row.metadata ? { ...row.metadata } : undefined };
+      this.detailActiveTab = isX402Usage(row) ? 'payment' : 'request';
       this.detailDialogVisible = true;
       this.detailLoading = true;
       if (row.id) {
+        const requestedId = row.id;
         apiUsageOperator
-          .get(row.id)
+          .get(requestedId)
           .then((response) => {
-            this.detailRow = response.data;
+            if (this.detailRow?.id === requestedId) this.detailRow = response.data;
           })
           .finally(() => {
-            this.detailLoading = false;
+            if (this.detailRow?.id === requestedId) this.detailLoading = false;
           });
       }
     },
@@ -1401,6 +1496,18 @@ export default defineComponent({
   font-variant-numeric: tabular-nums;
   color: var(--el-text-color-regular);
   font-size: 12px;
+}
+.payment-details {
+  display: grid;
+  grid-template-columns: minmax(110px, auto) minmax(0, 1fr);
+  gap: 12px 16px;
+}
+.payment-details dt {
+  color: var(--el-text-color-secondary);
+}
+.payment-details dd {
+  min-width: 0;
+  margin: 0;
 }
 .detail-json {
   background: var(--el-bg-color-page);

--- a/src/utils/usagePayment.test.ts
+++ b/src/utils/usagePayment.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { IApiUsage } from '@/models/usage';
+import { getX402CopyableTransaction, getX402UsagePayment, isX402Usage, omitX402Metadata } from './usagePayment';
+
+function usage(metadata: IApiUsage['metadata']): IApiUsage {
+  return { metadata };
+}
+
+const settled = usage({
+  x402: true,
+  x402_settlement_status: 'settled',
+  x402_amount_atomic: '13330',
+  x402_decimals: 6,
+  x402_currency: 'USDC',
+  x402_network: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+  x402_tx: 'signature',
+  x402_payer: 'payer'
+});
+
+describe('x402 usage payment', () => {
+  it('extracts a settled USDC payment and explorer URL', () => {
+    expect(getX402UsagePayment(settled)).toEqual({
+      amount: '0.01333',
+      currency: 'USDC',
+      network: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+      transaction: 'signature',
+      payer: 'payer',
+      explorerUrl: 'https://solscan.io/tx/signature'
+    });
+  });
+
+  it('does not claim old or unconfirmed records are paid', () => {
+    expect(getX402UsagePayment(usage({ x402: true, x402_tx: 'legacy-tx' }))).toBeUndefined();
+    expect(
+      getX402UsagePayment(
+        usage({
+          ...settled.metadata,
+          x402_settlement_status: 'unconfirmed'
+        })
+      )
+    ).toBeUndefined();
+  });
+
+  it('rejects malformed atomic amounts and decimals', () => {
+    expect(getX402UsagePayment(usage({ ...settled.metadata, x402_amount_atomic: '1.5' }))).toBeUndefined();
+    expect(getX402UsagePayment(usage({ ...settled.metadata, x402_decimals: 256 }))).toBeUndefined();
+  });
+
+  it('keeps unknown networks copyable without inventing a link', () => {
+    const payment = getX402UsagePayment(usage({ ...settled.metadata, x402_network: 'eip155:1' }));
+    expect(payment?.transaction).toBe('signature');
+    expect(payment?.explorerUrl).toBeUndefined();
+  });
+
+  it('exposes attempt transactions for copying and hides x402 metadata tags', () => {
+    const record = usage({ x402: true, x402_settle_attempt_tx: 'attempt', task_id: 'task-1', request: {} });
+    expect(isX402Usage(record)).toBe(true);
+    expect(getX402CopyableTransaction(record)).toBe('attempt');
+    expect(omitX402Metadata(record.metadata)).toEqual({ task_id: 'task-1' });
+  });
+});

--- a/src/utils/usagePayment.ts
+++ b/src/utils/usagePayment.ts
@@ -1,0 +1,75 @@
+import { formatAtomicTokenAmount, getX402TransactionExplorerUrl } from '@acedatacloud/core/x402';
+import { IApiUsage, IX402UsageMetadata } from '@/models/usage';
+
+export interface X402UsagePayment {
+  amount: string;
+  currency: string;
+  network: string;
+  transaction: string;
+  payer?: string;
+  explorerUrl?: string;
+}
+
+export function isX402Usage(usage: IApiUsage): boolean {
+  return usage.metadata?.x402 === true;
+}
+
+export function getX402UsagePayment(usage: IApiUsage): X402UsagePayment | undefined {
+  const metadata = usage.metadata;
+  if (!isSettledMetadata(metadata)) return undefined;
+
+  try {
+    const amount = formatAtomicTokenAmount(BigInt(metadata.x402_amount_atomic), metadata.x402_decimals);
+    return {
+      amount,
+      currency: metadata.x402_currency,
+      network: metadata.x402_network,
+      transaction: metadata.x402_tx,
+      payer: typeof metadata.x402_payer === 'string' ? metadata.x402_payer : undefined,
+      explorerUrl: getX402TransactionExplorerUrl(metadata.x402_network, metadata.x402_tx)
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+export function getX402CopyableTransaction(usage: IApiUsage): string | undefined {
+  const tx = usage.metadata?.x402_tx || usage.metadata?.x402_settle_attempt_tx;
+  return typeof tx === 'string' && tx.length > 0 ? tx : undefined;
+}
+
+export function omitX402Metadata(metadata?: IX402UsageMetadata): Record<string, unknown> {
+  if (!metadata) return {};
+  return Object.fromEntries(
+    Object.entries(metadata).filter(
+      ([key, value]) =>
+        !key.startsWith('x402') &&
+        key !== 'request' &&
+        key !== 'response' &&
+        (typeof value !== 'object' || value === null)
+    )
+  );
+}
+
+function isSettledMetadata(
+  metadata?: IX402UsageMetadata
+): metadata is IX402UsageMetadata &
+  Required<
+    Pick<IX402UsageMetadata, 'x402_amount_atomic' | 'x402_decimals' | 'x402_currency' | 'x402_network' | 'x402_tx'>
+  > {
+  return Boolean(
+    metadata?.x402 === true &&
+    metadata.x402_settlement_status === 'settled' &&
+    typeof metadata.x402_amount_atomic === 'string' &&
+    /^\d+$/.test(metadata.x402_amount_atomic) &&
+    Number.isSafeInteger(metadata.x402_decimals) &&
+    metadata.x402_decimals! >= 0 &&
+    metadata.x402_decimals! <= 255 &&
+    typeof metadata.x402_currency === 'string' &&
+    metadata.x402_currency.length > 0 &&
+    typeof metadata.x402_network === 'string' &&
+    metadata.x402_network.length > 0 &&
+    typeof metadata.x402_tx === 'string' &&
+    metadata.x402_tx.length > 0
+  );
+}


### PR DESCRIPTION
## Summary
- show confirmed x402 charges as exact USDC amounts instead of `0 Credits` / `100% OFF`
- link supported Solana, Base and SKALE transactions through a shared CAIP-2 allowlist
- distinguish settled, unconfirmed, failed and legacy payment records
- label attempt transactions separately and prevent stale detail responses from replacing the active row
- add payment details to the usage dialog and localize all 18 locale files

## Dependencies
- `@acedatacloud/core` 0.19.1 (published)
- Gateway settlement metadata: https://github.com/AceDataCloud/PlatformGateway/pull/239 (merged/deployed)

## Validation
- `npm run lint:check` (0 errors; 2 pre-existing warnings)
- `vitest run src/utils/usagePayment.test.ts` (5 passed)
- `npm run build:web`
- `python3 scripts/check_i18n_coverage.py`

## 🤖 对抗评审 (reviewer: codex, 3 rounds)
- RISK: unconfirmed/failed rows looked successful → fixed with status-aware tags and explicit attempt transaction labels
- RISK: stale detail requests could overwrite a newer row → fixed by applying response/finally only when row id still matches
- RISK: helper/locale files appeared absent → reviewer input omitted untracked/generated files; re-reviewed with complete logic and i18n gate evidence
- RISK: lockfile pointed to 0.18.0 → fixed with published 0.19.1 tarball shasum/integrity

🤖 Generated with [Claude Code](https://claude.com/claude-code)