### PR TITLE
feat(x402): show frozen usage discounts

### DIFF
--- a/change/@acedatacloud-nexior-x402-discount.json
+++ b/change/@acedatacloud-nexior-x402-discount.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Apply account usage discounts to x402 quotes and improve settlement history layout.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/nanobanana/ConfigPanel.vue
+++ b/src/components/nanobanana/ConfigPanel.vue
@@ -49,6 +49,9 @@ export default defineComponent({
     ResolutionSelector,
     ScenarioPaymentMode
   },
+  props: {
+    identityToken: { type: String, default: undefined }
+  },
   emits: ['generate'],
   data() {
     return {
@@ -90,6 +93,10 @@ export default defineComponent({
         if (this.walletMode) this.scheduleQuote();
       },
       deep: true
+    },
+    identityToken() {
+      this.quoteRunId += 1;
+      if (this.walletMode) this.scheduleQuote();
     }
   },
   beforeUnmount() {
@@ -107,7 +114,7 @@ export default defineComponent({
       state.quoteLoading = true;
       state.quoteUsdc = undefined;
       try {
-        const quote = await nanobananaOperator.quote(buildNanobananaRequest(this.config));
+        const quote = await nanobananaOperator.quote(buildNanobananaRequest(this.config), this.identityToken);
         if (runId === this.quoteRunId && state.mode === 'wallet') state.quoteUsdc = quote.amountUsdc;
       } catch (error) {
         console.warn('x402 quote failed', error);

--- a/src/components/openaiimage/ConfigPanel.vue
+++ b/src/components/openaiimage/ConfigPanel.vue
@@ -46,6 +46,9 @@ export default defineComponent({
     ResolutionSelector,
     ScenarioPaymentMode
   },
+  props: {
+    identityToken: { type: String, default: undefined }
+  },
   emits: ['generate'],
   data() {
     return {
@@ -85,6 +88,10 @@ export default defineComponent({
         if (this.walletMode) this.scheduleQuote();
       },
       deep: true
+    },
+    identityToken() {
+      this.quoteRunId += 1;
+      if (this.walletMode) this.scheduleQuote();
     }
   },
   beforeUnmount() {
@@ -102,7 +109,7 @@ export default defineComponent({
       state.quoteLoading = true;
       state.quoteUsdc = undefined;
       try {
-        const quote = await openaiimageOperator.quote(buildOpenAIImageGenerateRequest(this.config));
+        const quote = await openaiimageOperator.quote(buildOpenAIImageGenerateRequest(this.config), this.identityToken);
         if (runId === this.quoteRunId && state.mode === 'wallet') state.quoteUsdc = quote.amountUsdc;
       } catch (error) {
         console.warn('x402 quote failed', error);

--- a/src/components/x402ScenarioContract.test.ts
+++ b/src/components/x402ScenarioContract.test.ts
@@ -22,9 +22,13 @@ describe('x402 image scenario contract', () => {
     const openAI = source('components/openaiimage/ConfigPanel.vue');
     expect(selector).toContain('state.quoteUsdc');
     expect(nano).toContain('<scenario-payment-mode scenario="nanobanana"');
-    expect(nano).toContain('nanobananaOperator.quote(buildNanobananaRequest(this.config))');
+    expect(nano).toContain('nanobananaOperator.quote(');
+    expect(nano).toContain('this.identityToken');
+    expect(source('pages/nanobanana/Index.vue')).toContain(':identity-token="credential?.token"');
     expect(openAI).toContain('<scenario-payment-mode scenario="openaiimage"');
-    expect(openAI).toContain('openaiimageOperator.quote(buildOpenAIImageGenerateRequest(this.config))');
+    expect(openAI).toContain('openaiimageOperator.quote(');
+    expect(openAI).toContain('this.identityToken');
+    expect(source('pages/openaiimage/Index.vue')).toContain(':identity-token="credential?.token"');
   });
 
   it('keeps both submissions async and routes both modes through existing operators', () => {

--- a/src/i18n/ar/usage.json
+++ b/src/i18n/ar/usage.json
@@ -210,5 +210,17 @@
   "value.attemptTransaction": {
     "message": "محاولة المعاملة",
     "description": "محاولة معاملة لم يتم تأكيد نجاحها بعد."
+  },
+  "value.onChainBalanceNote": {
+    "message": "الدفع على السلسلة، دون استخدام رصيد النقاط",
+    "description": "يوضح أن سجل الاستخدام x402 لم يتم خصم رصيد النقاط بعد."
+  },
+  "value.aceDiscount": {
+    "message": "خصم ACE {percent}%",
+    "description": "علامة خصم استخدام API المكتسب من ACE."
+  },
+  "value.accountDiscount": {
+    "message": "خصم الحساب {percent}%",
+    "description": "علامة محايدة لخصم استخدام الحساب اليدوي."
   }
 }

--- a/src/i18n/de/usage.json
+++ b/src/i18n/de/usage.json
@@ -210,5 +210,17 @@
   "value.attemptTransaction": {
     "message": "Transaktion versuchen",
     "description": "Versuche einer Transaktion, die noch nicht erfolgreich bestätigt wurden."
+  },
+  "value.onChainBalanceNote": {
+    "message": "Zahlung auf der Blockchain, kein Einsatz von Punktesaldo",
+    "description": "Erläuterung, dass die x402-Nutzungsaufzeichnung den Punktesaldo nicht belastet."
+  },
+  "value.aceDiscount": {
+    "message": "ACE-Rabatt {percent}%",
+    "description": "Label für Rabatte auf die API-Nutzung, die durch den Besitz von ACE gewährt werden."
+  },
+  "value.accountDiscount": {
+    "message": "Konto-Rabatt {percent}%",
+    "description": "Neutrales Label für Rabatte, die manuell auf Konten angewendet werden."
   }
 }

--- a/src/i18n/el/usage.json
+++ b/src/i18n/el/usage.json
@@ -210,5 +210,17 @@
   "value.attemptTransaction": {
     "message": "Προσπάθεια Συναλλαγής",
     "description": "Μια προσπάθεια συναλλαγής που δεν έχει επιβεβαιωθεί ως επιτυχής."
+  },
+  "value.onChainBalanceNote": {
+    "message": "Πληρωμή στο blockchain, χωρίς χρήση υπολοίπου πόντων",
+    "description": "Εξηγεί ότι η καταγραφή x402 δεν έχει αφαιρέσει πόντους από το υπόλοιπο."
+  },
+  "value.aceDiscount": {
+    "message": "Έκπτωση ACE {percent}%",
+    "description": "Ετικέτα για την έκπτωση στη χρήση API που αποκτάται με την κατοχή ACE."
+  },
+  "value.accountDiscount": {
+    "message": "Έκπτωση λογαριασμού {percent}%",
+    "description": "Ουδέτερη ετικέτα για την έκπτωση που χρησιμοποιείται σε χειροκίνητους λογαριασμούς."
   }
 }

--- a/src/i18n/en/usage.json
+++ b/src/i18n/en/usage.json
@@ -210,5 +210,17 @@
   "value.attemptTransaction": {
     "message": "Attempt transaction",
     "description": "A settlement attempt transaction that is not confirmed as successful."
+  },
+  "value.onChainBalanceNote": {
+    "message": "On-chain payment; no credit balance used",
+    "description": "Explains why an x402 usage row has no post-payment credit balance."
+  },
+  "value.aceDiscount": {
+    "message": "ACE {percent}% OFF",
+    "description": "Discount badge for an API usage discount earned by holding ACE."
+  },
+  "value.accountDiscount": {
+    "message": "{percent}% OFF",
+    "description": "Neutral badge for a manual account usage discount."
   }
 }

--- a/src/i18n/es/usage.json
+++ b/src/i18n/es/usage.json
@@ -210,5 +210,17 @@
   "value.attemptTransaction": {
     "message": "Intentar transacción",
     "description": "Intento de transacción que aún no ha sido confirmado como exitoso."
+  },
+  "value.onChainBalanceNote": {
+    "message": "Pago en cadena, sin usar saldo de puntos",
+    "description": "Indica que el registro de uso x402 no ha deducido el saldo de puntos."
+  },
+  "value.aceDiscount": {
+    "message": "Descuento ACE {percent}%",
+    "description": "Etiqueta para el descuento de uso de API obtenido al poseer ACE."
+  },
+  "value.accountDiscount": {
+    "message": "Descuento de cuenta {percent}%",
+    "description": "Etiqueta neutral para el descuento de uso manual de la cuenta."
   }
 }

--- a/src/i18n/fi/usage.json
+++ b/src/i18n/fi/usage.json
@@ -210,5 +210,17 @@
   "value.attemptTransaction": {
     "message": "Yritä tapahtumaa",
     "description": "Vielä vahvistamaton onnistunut maksuyritys."
+  },
+  "value.onChainBalanceNote": {
+    "message": "Ketjussa maksaminen, ei käytetä pistesaldoa",
+    "description": "Selittää, että x402:n käyttörekisterissä ei ole vähennetty pistesaldoa."
+  },
+  "value.aceDiscount": {
+    "message": "ACE-alennus {percent}%",
+    "description": "Merkintä API-käytön alennuksesta, joka saadaan ACE:llä."
+  },
+  "value.accountDiscount": {
+    "message": "Tilialennus {percent}%",
+    "description": "Neutraali merkintä manuaaliselle tilille käytettävästä alennuksesta."
   }
 }

--- a/src/i18n/fr/usage.json
+++ b/src/i18n/fr/usage.json
@@ -210,5 +210,17 @@
   "value.attemptTransaction": {
     "message": "Essayer la transaction",
     "description": "Tentative de transaction de règlement qui n'a pas encore été confirmée comme réussie."
+  },
+  "value.onChainBalanceNote": {
+    "message": "Paiement en chaîne, sans utiliser le solde de points",
+    "description": "Indique que l'enregistrement d'utilisation x402 n'a pas déduit le solde de points."
+  },
+  "value.aceDiscount": {
+    "message": "Remise ACE {percent}%",
+    "description": "Étiquette pour la remise sur l'utilisation de l'API obtenue grâce à la détention d'ACE."
+  },
+  "value.accountDiscount": {
+    "message": "Remise sur le compte {percent}%",
+    "description": "Étiquette neutre pour la remise appliquée sur les comptes manuels."
   }
 }

--- a/src/i18n/it/usage.json
+++ b/src/i18n/it/usage.json
@@ -210,5 +210,17 @@
   "value.attemptTransaction": {
     "message": "Tentativo di transazione",
     "description": "Tentativo di transazione non ancora confermato come riuscito."
+  },
+  "value.onChainBalanceNote": {
+    "message": "Pagamento on-chain, senza utilizzare il saldo punti",
+    "description": "Indica che la registrazione x402 non ha sottratto punti dal saldo."
+  },
+  "value.aceDiscount": {
+    "message": "Sconto ACE {percent}%",
+    "description": "Etichetta per lo sconto sull'uso dell'API ottenuto con ACE."
+  },
+  "value.accountDiscount": {
+    "message": "Sconto account {percent}%",
+    "description": "Etichetta neutra per lo sconto sull'uso manuale dell'account."
   }
 }

--- a/src/i18n/ja/usage.json
+++ b/src/i18n/ja/usage.json
@@ -210,5 +210,17 @@
   "value.attemptTransaction": {
     "message": "取引を試みる",
     "description": "まだ成功が確認されていない決済の試みです。"
+  },
+  "value.onChainBalanceNote": {
+    "message": "チェーン上の支払い、ポイント残高は使用しません",
+    "description": "x402 使用記録がポイント残高を引き落とさないことを説明します。"
+  },
+  "value.aceDiscount": {
+    "message": "ACE 割引 {percent}%",
+    "description": "ACE 所持者に提供される API 使用割引のラベルです。"
+  },
+  "value.accountDiscount": {
+    "message": "アカウント割引 {percent}%",
+    "description": "手動アカウントで使用する割引の中立的なラベルです。"
   }
 }

--- a/src/i18n/ko/usage.json
+++ b/src/i18n/ko/usage.json
@@ -210,5 +210,17 @@
   "value.attemptTransaction": {
     "message": "거래 시도",
     "description": "아직 성공적으로 확인되지 않은 결제 시도 거래."
+  },
+  "value.onChainBalanceNote": {
+    "message": "체인 상의 결제, 포인트 잔액 미사용",
+    "description": "x402 사용 기록에서 포인트 잔액이 차감되지 않음을 설명합니다."
+  },
+  "value.aceDiscount": {
+    "message": "ACE 할인 {percent}%",
+    "description": "ACE 보유 시 API 사용에 대한 할인 레이블입니다."
+  },
+  "value.accountDiscount": {
+    "message": "계정 할인 {percent}%",
+    "description": "수동 계정 사용 시 할인에 대한 중립적인 레이블입니다."
   }
 }

--- a/src/i18n/pl/usage.json
+++ b/src/i18n/pl/usage.json
@@ -210,5 +210,17 @@
   "value.attemptTransaction": {
     "message": "Próba transakcji",
     "description": "Próba transakcji, która nie została jeszcze potwierdzona jako udana."
+  },
+  "value.onChainBalanceNote": {
+    "message": "Płatność na łańcuchu, bez użycia salda punktów",
+    "description": "Wyjaśnia, że zapis x402 nie odlicza salda punktów po transakcji."
+  },
+  "value.aceDiscount": {
+    "message": "Zniżka ACE {percent}%",
+    "description": "Etykieta zniżki na użycie API uzyskanej dzięki posiadaniu ACE."
+  },
+  "value.accountDiscount": {
+    "message": "Zniżka na konto {percent}%",
+    "description": "Neutralna etykieta dla ręcznie stosowanej zniżki na konto."
   }
 }

--- a/src/i18n/pt/usage.json
+++ b/src/i18n/pt/usage.json
@@ -210,5 +210,17 @@
   "value.attemptTransaction": {
     "message": "Tentar transação",
     "description": "Tentativa de transação de liquidação que ainda não foi confirmada como bem-sucedida."
+  },
+  "value.onChainBalanceNote": {
+    "message": "Pagamento na cadeia, sem usar saldo de pontos",
+    "description": "Explicação de que os registros de uso x402 não deduzem o saldo de pontos."
+  },
+  "value.aceDiscount": {
+    "message": "Desconto ACE {percent}%",
+    "description": "Etiqueta para descontos na utilização da API obtidos com ACE."
+  },
+  "value.accountDiscount": {
+    "message": "Desconto na conta {percent}%",
+    "description": "Etiqueta neutra para descontos aplicados em contas manuais."
   }
 }

--- a/src/i18n/ru/usage.json
+++ b/src/i18n/ru/usage.json
@@ -210,5 +210,17 @@
   "value.attemptTransaction": {
     "message": "Попробовать транзакцию",
     "description": "Попытка транзакции, которая еще не подтверждена как успешная."
+  },
+  "value.onChainBalanceNote": {
+    "message": "Оплата в сети, без использования баланса очков",
+    "description": "Указывает, что запись использования x402 не уменьшает баланс очков."
+  },
+  "value.aceDiscount": {
+    "message": "Скидка ACE {percent}%",
+    "description": "Метка для скидки на использование API, полученной за владение ACE."
+  },
+  "value.accountDiscount": {
+    "message": "Скидка на аккаунт {percent}%",
+    "description": "Нейтральная метка для скидки, применяемой к аккаунту вручную."
   }
 }

--- a/src/i18n/sr/usage.json
+++ b/src/i18n/sr/usage.json
@@ -210,5 +210,17 @@
   "value.attemptTransaction": {
     "message": "Pokušaj transakcije",
     "description": "Pokušaj transakcije koji još nije potvrđen kao uspešan."
+  },
+  "value.onChainBalanceNote": {
+    "message": "Плаћање на ланцу, без коришћења салда поена",
+    "description": "Objašnjava da x402 zapis korišćenja nije umanjio saldo poena."
+  },
+  "value.aceDiscount": {
+    "message": "ACE попуст {percent}%",
+    "description": "Oznaka za popust na korišćenje API-ja dobijenog držanjem ACE."
+  },
+  "value.accountDiscount": {
+    "message": "Попуст на рачун {percent}%",
+    "description": "Неутрална oznaka za popust na ručno korišćenje računa."
   }
 }

