### PR TITLE
fix(usage): keep API select visible while loading

### DIFF
--- a/change/@acedatacloud-nexior-usage-api-dropdown-loading.json
+++ b/change/@acedatacloud-nexior-usage-api-dropdown-loading.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Keep the usage API filter visible while its options preload and show loading inside the dropdown.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/pages/console/usage/List.vue
+++ b/src/pages/console/usage/List.vue
@@ -33,15 +33,10 @@
         </el-col>
         <el-col v-if="type === serviceType.API" :md="6" :xs="24" class="mb-5 flex px-2 gap-2 items-center">
           <span class="inline-block"> {{ $t('usage.field.api') }} </span>
-          <el-skeleton v-if="apisLoading" animated class="w-full">
-            <template #template>
-              <el-skeleton-item variant="rect" style="height: 32px; border-radius: 4px" />
-            </template>
-          </el-skeleton>
           <el-select
-            v-else
             v-model="apiIds"
             :placeholder="$t('usage.field.api')"
+            :loading="apisLoading"
             clearable
             filterable
             multiple
@@ -547,7 +542,6 @@ import {
   ElRadioGroup,
   ElRadioButton,
   ElSkeleton,
-  ElSkeletonItem,
   ElDialog,
   ElTabs,
   ElTabPane,
@@ -672,7 +666,6 @@ export default defineComponent({
     ElRadioButton,
     ElRadioGroup,
     ElSkeleton,
-    ElSkeletonItem,
     ElDialog,
     ElTabs,
     ElTabPane,

--- a/src/pages/console/usage/apiSelectLoading.test.ts
+++ b/src/pages/console/usage/apiSelectLoading.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const page = readFileSync(fileURLToPath(new URL('./List.vue', import.meta.url)), 'utf8');
+const apiFilter = page.match(/<el-col v-if="type === serviceType\.API"[^>]*>[\s\S]*?<\/el-col>/)?.[0] || '';
+
+describe('usage API select loading contract', () => {
+  it('keeps the select mounted and shows loading inside its dropdown', () => {
+    expect(apiFilter).toContain(':loading="apisLoading"');
+    expect(apiFilter).not.toContain('<el-skeleton');
+    expect(apiFilter).not.toMatch(/<el-select\s+v-else/);
+  });
+
+  it('preloads API options when the page mounts', () => {
+    expect(page).toMatch(/mounted\(\)\s*\{[\s\S]*?this\.onFetchApis\(\)/);
+  });
+});


### PR DESCRIPTION
## Summary
- keep the usage-history API selector mounted while options preload
- show Element Plus loading state inside the opened dropdown instead of replacing the field with a skeleton
- add a Vitest source contract and patch change file

Depends on the API service type response restored by https://github.com/AceDataCloud/PlatformBackend/pull/1362 (merged).

## Validation
- `npm run test:run -- src/pages/console/usage/apiSelectLoading.test.ts` — 2 passed
- `npm run lint:check` — 0 errors (2 pre-existing warnings)
- `npm run build:web`
- `npm run verify`

Local Git-worktree note: Husky pre-push makes Beachball resolve `change/change/...`; the identical `npm run verify` passes immediately before push, and CI reruns Beachball against `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)