### PR TITLE
fix(copy): unify success feedback

### DIFF
--- a/change/@acedatacloud-nexior-unify-copy-feedback.json
+++ b/change/@acedatacloud-nexior-unify-copy-feedback.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Unify copy controls and code blocks on consistent success icons, timing, and accessible feedback.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/assets/scss/_common.scss
+++ b/src/assets/scss/_common.scss
@@ -200,6 +200,45 @@ w3m-modal {
   border-radius: var(--adc-radius-card);
 }
 
+.code-copy-btn {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  z-index: 2;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: 0;
+  border-radius: 8px;
+  background: rgba(24, 24, 27, 0.88);
+  color: #f4f4f5;
+  cursor: pointer;
+  transition:
+    background-color var(--adc-motion-duration-fast),
+    color var(--adc-motion-duration-fast);
+
+  &:hover {
+    background: #3f3f46;
+    color: #fff;
+  }
+
+  &:focus-visible {
+    outline: var(--adc-focus-outline);
+    outline-offset: var(--adc-focus-outline-offset);
+  }
+
+  &.is-copied {
+    color: var(--el-color-success);
+  }
+
+  svg {
+    display: block;
+  }
+}
+
 .el-main {
   padding: 0 !important;
 }

--- a/src/components/browser/BrowserPairingDialog.vue
+++ b/src/components/browser/BrowserPairingDialog.vue
@@ -24,10 +24,18 @@
       <p class="pairing-intro">{{ $t('user.browserDevice.pairInstructions') }}</p>
       <div class="pairing-code-row">
         <code class="pairing-code">{{ challenge.code }}</code>
-        <el-button size="small" @click="copyCode">
-          <copy-icon class="mr-1" size="1em" aria-hidden="true" focusable="false" />
-          {{ $t('common.button.copy') }}
+        <el-button
+          size="small"
+          :aria-label="codeCopied ? $t('common.message.copied') : $t('common.button.copy')"
+          @click="copyCode"
+        >
+          <success-icon v-if="codeCopied" class="mr-1" size="1em" aria-hidden="true" focusable="false" />
+          <copy-icon v-else class="mr-1" size="1em" aria-hidden="true" focusable="false" />
+          {{ codeCopied ? $t('common.message.copied') : $t('common.button.copy') }}
         </el-button>
+        <span class="sr-only" role="status" aria-live="polite">
+          {{ codeCopied ? $t('common.message.copied') : '' }}
+        </span>
       </div>
       <p class="pairing-expiry">
         {{ $t('user.browserDevice.codeExpiresIn', { seconds: secondsRemaining }) }}
@@ -106,7 +114,7 @@
 <script lang="ts">
 import { defineComponent, PropType } from 'vue';
 import { ElAlert, ElButton, ElDialog, ElDivider, ElInput, ElMessage, ElSkeleton } from 'element-plus';
-import { CopyIcon, LoadingIcon } from '@acedatacloud/core/icons/components';
+import { CopyIcon, LoadingIcon, SuccessIcon } from '@acedatacloud/core/icons/components';
 import { browserDeviceOperator } from '@/operators/browserDevice';
 import { IBrowserDevice, IBrowserPairingChallenge, IBrowserPairingClaim } from '@/models/browserDevice';
 