--- a/src/i18n/sv/usage.json
+++ b/src/i18n/sv/usage.json
@@ -210,5 +210,17 @@
   "value.attemptTransaction": {
     "message": "Försök transaktion",
     "description": "Försök till transaktion som ännu inte bekräftats som lyckad."
+  },
+  "value.onChainBalanceNote": {
+    "message": "Kedjebetalning, ingen användning av poängsaldo",
+    "description": "Förklarar att x402 användningsposten inte har dragit från poängsaldot."
+  },
+  "value.aceDiscount": {
+    "message": "ACE-rabatt {percent}%",
+    "description": "Etikett för rabatt på API-användning som erhålls genom att inneha ACE."
+  },
+  "value.accountDiscount": {
+    "message": "Kontots rabatt {percent}%",
+    "description": "Neutral etikett för rabatt på manuella konton."
   }
 }

--- a/src/i18n/uk/usage.json
+++ b/src/i18n/uk/usage.json
@@ -210,5 +210,17 @@
   "value.attemptTransaction": {
     "message": "Спробувати транзакцію",
     "description": "Спроба транзакції, яка ще не підтверджена як успішна."
+  },
+  "value.onChainBalanceNote": {
+    "message": "Оплата в ланцюзі, без використання залишку балів",
+    "description": "Пояснює, що записи використання x402 не зменшують залишок балів."
+  },
+  "value.aceDiscount": {
+    "message": "Знижка ACE {percent}%",
+    "description": "Мітка знижки на використання API, отриманої за допомогою ACE."
+  },
+  "value.accountDiscount": {
+    "message": "Знижка на рахунок {percent}%",
+    "description": "Нейтральна мітка для знижки на рахунок, що використовується вручну."
   }
 }

--- a/src/i18n/zh-CN/usage.json
+++ b/src/i18n/zh-CN/usage.json
@@ -210,5 +210,17 @@
   "value.attemptTransaction": {
     "message": "尝试交易",
     "description": "尚未确认成功的结算尝试交易。"
+  },
+  "value.onChainBalanceNote": {
+    "message": "链上支付，不使用积分余额",
+    "description": "说明 x402 使用记录没有扣后积分余额。"
+  },
+  "value.aceDiscount": {
+    "message": "ACE 优惠 {percent}%",
+    "description": "持有 ACE 获得的 API 使用折扣标签。"
+  },
+  "value.accountDiscount": {
+    "message": "账户优惠 {percent}%",
+    "description": "手工账户使用折扣的中性标签。"
   }
 }

--- a/src/i18n/zh-TW/usage.json
+++ b/src/i18n/zh-TW/usage.json
@@ -210,5 +210,17 @@
   "value.attemptTransaction": {
     "message": "嘗試交易",
     "description": "尚未確認成功的結算嘗試交易。"
+  },
+  "value.onChainBalanceNote": {
+    "message": "鏈上支付，不使用積分餘額",
+    "description": "說明 x402 使用記錄沒有扣後積分餘額。"
+  },
+  "value.aceDiscount": {
+    "message": "ACE 優惠 {percent}%",
+    "description": "持有 ACE 獲得的 API 使用折扣標籤。"
+  },
+  "value.accountDiscount": {
+    "message": "帳戶優惠 {percent}%",
+    "description": "手工帳戶使用折扣的中性標籤。"
   }
 }