@@ -128,11 +136,13 @@ interface IData {
   clockTimer: number | null;
   decision: 'confirm' | 'reject' | null;
   requestGeneration: number;
+  codeCopied: boolean;
+  codeCopiedTimer: number | null;
 }
 
 export default defineComponent({
   name: 'BrowserPairingDialog',
-  components: { CopyIcon, ElAlert, ElButton, ElDialog, ElDivider, ElInput, ElSkeleton, LoadingIcon },
+  components: { CopyIcon, ElAlert, ElButton, ElDialog, ElDivider, ElInput, ElSkeleton, LoadingIcon, SuccessIcon },
   props: {
     modelValue: { type: Boolean as PropType<boolean>, default: false }
   },
@@ -150,7 +160,9 @@ export default defineComponent({
       pollTimer: null,
       clockTimer: null,
       decision: null,
-      requestGeneration: 0
+      requestGeneration: 0,
+      codeCopied: false,
+      codeCopiedTimer: null
     };
   },
   computed: {
@@ -183,6 +195,11 @@ export default defineComponent({
   methods: {
     async startPairing() {
       if (this.loading) return;
+      this.codeCopied = false;
+      if (this.codeCopiedTimer !== null) {
+        window.clearTimeout(this.codeCopiedTimer);
+        this.codeCopiedTimer = null;
+      }
       this.stopPolling();
       const generation = ++this.requestGeneration;
       this.loading = true;
@@ -245,7 +262,12 @@ export default defineComponent({
       if (!this.challenge) return;
       try {
         await navigator.clipboard.writeText(this.challenge.code);
-        ElMessage.success(this.$t('common.message.copied'));
+        this.codeCopied = true;
+        if (this.codeCopiedTimer !== null) window.clearTimeout(this.codeCopiedTimer);
+        this.codeCopiedTimer = window.setTimeout(() => {
+          this.codeCopied = false;
+          this.codeCopiedTimer = null;
+        }, 3000);
       } catch {
         ElMessage.error(this.$t('common.message.copyFailed'));
       }
@@ -325,6 +347,11 @@ export default defineComponent({
         window.clearInterval(this.clockTimer);
         this.clockTimer = null;
       }
+      if (this.codeCopiedTimer !== null) {
+        window.clearTimeout(this.codeCopiedTimer);
+        this.codeCopiedTimer = null;
+      }
+      this.codeCopied = false;
     },
     onClosed() {
       this.requestGeneration += 1;

--- a/src/components/chat/Message.vue
+++ b/src/components/chat/Message.vue
@@ -234,7 +234,6 @@
 import { ErrorIcon } from '@acedatacloud/core/icons/components';
 import { defineComponent } from 'vue';
 import AnsweringMark from './AnsweringMark.vue';
-import copy from 'copy-to-clipboard';
 import { ElButton, ElImage, ElInput } from 'element-plus';
 import MarkdownRenderer from '@/components/common/MarkdownRenderer.vue';
 import { IApplication, IChatMessage, IChatMessageState, IChatModelGroup } from '@/models';
@@ -274,7 +273,6 @@ import { ROUTE_CONSOLE_APPLICATION_EXTRA } from '@/router';
 import { isIOS, isRechargeDisabled } from '@/utils';
 
 interface IData {
-  copied: boolean;
   isEditing: boolean;
   questionValue: string;
   messageState: typeof IChatMessageState;
@@ -350,7 +348,6 @@ export default defineComponent({
   ],
   data(): IData {
     return {
-      copied: false,
       isEditing: false,
       questionValue: this.message.content as string,
       messageState: IChatMessageState
@@ -453,15 +450,6 @@ export default defineComponent({
     },
     onSubmit() {
       this.$emit('edit', this.message, this.questionValue);
-    },
-    onCopy() {
-      copy(this.message.content!.toString(), {
-        debug: true
-      });
-      this.copied = true;
-      setTimeout(() => {
-        this.copied = false;
-      }, 3000);
     },
     onBuyMore() {
       this.$router.push({

--- a/src/components/chat/ShareConversationDialog.vue
+++ b/src/components/chat/ShareConversationDialog.vue
@@ -5,7 +5,13 @@
     <div v-if="localShareId" class="share-linked">
       <div class="share-url-row">
         <el-input v-model="shareUrl" readonly class="share-url" @focus="selectAll" />
-        <el-button type="primary" @click="onCopy">
+        <el-button
+          type="primary"
+          :aria-label="copied ? $t('chat.share.copied') : $t('chat.share.copy')"
+          @click="onCopy"
+        >
+          <success-icon v-if="copied" class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
+          <copy-icon v-else class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
           {{ copied ? $t('chat.share.copied') : $t('chat.share.copy') }}
         </el-button>
       </div>
@@ -29,7 +35,7 @@
 </template>
 
 <script lang="ts">
-import { LinkIcon, UnlinkIcon } from '@acedatacloud/core/icons/components';
+import { CopyIcon, LinkIcon, SuccessIcon, UnlinkIcon } from '@acedatacloud/core/icons/components';
 import { defineComponent } from 'vue';
 import { ElDialog, ElInput, ElButton, ElMessage } from 'element-plus';
 import copy from 'copy-to-clipboard';
@@ -38,7 +44,9 @@ import { chatOperator } from '@/operators';
 export default defineComponent({
   name: 'ShareConversationDialog',
   components: {
+    CopyIcon,
     LinkIcon,
+    SuccessIcon,
     UnlinkIcon,
     ElDialog,
     ElInput,
@@ -137,7 +145,6 @@ export default defineComponent({
         return;
       }
       this.copied = true;
-      ElMessage.success(this.$t('chat.share.copied'));
       if (this.copiedTimer !== undefined) window.clearTimeout(this.copiedTimer);
       this.copiedTimer = window.setTimeout(() => {
         this.copied = false;

--- a/src/components/chat/ShareConversationDialog.vue
+++ b/src/components/chat/ShareConversationDialog.vue
@@ -64,7 +64,8 @@ export default defineComponent({
       localShareId: this.shareId,
       creating: false,
       disabling: false,
-      copied: false
+      copied: false,
+      copiedTimer: undefined as number | undefined
     };
   },
   computed: {
@@ -98,6 +99,9 @@ export default defineComponent({
       }
     }
   },
+  beforeUnmount() {
+    if (this.copiedTimer !== undefined) window.clearTimeout(this.copiedTimer);
+  },
   methods: {
     selectAll(event: FocusEvent) {
       (event.target as HTMLInputElement)?.select?.();
@@ -127,12 +131,14 @@ export default defineComponent({
     },
     onCopy() {
       if (!this.shareUrl) return;
-      copy(this.shareUrl, { debug: false });
+      if (!copy(this.shareUrl, { debug: false })) return;
       this.copied = true;
       ElMessage.success(this.$t('chat.share.copied'));
-      setTimeout(() => {
+      if (this.copiedTimer !== undefined) window.clearTimeout(this.copiedTimer);
+      this.copiedTimer = window.setTimeout(() => {
         this.copied = false;
-      }, 2500);
+        this.copiedTimer = undefined;
+      }, 3000);
     },
     async onDisable() {
       if (!this.token || !this.conversationId) {

--- a/src/components/chat/ShareConversationDialog.vue
+++ b/src/components/chat/ShareConversationDialog.vue
@@ -129,9 +129,13 @@ export default defineComponent({
         this.creating = false;
       }
     },
-    onCopy() {
+    async onCopy() {
       if (!this.shareUrl) return;
-      if (!copy(this.shareUrl, { debug: false })) return;
+      try {
+        if (!(await copy(this.shareUrl, { debug: false }))) return;
+      } catch {
+        return;
+      }
       this.copied = true;
       ElMessage.success(this.$t('chat.share.copied'));
       if (this.copiedTimer !== undefined) window.clearTimeout(this.copiedTimer);

--- a/src/components/common/CopyToClipboard.test.ts
+++ b/src/components/common/CopyToClipboard.test.ts
@@ -29,7 +29,7 @@ describe('CopyToClipboard', () => {
 
   it('keeps the button and shows the shared success icon after copying', async () => {
     vi.useFakeTimers();
-    copy.mockReturnValue(true);
+    copy.mockResolvedValue(true);
     const wrapper = mountCopyControl();
     const button = wrapper.get('button');
 
@@ -51,7 +51,7 @@ describe('CopyToClipboard', () => {
   });
 
   it('does not report success when the clipboard helper fails', async () => {
-    copy.mockReturnValue(false);
+    copy.mockResolvedValue(false);
     const wrapper = mountCopyControl();
 
     await wrapper.get('button').trigger('click');
@@ -63,7 +63,7 @@ describe('CopyToClipboard', () => {
 
   it('restarts the reset timer after a repeated copy', async () => {
     vi.useFakeTimers();
-    copy.mockReturnValue(true);
+    copy.mockResolvedValue(true);
     const wrapper = mountCopyControl();
 
     await wrapper.get('button').trigger('click');

--- a/src/components/common/CopyToClipboard.test.ts
+++ b/src/components/common/CopyToClipboard.test.ts
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+import { shallowMount } from '@vue/test-utils';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { nextTick } from 'vue';
+
+import CopyToClipboard from './CopyToClipboard.vue';
+
+const copy = vi.hoisted(() => vi.fn());
+vi.mock('copy-to-clipboard', () => ({ default: copy }));
+
+const mountCopyControl = () =>
+  shallowMount(CopyToClipboard, {
+    props: { content: 'copy me' },
+    global: {
+      mocks: { $t: (key: string) => key },
+      stubs: {
+        ElTooltip: { template: '<div><slot /></div>' },
+        CopyIcon: { template: '<svg data-testid="copy-icon" />' },
+        SuccessIcon: { template: '<svg data-testid="success-icon" />' }
+      }
+    }
+  });
+
+describe('CopyToClipboard', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    copy.mockReset();
+  });
+
+  it('keeps the button and shows the shared success icon after copying', async () => {
+    vi.useFakeTimers();
+    copy.mockReturnValue(true);
+    const wrapper = mountCopyControl();
+    const button = wrapper.get('button');
+
+    expect(button.attributes('aria-label')).toBe('common.button.copy');
+    expect(wrapper.find('[data-testid="copy-icon"]').exists()).toBe(true);
+
+    await button.trigger('click');
+
+    expect(copy).toHaveBeenCalledWith('copy me', { debug: true });
+    expect(wrapper.get('button').attributes('aria-label')).toBe('common.message.copied');
+    expect(wrapper.find('[data-testid="success-icon"]').exists()).toBe(true);
+    expect(wrapper.get('[role="status"]').text()).toBe('common.message.copied');
+
+    vi.advanceTimersByTime(3000);
+    await nextTick();
+
+    expect(wrapper.get('button').attributes('aria-label')).toBe('common.button.copy');
+    expect(wrapper.find('[data-testid="copy-icon"]').exists()).toBe(true);
+  });
+
+  it('does not report success when the clipboard helper fails', async () => {
+    copy.mockReturnValue(false);
+    const wrapper = mountCopyControl();
+
+    await wrapper.get('button').trigger('click');
+
+    expect(wrapper.get('button').attributes('aria-label')).toBe('common.button.copy');
+    expect(wrapper.find('[data-testid="success-icon"]').exists()).toBe(false);
+    expect(wrapper.get('[role="status"]').text()).toBe('');
+  });
+
+  it('restarts the reset timer after a repeated copy', async () => {
+    vi.useFakeTimers();
+    copy.mockReturnValue(true);
+    const wrapper = mountCopyControl();
+
+    await wrapper.get('button').trigger('click');
+    vi.advanceTimersByTime(2000);
+    await wrapper.get('button').trigger('click');
+    vi.advanceTimersByTime(1000);
+    await nextTick();
+
+    expect(wrapper.get('button').attributes('aria-label')).toBe('common.message.copied');
+
+    vi.advanceTimersByTime(2000);
+    await nextTick();
+
+    expect(wrapper.get('button').attributes('aria-label')).toBe('common.button.copy');
+  });
+});

--- a/src/components/common/CopyToClipboard.vue
+++ b/src/components/common/CopyToClipboard.vue
@@ -45,9 +45,14 @@ export default defineComponent({
     if (this.resetTimer !== undefined) window.clearTimeout(this.resetTimer);
   },
   methods: {
-    onCopy() {
+    async onCopy() {
       const text = this.content.toString();
-      if (!text || !copy(text, { debug: true })) {
+      if (!text) {
+        return;
+      }
+      try {
+        if (!(await copy(text, { debug: true }))) return;
+      } catch {
         return;
       }
       this.copied = true;

--- a/src/components/common/CopyToClipboard.vue
+++ b/src/components/common/CopyToClipboard.vue
@@ -1,22 +1,22 @@
 <template>
-  <el-tooltip v-if="!copied" effect="dark" :content="$t('common.button.copy')" placement="bottom">
-    <button
-      type="button"
-      class="icon-copy"
-      :aria-label="$t('common.button.copy')"
-      :title="$t('common.button.copy')"
-      @click.stop="onCopy"
-    >
-      <copy-icon :size="'1em' as any" aria-hidden="true" focusable="false" />
-    </button>
-  </el-tooltip>
-  <el-tooltip v-else :visible="copied" effect="dark" :content="$t('common.message.copied')" placement="bottom">
-    <confirm-icon class="icon-check" :size="'1em' as any" aria-hidden="true" focusable="false" />
-  </el-tooltip>
+  <span class="copy-control">
+    <el-tooltip :visible="copied" effect="dark" :content="$t('common.message.copied')" placement="top-start">
+      <button
+        type="button"
+        class="copy-control__button"
+        :aria-label="copied ? $t('common.message.copied') : $t('common.button.copy')"
+        @click.stop="onCopy"
+      >
+        <success-icon v-if="copied" :size="16" aria-hidden="true" focusable="false" />
+        <copy-icon v-else :size="16" aria-hidden="true" focusable="false" />
+      </button>
+    </el-tooltip>
+    <span class="sr-only" role="status" aria-live="polite">{{ copied ? $t('common.message.copied') : '' }}</span>
+  </span>
 </template>
 
 <script lang="ts">
-import { ConfirmIcon, CopyIcon } from '@acedatacloud/core/icons/components';
+import { CopyIcon, SuccessIcon } from '@acedatacloud/core/icons/components';
 import { defineComponent } from 'vue';
 import copy from 'copy-to-clipboard';
 import { ElTooltip } from 'element-plus';
@@ -24,8 +24,8 @@ import { ElTooltip } from 'element-plus';
 export default defineComponent({
   name: 'CopyToClipboard',
   components: {
-    ConfirmIcon,
     CopyIcon,
+    SuccessIcon,
     ElTooltip
   },
   props: {
@@ -37,20 +37,24 @@ export default defineComponent({
   },
   data() {
     return {
-      copied: false
+      copied: false,
+      resetTimer: undefined as number | undefined
     };
+  },
+  beforeUnmount() {
+    if (this.resetTimer !== undefined) window.clearTimeout(this.resetTimer);
   },
   methods: {
     onCopy() {
-      if (!this.content) {
+      const text = this.content.toString();
+      if (!text || !copy(text, { debug: true })) {
         return;
       }
-      copy(this.content.toString(), {
-        debug: true
-      });
       this.copied = true;
-      setTimeout(() => {
+      if (this.resetTimer !== undefined) window.clearTimeout(this.resetTimer);
+      this.resetTimer = window.setTimeout(() => {
         this.copied = false;
+        this.resetTimer = undefined;
       }, 3000);
     }
   }
@@ -58,17 +62,45 @@ export default defineComponent({
 </script>
 
 <style lang="scss" scoped>
-.icon-check,
-.icon-copy {
-  margin-inline-start: 5px;
-  cursor: pointer;
-  color: inherit;
+.copy-control {
+  display: inline-flex;
+  align-items: center;
+  vertical-align: middle;
+  line-height: 1;
 }
 
-.icon-copy {
+.copy-control__button {
   display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  margin-inline-start: 4px;
   padding: 0;
   border: 0;
+  border-radius: 4px;
   background: transparent;
+  color: inherit;
+  cursor: pointer;
+  line-height: 1;
+  transition:
+    color var(--adc-motion-duration-fast),
+    background-color var(--adc-motion-duration-fast);
+
+  &:hover {
+    color: var(--el-color-primary);
+    background: var(--el-fill-color-light);
+  }
+
+  &:focus-visible {
+    outline: var(--adc-focus-outline);
+    outline-offset: var(--adc-focus-outline-offset);
+  }
+}
+
+.copy-control__button :deep(svg) {
+  display: block;
+  width: 14px;
+  height: 14px;
 }
 </style>

--- a/src/components/order/WechatPay.vue
+++ b/src/components/order/WechatPay.vue
@@ -18,7 +18,16 @@
       <p class="text-[12px] text-gray-500 mb-4 leading-relaxed">
         {{ $t('order.message.wechatPayMobileHint') }}
       </p>
-      <el-button v-if="payPageUrl" size="default" round class="w-[220px]" @click="onCopyLink">
+      <el-button
+        v-if="payPageUrl"
+        size="default"
+        round
+        class="w-[220px]"
+        :aria-label="copied ? $t('common.message.copied') : $t('order.button.copyPayLink')"
+        @click="onCopyLink"
+      >
+        <success-icon v-if="copied" class="mr-1" size="1em" aria-hidden="true" focusable="false" />
+        <copy-icon v-else class="mr-1" size="1em" aria-hidden="true" focusable="false" />
         {{ copied ? $t('common.message.copied') : $t('order.button.copyPayLink') }}
       </el-button>
     </div>
@@ -76,6 +85,7 @@ import { defineComponent } from 'vue';
 import { ElDialog, ElRow, ElCol, ElButton, ElMessage } from 'element-plus';
 import QrCode from 'vue-qrcode';
 import copy from 'copy-to-clipboard';
+import { CopyIcon, SuccessIcon } from '@acedatacloud/core/icons/components';
 import { IOrder, IOrderDetailResponse, OrderState } from '@/models';
 import { isInWeChat, isMobileBrowser } from '@/utils/wechat';
 
@@ -90,9 +100,11 @@ export default defineComponent({
   components: {
     ElDialog,
     ElButton,
+    CopyIcon,
     QrCode,
     ElRow,
-    ElCol
+    ElCol,
+    SuccessIcon
   },
   props: {
     modelValue: {

--- a/src/components/order/WechatPay.vue
+++ b/src/components/order/WechatPay.vue
@@ -194,7 +194,7 @@ export default defineComponent({
         }
         this.copiedTimer = window.setTimeout(() => {
           this.copied = false;
-        }, 2000);
+        }, 3000);
       } else {
         ElMessage.error(String(this.$t('common.message.copyFailed') || 'Copy failed'));
       }

--- a/src/components/order/public/WechatPay.vue
+++ b/src/components/order/public/WechatPay.vue
@@ -141,7 +141,7 @@ export default defineComponent({
         if (this.copiedTimer) clearTimeout(this.copiedTimer);
         this.copiedTimer = window.setTimeout(() => {
           this.copied = false;
-        }, 2000);
+        }, 3000);
       } else {
         ElMessage.error(String(this.$t('common.message.copyFailed') || 'Copy failed'));
       }

--- a/src/components/order/public/WechatPay.vue
+++ b/src/components/order/public/WechatPay.vue
@@ -21,7 +21,15 @@
       <p class="text-[12px] text-gray-500 mb-4 leading-relaxed">
         {{ $t('order.message.wechatPayMobileHint') }}
       </p>
-      <el-button size="default" round class="w-[220px]" @click="onCopyLink">
+      <el-button
+        size="default"
+        round
+        class="w-[220px]"
+        :aria-label="copied ? $t('common.message.copied') : $t('order.button.copyPayLink')"
+        @click="onCopyLink"
+      >
+        <success-icon v-if="copied" class="mr-1" size="1em" aria-hidden="true" focusable="false" />
+        <copy-icon v-else class="mr-1" size="1em" aria-hidden="true" focusable="false" />
         {{ copied ? $t('common.message.copied') : $t('order.button.copyPayLink') }}
       </el-button>
     </div>
@@ -72,6 +80,7 @@ import { defineComponent } from 'vue';
 import { ElDialog, ElRow, ElCol, ElButton, ElMessage } from 'element-plus';
 import QrCode from 'vue-qrcode';
 import copy from 'copy-to-clipboard';
+import { CopyIcon, SuccessIcon } from '@acedatacloud/core/icons/components';
 import { IOrder } from '@/models';
 import { isInWeChat, isMobileBrowser } from '@/utils/wechat';
 
@@ -85,9 +94,11 @@ export default defineComponent({
   components: {
     ElDialog,
     ElButton,
+    CopyIcon,
     QrCode,
     ElRow,
-    ElCol
+    ElCol,
+    SuccessIcon
   },
   props: {
     order: {

--- a/src/components/setting/Memory.vue
+++ b/src/components/setting/Memory.vue
@@ -56,7 +56,17 @@
       <div class="import-step">
         <div class="import-step-title">{{ $t('common.settings.memoryImportExportStep') }}</div>
         <el-input :model-value="importPrompt" type="textarea" :rows="7" readonly resize="none" />
-        <el-button size="small" @click="copyImportPrompt">{{ $t('common.settings.memoryImportCopy') }}</el-button>
+        <el-button
+          size="small"
+          :aria-label="
+            importPromptCopied ? $t('common.settings.memoryImportCopied') : $t('common.settings.memoryImportCopy')
+          "
+          @click="copyImportPrompt"
+        >
+          <success-icon v-if="importPromptCopied" class="mr-1" size="1em" aria-hidden="true" focusable="false" />
+          <copy-icon v-else class="mr-1" size="1em" aria-hidden="true" focusable="false" />
+          {{ importPromptCopied ? $t('common.settings.memoryImportCopied') : $t('common.settings.memoryImportCopy') }}
+        </el-button>
       </div>
       <div class="import-step">
         <div class="import-step-title">{{ $t('common.settings.memoryImportPasteStep') }}</div>
@@ -80,7 +90,7 @@
 </template>
 
 <script lang="ts">
-import { IdeaIcon } from '@acedatacloud/core/icons/components';
+import { CopyIcon, IdeaIcon, SuccessIcon } from '@acedatacloud/core/icons/components';
 import { defineComponent } from 'vue';
 import copy from 'copy-to-clipboard';
 import { ElButton, ElDialog, ElEmpty, ElInput, ElMessage, ElMessageBox, ElSwitch, vLoading } from 'element-plus';
@@ -90,7 +100,7 @@ import { ensureStoreModule } from '@/store/lazy';
 
 export default defineComponent({
   name: 'MemorySetting',
-  components: { ElButton, ElDialog, ElEmpty, ElInput, ElSwitch, IdeaIcon },
+  components: { CopyIcon, ElButton, ElDialog, ElEmpty, ElInput, ElSwitch, IdeaIcon, SuccessIcon },
   directives: { loading: vLoading },
   data() {
     return {
@@ -103,7 +113,9 @@ export default defineComponent({
       importing: false,
       importText: '',
       importController: null as AbortController | null,
-      entries: [] as IMemoryEntry[]
+      entries: [] as IMemoryEntry[],
+      importPromptCopied: false,
+      importPromptCopiedTimer: undefined as number | undefined
     };
   },
   computed: {
@@ -138,22 +150,38 @@ export default defineComponent({
   },
   beforeUnmount() {
     this.importController?.abort();
+    if (this.importPromptCopiedTimer !== undefined) window.clearTimeout(this.importPromptCopiedTimer);
   },
   methods: {
     openImport() {
+      this.importPromptCopied = false;
+      if (this.importPromptCopiedTimer !== undefined) {
+        window.clearTimeout(this.importPromptCopiedTimer);
+        this.importPromptCopiedTimer = undefined;
+      }
       this.importText = '';
       this.importVisible = true;
     },
     closeImport() {
       if (this.importing) return;
       this.importVisible = false;
+      this.importPromptCopied = false;
+      if (this.importPromptCopiedTimer !== undefined) {
+        window.clearTimeout(this.importPromptCopiedTimer);
+        this.importPromptCopiedTimer = undefined;
+      }
       this.importController?.abort();
       this.importController = null;
     },
     async copyImportPrompt() {
       try {
         if (await copy(this.importPrompt)) {
-          ElMessage.success(this.$t('common.settings.memoryImportCopied'));
+          this.importPromptCopied = true;
+          if (this.importPromptCopiedTimer !== undefined) window.clearTimeout(this.importPromptCopiedTimer);
+          this.importPromptCopiedTimer = window.setTimeout(() => {
+            this.importPromptCopied = false;
+            this.importPromptCopiedTimer = undefined;
+          }, 3000);
           return;
         }
       } catch (error) {

--- a/src/components/skill/SkillFilePreview.vue
+++ b/src/components/skill/SkillFilePreview.vue
@@ -278,6 +278,11 @@ export default defineComponent({
     },
     async fetch() {
       if (!this.path) return;
+      this.copied = false;
+      if (this.copiedTimer !== undefined) {
+        window.clearTimeout(this.copiedTimer);
+        this.copiedTimer = undefined;
+      }
       this.loading = true;
       this.error = '';
       this.textContent = '';

--- a/src/components/skill/SkillFilePreview.vue
+++ b/src/components/skill/SkillFilePreview.vue
@@ -21,16 +21,21 @@
         {{ $t('skill.button.save') }}
       </el-button>
 
-      <el-tooltip :content="$t('skill.preview.copy')" placement="bottom">
+      <el-tooltip
+        :visible="copied"
+        :content="copied ? $t('skill.preview.copied') : $t('skill.preview.copy')"
+        placement="top-start"
+      >
         <el-button
           size="small"
           circle
           :disabled="!textContent"
-          :aria-label="$t('skill.preview.copy')"
-          :title="$t('skill.preview.copy')"
+          :aria-label="copied ? $t('skill.preview.copied') : $t('skill.preview.copy')"
+          :title="copied ? $t('skill.preview.copied') : $t('skill.preview.copy')"
           @click="onCopy"
         >
-          <copy-icon :size="16" aria-hidden="true" focusable="false" />
+          <success-icon v-if="copied" :size="16" aria-hidden="true" focusable="false" />
+          <copy-icon v-else :size="16" aria-hidden="true" focusable="false" />
         </el-button>
       </el-tooltip>
     </div>
@@ -112,7 +117,15 @@
 <script lang="ts">
 import { defineComponent, PropType } from 'vue';
 import { ElButton, ElTooltip, ElTabs, ElTabPane, ElMessage, vLoading } from 'element-plus';
-import { CodeIcon, CopyIcon, FileIcon, SaveIcon, ViewIcon, WarningIcon } from '@acedatacloud/core/icons/components';
+import {
+  CodeIcon,
+  CopyIcon,
+  FileIcon,
+  SaveIcon,
+  SuccessIcon,
+  ViewIcon,
+  WarningIcon
+} from '@acedatacloud/core/icons/components';
 import VueMarkdown from '@/components/common/VueMarkdown.vue';
 import hljs from 'highlight.js/lib/core';
 import bash from 'highlight.js/lib/languages/bash';
@@ -188,6 +201,7 @@ export default defineComponent({
     CopyIcon,
     FileIcon,
     SaveIcon,
+    SuccessIcon,
     ViewIcon,
     WarningIcon,
     VueMarkdown
@@ -224,7 +238,9 @@ export default defineComponent({
       truncated: false,
       viewMode: 'rendered' as 'rendered' | 'source',
       dirty: false,
-      saving: false
+      saving: false,
+      copied: false,
+      copiedTimer: undefined as number | undefined
     };
   },
   computed: {
@@ -252,6 +268,7 @@ export default defineComponent({
   },
   beforeUnmount() {
     if (this.imageUrl) URL.revokeObjectURL(this.imageUrl);
+    if (this.copiedTimer !== undefined) window.clearTimeout(this.copiedTimer);
   },
   methods: {
     humanSize(bytes: number): string {
@@ -316,6 +333,12 @@ export default defineComponent({
       if (!this.textContent) return;
       try {
         await navigator.clipboard.writeText(this.textContent);
+        this.copied = true;
+        if (this.copiedTimer !== undefined) window.clearTimeout(this.copiedTimer);
+        this.copiedTimer = window.setTimeout(() => {
+          this.copied = false;
+          this.copiedTimer = undefined;
+        }, 3000);
         ElMessage.success(this.$t('skill.preview.copied'));
       } catch {
         ElMessage.error(this.$t('skill.preview.copyFailed'));

--- a/src/pages/chat/ScheduledTasks.test.ts
+++ b/src/pages/chat/ScheduledTasks.test.ts
@@ -401,7 +401,7 @@ describe('chat/ScheduledTasks', () => {
 
     expect(wrapper.find('.task-id-text').text()).toBe('common.entity.id: task-1');
 
-    await wrapper.find('.task-id .icon-copy').trigger('click');
+    await wrapper.get('.task-id button[aria-label="common.button.copy"]').trigger('click');
 
     expect(copyToClipboard).toHaveBeenCalledWith('task-1', expect.anything());
     expect((wrapper.vm as unknown as { showRunHistory: boolean }).showRunHistory).toBe(false);

--- a/src/utils/highlight.ts
+++ b/src/utils/highlight.ts
@@ -58,16 +58,23 @@ export const highlight = async (el: HTMLElement) => {
     btn.className = 'code-copy-btn';
     btn.setAttribute('aria-label', i18n.global.t('common.button.copy').toString());
     btn.innerHTML = COPY_SVG;
+    let resetTimer: number | undefined;
 
-    btn.addEventListener('click', () => {
-      if (!copyToClipboard(code.innerText)) return;
+    btn.addEventListener('click', async () => {
+      try {
+        if (!(await copyToClipboard(code.innerText))) return;
+      } catch {
+        return;
+      }
       btn.classList.add('is-copied');
       btn.setAttribute('aria-label', i18n.global.t('common.message.copied').toString());
       btn.innerHTML = CHECK_SVG;
-      window.setTimeout(() => {
+      if (resetTimer !== undefined) window.clearTimeout(resetTimer);
+      resetTimer = window.setTimeout(() => {
         btn.classList.remove('is-copied');
         btn.setAttribute('aria-label', i18n.global.t('common.button.copy').toString());
         btn.innerHTML = COPY_SVG;
+        resetTimer = undefined;
       }, 3000);
     });
 

--- a/src/utils/highlight.ts
+++ b/src/utils/highlight.ts
@@ -1,6 +1,13 @@
 import i18n from '@/i18n';
 import copyToClipboard from 'copy-to-clipboard';
 
+const COPY_SVG =
+  '<svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true" focusable="false" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">' +
+  '<rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>';
+const CHECK_SVG =
+  '<svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true" focusable="false" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">' +
+  '<circle cx="12" cy="12" r="10"/><path d="m9 12 2 2 4-4"/></svg>';
+
 export const highlight = async (el: HTMLElement) => {
   const hl = (await import('highlight.js/lib/common')).default;
   const blocks = el.querySelectorAll<HTMLElement>('pre code');
@@ -48,16 +55,20 @@ export const highlight = async (el: HTMLElement) => {
     const btn = document.createElement('button');
     btn.type = 'button';
     btn.dataset.copyBtn = '1';
-    btn.className =
-      'absolute top-1 right-1 z-10 rounded-md px-2 py-1 text-xs ' +
-      'bg-zinc-800 text-white hover:bg-zinc-700 active:scale-95';
-    btn.textContent = i18n.global.t('common.button.copy').toString();
+    btn.className = 'code-copy-btn';
+    btn.setAttribute('aria-label', i18n.global.t('common.button.copy').toString());
+    btn.innerHTML = COPY_SVG;
 
     btn.addEventListener('click', () => {
-      copyToClipboard(code.innerText);
-      const old = btn.textContent!;
-      btn.textContent = i18n.global.t('common.button.copied')?.toString();
-      setTimeout(() => (btn.textContent = old), 5000);
+      if (!copyToClipboard(code.innerText)) return;
+      btn.classList.add('is-copied');
+      btn.setAttribute('aria-label', i18n.global.t('common.message.copied').toString());
+      btn.innerHTML = CHECK_SVG;
+      window.setTimeout(() => {
+        btn.classList.remove('is-copied');
+        btn.setAttribute('aria-label', i18n.global.t('common.button.copy').toString());
+        btn.innerHTML = COPY_SVG;
+      }, 3000);
     });
 
     wrapper.appendChild(btn);


### PR DESCRIPTION
## Summary
- standardize every copy success state on CircleCheck, copied labels/aria feedback, and a restartable 3-second reset
- cover shared/markdown controls, chat sharing, browser pairing, payment links, Memory import, and skill file previews
- await copy-to-clipboard v4 results, suppress false success, and reset state when dialogs/files change
- remove the unused legacy message copy handler

## Validation
- 3 Promise-based Vitest regression cases
- focused ESLint across all copy surfaces
- full vue-tsc build and production Vite build
- beachball check in the real pre-push hook
- browser DOM verification of the real highlight directive