--- a/src/models/usage.ts
+++ b/src/models/usage.ts
@@ -8,7 +8,11 @@ export interface IUsageCredential {
 export interface IX402UsageMetadata extends Record<string, unknown> {
   x402?: boolean;
   x402_settlement_status?: 'settled' | 'unconfirmed';
+  x402_list_amount_atomic?: string;
   x402_amount_atomic?: string;
+  x402_discount_percent?: string;
+  x402_discount_type?: 'Coin' | 'Manual';
+  x402_discount_coin_policy_id?: string;
   x402_decimals?: number;
   x402_currency?: string;
   x402_network?: string;
@@ -17,6 +21,8 @@ export interface IX402UsageMetadata extends Record<string, unknown> {
   x402_settle_error?: string;
   x402_settle_attempt_tx?: string;
   x402_skipped?: boolean;
+  request?: unknown;
+  response?: unknown;
 }
 
 export interface IApiUsage {

--- a/src/operators/baseTaskOperator.ts
+++ b/src/operators/baseTaskOperator.ts
@@ -137,8 +137,8 @@ export class BaseTaskOperator<
     );
   }
 
-  async quote(data: TGenerateRequest) {
-    return quoteX402(this.generatePath, data, X402_GENERATE_HEADERS);
+  async quote(data: TGenerateRequest, identityToken?: string) {
+    return quoteX402(this.generatePath, data, X402_GENERATE_HEADERS, identityToken);
   }
 
   async generate(data: TGenerateRequest, options: OperatorRequestOptions): Promise<AxiosResponse<TGenerateResponse>> {

--- a/src/operators/x402.test.ts
+++ b/src/operators/x402.test.ts
@@ -114,7 +114,7 @@ describe('postWithX402', () => {
       'fresh-blockhash'
     );
     const initialConfig = mocks.post.mock.calls[0][2];
-    expect(initialConfig.headers).not.toHaveProperty('authorization');
+    expect(initialConfig.headers.authorization).toBe('Bearer identity-token');
     const retryConfig = mocks.post.mock.calls[1][2];
     expect(retryConfig.headers.authorization).toBe('Bearer identity-token');
     const envelope = JSON.parse(Buffer.from(retryConfig.headers['PAYMENT-SIGNATURE'], 'base64').toString('utf8'));

--- a/src/operators/x402.ts
+++ b/src/operators/x402.ts
@@ -80,10 +80,14 @@ function quoteFromChallenge(challenge: { accepts: PaymentRequirement[] }): X402P
 export async function quoteX402(
   path: string,
   data: unknown,
-  headers: Record<string, string> = { accept: 'application/json', 'content-type': 'application/json' }
+  headers: Record<string, string> = { accept: 'application/json', 'content-type': 'application/json' },
+  identityToken?: string
 ): Promise<X402PaymentQuote> {
   try {
-    await axios.post(path, data, { baseURL: BASE_URL_X402, headers });
+    await axios.post(path, data, {
+      baseURL: BASE_URL_X402,
+      headers: { ...headers, ...(identityToken ? { authorization: `Bearer ${identityToken}` } : {}) }
+    });
     throw new Error('x402 endpoint did not return a payment requirement');
   } catch (error) {
     return quoteFromChallenge(paymentRequired(error));
@@ -106,7 +110,13 @@ export async function postWithX402<T>(
   headers: Record<string, string> = { accept: 'application/json', 'content-type': 'application/json' }
 ): Promise<AxiosResponse<T>> {
   try {
-    return await axios.post<T>(path, data, { baseURL: BASE_URL_X402, headers });
+    return await axios.post<T>(path, data, {
+      baseURL: BASE_URL_X402,
+      headers: {
+        ...headers,
+        ...(options.identityToken ? { authorization: `Bearer ${options.identityToken}` } : {})
+      }
+    });
   } catch (error) {
     const quote = quoteFromChallenge(paymentRequired(error));
     const { requirement } = quote;

--- a/src/pages/console/usage/List.vue
+++ b/src/pages/console/usage/List.vue
@@ -212,9 +212,17 @@
               >
                 <template #default="scope">
                   <div v-if="isX402Usage(scope.row)" class="space-y-1">
-                    <strong v-if="getX402Payment(scope.row)">
-                      {{ getX402Payment(scope.row)?.amount }} {{ getX402Payment(scope.row)?.currency }}
-                    </strong>
+                    <template v-if="getX402Payment(scope.row)">
+                      <span>{{ getX402Payment(scope.row)?.amount }} {{ getX402Payment(scope.row)?.currency }}</span>
+                      <div v-if="getX402Payment(scope.row)?.originalAmount">
+                        <del>
+                          {{ getX402Payment(scope.row)?.originalAmount }} {{ getX402Payment(scope.row)?.currency }}
+                        </del>
+                      </div>
+                      <el-tag v-if="getX402Payment(scope.row)?.discountPercent" type="success" size="small">
+                        {{ getX402DiscountLabel(scope.row) }}
+                      </el-tag>
+                    </template>
                     <span v-else class="text-gray-400">{{ $t('usage.value.paymentUnavailable') }}</span>
                   </div>
                   <div v-else-if="getDeductedAmount(scope.row) === getOriginalAmount(scope.row)">
@@ -234,11 +242,39 @@
               <el-table-column
                 prop="remaining_amount"
                 :label="$t('usage.field.balanceAfter')"
-                width="160px"
+                width="190px"
                 class-name="text-center"
               >
                 <template #default="scope">
-                  <span v-if="isX402Usage(scope.row)">{{ $t('usage.value.balanceNotApplicable') }}</span>
+                  <div v-if="isX402Usage(scope.row)" class="space-y-1">
+                    <div class="flex min-w-0 items-center justify-center gap-1">
+                      <a
+                        v-if="getX402Payment(scope.row)?.explorerUrl"
+                        :href="getX402Payment(scope.row)?.explorerUrl"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="truncate text-primary"
+                      >
+                        {{ $t('usage.button.viewTransaction') }}
+                        <external-link-icon class="ml-1 inline-block h-3.5 w-3.5" />
+                      </a>
+                      <span v-else-if="getX402Transaction(scope.row)" class="key truncate">
+                        {{
+                          scope.row.metadata?.x402_settle_attempt_tx ? `${$t('usage.value.attemptTransaction')}: ` : ''
+                        }}{{ shortTransaction(getX402Transaction(scope.row)) }}
+                      </span>
+                      <copy-to-clipboard
+                        v-if="getX402Transaction(scope.row)"
+                        :content="getX402Transaction(scope.row)"
+                        class="inline-block shrink-0"
+                      />
+                    </div>
+                    <div class="text-xs text-gray-400">
+                      {{
+                        $t(getX402Payment(scope.row) ? 'usage.value.onChainBalanceNote' : getX402StatusKey(scope.row))
+                      }}
+                    </div>
+                  </div>
                   <span v-else>{{ getRemainingAmount(scope.row) }}</span>
                 </template>
               </el-table-column>
@@ -273,26 +309,6 @@
                     </el-tag>
                     <div v-if="isX402Usage(scope.row)" class="flex min-w-0 items-center gap-1">
                       <el-tag :type="getX402StatusType(scope.row)">{{ $t(getX402StatusKey(scope.row)) }}</el-tag>
-                      <a
-                        v-if="getX402Payment(scope.row)?.explorerUrl"
-                        :href="getX402Payment(scope.row)?.explorerUrl"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        class="truncate text-primary"
-                      >
-                        {{ $t('usage.button.viewTransaction') }}
-                        <external-link-icon class="ml-1 inline-block h-3.5 w-3.5" />
-                      </a>
-                      <span v-else-if="getX402Transaction(scope.row)" class="key truncate">
-                        {{
-                          scope.row.metadata?.x402_settle_attempt_tx ? `${$t('usage.value.attemptTransaction')}: ` : ''
-                        }}{{ shortTransaction(getX402Transaction(scope.row)) }}
-                      </span>
-                      <copy-to-clipboard
-                        v-if="getX402Transaction(scope.row)"
-                        :content="getX402Transaction(scope.row)"
-                        class="inline-block shrink-0"
-                      />
                     </div>
                     <el-tag
                       v-for="(name, key) in getSimpleMetadata(scope.row.metadata)"
@@ -455,7 +471,13 @@
               </dd>
               <dt>{{ $t('usage.field.paidAmount') }}</dt>
               <dd v-if="getX402Payment(detailRow)">
-                {{ getX402Payment(detailRow)?.amount }} {{ getX402Payment(detailRow)?.currency }}
+                <span>{{ getX402Payment(detailRow)?.amount }} {{ getX402Payment(detailRow)?.currency }}</span>
+                <del v-if="getX402Payment(detailRow)?.originalAmount" class="ml-2">
+                  {{ getX402Payment(detailRow)?.originalAmount }} {{ getX402Payment(detailRow)?.currency }}
+                </del>
+                <el-tag v-if="getX402Payment(detailRow)?.discountPercent" type="success" size="small" class="ml-2">
+                  {{ getX402DiscountLabel(detailRow) }}
+                </el-tag>
               </dd>
               <dd v-else>{{ $t('usage.value.paymentUnavailable') }}</dd>
               <dt>{{ $t('usage.field.network') }}</dt>
@@ -1123,6 +1145,12 @@ export default defineComponent({
     isX402Usage,
     getX402Payment: getX402UsagePayment,
     getX402Transaction: getX402CopyableTransaction,
+    getX402DiscountLabel(usage: IApiUsage) {
+      const payment = getX402UsagePayment(usage);
+      if (!payment?.discountPercent) return '';
+      const key = payment.discountSource === 'ace' ? 'usage.value.aceDiscount' : 'usage.value.accountDiscount';
+      return this.$t(key, { percent: payment.discountPercent });
+    },
     getX402StatusType(usage: IApiUsage) {
       if (getX402UsagePayment(usage)) return 'success';
       if (usage.metadata?.x402_settlement_status === 'unconfirmed') return 'warning';

--- a/src/pages/nanobanana/Index.vue
+++ b/src/pages/nanobanana/Index.vue
@@ -1,7 +1,7 @@
 <template>
   <layout>
     <template #config>
-      <config-panel @generate="onGenerate" />
+      <config-panel :identity-token="credential?.token" @generate="onGenerate" />
     </template>
     <template #result>
       <recent-panel ref="recentPanel" :loading="loading" @reach-top="onReachTop" />

--- a/src/pages/openaiimage/Index.vue
+++ b/src/pages/openaiimage/Index.vue
@@ -1,7 +1,7 @@
 <template>
   <layout>
     <template #config>
-      <config-panel @generate="onGenerate" />
+      <config-panel :identity-token="credential?.token" @generate="onGenerate" />
     </template>
     <template #result>
       <recent-panel ref="recentPanel" :loading="loading" @reach-top="onReachTop" />

--- a/src/utils/usagePayment.test.ts
+++ b/src/utils/usagePayment.test.ts
@@ -9,7 +9,11 @@ function usage(metadata: IApiUsage['metadata']): IApiUsage {
 const settled = usage({
   x402: true,
   x402_settlement_status: 'settled',
-  x402_amount_atomic: '13330',
+  x402_list_amount_atomic: '13330',
+  x402_amount_atomic: '12263',
+  x402_discount_percent: '0.08',
+  x402_discount_type: 'Coin',
+  x402_discount_coin_policy_id: 'policy-1',
   x402_decimals: 6,
   x402_currency: 'USDC',
   x402_network: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
@@ -20,7 +24,10 @@ const settled = usage({
 describe('x402 usage payment', () => {
   it('extracts a settled USDC payment and explorer URL', () => {
     expect(getX402UsagePayment(settled)).toEqual({
-      amount: '0.01333',
+      amount: '0.012263',
+      originalAmount: '0.01333',
+      discountPercent: '8',
+      discountSource: 'ace',
       currency: 'USDC',
       network: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
       transaction: 'signature',
@@ -29,7 +36,22 @@ describe('x402 usage payment', () => {
     });
   });
 
-  it('does not claim old or unconfirmed records are paid', () => {
+  it('keeps a settled legacy payment without inventing a discount', () => {
+    const payment = getX402UsagePayment(
+      usage({
+        ...settled.metadata,
+        x402_list_amount_atomic: undefined,
+        x402_discount_percent: undefined,
+        x402_discount_type: undefined,
+        x402_discount_coin_policy_id: undefined
+      })
+    );
+    expect(payment?.amount).toBe('0.012263');
+    expect(payment?.originalAmount).toBeUndefined();
+    expect(payment?.discountSource).toBeUndefined();
+  });
+
+  it('does not claim incomplete or unconfirmed records are paid', () => {
     expect(getX402UsagePayment(usage({ x402: true, x402_tx: 'legacy-tx' }))).toBeUndefined();
     expect(
       getX402UsagePayment(
@@ -44,6 +66,26 @@ describe('x402 usage payment', () => {
   it('rejects malformed atomic amounts and decimals', () => {
     expect(getX402UsagePayment(usage({ ...settled.metadata, x402_amount_atomic: '1.5' }))).toBeUndefined();
     expect(getX402UsagePayment(usage({ ...settled.metadata, x402_decimals: 256 }))).toBeUndefined();
+  });
+
+  it('uses a neutral source for a manual discount and ignores malformed list prices', () => {
+    const manual = getX402UsagePayment(
+      usage({ ...settled.metadata, x402_discount_type: 'Manual', x402_discount_coin_policy_id: undefined })
+    );
+    expect(manual?.discountSource).toBe('manual');
+
+    const fractional = getX402UsagePayment(
+      usage({ ...settled.metadata, x402_discount_type: 'Manual', x402_discount_percent: '0.075' })
+    );
+    expect(fractional?.discountPercent).toBe('7.5');
+
+    const unknown = getX402UsagePayment(usage({ ...settled.metadata, x402_discount_type: undefined }));
+    expect(unknown?.originalAmount).toBe('0.01333');
+    expect(unknown?.discountPercent).toBeUndefined();
+
+    const malformed = getX402UsagePayment(usage({ ...settled.metadata, x402_list_amount_atomic: '13.330' }));
+    expect(malformed?.amount).toBe('0.012263');
+    expect(malformed?.originalAmount).toBeUndefined();
   });
 
   it('keeps unknown networks copyable without inventing a link', () => {

--- a/src/utils/usagePayment.ts
+++ b/src/utils/usagePayment.ts
@@ -3,6 +3,9 @@ import { IApiUsage, IX402UsageMetadata } from '@/models/usage';
 
 export interface X402UsagePayment {
   amount: string;
+  originalAmount?: string;
+  discountPercent?: string;
+  discountSource?: 'ace' | 'manual';
   currency: string;
   network: string;
   transaction: string;
@@ -19,9 +22,26 @@ export function getX402UsagePayment(usage: IApiUsage): X402UsagePayment | undefi
   if (!isSettledMetadata(metadata)) return undefined;
 
   try {
-    const amount = formatAtomicTokenAmount(BigInt(metadata.x402_amount_atomic), metadata.x402_decimals);
+    const paidAtomic = BigInt(metadata.x402_amount_atomic);
+    const amount = formatAtomicTokenAmount(paidAtomic, metadata.x402_decimals);
+    let originalAmount: string | undefined;
+    let discountPercent: string | undefined;
+    let discountSource: 'ace' | 'manual' | undefined;
+    if (typeof metadata.x402_list_amount_atomic === 'string' && /^\d+$/.test(metadata.x402_list_amount_atomic)) {
+      const listAtomic = BigInt(metadata.x402_list_amount_atomic);
+      const percent = Number(metadata.x402_discount_percent);
+      if (listAtomic > paidAtomic && Number.isFinite(percent) && percent > 0 && percent < 1) {
+        originalAmount = formatAtomicTokenAmount(listAtomic, metadata.x402_decimals);
+        if (metadata.x402_discount_type === 'Coin' && metadata.x402_discount_coin_policy_id) discountSource = 'ace';
+        else if (metadata.x402_discount_type === 'Manual') discountSource = 'manual';
+        if (discountSource) discountPercent = Number((percent * 100).toFixed(2)).toString();
+      }
+    }
     return {
       amount,
+      originalAmount,
+      discountPercent,
+      discountSource,
       currency: metadata.x402_currency,
       network: metadata.x402_network,
       transaction: metadata.x402_tx,


### PR DESCRIPTION
## Summary
- send the selected API credential on the first dedicated-host x402 quote so ACE discounts are priced before signing
- display paid USDC at normal weight with authoritative list price and ACE/manual discount badge
- move transaction actions into the balance-after column and keep metadata focused on status
- keep legacy rows honest: no inferred list price or discount

## Dependencies
- Gateway metadata producer/discount rollout PR (must deploy first)

## Validation
- lint (0 errors; 2 existing warnings)
- 21 focused Vitest tests
- i18n coverage: 17 locales × 49 namespaces
- production build

## 🤖 对抗评审 (reviewer: codex, 2 completed rounds)
- RISK: quote used Auth JWT → fixed with credential token prop from the owning page
- RISK: stale quote after credential change → fixed with identityToken watcher/invalidation
- RISK: percentages rounded materially → fixed with up to two decimal places
- RISK: unknown discount source mislabeled → badge now requires recognized Coin/Manual source
- RISK: failed rows claimed payment → balance note is status-aware

🤖 Generated with [Claude Code](https://claude.com/claude-code)