### PR TITLE
feat(x402): add standard video wallet payments

### DIFF
--- a/change/@acedatacloud-nexior-0f79d770-5e15-4e95-9159-fcad6ab6fe22.json
+++ b/change/@acedatacloud-nexior-0f79d770-5e15-4e95-9159-fcad6ab6fe22.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add Solana x402 wallet payments to standard video scenarios.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "minor"
+}

--- a/src/components/grokvideo/ConfigPanel.vue
+++ b/src/components/grokvideo/ConfigPanel.vue
@@ -10,7 +10,8 @@
       <reference-images-input v-if="supportsReferenceImages" class="mb-4" />
     </div>
     <div class="flex flex-col items-center justify-center px-5 pb-5">
-      <consumption :value="consumption" :service="service" />
+      <scenario-payment-mode scenario="grokvideo" />
+      <consumption v-if="!walletMode" :value="consumption" :service="service" />
       <el-button type="primary" class="btn w-full" round @click="onGenerate">
         <magic-icon class="mr-2" :size="'1em' as any" aria-hidden="true" focusable="false" />
         {{ $t('grokvideo.button.generate') }}
@@ -32,6 +33,9 @@ import ImageInput from './config/ImageInput.vue';
 import ReferenceImagesInput from './config/ReferenceImagesInput.vue';
 import Consumption from '../common/Consumption.vue';
 import { getConsumption } from '@/utils';
+import ScenarioPaymentMode from '../common/ScenarioPaymentMode.vue';
+import { isScenarioX402Enabled, scenarioPaymentState } from '@/utils/x402/scenarioPayment';
+import { buildGrokVideoRequest, grokvideoOperator } from '@/operators/grokvideo';
 import { isGrokVideoImageOnlyModel } from '@/constants';
 
 export default defineComponent({
@@ -46,9 +50,13 @@ export default defineComponent({
     RatioSelector,
     ImageInput,
     ReferenceImagesInput,
-    Consumption
+    Consumption,
+    ScenarioPaymentMode
   },
   emits: ['generate'],
+  data() {
+    return { quoteTimer: 0, quoteRunId: 0 };
+  },
   computed: {
     config() {
       return this.$store.state.grokvideo?.config;
@@ -63,9 +71,48 @@ export default defineComponent({
     },
     service() {
       return this.$store.state.grokvideo?.service;
+    },
+    walletMode(): boolean {
+      return isScenarioX402Enabled() && scenarioPaymentState('grokvideo').mode === 'wallet';
     }
   },
+  watch: {
+    walletMode: {
+      handler(enabled: boolean) {
+        if (enabled) this.scheduleQuote();
+      },
+      immediate: true
+    },
+    config: {
+      handler() {
+        if (this.walletMode) this.scheduleQuote();
+      },
+      deep: true
+    }
+  },
+  beforeUnmount() {
+    window.clearTimeout(this.quoteTimer);
+    this.quoteRunId += 1;
+  },
   methods: {
+    scheduleQuote() {
+      window.clearTimeout(this.quoteTimer);
+      this.quoteTimer = window.setTimeout(this.refreshQuote, 350);
+    },
+    async refreshQuote() {
+      const state = scenarioPaymentState('grokvideo');
+      const runId = ++this.quoteRunId;
+      state.quoteLoading = true;
+      state.quoteUsdc = undefined;
+      try {
+        const quote = await grokvideoOperator.quote(buildGrokVideoRequest(this.config));
+        if (runId === this.quoteRunId && state.mode === 'wallet') state.quoteUsdc = quote.amountUsdc;
+      } catch (error) {
+        console.warn('x402 quote failed', error);
+      } finally {
+        if (runId === this.quoteRunId) state.quoteLoading = false;
+      }
+    },
     onGenerate() {
       this.$emit('generate');
     }

--- a/src/components/hailuo/ConfigPanel.vue
+++ b/src/components/hailuo/ConfigPanel.vue
@@ -6,7 +6,8 @@
       <start-image-url-input v-if="config?.model === 'minimax-i2v'" class="mb-4" />
     </div>
     <div class="flex flex-col items-center justify-center px-5 pb-5">
-      <consumption :value="consumption" :service="service" />
+      <scenario-payment-mode scenario="hailuo" />
+      <consumption v-if="!walletMode" :value="consumption" :service="service" />
       <el-button
         v-if="config?.video_url !== undefined || config?.custom"
         type="primary"
@@ -34,6 +35,9 @@ import StartImageUrlInput from './config/StartImageUrlInput.vue';
 import PromptInput from './config/PromptInput.vue';
 import Consumption from '../common/Consumption.vue';
 import { getConsumption } from '@/utils';
+import ScenarioPaymentMode from '../common/ScenarioPaymentMode.vue';
+import { isScenarioX402Enabled, scenarioPaymentState } from '@/utils/x402/scenarioPayment';
+import { buildHailuoRequest, hailuoOperator } from '@/operators/hailuo';
 
 export default defineComponent({
   name: 'PresetPanel',
@@ -43,9 +47,13 @@ export default defineComponent({
     PromptInput,
     StartImageUrlInput,
     ModelSelector,
-    Consumption
+    Consumption,
+    ScenarioPaymentMode
   },
   emits: ['generate'],
+  data() {
+    return { quoteTimer: 0, quoteRunId: 0 };
+  },
   computed: {
     config() {
       return this.$store.state.hailuo?.config;
@@ -55,9 +63,48 @@ export default defineComponent({
     },
     service() {
       return this.$store.state.hailuo?.service;
+    },
+    walletMode(): boolean {
+      return isScenarioX402Enabled() && scenarioPaymentState('hailuo').mode === 'wallet';
     }
   },
+  watch: {
+    walletMode: {
+      handler(enabled: boolean) {
+        if (enabled) this.scheduleQuote();
+      },
+      immediate: true
+    },
+    config: {
+      handler() {
+        if (this.walletMode) this.scheduleQuote();
+      },
+      deep: true
+    }
+  },
+  beforeUnmount() {
+    window.clearTimeout(this.quoteTimer);
+    this.quoteRunId += 1;
+  },
   methods: {
+    scheduleQuote() {
+      window.clearTimeout(this.quoteTimer);
+      this.quoteTimer = window.setTimeout(this.refreshQuote, 350);
+    },
+    async refreshQuote() {
+      const state = scenarioPaymentState('hailuo');
+      const runId = ++this.quoteRunId;
+      state.quoteLoading = true;
+      state.quoteUsdc = undefined;
+      try {
+        const quote = await hailuoOperator.quote(buildHailuoRequest(this.config));
+        if (runId === this.quoteRunId && state.mode === 'wallet') state.quoteUsdc = quote.amountUsdc;
+      } catch (error) {
+        console.warn('x402 quote failed', error);
+      } finally {
+        if (runId === this.quoteRunId) state.quoteLoading = false;
+      }
+    },
     onGenerate() {
       this.$emit('generate');
     }

--- a/src/components/luma/ConfigPanel.vue
+++ b/src/components/luma/ConfigPanel.vue
@@ -11,7 +11,8 @@
       <loop-selector class="mb-4" />
     </div>
     <div class="flex flex-col items-center justify-center px-5 pb-5">
-      <consumption :value="consumption" :service="service" />
+      <scenario-payment-mode scenario="luma" />
+      <consumption v-if="!walletMode" :value="consumption" :service="service" />
       <el-button
         v-if="config?.video_url !== undefined || config?.custom"
         type="primary"
@@ -45,6 +46,9 @@ import PromptInput from './config/PromptInput.vue';
 import ExtendFromInput from './config/ExtendFromInput.vue';
 import Consumption from '../common/Consumption.vue';
 import { getConsumption } from '@/utils';
+import ScenarioPaymentMode from '../common/ScenarioPaymentMode.vue';
+import { isScenarioX402Enabled, scenarioPaymentState } from '@/utils/x402/scenarioPayment';
+import { buildLumaRequest, lumaOperator } from '@/operators/luma';
 
 export default defineComponent({
   name: 'ConfigPanel',
@@ -59,9 +63,13 @@ export default defineComponent({
     ExtendFromInput,
     CustomSelector,
     UploadVideo,
-    Consumption
+    Consumption,
+    ScenarioPaymentMode
   },
   emits: ['generate'],
+  data() {
+    return { quoteTimer: 0, quoteRunId: 0 };
+  },
   computed: {
     config() {
       return this.$store.state.luma?.config;
@@ -71,9 +79,48 @@ export default defineComponent({
     },
     service() {
       return this.$store.state.luma?.service;
+    },
+    walletMode(): boolean {
+      return isScenarioX402Enabled() && scenarioPaymentState('luma').mode === 'wallet';
     }
   },
+  watch: {
+    walletMode: {
+      handler(enabled: boolean) {
+        if (enabled) this.scheduleQuote();
+      },
+      immediate: true
+    },
+    config: {
+      handler() {
+        if (this.walletMode) this.scheduleQuote();
+      },
+      deep: true
+    }
+  },
+  beforeUnmount() {
+    window.clearTimeout(this.quoteTimer);
+    this.quoteRunId += 1;
+  },
   methods: {
+    scheduleQuote() {
+      window.clearTimeout(this.quoteTimer);
+      this.quoteTimer = window.setTimeout(this.refreshQuote, 350);
+    },
+    async refreshQuote() {
+      const state = scenarioPaymentState('luma');
+      const runId = ++this.quoteRunId;
+      state.quoteLoading = true;
+      state.quoteUsdc = undefined;
+      try {
+        const quote = await lumaOperator.quote(buildLumaRequest(this.config));
+        if (runId === this.quoteRunId && state.mode === 'wallet') state.quoteUsdc = quote.amountUsdc;
+      } catch (error) {
+        console.warn('x402 quote failed', error);
+      } finally {
+        if (runId === this.quoteRunId) state.quoteLoading = false;
+      }
+    },
     onGenerate() {
       this.$emit('generate');
     }

--- a/src/components/maestro/ConfigPanel.vue
+++ b/src/components/maestro/ConfigPanel.vue
@@ -238,6 +238,7 @@
     </div>
 
     <div class="flex flex-col items-center justify-center px-5 pb-5">
+      <scenario-payment-mode scenario="maestro" />
       <el-button type="primary" class="btn w-full" round :disabled="!canGenerate" @click="onGenerate">
         <magic-icon class="mr-2" :size="'1em' as any" aria-hidden="true" focusable="false" />
         {{ $t('maestro.button.generate') }}
@@ -280,6 +281,9 @@ import {
   setMaestroPrimaryLanguage,
   type IMaestroLanguageOption
 } from '@/utils/maestroLanguages';
+import ScenarioPaymentMode from '../common/ScenarioPaymentMode.vue';
+import { isScenarioX402Enabled, scenarioPaymentState } from '@/utils/x402/scenarioPayment';
+import { buildMaestroRequest, maestroOperator } from '@/operators/maestro';
 
 // Preview rectangle dimensions (px) for each aspect-ratio chip.
 const RATIO_PREVIEW: Record<string, { width: number; height: number }> = {
@@ -302,7 +306,8 @@ export default defineComponent({
     PauseIcon,
     PlayIcon,
     PromptTextarea,
-    FileUrlsInput
+    FileUrlsInput,
+    ScenarioPaymentMode
   },
   emits: ['generate'],
   data() {
@@ -315,7 +320,9 @@ export default defineComponent({
       MAESTRO_ALLOWED_STYLES,
       MAESTRO_ALLOWED_VOICES,
       playing: false,
-      audioEl: null as HTMLAudioElement | null
+      audioEl: null as HTMLAudioElement | null,
+      quoteTimer: 0,
+      quoteRunId: 0
     };
   },
   computed: {
@@ -466,9 +473,24 @@ export default defineComponent({
     },
     currentSample(): string | undefined {
       return MAESTRO_ALLOWED_VOICES.find((v) => v.key === this.voice)?.sample;
+    },
+    walletMode(): boolean {
+      return isScenarioX402Enabled() && scenarioPaymentState('maestro').mode === 'wallet';
     }
   },
   watch: {
+    walletMode: {
+      handler(enabled: boolean) {
+        if (enabled) this.scheduleQuote();
+      },
+      immediate: true
+    },
+    config: {
+      handler() {
+        if (this.walletMode) this.scheduleQuote();
+      },
+      deep: true
+    },
     voiceCustomizationEnabled(enabled: boolean) {
       if (!enabled) this.stopSample();
     },
@@ -487,8 +509,28 @@ export default defineComponent({
   },
   beforeUnmount() {
     this.stopSample();
+    window.clearTimeout(this.quoteTimer);
+    this.quoteRunId += 1;
   },
   methods: {
+    scheduleQuote() {
+      window.clearTimeout(this.quoteTimer);
+      this.quoteTimer = window.setTimeout(this.refreshQuote, 350);
+    },
+    async refreshQuote() {
+      const state = scenarioPaymentState('maestro');
+      const runId = ++this.quoteRunId;
+      state.quoteLoading = true;
+      state.quoteUsdc = undefined;
+      try {
+        const quote = await maestroOperator.quote(buildMaestroRequest(this.config));
+        if (runId === this.quoteRunId && state.mode === 'wallet') state.quoteUsdc = quote.amountUsdc;
+      } catch (error) {
+        console.warn('x402 quote failed', error);
+      } finally {
+        if (runId === this.quoteRunId) state.quoteLoading = false;
+      }
+    },
     update(patch: Partial<IMaestroConfig>) {
       this.$store.commit('maestro/setConfig', {
         ...this.config,

--- a/src/components/minimax/ConfigPanel.vue
+++ b/src/components/minimax/ConfigPanel.vue
@@ -76,7 +76,8 @@
       </div>
     </div>
     <div class="flex flex-col items-center justify-center px-5 pb-5">
-      <consumption :value="consumption" :service="service" />
+      <scenario-payment-mode scenario="minimax" />
+      <consumption v-if="!walletMode" :value="consumption" :service="service" />
       <el-button type="primary" class="btn w-full" round @click="onGenerate">
         <magic-icon class="mr-2" :size="'1em' as any" aria-hidden="true" focusable="false" />
         {{ $t('minimax.button.generate') }}
@@ -96,6 +97,9 @@ import Consumption from '../common/Consumption.vue';
 import { IMinimaxConfig, IMinimaxContentItem, IMinimaxRatio } from '@/models';
 import { getConsumption } from '@/utils';
 import { validateMinimaxConfig } from '@/utils/minimax';
+import ScenarioPaymentMode from '../common/ScenarioPaymentMode.vue';
+import { isScenarioX402Enabled, scenarioPaymentState } from '@/utils/x402/scenarioPayment';
+import { buildMinimaxRequest, minimaxOperator } from '@/operators/minimax';
 
 export default defineComponent({
   name: 'MinimaxConfigPanel',
@@ -109,7 +113,8 @@ export default defineComponent({
     ElSwitch,
     FieldTitle,
     PromptTextarea,
-    ReferenceMediaInput
+    ReferenceMediaInput,
+    ScenarioPaymentMode
   },
   emits: ['generate'],
   data() {
@@ -133,7 +138,9 @@ export default defineComponent({
         { value: '3:4' as const, width: '17px', height: '22px' },
         { value: '9:16' as const, width: '13px', height: '25px' }
       ],
-      durations: Array.from({ length: 12 }, (_, index) => index + 4)
+      durations: Array.from({ length: 12 }, (_, index) => index + 4),
+      quoteTimer: 0,
+      quoteRunId: 0
     };
   },
   computed: {
@@ -166,18 +173,50 @@ export default defineComponent({
     },
     service() {
       return this.$store.state.minimax?.service;
+    },
+    walletMode(): boolean {
+      return isScenarioX402Enabled() && scenarioPaymentState('minimax').mode === 'wallet';
     }
   },
   watch: {
+    walletMode: {
+      handler(enabled: boolean) {
+        if (enabled) this.scheduleQuote();
+      },
+      immediate: true
+    },
     config: {
       handler(value: IMinimaxConfig) {
         this.$store.commit('minimax/setConfig', value);
+        if (this.walletMode) this.scheduleQuote();
       },
       deep: true,
       immediate: true
     }
   },
+  beforeUnmount() {
+    window.clearTimeout(this.quoteTimer);
+    this.quoteRunId += 1;
+  },
   methods: {
+    scheduleQuote() {
+      window.clearTimeout(this.quoteTimer);
+      this.quoteTimer = window.setTimeout(this.refreshQuote, 350);
+    },
+    async refreshQuote() {
+      const state = scenarioPaymentState('minimax');
+      const runId = ++this.quoteRunId;
+      state.quoteLoading = true;
+      state.quoteUsdc = undefined;
+      try {
+        const quote = await minimaxOperator.quote(buildMinimaxRequest(this.config));
+        if (runId === this.quoteRunId && state.mode === 'wallet') state.quoteUsdc = quote.amountUsdc;
+      } catch (error) {
+        console.warn('x402 quote failed', error);
+      } finally {
+        if (runId === this.quoteRunId) state.quoteLoading = false;
+      }
+    },
     onGenerate() {
       const error = validateMinimaxConfig(this.config);
       if (error) {

--- a/src/components/omni/ConfigPanel.vue
+++ b/src/components/omni/ConfigPanel.vue
@@ -8,7 +8,8 @@
       <video-input class="mb-4" />
     </div>
     <div class="flex flex-col items-center justify-center px-5 pb-5">
-      <consumption :value="consumption" :service="service" />
+      <scenario-payment-mode scenario="omni" />
+      <consumption v-if="!walletMode" :value="consumption" :service="service" />
       <el-button type="primary" class="btn w-full" round @click="onGenerate">
         <magic-icon class="mr-2" :size="'1em' as any" aria-hidden="true" focusable="false" />
         {{ $t('omni.button.generate') }}
@@ -28,6 +29,9 @@ import ReferenceImagesInput from './config/ReferenceImagesInput.vue';
 import VideoInput from './config/VideoInput.vue';
 import Consumption from '../common/Consumption.vue';
 import { getConsumption } from '@/utils';
+import ScenarioPaymentMode from '../common/ScenarioPaymentMode.vue';
+import { isScenarioX402Enabled, scenarioPaymentState } from '@/utils/x402/scenarioPayment';
+import { buildOmniRequest, omniOperator } from '@/operators/omni';
 
 export default defineComponent({
   name: 'OmniConfigPanel',
@@ -39,9 +43,13 @@ export default defineComponent({
     RatioSelector,
     ReferenceImagesInput,
     VideoInput,
-    Consumption
+    Consumption,
+    ScenarioPaymentMode
   },
   emits: ['generate'],
+  data() {
+    return { quoteTimer: 0, quoteRunId: 0 };
+  },
   computed: {
     config() {
       return this.$store.state.omni?.config;
@@ -51,9 +59,48 @@ export default defineComponent({
     },
     service() {
       return this.$store.state.omni?.service;
+    },
+    walletMode(): boolean {
+      return isScenarioX402Enabled() && scenarioPaymentState('omni').mode === 'wallet';
     }
   },
+  watch: {
+    walletMode: {
+      handler(enabled: boolean) {
+        if (enabled) this.scheduleQuote();
+      },
+      immediate: true
+    },
+    config: {
+      handler() {
+        if (this.walletMode) this.scheduleQuote();
+      },
+      deep: true
+    }
+  },
+  beforeUnmount() {
+    window.clearTimeout(this.quoteTimer);
+    this.quoteRunId += 1;
+  },
   methods: {
+    scheduleQuote() {
+      window.clearTimeout(this.quoteTimer);
+      this.quoteTimer = window.setTimeout(this.refreshQuote, 350);
+    },
+    async refreshQuote() {
+      const state = scenarioPaymentState('omni');
+      const runId = ++this.quoteRunId;
+      state.quoteLoading = true;
+      state.quoteUsdc = undefined;
+      try {
+        const quote = await omniOperator.quote(buildOmniRequest(this.config));
+        if (runId === this.quoteRunId && state.mode === 'wallet') state.quoteUsdc = quote.amountUsdc;
+      } catch (error) {
+        console.warn('x402 quote failed', error);
+      } finally {
+        if (runId === this.quoteRunId) state.quoteLoading = false;
+      }
+    },
     onGenerate() {
       this.$emit('generate');
     }

--- a/src/components/pika/ConfigPanel.vue
+++ b/src/components/pika/ConfigPanel.vue
@@ -9,7 +9,8 @@
       <ingredients-model-selector v-if="config?.ingredients" class="mb-4" />
     </div>
     <div class="flex flex-col items-center justify-center px-5 pb-5">
-      <consumption :value="consumption" :service="service" />
+      <scenario-payment-mode scenario="pika" />
+      <consumption v-if="!walletMode" :value="consumption" :service="service" />
       <el-button type="primary" class="btn w-full" round @click="onGenerate">
         <magic-icon class="mr-2" :size="'1em' as any" aria-hidden="true" focusable="false" />
         {{ $t('pika.button.generate') }}
@@ -30,6 +31,9 @@ import ImageUrlInput from './config/ImageUrlInput.vue';
 import PromptInput from './config/PromptInput.vue';
 import Consumption from '../common/Consumption.vue';
 import { getConsumption } from '@/utils';
+import ScenarioPaymentMode from '../common/ScenarioPaymentMode.vue';
+import { isScenarioX402Enabled, scenarioPaymentState } from '@/utils/x402/scenarioPayment';
+import { buildPikaRequest, pikaOperator } from '@/operators/pika';
 export default defineComponent({
   name: 'PresetPanel',
   components: {
@@ -41,9 +45,13 @@ export default defineComponent({
     IngredientsSelector,
     IngredientsModelSelector,
     ModelSelector,
-    EffectSelector
+    EffectSelector,
+    ScenarioPaymentMode
   },
   emits: ['generate'],
+  data() {
+    return { quoteTimer: 0, quoteRunId: 0 };
+  },
   computed: {
     config() {
       return this.$store.state.pika?.config;
@@ -53,9 +61,48 @@ export default defineComponent({
     },
     service() {
       return this.$store.state.pika?.service;
+    },
+    walletMode(): boolean {
+      return isScenarioX402Enabled() && scenarioPaymentState('pika').mode === 'wallet';
     }
   },
+  watch: {
+    walletMode: {
+      handler(enabled: boolean) {
+        if (enabled) this.scheduleQuote();
+      },
+      immediate: true
+    },
+    config: {
+      handler() {
+        if (this.walletMode) this.scheduleQuote();
+      },
+      deep: true
+    }
+  },
+  beforeUnmount() {
+    window.clearTimeout(this.quoteTimer);
+    this.quoteRunId += 1;
+  },
   methods: {
+    scheduleQuote() {
+      window.clearTimeout(this.quoteTimer);
+      this.quoteTimer = window.setTimeout(this.refreshQuote, 350);
+    },
+    async refreshQuote() {
+      const state = scenarioPaymentState('pika');
+      const runId = ++this.quoteRunId;
+      state.quoteLoading = true;
+      state.quoteUsdc = undefined;
+      try {
+        const quote = await pikaOperator.quote(buildPikaRequest(this.config));
+        if (runId === this.quoteRunId && state.mode === 'wallet') state.quoteUsdc = quote.amountUsdc;
+      } catch (error) {
+        console.warn('x402 quote failed', error);
+      } finally {
+        if (runId === this.quoteRunId) state.quoteLoading = false;
+      }
+    },
     onGenerate() {
       this.$emit('generate');
     }

--- a/src/components/pixverse/ConfigPanel.vue
+++ b/src/components/pixverse/ConfigPanel.vue
@@ -12,7 +12,8 @@
       <duration-selector class="mb-4" />
     </div>
     <div class="flex flex-col items-center justify-center px-5 pb-5">
-      <consumption :value="consumption" :service="service" />
+      <scenario-payment-mode scenario="pixverse" />
+      <consumption v-if="!walletMode" :value="consumption" :service="service" />
       <el-button type="primary" class="btn w-full" round @click="onGenerate">
         <magic-icon class="mr-2" :size="'1em' as any" aria-hidden="true" focusable="false" />
         {{ $t('pixverse.button.generate') }}
@@ -36,6 +37,9 @@ import StartImage from './config/StartImage.vue';
 import PromptInput from './config/PromptInput.vue';
 import Consumption from '../common/Consumption.vue';
 import { getConsumption } from '@/utils';
+import ScenarioPaymentMode from '../common/ScenarioPaymentMode.vue';
+import { isScenarioX402Enabled, scenarioPaymentState } from '@/utils/x402/scenarioPayment';
+import { buildPixverseRequest, pixverseOperator } from '@/operators/pixverse';
 
 export default defineComponent({
   name: 'ConfigPanel',
@@ -51,9 +55,13 @@ export default defineComponent({
     StartImage,
     SeedSelector,
     RatioSelector,
-    Consumption
+    Consumption,
+    ScenarioPaymentMode
   },
   emits: ['generate'],
+  data() {
+    return { quoteTimer: 0, quoteRunId: 0 };
+  },
   computed: {
     config() {
       return this.$store.state.pixverse?.config;
@@ -63,9 +71,48 @@ export default defineComponent({
     },
     service() {
       return this.$store.state.pixverse?.service;
+    },
+    walletMode(): boolean {
+      return isScenarioX402Enabled() && scenarioPaymentState('pixverse').mode === 'wallet';
     }
   },
+  watch: {
+    walletMode: {
+      handler(enabled: boolean) {
+        if (enabled) this.scheduleQuote();
+      },
+      immediate: true
+    },
+    config: {
+      handler() {
+        if (this.walletMode) this.scheduleQuote();
+      },
+      deep: true
+    }
+  },
+  beforeUnmount() {
+    window.clearTimeout(this.quoteTimer);
+    this.quoteRunId += 1;
+  },
   methods: {
+    scheduleQuote() {
+      window.clearTimeout(this.quoteTimer);
+      this.quoteTimer = window.setTimeout(this.refreshQuote, 350);
+    },
+    async refreshQuote() {
+      const state = scenarioPaymentState('pixverse');
+      const runId = ++this.quoteRunId;
+      state.quoteLoading = true;
+      state.quoteUsdc = undefined;
+      try {
+        const quote = await pixverseOperator.quote(buildPixverseRequest(this.config));
+        if (runId === this.quoteRunId && state.mode === 'wallet') state.quoteUsdc = quote.amountUsdc;
+      } catch (error) {
+        console.warn('x402 quote failed', error);
+      } finally {
+        if (runId === this.quoteRunId) state.quoteLoading = false;
+      }
+    },
     onGenerate() {
       this.$emit('generate');
     }

--- a/src/components/seedance/ConfigPanel.vue
+++ b/src/components/seedance/ConfigPanel.vue
@@ -17,7 +17,8 @@
       <reference-video class="mb-4" />
     </div>
     <div class="flex flex-col items-center justify-center px-5 pb-5">
-      <consumption :value="consumption" :service="service" />
+      <scenario-payment-mode scenario="seedance" />
+      <consumption v-if="!walletMode" :value="consumption" :service="service" />
       <el-button type="primary" class="btn w-full" round @click="onGenerate">
         <magic-icon class="mr-2" :size="'1em' as any" aria-hidden="true" focusable="false" />
         {{ $t('seedance.button.generate') }}
@@ -46,6 +47,10 @@ import ReturnLastFrameSwitch from './config/ReturnLastFrameSwitch.vue';
 import SeedInput from './config/SeedInput.vue';
 import Consumption from '../common/Consumption.vue';
 import { getConsumption } from '@/utils';
+import { normalizeSeedanceRequest } from '@/utils/seedance';
+import ScenarioPaymentMode from '../common/ScenarioPaymentMode.vue';
+import { isScenarioX402Enabled, scenarioPaymentState } from '@/utils/x402/scenarioPayment';
+import { seedanceOperator } from '@/operators/seedance';
 
 export default defineComponent({
   name: 'SeedanceConfigPanel',
@@ -66,9 +71,13 @@ export default defineComponent({
     ReferenceImage,
     ReferenceAudio,
     ReferenceVideo,
-    Consumption
+    Consumption,
+    ScenarioPaymentMode
   },
   emits: ['generate'],
+  data() {
+    return { quoteTimer: 0, quoteRunId: 0 };
+  },
   computed: {
     config() {
       return this.$store.state.seedance?.config;
@@ -78,9 +87,50 @@ export default defineComponent({
     },
     service() {
       return this.$store.state.seedance?.service;
+    },
+    walletMode(): boolean {
+      return isScenarioX402Enabled() && scenarioPaymentState('seedance').mode === 'wallet';
     }
   },
+  watch: {
+    walletMode: {
+      handler(enabled: boolean) {
+        if (enabled) this.scheduleQuote();
+      },
+      immediate: true
+    },
+    config: {
+      handler() {
+        if (this.walletMode) this.scheduleQuote();
+      },
+      deep: true
+    }
+  },
+  beforeUnmount() {
+    window.clearTimeout(this.quoteTimer);
+    this.quoteRunId += 1;
+  },
   methods: {
+    scheduleQuote() {
+      window.clearTimeout(this.quoteTimer);
+      this.quoteTimer = window.setTimeout(this.refreshQuote, 350);
+    },
+    async refreshQuote() {
+      const state = scenarioPaymentState('seedance');
+      const runId = ++this.quoteRunId;
+      state.quoteLoading = true;
+      state.quoteUsdc = undefined;
+      const { request } = normalizeSeedanceRequest(this.config);
+      try {
+        if (!request) return;
+        const quote = await seedanceOperator.quote(request);
+        if (runId === this.quoteRunId && state.mode === 'wallet') state.quoteUsdc = quote.amountUsdc;
+      } catch (error) {
+        console.warn('x402 quote failed', error);
+      } finally {
+        if (runId === this.quoteRunId) state.quoteLoading = false;
+      }
+    },
     onGenerate() {
       this.$emit('generate');
     }

--- a/src/components/sora/ConfigPanel.vue
+++ b/src/components/sora/ConfigPanel.vue
@@ -10,7 +10,8 @@
       <start-end-image v-show="config?.action === 'image2video'" class="mb-4" />
     </div>
     <div class="flex flex-col items-center justify-center px-5 pb-5">
-      <consumption :value="consumption" :service="service" />
+      <scenario-payment-mode scenario="sora" />
+      <consumption v-if="!walletMode" :value="consumption" :service="service" />
       <el-button type="primary" class="btn w-full" round @click="onGenerate">
         <magic-icon class="mr-2" :size="'1em' as any" aria-hidden="true" focusable="false" />
         {{ $t('sora.button.generate') }}
@@ -32,6 +33,9 @@ import SizeSelector from './config/SizeSelector.vue';
 import Consumption from '../common/Consumption.vue';
 import PromptInput from './config/PromptInput.vue';
 import { getConsumption } from '@/utils';
+import ScenarioPaymentMode from '../common/ScenarioPaymentMode.vue';
+import { isScenarioX402Enabled, scenarioPaymentState } from '@/utils/x402/scenarioPayment';
+import { buildSoraRequest, soraOperator } from '@/operators/sora';
 
 export default defineComponent({
   name: 'ConfigPanel',
@@ -45,9 +49,13 @@ export default defineComponent({
     SizeSelector,
     ActionSelector,
     OrientationSelector,
-    DurationSelector
+    DurationSelector,
+    ScenarioPaymentMode
   },
   emits: ['generate'],
+  data() {
+    return { quoteTimer: 0, quoteRunId: 0 };
+  },
   computed: {
     config() {
       return this.$store.state.sora?.config;
@@ -57,9 +65,48 @@ export default defineComponent({
     },
     service() {
       return this.$store.state.sora?.service;
+    },
+    walletMode(): boolean {
+      return isScenarioX402Enabled() && scenarioPaymentState('sora').mode === 'wallet';
     }
   },
+  watch: {
+    walletMode: {
+      handler(enabled: boolean) {
+        if (enabled) this.scheduleQuote();
+      },
+      immediate: true
+    },
+    config: {
+      handler() {
+        if (this.walletMode) this.scheduleQuote();
+      },
+      deep: true
+    }
+  },
+  beforeUnmount() {
+    window.clearTimeout(this.quoteTimer);
+    this.quoteRunId += 1;
+  },
   methods: {
+    scheduleQuote() {
+      window.clearTimeout(this.quoteTimer);
+      this.quoteTimer = window.setTimeout(this.refreshQuote, 350);
+    },
+    async refreshQuote() {
+      const state = scenarioPaymentState('sora');
+      const runId = ++this.quoteRunId;
+      state.quoteLoading = true;
+      state.quoteUsdc = undefined;
+      try {
+        const quote = await soraOperator.quote(buildSoraRequest(this.config));
+        if (runId === this.quoteRunId && state.mode === 'wallet') state.quoteUsdc = quote.amountUsdc;
+      } catch (error) {
+        console.warn('x402 quote failed', error);
+      } finally {
+        if (runId === this.quoteRunId) state.quoteLoading = false;
+      }
+    },
     onGenerate() {
       this.$emit('generate');
     }

--- a/src/components/veo/ConfigPanel.vue
+++ b/src/components/veo/ConfigPanel.vue
@@ -16,7 +16,8 @@
       <translation-selector class="mb-4" />
     </div>
     <div class="flex flex-col items-center justify-center px-5 pb-5">
-      <consumption :value="consumption" :service="service" />
+      <scenario-payment-mode scenario="veo" />
+      <consumption v-if="!walletMode" :value="consumption" :service="service" />
       <el-button type="primary" class="btn w-full" round @click="onGenerate">
         <magic-icon class="mr-2" :size="'1em' as any" aria-hidden="true" focusable="false" />
         {{ $t('veo.button.generate') }}
@@ -37,6 +38,9 @@ import StartEndImage from './config/StartEndImage.vue';
 import Consumption from '../common/Consumption.vue';
 import PromptInput from './config/PromptInput.vue';
 import { getConsumption } from '@/utils';
+import ScenarioPaymentMode from '../common/ScenarioPaymentMode.vue';
+import { isScenarioX402Enabled, scenarioPaymentState } from '@/utils/x402/scenarioPayment';
+import { buildVeoRequest, veoOperator } from '@/operators/veo';
 
 export default defineComponent({
   name: 'ConfigPanel',
@@ -49,9 +53,13 @@ export default defineComponent({
     StartEndImage,
     ActionSelector,
     TranslationSelector,
-    AspectRatioSelector
+    AspectRatioSelector,
+    ScenarioPaymentMode
   },
   emits: ['generate'],
+  data() {
+    return { quoteTimer: 0, quoteRunId: 0 };
+  },
   computed: {
     config() {
       return this.$store.state.veo?.config;
@@ -67,9 +75,48 @@ export default defineComponent({
     },
     service() {
       return this.$store.state.veo?.service;
+    },
+    walletMode(): boolean {
+      return isScenarioX402Enabled() && scenarioPaymentState('veo').mode === 'wallet';
     }
   },
+  watch: {
+    walletMode: {
+      handler(enabled: boolean) {
+        if (enabled) this.scheduleQuote();
+      },
+      immediate: true
+    },
+    config: {
+      handler() {
+        if (this.walletMode) this.scheduleQuote();
+      },
+      deep: true
+    }
+  },
+  beforeUnmount() {
+    window.clearTimeout(this.quoteTimer);
+    this.quoteRunId += 1;
+  },
   methods: {
+    scheduleQuote() {
+      window.clearTimeout(this.quoteTimer);
+      this.quoteTimer = window.setTimeout(this.refreshQuote, 350);
+    },
+    async refreshQuote() {
+      const state = scenarioPaymentState('veo');
+      const runId = ++this.quoteRunId;
+      state.quoteLoading = true;
+      state.quoteUsdc = undefined;
+      try {
+        const quote = await veoOperator.quote(buildVeoRequest(this.config));
+        if (runId === this.quoteRunId && state.mode === 'wallet') state.quoteUsdc = quote.amountUsdc;
+      } catch (error) {
+        console.warn('x402 quote failed', error);
+      } finally {
+        if (runId === this.quoteRunId) state.quoteLoading = false;
+      }
+    },
     onGenerate() {
       this.$emit('generate');
     }

--- a/src/components/wan/ConfigPanel.vue
+++ b/src/components/wan/ConfigPanel.vue
@@ -8,7 +8,8 @@
       <image-url-input v-if="supportsImageUrl" class="mb-4" />
     </div>
     <div class="flex flex-col items-center justify-center px-5 pb-5">
-      <consumption :value="consumption" :service="service" />
+      <scenario-payment-mode scenario="wan" />
+      <consumption v-if="!walletMode" :value="consumption" :service="service" />
       <el-button type="primary" class="btn w-full" round @click="onGenerate">
         <magic-icon class="mr-2" :size="'1em' as any" aria-hidden="true" focusable="false" />
         {{ $t('wan.button.generate') }}
@@ -28,6 +29,9 @@ import ImageUrlInput from './config/ImageUrlInput.vue';
 import PromptInput from './config/PromptInput.vue';
 import Consumption from '../common/Consumption.vue';
 import { getConsumption } from '@/utils';
+import ScenarioPaymentMode from '../common/ScenarioPaymentMode.vue';
+import { isScenarioX402Enabled, scenarioPaymentState } from '@/utils/x402/scenarioPayment';
+import { buildWanRequest, wanOperator } from '@/operators/wan';
 
 export default defineComponent({
   name: 'PresetPanel',
@@ -39,9 +43,13 @@ export default defineComponent({
     ModelSelector,
     ResolutionSelector,
     DurationSelector,
-    Consumption
+    Consumption,
+    ScenarioPaymentMode
   },
   emits: ['generate'],
+  data() {
+    return { quoteTimer: 0, quoteRunId: 0 };
+  },
   computed: {
     config() {
       return this.$store.state.wan?.config;
@@ -62,9 +70,48 @@ export default defineComponent({
     supportsImageUrl() {
       const model = this.config?.model;
       return model === 'wan2.6-i2v' || model === 'wan2.6-i2v-flash';
+    },
+    walletMode(): boolean {
+      return isScenarioX402Enabled() && scenarioPaymentState('wan').mode === 'wallet';
     }
   },
+  watch: {
+    walletMode: {
+      handler(enabled: boolean) {
+        if (enabled) this.scheduleQuote();
+      },
+      immediate: true
+    },
+    config: {
+      handler() {
+        if (this.walletMode) this.scheduleQuote();
+      },
+      deep: true
+    }
+  },
+  beforeUnmount() {
+    window.clearTimeout(this.quoteTimer);
+    this.quoteRunId += 1;
+  },
   methods: {
+    scheduleQuote() {
+      window.clearTimeout(this.quoteTimer);
+      this.quoteTimer = window.setTimeout(this.refreshQuote, 350);
+    },
+    async refreshQuote() {
+      const state = scenarioPaymentState('wan');
+      const runId = ++this.quoteRunId;
+      state.quoteLoading = true;
+      state.quoteUsdc = undefined;
+      try {
+        const quote = await wanOperator.quote(buildWanRequest(this.config));
+        if (runId === this.quoteRunId && state.mode === 'wallet') state.quoteUsdc = quote.amountUsdc;
+      } catch (error) {
+        console.warn('x402 quote failed', error);
+      } finally {
+        if (runId === this.quoteRunId) state.quoteLoading = false;
+      }
+    },
     onGenerate() {
       this.$emit('generate');
     }

--- a/src/components/x402FluxQrContract.test.ts
+++ b/src/components/x402FluxQrContract.test.ts
@@ -7,7 +7,7 @@ const source = (relativePath: string) => fs.readFileSync(path.resolve(process.cw
 describe('Flux and QR Art x402 contract', () => {
   it('adds both scenarios to the existing floating payment selector', () => {
     const main = source('layouts/Main.vue');
-    expect(main).toContain("['nanobanana', 'openaiimage', 'flux', 'qrart']");
+    ['nanobanana', 'openaiimage', 'flux', 'qrart'].forEach((scenario) => expect(main).toContain(`'${scenario}'`));
   });
 
   it('quotes and submits each scenario through its own operator', () => {

--- a/src/components/x402VideoScenariosContract.test.ts
+++ b/src/components/x402VideoScenariosContract.test.ts
@@ -1,0 +1,67 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = (relativePath: string) => fs.readFileSync(path.resolve(process.cwd(), 'src', relativePath), 'utf8');
+
+const scenarios = [
+  'luma',
+  'pika',
+  'pixverse',
+  'hailuo',
+  'veo',
+  'seedance',
+  'sora',
+  'wan',
+  'omni',
+  'grokvideo',
+  'minimax',
+  'maestro'
+] as const;
+
+const builders: Record<(typeof scenarios)[number], string> = {
+  luma: 'buildLumaRequest',
+  pika: 'buildPikaRequest',
+  pixverse: 'buildPixverseRequest',
+  hailuo: 'buildHailuoRequest',
+  veo: 'buildVeoRequest',
+  seedance: 'normalizeSeedanceRequest',
+  sora: 'buildSoraRequest',
+  wan: 'buildWanRequest',
+  omni: 'buildOmniRequest',
+  grokvideo: 'buildGrokVideoRequest',
+  minimax: 'buildMinimaxRequest',
+  maestro: 'buildMaestroRequest'
+};
+
+describe('standard video x402 contract', () => {
+  it('registers every standard video scenario in the floating payment selector', () => {
+    const main = source('layouts/Main.vue');
+    scenarios.forEach((scenario) => expect(main).toContain(`'${scenario}'`));
+  });
+
+  it.each(scenarios)('%s quotes and submits its scenario-owned request', (scenario) => {
+    const config = source(`components/${scenario}/ConfigPanel.vue`);
+    const page = source(`pages/${scenario}/Index.vue`);
+    const builder = builders[scenario];
+
+    expect(config).toContain(`<scenario-payment-mode scenario="${scenario}" />`);
+    expect(config).toContain('.quote(');
+    expect(config).toContain(builder);
+    expect(page).toContain(builder);
+    expect(page).toContain("mode: 'x402'");
+    expect(page).toContain('identityToken: this.credential?.token');
+    expect(page).toContain('walletTaskIds: string[]');
+    expect(page).toContain("mode: 'x402', ids: this.walletTaskIds");
+    expect(page).toContain('error instanceof X402PaymentCancelledError');
+  });
+
+  it('keeps wallet task discovery in memory and leaves shared history/delete behavior untouched', () => {
+    scenarios.forEach((scenario) => {
+      const page = source(`pages/${scenario}/Index.vue`);
+      expect(page).not.toContain('localStorage');
+      expect(page).not.toContain('sessionStorage');
+    });
+    expect(source('store/factories/createTaskActions.ts')).not.toContain('x402-video-standard');
+  });
+});

--- a/src/layouts/Main.vue
+++ b/src/layouts/Main.vue
@@ -61,7 +61,26 @@ export default defineComponent({
       return this.$route.meta.appName as keyof IAppState;
     },
     x402ScenarioEnabled(): boolean {
-      return ['nanobanana', 'openaiimage', 'flux', 'qrart'].includes(String(this.appName)) && isScenarioX402Enabled();
+      return (
+        [
+          'nanobanana',
+          'openaiimage',
+          'flux',
+          'qrart',
+          'luma',
+          'pika',
+          'pixverse',
+          'hailuo',
+          'veo',
+          'seedance',
+          'sora',
+          'wan',
+          'omni',
+          'grokvideo',
+          'minimax',
+          'maestro'
+        ].includes(String(this.appName)) && isScenarioX402Enabled()
+      );
     },
     application() {
       // Global application and individual application can be used here

--- a/src/operators/grokvideo.ts
+++ b/src/operators/grokvideo.ts
@@ -1,10 +1,28 @@
 import {
+  IGrokVideoConfig,
   IGrokVideoGenerateRequest,
   IGrokVideoGenerateResponse,
   IGrokVideoTaskResponse,
   IGrokVideoTasksResponse
 } from '@/models';
+import { isGrokVideoImageOnlyModel } from '@/constants';
 import { BaseTaskOperator, ITaskListFilter } from './baseTaskOperator';
+
+export function buildGrokVideoRequest(config?: IGrokVideoConfig): IGrokVideoGenerateRequest {
+  const request: IGrokVideoGenerateRequest = { ...(config || {}), async: true };
+  if (typeof request.prompt === 'string') {
+    request.prompt = request.prompt.trim();
+    if (!request.prompt) delete request.prompt;
+  }
+  if (typeof request.image_url === 'string' && !request.image_url.trim()) delete request.image_url;
+  if (
+    isGrokVideoImageOnlyModel(request.model) ||
+    !(Array.isArray(request.reference_image_urls) && request.reference_image_urls.length)
+  ) {
+    delete request.reference_image_urls;
+  }
+  return request;
+}
 
 class GrokVideoOperator extends BaseTaskOperator<
   IGrokVideoGenerateRequest,

--- a/src/operators/hailuo.ts
+++ b/src/operators/hailuo.ts
@@ -1,5 +1,15 @@
-import { IHailuoGenerateRequest, IHailuoGenerateResponse, IHailuoTaskResponse, IHailuoTasksResponse } from '@/models';
+import {
+  IHailuoConfig,
+  IHailuoGenerateRequest,
+  IHailuoGenerateResponse,
+  IHailuoTaskResponse,
+  IHailuoTasksResponse
+} from '@/models';
 import { BaseTaskOperator, ITaskListFilter } from './baseTaskOperator';
+
+export function buildHailuoRequest(config?: IHailuoConfig): IHailuoGenerateRequest {
+  return { ...(config || {}), async: true } as IHailuoGenerateRequest;
+}
 
 class HailuoOperator extends BaseTaskOperator<
   IHailuoGenerateRequest,

--- a/src/operators/luma.ts
+++ b/src/operators/luma.ts
@@ -1,5 +1,15 @@
-import { ILumaGenerateRequest, ILumaGenerateResponse, ILumaTaskResponse, ILumaTasksResponse } from '@/models';
+import {
+  ILumaConfig,
+  ILumaGenerateRequest,
+  ILumaGenerateResponse,
+  ILumaTaskResponse,
+  ILumaTasksResponse
+} from '@/models';
 import { BaseTaskOperator, ITaskListFilter } from './baseTaskOperator';
+
+export function buildLumaRequest(config?: ILumaConfig): ILumaGenerateRequest {
+  return { ...(config || {}), async: true } as ILumaGenerateRequest;
+}
 
 class LumaOperator extends BaseTaskOperator<
   ILumaGenerateRequest,

--- a/src/operators/maestro.ts
+++ b/src/operators/maestro.ts
@@ -1,10 +1,16 @@
 import {
+  IMaestroConfig,
   IMaestroGenerateRequest,
   IMaestroGenerateResponse,
   IMaestroTaskResponse,
   IMaestroTasksResponse
 } from '@/models';
+import { buildMaestroGenerateRequest } from '@/utils/maestro';
 import { BaseTaskOperator, ITaskListFilter } from './baseTaskOperator';
+
+export function buildMaestroRequest(config?: IMaestroConfig): IMaestroGenerateRequest {
+  return buildMaestroGenerateRequest(config);
+}
 
 class MaestroOperator extends BaseTaskOperator<
   IMaestroGenerateRequest,

--- a/src/operators/minimax.ts
+++ b/src/operators/minimax.ts
@@ -1,10 +1,15 @@
 import {
+  IMinimaxConfig,
   IMinimaxGenerateRequest,
   IMinimaxGenerateResponse,
   IMinimaxTaskResponse,
   IMinimaxTasksResponse
 } from '@/models';
 import { BaseTaskOperator, ITaskListFilter } from './baseTaskOperator';
+
+export function buildMinimaxRequest(config?: IMinimaxConfig): IMinimaxGenerateRequest {
+  return { ...(config || {}) } as IMinimaxGenerateRequest;
+}
 
 class MinimaxOperator extends BaseTaskOperator<
   IMinimaxGenerateRequest,

--- a/src/operators/omni.ts
+++ b/src/operators/omni.ts
@@ -1,5 +1,28 @@
-import { IOmniGenerateRequest, IOmniGenerateResponse, IOmniTaskResponse, IOmniTasksResponse } from '@/models';
+import {
+  IOmniConfig,
+  IOmniGenerateRequest,
+  IOmniGenerateResponse,
+  IOmniTaskResponse,
+  IOmniTasksResponse
+} from '@/models';
 import { BaseTaskOperator, ITaskListFilter } from './baseTaskOperator';
+
+export function buildOmniRequest(config?: IOmniConfig): IOmniGenerateRequest {
+  const request: IOmniGenerateRequest = { ...(config || {}), async: true };
+  if (typeof request.prompt === 'string') {
+    request.prompt = request.prompt.trim();
+    if (!request.prompt) delete request.prompt;
+  }
+  if (Array.isArray(request.image_urls)) {
+    request.image_urls = request.image_urls.filter((url) => typeof url === 'string' && url.trim());
+    if (!request.image_urls.length) delete request.image_urls;
+  }
+  if (Array.isArray(request.video_urls)) {
+    request.video_urls = request.video_urls.filter((url) => typeof url === 'string' && url.trim());
+    if (!request.video_urls.length) delete request.video_urls;
+  }
+  return request;
+}
 
 class OmniOperator extends BaseTaskOperator<
   IOmniGenerateRequest,

--- a/src/operators/pika.ts
+++ b/src/operators/pika.ts
@@ -1,5 +1,15 @@
-import { IPikaGenerateRequest, IPikaGenerateResponse, IPikaTaskResponse, IPikaTasksResponse } from '@/models';
+import {
+  IPikaConfig,
+  IPikaGenerateRequest,
+  IPikaGenerateResponse,
+  IPikaTaskResponse,
+  IPikaTasksResponse
+} from '@/models';
 import { BaseTaskOperator, ITaskListFilter } from './baseTaskOperator';
+
+export function buildPikaRequest(config?: IPikaConfig): IPikaGenerateRequest {
+  return { ...(config || {}), async: true } as IPikaGenerateRequest;
+}
 
 class PikaOperator extends BaseTaskOperator<
   IPikaGenerateRequest,

--- a/src/operators/pixverse.ts
+++ b/src/operators/pixverse.ts
@@ -1,10 +1,15 @@
 import {
+  IPixverseConfig,
   IPixverseGenerateRequest,
   IPixverseGenerateResponse,
   IPixverseTaskResponse,
   IPixverseTasksResponse
 } from '@/models';
 import { BaseTaskOperator, ITaskListFilter } from './baseTaskOperator';
+
+export function buildPixverseRequest(config?: IPixverseConfig): IPixverseGenerateRequest {
+  return { ...(config || {}), async: true } as IPixverseGenerateRequest;
+}
 
 class PixverseOperator extends BaseTaskOperator<
   IPixverseGenerateRequest,

--- a/src/operators/seedance.ts
+++ b/src/operators/seedance.ts
@@ -7,6 +7,26 @@ import {
 } from '@/models';
 import type { AxiosResponse } from 'axios';
 import { BaseTaskOperator, ITaskListFilter } from './baseTaskOperator';
+import type { OperatorRequestOptions } from './x402';
+
+export function buildSeedanceRequest(data: ISeedanceGenerateRequest): ISeedanceGenerateRequest {
+  const audios = (data.audios ?? []).filter((audio) => audio?.url);
+  const videos = (data.videos ?? []).filter((video) => video?.url);
+  if (audios.length === 0 && videos.length === 0) {
+    const { audios: _audios, videos: _videos, content: _content, ...rest } = data;
+    return rest;
+  }
+  const content: ISeedanceContentItem[] = [];
+  const prompt = (data.prompt ?? '').trim();
+  if (prompt) content.push({ type: 'text', text: prompt });
+  (data.images ?? []).forEach((image) => {
+    if (image?.url) content.push({ type: 'image_url', role: image.role, image_url: { url: image.url } });
+  });
+  audios.forEach((audio) => content.push({ type: 'audio_url', audio_url: { url: audio.url } }));
+  videos.forEach((video) => content.push({ type: 'video_url', video_url: { url: video.url } }));
+  const { prompt: _prompt, images: _images, audios: _audios, videos: _videos, ...rest } = data;
+  return { ...rest, content };
+}
 
 class SeedanceOperator extends BaseTaskOperator<
   ISeedanceGenerateRequest,
@@ -19,38 +39,15 @@ class SeedanceOperator extends BaseTaskOperator<
     super({ tasksPath: '/seedance/tasks', generatePath: '/seedance/videos' });
   }
 
-  // Reference audio/video can only travel via the native multimodal `content[]`
-  // array (the flat `images[]` path the API exposes is image-only). When the
-  // request carries audio or video, fold prompt + images + audios + videos into
-  // a single `content[]` and drop the flat fields; otherwise send as-is.
-  async generate(
-    data: ISeedanceGenerateRequest,
-    options: { token: string }
-  ): Promise<AxiosResponse<ISeedanceGenerateResponse>> {
-    return super.generate(this.buildRequest(data), options);
+  async quote(data: ISeedanceGenerateRequest) {
+    return super.quote(buildSeedanceRequest(data));
   }
 
-  private buildRequest(data: ISeedanceGenerateRequest): ISeedanceGenerateRequest {
-    const audios = (data.audios ?? []).filter((a) => a?.url);
-    const videos = (data.videos ?? []).filter((v) => v?.url);
-    if (audios.length === 0 && videos.length === 0) {
-      const { audios: _audios, videos: _videos, content: _content, ...rest } = data;
-      return rest;
-    }
-    const content: ISeedanceContentItem[] = [];
-    const prompt = (data.prompt ?? '').trim();
-    if (prompt) {
-      content.push({ type: 'text', text: prompt });
-    }
-    (data.images ?? []).forEach((image) => {
-      if (image?.url) {
-        content.push({ type: 'image_url', role: image.role, image_url: { url: image.url } });
-      }
-    });
-    audios.forEach((audio) => content.push({ type: 'audio_url', audio_url: { url: audio.url } }));
-    videos.forEach((video) => content.push({ type: 'video_url', video_url: { url: video.url } }));
-    const { prompt: _prompt, images: _images, audios: _audios, videos: _videos, ...rest } = data;
-    return { ...rest, content };
+  async generate(
+    data: ISeedanceGenerateRequest,
+    options: OperatorRequestOptions
+  ): Promise<AxiosResponse<ISeedanceGenerateResponse>> {
+    return super.generate(buildSeedanceRequest(data), options);
   }
 }
 

--- a/src/operators/sora.ts
+++ b/src/operators/sora.ts
@@ -1,5 +1,15 @@
-import { ISoraGenerateRequest, ISoraGenerateResponse, ISoraTaskResponse, ISoraTasksResponse } from '@/models';
+import {
+  ISoraConfig,
+  ISoraGenerateRequest,
+  ISoraGenerateResponse,
+  ISoraTaskResponse,
+  ISoraTasksResponse
+} from '@/models';
 import { BaseTaskOperator, ITaskListFilter } from './baseTaskOperator';
+
+export function buildSoraRequest(config?: ISoraConfig): ISoraGenerateRequest {
+  return { ...(config || {}), async: true } as ISoraGenerateRequest;
+}
 
 class SoraOperator extends BaseTaskOperator<
   ISoraGenerateRequest,

--- a/src/operators/veo.ts
+++ b/src/operators/veo.ts
@@ -1,5 +1,10 @@
-import { IVeoGenerateRequest, IVeoGenerateResponse, IVeoTaskResponse, IVeoTasksResponse } from '@/models';
+import { IVeoConfig, IVeoGenerateRequest, IVeoGenerateResponse, IVeoTaskResponse, IVeoTasksResponse } from '@/models';
+import { buildVeoGenerateRequest } from '@/utils/veo/config';
 import { BaseTaskOperator, ITaskListFilter } from './baseTaskOperator';
+
+export function buildVeoRequest(config?: IVeoConfig): IVeoGenerateRequest {
+  return buildVeoGenerateRequest(config);
+}
 
 class VeoOperator extends BaseTaskOperator<
   IVeoGenerateRequest,

--- a/src/operators/wan.ts
+++ b/src/operators/wan.ts
@@ -1,5 +1,9 @@
-import { IWanGenerateRequest, IWanGenerateResponse, IWanTaskResponse, IWanTasksResponse } from '@/models';
+import { IWanConfig, IWanGenerateRequest, IWanGenerateResponse, IWanTaskResponse, IWanTasksResponse } from '@/models';
 import { BaseTaskOperator, ITaskListFilter } from './baseTaskOperator';
+
+export function buildWanRequest(config?: IWanConfig): IWanGenerateRequest {
+  return { ...(config || {}), async: true } as IWanGenerateRequest;
+}
 
 class WanOperator extends BaseTaskOperator<
   IWanGenerateRequest,

--- a/src/operators/x402ScenarioRequests.test.ts
+++ b/src/operators/x402ScenarioRequests.test.ts
@@ -1,6 +1,18 @@
 import { describe, expect, it } from 'vitest';
 import { buildFluxRequest } from './flux';
 import { buildQrartRequest } from './qrart';
+import { buildLumaRequest } from './luma';
+import { buildPikaRequest } from './pika';
+import { buildPixverseRequest } from './pixverse';
+import { buildHailuoRequest } from './hailuo';
+import { buildVeoRequest } from './veo';
+import { buildSeedanceRequest } from './seedance';
+import { buildSoraRequest } from './sora';
+import { buildWanRequest } from './wan';
+import { buildOmniRequest } from './omni';
+import { buildGrokVideoRequest } from './grokvideo';
+import { buildMinimaxRequest } from './minimax';
+import { buildMaestroRequest } from './maestro';
 
 describe('scenario-owned x402 requests', () => {
   it('preserves selected Flux pricing parameters', () => {
@@ -46,5 +58,102 @@ describe('scenario-owned x402 requests', () => {
       padding_noise: 0.2,
       async: true
     });
+  });
+
+  it.each([
+    ['luma', buildLumaRequest, { prompt: 'video', enhancement: true, loop: true }],
+    ['pika', buildPikaRequest, { model: 'pika-2.2', prompt: 'video', ingredients: true }],
+    ['pixverse', buildPixverseRequest, { model: 'v4.5', duration: 8, quality: '1080p' }],
+    ['hailuo', buildHailuoRequest, { model: 'MiniMax-Hailuo-02', prompt: 'video' }],
+    ['sora', buildSoraRequest, { model: 'sora-2', duration: 12, size: '1280x720' }],
+    ['wan', buildWanRequest, { model: 'wan2.6-i2v', duration: 10, resolution: '1080p' }]
+  ])('preserves %s pricing inputs and enables async mode', (_scenario, builder, config) => {
+    expect(builder(config as never)).toMatchObject({ ...config, async: true });
+  });
+
+  it('uses the existing Veo action normalizer for quote and submit payloads', () => {
+    expect(buildVeoRequest({ action: 'ingredients2video', image_urls: ['a', 'b', 'c', 'd'] })).toMatchObject({
+      action: 'ingredients2video',
+      model: 'veo31-fast-ingredients',
+      image_urls: ['a', 'b', 'c'],
+      async: true
+    });
+  });
+
+  it('folds Seedance audio and video references into the native content array', () => {
+    expect(
+      buildSeedanceRequest({
+        model: 'seedance-2.0',
+        prompt: '  animate  ',
+        images: [{ role: 'reference_image', url: 'https://example.com/image.png' }],
+        audios: [{ url: 'https://example.com/audio.mp3' }],
+        videos: [{ url: 'https://example.com/video.mp4' }],
+        async: true
+      })
+    ).toMatchObject({
+      model: 'seedance-2.0',
+      async: true,
+      content: [
+        { type: 'text', text: 'animate' },
+        { type: 'image_url', role: 'reference_image' },
+        { type: 'audio_url' },
+        { type: 'video_url' }
+      ]
+    });
+  });
+
+  it('cleans Omni and Grok reference inputs without losing pricing fields', () => {
+    expect(
+      buildOmniRequest({
+        model: 'veo-3.1-generate-preview',
+        prompt: '  animate  ',
+        image_urls: ['', 'https://example.com/image.png'],
+        video_urls: [],
+        resolution: '1080p'
+      })
+    ).toEqual({
+      model: 'veo-3.1-generate-preview',
+      prompt: 'animate',
+      image_urls: ['https://example.com/image.png'],
+      resolution: '1080p',
+      async: true
+    });
+    expect(
+      buildGrokVideoRequest({
+        model: 'grok-imagine-video-1.5:official',
+        prompt: '  animate  ',
+        image_url: 'https://example.com/image.png',
+        reference_image_urls: ['https://example.com/reference.png'],
+        duration: 15,
+        resolution: '1080p'
+      })
+    ).toEqual({
+      model: 'grok-imagine-video-1.5:official',
+      prompt: 'animate',
+      image_url: 'https://example.com/image.png',
+      duration: 15,
+      resolution: '1080p',
+      async: true
+    });
+  });
+
+  it('preserves native MiniMax and Maestro wire contracts', () => {
+    expect(
+      buildMinimaxRequest({
+        model: 'MiniMax-H3',
+        content: [{ type: 'text', text: 'video' }],
+        resolution: '2K',
+        duration: 10
+      })
+    ).not.toHaveProperty('async');
+    expect(
+      buildMaestroRequest({
+        prompt: 'video',
+        duration: 30,
+        quality: 'premium',
+        scenario_customization_enabled: true,
+        scenario: 'drama'
+      })
+    ).toMatchObject({ prompt: 'video', duration: 30, quality: 'premium', scenario: 'drama' });
   });
 });

--- a/src/pages/grokvideo/Index.vue
+++ b/src/pages/grokvideo/Index.vue
@@ -14,19 +14,22 @@ import { defineComponent } from 'vue';
 import Layout from '@/layouts/GrokVideo.vue';
 import ConfigPanel from '@/components/grokvideo/ConfigPanel.vue';
 import RecentPanel from '@/components/grokvideo/RecentPanel.vue';
-import { grokvideoOperator } from '@/operators';
+import { buildGrokVideoRequest, grokvideoOperator } from '@/operators/grokvideo';
 import { instrumentGeneration } from '@/plugins/telemetry';
-import { IGrokVideoGenerateRequest, IGrokVideoTask, Status } from '@/models';
-import { ElMessage } from 'element-plus';
+import { IGrokVideoTask, Status } from '@/models';
+import { ElMessage, ElMessageBox } from 'element-plus';
 import { ERROR_CODE_USED_UP, isGrokVideoImageOnlyModel } from '@/constants';
 import { loadPreviousPage } from '@/utils/pagination';
 import { uploadTrackerProviderMixin, ensureNoPendingUpload, ensureLoggedIn } from '@/utils';
+import { isScenarioX402Enabled, scenarioPaymentState } from '@/utils/x402/scenarioPayment';
+import { X402PaymentCancelledError, type X402PaymentQuote, type X402WalletContext } from '@/operators/x402';
 
 interface IData {
   task: IGrokVideoTask | undefined;
   job: number;
   loadingMore: boolean;
   fetchingTasks: boolean;
+  walletTaskIds: string[];
 }
 
 export default defineComponent({
@@ -43,7 +46,8 @@ export default defineComponent({
       task: undefined,
       job: 0,
       loadingMore: false,
-      fetchingTasks: false
+      fetchingTasks: false,
+      walletTaskIds: []
     };
   },
   computed: {
@@ -61,17 +65,33 @@ export default defineComponent({
     },
     tasks() {
       return this.$store.state.grokvideo?.tasks;
+    },
+    walletMode(): boolean {
+      return isScenarioX402Enabled() && scenarioPaymentState('grokvideo').mode === 'wallet';
     }
   },
   watch: {
+    walletMode: {
+      async handler(value: boolean, oldValue: boolean | undefined) {
+        if (oldValue === undefined || value === oldValue) return;
+        this.$store.commit('grokvideo/setTasks', undefined);
+        if (value && !this.job) this.job = window.setInterval(this.onGetTasks, 5000);
+        if (!value && !this.credential?.token) {
+          window.clearInterval(this.job);
+          this.job = 0;
+          await this.onScrollDown();
+          return;
+        }
+        await this.onGetTasks();
+        await this.onScrollDown();
+      }
+    },
     initialized: {
       async handler(newValue) {
         if (newValue) {
           await this.onGetTasks();
           await this.onScrollDown();
-          this.job = window.setInterval(() => {
-            this.onGetTasks();
-          }, 5000);
+          if (!this.job) this.job = window.setInterval(this.onGetTasks, 5000);
         }
       },
       immediate: true
@@ -117,7 +137,8 @@ export default defineComponent({
         await this.$store.dispatch('grokvideo/getTasks', {
           limit,
           createdAtMin,
-          createdAtMax
+          createdAtMax,
+          ...(this.walletMode && !this.credential?.token ? { mode: 'x402', ids: this.walletTaskIds } : {})
         });
       } finally {
         this.fetchingTasks = false;
@@ -133,57 +154,56 @@ export default defineComponent({
       ) {
         return;
       }
-      const cfg: any = { ...(this.config || {}) };
-      if (typeof cfg?.prompt === 'string') {
-        cfg.prompt = cfg.prompt.trim();
-        if (!cfg.prompt) delete cfg.prompt;
-      }
-      if (typeof cfg?.image_url === 'string' && !cfg.image_url.trim()) {
-        delete cfg.image_url;
-      }
-      // Drop stale reference images (e.g. uploaded then switched to an
-      // image-only model) and empty arrays.
-      if (
-        isGrokVideoImageOnlyModel(cfg?.model) ||
-        !(Array.isArray(cfg?.reference_image_urls) && cfg.reference_image_urls.length)
-      ) {
-        delete cfg.reference_image_urls;
-      }
-
-      const hasImage = !!cfg?.image_url;
+      const request = buildGrokVideoRequest(this.config);
+      const hasImage = !!request.image_url;
       // grok-imagine-video-1.5:official is image-to-video only.
-      if (isGrokVideoImageOnlyModel(cfg?.model) && !hasImage) {
+      if (isGrokVideoImageOnlyModel(request.model) && !hasImage) {
         ElMessage.warning(this.$t('grokvideo.message.modelRequiresImage'));
         return;
       }
       // Text-to-video needs a prompt when no image is provided.
-      if (!hasImage && !cfg?.prompt) {
+      if (!hasImage && !request.prompt) {
         ElMessage.warning(this.$t('grokvideo.message.promptOrImageRequired'));
         return;
       }
 
-      const request = {
-        ...cfg,
-        async: true
-      } as IGrokVideoGenerateRequest;
-
-      if (!ensureLoggedIn()) {
-        return;
-      }
-      const token = this.credential?.token;
-      if (!token) {
-        console.error('no token specified');
-        return;
+      let operation: Promise<unknown>;
+      if (this.walletMode) {
+        const wallet = this.getWalletContext();
+        if (!wallet) {
+          ElMessage.warning(this.$t('common.x402Scenario.connectWalletFirst'));
+          return;
+        }
+        operation = grokvideoOperator.generate(request, {
+          mode: 'x402',
+          x402: {
+            wallet,
+            confirm: (quote) => this.confirmWalletPayment(quote),
+            identityToken: this.credential?.token
+          }
+        });
+      } else {
+        if (!ensureLoggedIn()) return;
+        const token = this.credential?.token;
+        if (!token) return;
+        operation = grokvideoOperator.generate(request, { token });
       }
       ElMessage.info(this.$t('grokvideo.message.startingTask'));
-      instrumentGeneration('grokvideo', grokvideoOperator.generate(request, { token }))
-        .then(() => {
+      instrumentGeneration('grokvideo', operation)
+        .then((response: any) => {
+          const taskId = response?.data?.task_id;
+          if (this.walletMode && !this.credential?.token && taskId && !this.walletTaskIds.includes(taskId)) {
+            this.walletTaskIds.unshift(taskId);
+          }
           ElMessage.success(this.$t('grokvideo.message.startTaskSuccess'));
         })
         .catch((error) => {
           const response = error?.response?.data;
+          if (error instanceof X402PaymentCancelledError) return;
           if (response?.error?.code === ERROR_CODE_USED_UP) {
             ElMessage.error(this.$t('grokvideo.message.usedUp'));
+          } else if (this.walletMode) {
+            ElMessage.error(`${this.$t('common.x402Scenario.paymentFailed')} ${error?.message || ''}`.trim());
           } else {
             ElMessage.error(this.$t('grokvideo.message.startTaskFailed') + (response?.error?.message || ''));
           }
@@ -194,6 +214,26 @@ export default defineComponent({
             await this.onScrollDown();
           }, 1000);
         });
+    },
+    getWalletContext(): X402WalletContext | undefined {
+      const walletApi = (this as any).$wallet;
+      const publicKey = walletApi?.publicKey?.value;
+      const adapter = walletApi?.wallet?.value?.adapter;
+      if (!publicKey || !adapter?.signTransaction) return undefined;
+      return { publicKey, signTransaction: adapter.signTransaction.bind(adapter) };
+    },
+    async confirmWalletPayment(quote: X402PaymentQuote): Promise<boolean> {
+      return ElMessageBox.confirm(
+        this.$t('common.x402Scenario.confirmPayment', { amount: quote.amountUsdc }),
+        this.$t('order.message.x402ConfirmTitle'),
+        {
+          confirmButtonText: this.$t('order.message.x402WalletPayCta'),
+          cancelButtonText: this.$t('common.button.cancel'),
+          type: 'warning'
+        }
+      )
+        .then(() => true)
+        .catch(() => false);
     },
     getTasksScrollElement(): HTMLElement | undefined {
       const panel = this.$refs.recentPanel as any;

--- a/src/pages/hailuo/Index.vue
+++ b/src/pages/hailuo/Index.vue
@@ -13,21 +13,24 @@
 import { defineComponent } from 'vue';
 import Layout from '@/layouts/Hailuo.vue';
 import ConfigPanel from '@/components/hailuo/ConfigPanel.vue';
-import { hailuoOperator } from '@/operators';
+import { buildHailuoRequest, hailuoOperator } from '@/operators/hailuo';
 import { instrumentGeneration } from '@/plugins/telemetry';
-import { IHailuoGenerateRequest, Status } from '@/models';
-import { ElMessage } from 'element-plus';
+import { Status } from '@/models';
+import { ElMessage, ElMessageBox } from 'element-plus';
 import { ERROR_CODE_USED_UP } from '@/constants';
 import RecentPanel from '@/components/hailuo/RecentPanel.vue';
 import { IHailuoTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
 import { uploadTrackerProviderMixin, ensureNoPendingUpload, ensureLoggedIn } from '@/utils';
+import { isScenarioX402Enabled, scenarioPaymentState } from '@/utils/x402/scenarioPayment';
+import { X402PaymentCancelledError, type X402PaymentQuote, type X402WalletContext } from '@/operators/x402';
 
 interface IData {
   task: IHailuoTask | undefined;
   job: number;
   loadingMore: boolean;
   fetchingTasks: boolean;
+  walletTaskIds: string[];
 }
 
 export default defineComponent({
@@ -46,7 +49,8 @@ export default defineComponent({
       // @ts-ignore
       timer: undefined,
       loadingMore: false,
-      fetchingTasks: false
+      fetchingTasks: false,
+      walletTaskIds: []
     };
   },
   computed: {
@@ -67,9 +71,27 @@ export default defineComponent({
     },
     tasks() {
       return this.$store.state.hailuo.tasks;
+    },
+    walletMode(): boolean {
+      return isScenarioX402Enabled() && scenarioPaymentState('hailuo').mode === 'wallet';
     }
   },
   watch: {
+    walletMode: {
+      async handler(value: boolean, oldValue: boolean | undefined) {
+        if (oldValue === undefined || value === oldValue) return;
+        this.$store.commit('hailuo/setTasks', undefined);
+        if (value && !this.job) this.job = window.setInterval(this.onGetTasks, 5000);
+        if (!value && !this.credential?.token) {
+          window.clearInterval(this.job);
+          this.job = 0;
+          await this.onScrollDown();
+          return;
+        }
+        await this.onGetTasks();
+        await this.onScrollDown();
+      }
+    },
     tasks: {
       handler(value, oldValue) {
         // scroll down if new tasks are added
@@ -86,9 +108,7 @@ export default defineComponent({
           console.debug('layout initialized');
           await this.onGetTasks();
           await this.onScrollDown();
-          this.job = window.setInterval(() => {
-            this.onGetTasks();
-          }, 5000);
+          if (!this.job) this.job = window.setInterval(this.onGetTasks, 5000);
         }
       },
       immediate: true
@@ -146,7 +166,8 @@ export default defineComponent({
         await this.$store.dispatch('hailuo/getTasks', {
           limit,
           createdAtMin,
-          createdAtMax
+          createdAtMax,
+          ...(this.walletMode && !this.credential?.token ? { mode: 'x402', ids: this.walletTaskIds } : {})
         });
       } finally {
         this.fetchingTasks = false;
@@ -162,27 +183,44 @@ export default defineComponent({
       ) {
         return;
       }
-      const request = {
-        ...this.config,
-        async: true
-      } as IHailuoGenerateRequest;
-      if (!ensureLoggedIn()) {
-        return;
-      }
-      const token = this.credential?.token;
-      if (!token) {
-        console.error('no token specified');
-        return;
+      const request = buildHailuoRequest(this.config);
+      let operation: Promise<unknown>;
+      if (this.walletMode) {
+        const wallet = this.getWalletContext();
+        if (!wallet) {
+          ElMessage.warning(this.$t('common.x402Scenario.connectWalletFirst'));
+          return;
+        }
+        operation = hailuoOperator.generate(request, {
+          mode: 'x402',
+          x402: {
+            wallet,
+            confirm: (quote) => this.confirmWalletPayment(quote),
+            identityToken: this.credential?.token
+          }
+        });
+      } else {
+        if (!ensureLoggedIn()) return;
+        const token = this.credential?.token;
+        if (!token) return;
+        operation = hailuoOperator.generate(request, { token });
       }
       ElMessage.info(this.$t('hailuo.message.startingTask'));
-      instrumentGeneration('hailuo', hailuoOperator.generate(request, { token }))
-        .then(() => {
+      instrumentGeneration('hailuo', operation)
+        .then((response: any) => {
+          const taskId = response?.data?.task_id;
+          if (this.walletMode && !this.credential?.token && taskId && !this.walletTaskIds.includes(taskId)) {
+            this.walletTaskIds.unshift(taskId);
+          }
           ElMessage.success(this.$t('hailuo.message.startTaskSuccess'));
         })
         .catch((error) => {
           const response = error?.response?.data;
+          if (error instanceof X402PaymentCancelledError) return;
           if (response?.error?.code === ERROR_CODE_USED_UP) {
             ElMessage.error(this.$t('hailuo.message.usedUp'));
+          } else if (this.walletMode) {
+            ElMessage.error(`${this.$t('common.x402Scenario.paymentFailed')} ${error?.message || ''}`.trim());
           } else {
             ElMessage.error(this.$t('hailuo.message.startTaskFailed'));
           }
@@ -193,6 +231,26 @@ export default defineComponent({
             await this.onScrollDown();
           }, 1000);
         });
+    },
+    getWalletContext(): X402WalletContext | undefined {
+      const walletApi = (this as any).$wallet;
+      const publicKey = walletApi?.publicKey?.value;
+      const adapter = walletApi?.wallet?.value?.adapter;
+      if (!publicKey || !adapter?.signTransaction) return undefined;
+      return { publicKey, signTransaction: adapter.signTransaction.bind(adapter) };
+    },
+    async confirmWalletPayment(quote: X402PaymentQuote): Promise<boolean> {
+      return ElMessageBox.confirm(
+        this.$t('common.x402Scenario.confirmPayment', { amount: quote.amountUsdc }),
+        this.$t('order.message.x402ConfirmTitle'),
+        {
+          confirmButtonText: this.$t('order.message.x402WalletPayCta'),
+          cancelButtonText: this.$t('common.button.cancel'),
+          type: 'warning'
+        }
+      )
+        .then(() => true)
+        .catch(() => false);
     },
     getTasksScrollElement(): HTMLElement | undefined {
       const panel = this.$refs.recentPanel as any;

--- a/src/pages/luma/Index.vue
+++ b/src/pages/luma/Index.vue
@@ -13,21 +13,24 @@
 import { defineComponent } from 'vue';
 import Layout from '@/layouts/Luma.vue';
 import ConfigPanel from '@/components/luma/ConfigPanel.vue';
-import { lumaOperator } from '@/operators';
+import { buildLumaRequest, lumaOperator } from '@/operators/luma';
 import { instrumentGeneration } from '@/plugins/telemetry';
-import { ILumaGenerateRequest, Status } from '@/models';
-import { ElMessage } from 'element-plus';
+import { Status } from '@/models';
+import { ElMessage, ElMessageBox } from 'element-plus';
 import { ERROR_CODE_USED_UP } from '@/constants';
 import RecentPanel from '@/components/luma/RecentPanel.vue';
 import { ILumaTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
 import { uploadTrackerProviderMixin, ensureNoPendingUpload, ensureLoggedIn } from '@/utils';
+import { isScenarioX402Enabled, scenarioPaymentState } from '@/utils/x402/scenarioPayment';
+import { X402PaymentCancelledError, type X402PaymentQuote, type X402WalletContext } from '@/operators/x402';
 
 interface IData {
   task: ILumaTask | undefined;
   job: number;
   loadingMore: boolean;
   fetchingTasks: boolean;
+  walletTaskIds: string[];
 }
 
 export default defineComponent({
@@ -45,7 +48,8 @@ export default defineComponent({
       task: undefined,
       job: 0,
       loadingMore: false,
-      fetchingTasks: false
+      fetchingTasks: false,
+      walletTaskIds: []
     };
   },
   computed: {
@@ -66,9 +70,27 @@ export default defineComponent({
     },
     tasks() {
       return this.$store.state.luma.tasks;
+    },
+    walletMode(): boolean {
+      return isScenarioX402Enabled() && scenarioPaymentState('luma').mode === 'wallet';
     }
   },
   watch: {
+    walletMode: {
+      async handler(value: boolean, oldValue: boolean | undefined) {
+        if (oldValue === undefined || value === oldValue) return;
+        this.$store.commit('luma/setTasks', undefined);
+        if (value && !this.job) this.job = window.setInterval(this.onGetTasks, 5000);
+        if (!value && !this.credential?.token) {
+          window.clearInterval(this.job);
+          this.job = 0;
+          await this.onScrollDown();
+          return;
+        }
+        await this.onGetTasks();
+        await this.onScrollDown();
+      }
+    },
     tasks: {
       handler(value, oldValue) {
         // scroll down if new tasks are added
@@ -85,9 +107,7 @@ export default defineComponent({
           console.debug('layout initialized');
           await this.onGetTasks();
           await this.onScrollDown();
-          this.job = window.setInterval(() => {
-            this.onGetTasks();
-          }, 5000);
+          if (!this.job) this.job = window.setInterval(this.onGetTasks, 5000);
         }
       },
       immediate: true
@@ -146,7 +166,8 @@ export default defineComponent({
         await this.$store.dispatch('luma/getTasks', {
           limit,
           createdAtMin,
-          createdAtMax
+          createdAtMax,
+          ...(this.walletMode && !this.credential?.token ? { mode: 'x402', ids: this.walletTaskIds } : {})
         });
       } finally {
         this.fetchingTasks = false;
@@ -162,32 +183,49 @@ export default defineComponent({
       ) {
         return;
       }
-      const request = {
-        ...this.config,
-        async: true
-      } as ILumaGenerateRequest;
+      const request = buildLumaRequest(this.config);
       if (!this.hasText(request.prompt)) {
         ElMessage.error(this.$t('luma.message.promptRequired'));
         return;
       }
       request.prompt = request.prompt?.trim();
-      if (!ensureLoggedIn()) {
-        return;
-      }
-      const token = this.credential?.token;
-      if (!token) {
-        console.error('no token specified');
-        return;
+      let operation: Promise<unknown>;
+      if (this.walletMode) {
+        const wallet = this.getWalletContext();
+        if (!wallet) {
+          ElMessage.warning(this.$t('common.x402Scenario.connectWalletFirst'));
+          return;
+        }
+        operation = lumaOperator.generate(request, {
+          mode: 'x402',
+          x402: {
+            wallet,
+            confirm: (quote) => this.confirmWalletPayment(quote),
+            identityToken: this.credential?.token
+          }
+        });
+      } else {
+        if (!ensureLoggedIn()) return;
+        const token = this.credential?.token;
+        if (!token) return;
+        operation = lumaOperator.generate(request, { token });
       }
       ElMessage.info(this.$t('luma.message.startingTask'));
-      instrumentGeneration('luma', lumaOperator.generate(request, { token }))
-        .then(() => {
+      instrumentGeneration('luma', operation)
+        .then((response: any) => {
+          const taskId = response?.data?.task_id;
+          if (this.walletMode && !this.credential?.token && taskId && !this.walletTaskIds.includes(taskId)) {
+            this.walletTaskIds.unshift(taskId);
+          }
           ElMessage.success(this.$t('luma.message.startTaskSuccess'));
         })
         .catch((error) => {
           const response = error?.response?.data;
+          if (error instanceof X402PaymentCancelledError) return;
           if (response?.error?.code === ERROR_CODE_USED_UP) {
             ElMessage.error(this.$t('luma.message.usedUp'));
+          } else if (this.walletMode) {
+            ElMessage.error(`${this.$t('common.x402Scenario.paymentFailed')} ${error?.message || ''}`.trim());
           } else {
             ElMessage.error(this.$t('luma.message.startTaskFailed'));
           }
@@ -198,6 +236,26 @@ export default defineComponent({
             await this.onScrollDown();
           }, 1000);
         });
+    },
+    getWalletContext(): X402WalletContext | undefined {
+      const walletApi = (this as any).$wallet;
+      const publicKey = walletApi?.publicKey?.value;
+      const adapter = walletApi?.wallet?.value?.adapter;
+      if (!publicKey || !adapter?.signTransaction) return undefined;
+      return { publicKey, signTransaction: adapter.signTransaction.bind(adapter) };
+    },
+    async confirmWalletPayment(quote: X402PaymentQuote): Promise<boolean> {
+      return ElMessageBox.confirm(
+        this.$t('common.x402Scenario.confirmPayment', { amount: quote.amountUsdc }),
+        this.$t('order.message.x402ConfirmTitle'),
+        {
+          confirmButtonText: this.$t('order.message.x402WalletPayCta'),
+          cancelButtonText: this.$t('common.button.cancel'),
+          type: 'warning'
+        }
+      )
+        .then(() => true)
+        .catch(() => false);
     },
     getTasksScrollElement(): HTMLElement | undefined {
       const panel = this.$refs.recentPanel as any;

--- a/src/pages/maestro/Index.vue
+++ b/src/pages/maestro/Index.vue
@@ -14,19 +14,21 @@ import { defineComponent } from 'vue';
 import Layout from '@/layouts/Maestro.vue';
 import ConfigPanel from '@/components/maestro/ConfigPanel.vue';
 import RecentPanel from '@/components/maestro/RecentPanel.vue';
-import { maestroOperator } from '@/operators';
+import { buildMaestroRequest, maestroOperator } from '@/operators/maestro';
 import { ensureLoggedIn } from '@/utils';
 import { instrumentGeneration } from '@/plugins/telemetry';
-import { IMaestroGenerateRequest, Status } from '@/models';
-import { ElMessage } from 'element-plus';
+import { Status } from '@/models';
+import { ElMessage, ElMessageBox } from 'element-plus';
 import { ERROR_CODE_USED_UP } from '@/constants';
 import { loadPreviousPage } from '@/utils/pagination';
-import { buildMaestroGenerateRequest } from '@/utils/maestro';
+import { isScenarioX402Enabled, scenarioPaymentState } from '@/utils/x402/scenarioPayment';
+import { X402PaymentCancelledError, type X402PaymentQuote, type X402WalletContext } from '@/operators/x402';
 
 interface IData {
   job: number;
   loadingMore: boolean;
   fetchingTasks: boolean;
+  walletTaskIds: string[];
 }
 
 export default defineComponent({
@@ -41,7 +43,8 @@ export default defineComponent({
     return {
       job: 0,
       loadingMore: false,
-      fetchingTasks: false
+      fetchingTasks: false,
+      walletTaskIds: []
     };
   },
   computed: {
@@ -59,17 +62,33 @@ export default defineComponent({
     },
     tasks() {
       return this.$store.state.maestro.tasks;
+    },
+    walletMode(): boolean {
+      return isScenarioX402Enabled() && scenarioPaymentState('maestro').mode === 'wallet';
     }
   },
   watch: {
+    walletMode: {
+      async handler(value: boolean, oldValue: boolean | undefined) {
+        if (oldValue === undefined || value === oldValue) return;
+        this.$store.commit('maestro/setTasks', undefined);
+        if (value && !this.job) this.job = window.setInterval(this.onGetTasks, 5000);
+        if (!value && !this.credential?.token) {
+          window.clearInterval(this.job);
+          this.job = 0;
+          await this.onScrollDown();
+          return;
+        }
+        await this.onGetTasks();
+        await this.onScrollDown();
+      }
+    },
     initialized: {
       async handler(newValue) {
         if (newValue) {
           await this.onGetTasks();
           await this.onScrollDown();
-          this.job = window.setInterval(() => {
-            this.onGetTasks();
-          }, 5000);
+          if (!this.job) this.job = window.setInterval(this.onGetTasks, 5000);
         }
       },
       immediate: true
@@ -110,30 +129,55 @@ export default defineComponent({
       const { limit = 5, createdAtMin, createdAtMax } = payload || {};
       this.fetchingTasks = true;
       try {
-        await this.$store.dispatch('maestro/getTasks', { limit, createdAtMin, createdAtMax });
+        await this.$store.dispatch('maestro/getTasks', {
+          limit,
+          createdAtMin,
+          createdAtMax,
+          ...(this.walletMode && !this.credential?.token ? { mode: 'x402', ids: this.walletTaskIds } : {})
+        });
       } finally {
         this.fetchingTasks = false;
       }
     },
     async onGenerate() {
-      const request: IMaestroGenerateRequest = buildMaestroGenerateRequest(this.config);
-      if (!ensureLoggedIn()) {
-        return;
-      }
-      const token = this.credential?.token;
-      if (!token) {
-        console.error('no token specified');
-        return;
+      const request = buildMaestroRequest(this.config);
+      let operation: Promise<unknown>;
+      if (this.walletMode) {
+        const wallet = this.getWalletContext();
+        if (!wallet) {
+          ElMessage.warning(this.$t('common.x402Scenario.connectWalletFirst'));
+          return;
+        }
+        operation = maestroOperator.generate(request, {
+          mode: 'x402',
+          x402: {
+            wallet,
+            confirm: (quote) => this.confirmWalletPayment(quote),
+            identityToken: this.credential?.token
+          }
+        });
+      } else {
+        if (!ensureLoggedIn()) return;
+        const token = this.credential?.token;
+        if (!token) return;
+        operation = maestroOperator.generate(request, { token });
       }
       ElMessage.info(this.$t('maestro.message.startingTask'));
-      instrumentGeneration('maestro', maestroOperator.generate(request, { token }))
-        .then(() => {
+      instrumentGeneration('maestro', operation)
+        .then((response: any) => {
+          const taskId = response?.data?.task_id;
+          if (this.walletMode && !this.credential?.token && taskId && !this.walletTaskIds.includes(taskId)) {
+            this.walletTaskIds.unshift(taskId);
+          }
           ElMessage.success(this.$t('maestro.message.startTaskSuccess'));
         })
         .catch((error) => {
           const response = error?.response?.data;
+          if (error instanceof X402PaymentCancelledError) return;
           if (response?.error?.code === ERROR_CODE_USED_UP) {
             ElMessage.error(this.$t('maestro.message.usedUp'));
+          } else if (this.walletMode) {
+            ElMessage.error(`${this.$t('common.x402Scenario.paymentFailed')} ${error?.message || ''}`.trim());
           } else {
             ElMessage.error(this.$t('maestro.message.startTaskFailed'));
           }
@@ -144,6 +188,26 @@ export default defineComponent({
             await this.onScrollDown();
           }, 1000);
         });
+    },
+    getWalletContext(): X402WalletContext | undefined {
+      const walletApi = (this as any).$wallet;
+      const publicKey = walletApi?.publicKey?.value;
+      const adapter = walletApi?.wallet?.value?.adapter;
+      if (!publicKey || !adapter?.signTransaction) return undefined;
+      return { publicKey, signTransaction: adapter.signTransaction.bind(adapter) };
+    },
+    async confirmWalletPayment(quote: X402PaymentQuote): Promise<boolean> {
+      return ElMessageBox.confirm(
+        this.$t('common.x402Scenario.confirmPayment', { amount: quote.amountUsdc }),
+        this.$t('order.message.x402ConfirmTitle'),
+        {
+          confirmButtonText: this.$t('order.message.x402WalletPayCta'),
+          cancelButtonText: this.$t('common.button.cancel'),
+          type: 'warning'
+        }
+      )
+        .then(() => true)
+        .catch(() => false);
     },
     getTasksScrollElement(): HTMLElement | undefined {
       const panel = this.$refs.recentPanel as any;

--- a/src/pages/minimax/Index.vue
+++ b/src/pages/minimax/Index.vue
@@ -13,21 +13,24 @@
 import { defineComponent } from 'vue';
 import Layout from '@/layouts/Hailuo.vue';
 import ConfigPanel from '@/components/minimax/ConfigPanel.vue';
-import { minimaxOperator } from '@/operators';
+import { buildMinimaxRequest, minimaxOperator } from '@/operators/minimax';
 import { instrumentGeneration } from '@/plugins/telemetry';
-import { IMinimaxGenerateRequest, Status } from '@/models';
-import { ElMessage } from 'element-plus';
+import { Status } from '@/models';
+import { ElMessage, ElMessageBox } from 'element-plus';
 import { ERROR_CODE_USED_UP } from '@/constants';
 import RecentPanel from '@/components/minimax/RecentPanel.vue';
 import { IMinimaxTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
 import { uploadTrackerProviderMixin, ensureNoPendingUpload, ensureLoggedIn } from '@/utils';
+import { isScenarioX402Enabled, scenarioPaymentState } from '@/utils/x402/scenarioPayment';
+import { X402PaymentCancelledError, type X402PaymentQuote, type X402WalletContext } from '@/operators/x402';
 
 interface IData {
   task: IMinimaxTask | undefined;
   job: number;
   loadingMore: boolean;
   fetchingTasks: boolean;
+  walletTaskIds: string[];
 }
 
 export default defineComponent({
@@ -46,7 +49,8 @@ export default defineComponent({
       // @ts-ignore
       timer: undefined,
       loadingMore: false,
-      fetchingTasks: false
+      fetchingTasks: false,
+      walletTaskIds: []
     };
   },
   computed: {
@@ -67,9 +71,27 @@ export default defineComponent({
     },
     tasks() {
       return this.$store.state.minimax.tasks;
+    },
+    walletMode(): boolean {
+      return isScenarioX402Enabled() && scenarioPaymentState('minimax').mode === 'wallet';
     }
   },
   watch: {
+    walletMode: {
+      async handler(value: boolean, oldValue: boolean | undefined) {
+        if (oldValue === undefined || value === oldValue) return;
+        this.$store.commit('minimax/setTasks', undefined);
+        if (value && !this.job) this.job = window.setInterval(this.onGetTasks, 5000);
+        if (!value && !this.credential?.token) {
+          window.clearInterval(this.job);
+          this.job = 0;
+          await this.onScrollDown();
+          return;
+        }
+        await this.onGetTasks();
+        await this.onScrollDown();
+      }
+    },
     tasks: {
       handler(value, oldValue) {
         // scroll down if new tasks are added
@@ -86,9 +108,7 @@ export default defineComponent({
           console.debug('layout initialized');
           await this.onGetTasks();
           await this.onScrollDown();
-          this.job = window.setInterval(() => {
-            this.onGetTasks();
-          }, 5000);
+          if (!this.job) this.job = window.setInterval(this.onGetTasks, 5000);
         }
       },
       immediate: true
@@ -146,7 +166,8 @@ export default defineComponent({
         await this.$store.dispatch('minimax/getTasks', {
           limit,
           createdAtMin,
-          createdAtMax
+          createdAtMax,
+          ...(this.walletMode && !this.credential?.token ? { mode: 'x402', ids: this.walletTaskIds } : {})
         });
       } finally {
         this.fetchingTasks = false;
@@ -162,26 +183,44 @@ export default defineComponent({
       ) {
         return;
       }
-      const request = {
-        ...this.config
-      } as IMinimaxGenerateRequest;
-      if (!ensureLoggedIn()) {
-        return;
-      }
-      const token = this.credential?.token;
-      if (!token) {
-        console.error('no token specified');
-        return;
+      const request = buildMinimaxRequest(this.config);
+      let operation: Promise<unknown>;
+      if (this.walletMode) {
+        const wallet = this.getWalletContext();
+        if (!wallet) {
+          ElMessage.warning(this.$t('common.x402Scenario.connectWalletFirst'));
+          return;
+        }
+        operation = minimaxOperator.generate(request, {
+          mode: 'x402',
+          x402: {
+            wallet,
+            confirm: (quote) => this.confirmWalletPayment(quote),
+            identityToken: this.credential?.token
+          }
+        });
+      } else {
+        if (!ensureLoggedIn()) return;
+        const token = this.credential?.token;
+        if (!token) return;
+        operation = minimaxOperator.generate(request, { token });
       }
       ElMessage.info(this.$t('minimax.message.startingTask'));
-      instrumentGeneration('minimax', minimaxOperator.generate(request, { token }))
-        .then(() => {
+      instrumentGeneration('minimax', operation)
+        .then((response: any) => {
+          const taskId = response?.data?.task_id;
+          if (this.walletMode && !this.credential?.token && taskId && !this.walletTaskIds.includes(taskId)) {
+            this.walletTaskIds.unshift(taskId);
+          }
           ElMessage.success(this.$t('minimax.message.startTaskSuccess'));
         })
         .catch((error) => {
           const response = error?.response?.data;
+          if (error instanceof X402PaymentCancelledError) return;
           if (response?.error?.code === ERROR_CODE_USED_UP) {
             ElMessage.error(this.$t('minimax.message.usedUp'));
+          } else if (this.walletMode) {
+            ElMessage.error(`${this.$t('common.x402Scenario.paymentFailed')} ${error?.message || ''}`.trim());
           } else {
             ElMessage.error(this.$t('minimax.message.startTaskFailed'));
           }
@@ -192,6 +231,26 @@ export default defineComponent({
             await this.onScrollDown();
           }, 1000);
         });
+    },
+    getWalletContext(): X402WalletContext | undefined {
+      const walletApi = (this as any).$wallet;
+      const publicKey = walletApi?.publicKey?.value;
+      const adapter = walletApi?.wallet?.value?.adapter;
+      if (!publicKey || !adapter?.signTransaction) return undefined;
+      return { publicKey, signTransaction: adapter.signTransaction.bind(adapter) };
+    },
+    async confirmWalletPayment(quote: X402PaymentQuote): Promise<boolean> {
+      return ElMessageBox.confirm(
+        this.$t('common.x402Scenario.confirmPayment', { amount: quote.amountUsdc }),
+        this.$t('order.message.x402ConfirmTitle'),
+        {
+          confirmButtonText: this.$t('order.message.x402WalletPayCta'),
+          cancelButtonText: this.$t('common.button.cancel'),
+          type: 'warning'
+        }
+      )
+        .then(() => true)
+        .catch(() => false);
     },
     getTasksScrollElement(): HTMLElement | undefined {
       const panel = this.$refs.recentPanel as any;

--- a/src/pages/omni/Index.vue
+++ b/src/pages/omni/Index.vue
@@ -14,19 +14,22 @@ import { defineComponent } from 'vue';
 import Layout from '@/layouts/Omni.vue';
 import ConfigPanel from '@/components/omni/ConfigPanel.vue';
 import RecentPanel from '@/components/omni/RecentPanel.vue';
-import { omniOperator } from '@/operators';
+import { buildOmniRequest, omniOperator } from '@/operators/omni';
 import { instrumentGeneration } from '@/plugins/telemetry';
-import { IOmniGenerateRequest, IOmniTask, Status } from '@/models';
-import { ElMessage } from 'element-plus';
+import { IOmniTask, Status } from '@/models';
+import { ElMessage, ElMessageBox } from 'element-plus';
 import { ERROR_CODE_USED_UP } from '@/constants';
 import { loadPreviousPage } from '@/utils/pagination';
 import { uploadTrackerProviderMixin, ensureNoPendingUpload, ensureLoggedIn } from '@/utils';
+import { isScenarioX402Enabled, scenarioPaymentState } from '@/utils/x402/scenarioPayment';
+import { X402PaymentCancelledError, type X402PaymentQuote, type X402WalletContext } from '@/operators/x402';
 
 interface IData {
   task: IOmniTask | undefined;
   job: number;
   loadingMore: boolean;
   fetchingTasks: boolean;
+  walletTaskIds: string[];
 }
 
 export default defineComponent({
@@ -43,7 +46,8 @@ export default defineComponent({
       task: undefined,
       job: 0,
       loadingMore: false,
-      fetchingTasks: false
+      fetchingTasks: false,
+      walletTaskIds: []
     };
   },
   computed: {
@@ -61,17 +65,33 @@ export default defineComponent({
     },
     tasks() {
       return this.$store.state.omni?.tasks;
+    },
+    walletMode(): boolean {
+      return isScenarioX402Enabled() && scenarioPaymentState('omni').mode === 'wallet';
     }
   },
   watch: {
+    walletMode: {
+      async handler(value: boolean, oldValue: boolean | undefined) {
+        if (oldValue === undefined || value === oldValue) return;
+        this.$store.commit('omni/setTasks', undefined);
+        if (value && !this.job) this.job = window.setInterval(this.onGetTasks, 5000);
+        if (!value && !this.credential?.token) {
+          window.clearInterval(this.job);
+          this.job = 0;
+          await this.onScrollDown();
+          return;
+        }
+        await this.onGetTasks();
+        await this.onScrollDown();
+      }
+    },
     initialized: {
       async handler(newValue) {
         if (newValue) {
           await this.onGetTasks();
           await this.onScrollDown();
-          this.job = window.setInterval(() => {
-            this.onGetTasks();
-          }, 5000);
+          if (!this.job) this.job = window.setInterval(this.onGetTasks, 5000);
         }
       },
       immediate: true
@@ -117,7 +137,8 @@ export default defineComponent({
         await this.$store.dispatch('omni/getTasks', {
           limit,
           createdAtMin,
-          createdAtMax
+          createdAtMax,
+          ...(this.walletMode && !this.credential?.token ? { mode: 'x402', ids: this.walletTaskIds } : {})
         });
       } finally {
         this.fetchingTasks = false;
@@ -133,54 +154,55 @@ export default defineComponent({
       ) {
         return;
       }
-      const cfg: any = { ...(this.config || {}) };
-      if (typeof cfg?.prompt === 'string') {
-        cfg.prompt = cfg.prompt.trim();
-        if (!cfg.prompt) delete cfg.prompt;
-      }
-      // Normalize reference images / video: drop blank entries and empty arrays.
-      if (Array.isArray(cfg?.image_urls)) {
-        cfg.image_urls = cfg.image_urls.filter((u: string) => typeof u === 'string' && u.trim());
-        if (!cfg.image_urls.length) delete cfg.image_urls;
-      }
-      if (Array.isArray(cfg?.video_urls)) {
-        cfg.video_urls = cfg.video_urls.filter((u: string) => typeof u === 'string' && u.trim());
-        if (!cfg.video_urls.length) delete cfg.video_urls;
-      }
-
+      const request = buildOmniRequest(this.config);
       // Prompt is always required by /gemini/videos.
-      if (!cfg?.prompt) {
+      if (!request.prompt) {
         ElMessage.warning(this.$t('omni.message.promptRequired'));
         return;
       }
       // Video editing (video_urls) requires at least one reference image upstream.
-      if (cfg?.video_urls && !cfg?.image_urls) {
+      if (request.video_urls && !request.image_urls) {
         ElMessage.warning(this.$t('omni.message.videoRequiresImage'));
         return;
       }
 
-      const request = {
-        ...cfg,
-        async: true
-      } as IOmniGenerateRequest;
-
-      if (!ensureLoggedIn()) {
-        return;
-      }
-      const token = this.credential?.token;
-      if (!token) {
-        console.error('no token specified');
-        return;
+      let operation: Promise<unknown>;
+      if (this.walletMode) {
+        const wallet = this.getWalletContext();
+        if (!wallet) {
+          ElMessage.warning(this.$t('common.x402Scenario.connectWalletFirst'));
+          return;
+        }
+        operation = omniOperator.generate(request, {
+          mode: 'x402',
+          x402: {
+            wallet,
+            confirm: (quote) => this.confirmWalletPayment(quote),
+            identityToken: this.credential?.token
+          }
+        });
+      } else {
+        if (!ensureLoggedIn()) return;
+        const token = this.credential?.token;
+        if (!token) return;
+        operation = omniOperator.generate(request, { token });
       }
       ElMessage.info(this.$t('omni.message.startingTask'));
-      instrumentGeneration('omni', omniOperator.generate(request, { token }))
-        .then(() => {
+      instrumentGeneration('omni', operation)
+        .then((response: any) => {
+          const taskId = response?.data?.task_id;
+          if (this.walletMode && !this.credential?.token && taskId && !this.walletTaskIds.includes(taskId)) {
+            this.walletTaskIds.unshift(taskId);
+          }
           ElMessage.success(this.$t('omni.message.startTaskSuccess'));
         })
         .catch((error) => {
           const response = error?.response?.data;
+          if (error instanceof X402PaymentCancelledError) return;
           if (response?.error?.code === ERROR_CODE_USED_UP) {
             ElMessage.error(this.$t('omni.message.usedUp'));
+          } else if (this.walletMode) {
+            ElMessage.error(`${this.$t('common.x402Scenario.paymentFailed')} ${error?.message || ''}`.trim());
           } else {
             ElMessage.error(this.$t('omni.message.startTaskFailed') + (response?.error?.message || ''));
           }
@@ -191,6 +213,26 @@ export default defineComponent({
             await this.onScrollDown();
           }, 1000);
         });
+    },
+    getWalletContext(): X402WalletContext | undefined {
+      const walletApi = (this as any).$wallet;
+      const publicKey = walletApi?.publicKey?.value;
+      const adapter = walletApi?.wallet?.value?.adapter;
+      if (!publicKey || !adapter?.signTransaction) return undefined;
+      return { publicKey, signTransaction: adapter.signTransaction.bind(adapter) };
+    },
+    async confirmWalletPayment(quote: X402PaymentQuote): Promise<boolean> {
+      return ElMessageBox.confirm(
+        this.$t('common.x402Scenario.confirmPayment', { amount: quote.amountUsdc }),
+        this.$t('order.message.x402ConfirmTitle'),
+        {
+          confirmButtonText: this.$t('order.message.x402WalletPayCta'),
+          cancelButtonText: this.$t('common.button.cancel'),
+          type: 'warning'
+        }
+      )
+        .then(() => true)
+        .catch(() => false);
     },
     getTasksScrollElement(): HTMLElement | undefined {
       const panel = this.$refs.recentPanel as any;

--- a/src/pages/pika/Index.vue
+++ b/src/pages/pika/Index.vue
@@ -13,21 +13,25 @@
 import { defineComponent } from 'vue';
 import Layout from '@/layouts/Pika.vue';
 import ConfigPanel from '@/components/pika/ConfigPanel.vue';
-import { applicationOperator, pikaOperator } from '@/operators';
+import { applicationOperator } from '@/operators';
+import { buildPikaRequest, pikaOperator } from '@/operators/pika';
 import { instrumentGeneration } from '@/plugins/telemetry';
-import { IApplicationDetailResponse, IPikaGenerateRequest, Status } from '@/models';
-import { ElMessage } from 'element-plus';
+import { IApplicationDetailResponse, Status } from '@/models';
+import { ElMessage, ElMessageBox } from 'element-plus';
 import { ERROR_CODE_DUPLICATION, ERROR_CODE_USED_UP } from '@/constants';
 import RecentPanel from '@/components/pika/RecentPanel.vue';
 import { IPikaTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
 import { uploadTrackerProviderMixin, ensureNoPendingUpload, ensureLoggedIn } from '@/utils';
+import { isScenarioX402Enabled, scenarioPaymentState } from '@/utils/x402/scenarioPayment';
+import { X402PaymentCancelledError, type X402PaymentQuote, type X402WalletContext } from '@/operators/x402';
 
 interface IData {
   task: IPikaTask | undefined;
   job: number;
   loadingMore: boolean;
   fetchingTasks: boolean;
+  walletTaskIds: string[];
 }
 
 export default defineComponent({
@@ -44,7 +48,8 @@ export default defineComponent({
       task: undefined,
       job: 0,
       loadingMore: false,
-      fetchingTasks: false
+      fetchingTasks: false,
+      walletTaskIds: []
     };
   },
   computed: {
@@ -77,9 +82,27 @@ export default defineComponent({
     },
     tasks() {
       return this.$store.state.pika.tasks;
+    },
+    walletMode(): boolean {
+      return isScenarioX402Enabled() && scenarioPaymentState('pika').mode === 'wallet';
     }
   },
   watch: {
+    walletMode: {
+      async handler(value: boolean, oldValue: boolean | undefined) {
+        if (oldValue === undefined || value === oldValue) return;
+        this.$store.commit('pika/setTasks', undefined);
+        if (value && !this.job) this.job = window.setInterval(this.onGetTasks, 5000);
+        if (!value && !this.credential?.token) {
+          window.clearInterval(this.job);
+          this.job = 0;
+          await this.onScrollDown();
+          return;
+        }
+        await this.onGetTasks();
+        await this.onScrollDown();
+      }
+    },
     tasks: {
       handler(value, oldValue) {
         // scroll down if new tasks are added
@@ -96,9 +119,7 @@ export default defineComponent({
           console.debug('layout initialized');
           await this.onGetTasks();
           await this.onScrollDown();
-          this.job = window.setInterval(() => {
-            this.onGetTasks();
-          }, 5000);
+          if (!this.job) this.job = window.setInterval(this.onGetTasks, 5000);
         }
       },
       immediate: true
@@ -172,7 +193,8 @@ export default defineComponent({
         await this.$store.dispatch('pika/getTasks', {
           limit,
           createdAtMin,
-          createdAtMax
+          createdAtMax,
+          ...(this.walletMode && !this.credential?.token ? { mode: 'x402', ids: this.walletTaskIds } : {})
         });
       } finally {
         this.fetchingTasks = false;
@@ -188,21 +210,35 @@ export default defineComponent({
       ) {
         return;
       }
-      const request = {
-        ...this.config,
-        async: true
-      } as IPikaGenerateRequest;
-      if (!ensureLoggedIn()) {
-        return;
-      }
-      const token = this.credential?.token;
-      if (!token) {
-        console.error('no token specified');
-        return;
+      const request = buildPikaRequest(this.config);
+      let operation: Promise<unknown>;
+      if (this.walletMode) {
+        const wallet = this.getWalletContext();
+        if (!wallet) {
+          ElMessage.warning(this.$t('common.x402Scenario.connectWalletFirst'));
+          return;
+        }
+        operation = pikaOperator.generate(request, {
+          mode: 'x402',
+          x402: {
+            wallet,
+            confirm: (quote) => this.confirmWalletPayment(quote),
+            identityToken: this.credential?.token
+          }
+        });
+      } else {
+        if (!ensureLoggedIn()) return;
+        const token = this.credential?.token;
+        if (!token) return;
+        operation = pikaOperator.generate(request, { token });
       }
       ElMessage.info(this.$t('pika.message.startingTask'));
-      instrumentGeneration('pika', pikaOperator.generate(request, { token }))
-        .then(() => {
+      instrumentGeneration('pika', operation)
+        .then((response: any) => {
+          const taskId = response?.data?.task_id;
+          if (this.walletMode && !this.credential?.token && taskId && !this.walletTaskIds.includes(taskId)) {
+            this.walletTaskIds.unshift(taskId);
+          }
           ElMessage.success(this.$t('pika.message.startTaskSuccess'));
           this.$store.commit('pika/setConfig', {
             config: undefined
@@ -210,8 +246,11 @@ export default defineComponent({
         })
         .catch((error) => {
           const response = error?.response?.data;
+          if (error instanceof X402PaymentCancelledError) return;
           if (response?.error?.code === ERROR_CODE_USED_UP) {
             ElMessage.error(this.$t('pika.message.usedUp'));
+          } else if (this.walletMode) {
+            ElMessage.error(`${this.$t('common.x402Scenario.paymentFailed')} ${error?.message || ''}`.trim());
           } else {
             ElMessage.error(this.$t('pika.message.startTaskFailed'));
           }
@@ -222,6 +261,26 @@ export default defineComponent({
             await this.onScrollDown();
           }, 1000);
         });
+    },
+    getWalletContext(): X402WalletContext | undefined {
+      const walletApi = (this as any).$wallet;
+      const publicKey = walletApi?.publicKey?.value;
+      const adapter = walletApi?.wallet?.value?.adapter;
+      if (!publicKey || !adapter?.signTransaction) return undefined;
+      return { publicKey, signTransaction: adapter.signTransaction.bind(adapter) };
+    },
+    async confirmWalletPayment(quote: X402PaymentQuote): Promise<boolean> {
+      return ElMessageBox.confirm(
+        this.$t('common.x402Scenario.confirmPayment', { amount: quote.amountUsdc }),
+        this.$t('order.message.x402ConfirmTitle'),
+        {
+          confirmButtonText: this.$t('order.message.x402WalletPayCta'),
+          cancelButtonText: this.$t('common.button.cancel'),
+          type: 'warning'
+        }
+      )
+        .then(() => true)
+        .catch(() => false);
     },
     getTasksScrollElement(): HTMLElement | undefined {
       const panel = this.$refs.recentPanel as any;

--- a/src/pages/pixverse/Index.vue
+++ b/src/pages/pixverse/Index.vue
@@ -13,21 +13,24 @@
 import { defineComponent } from 'vue';
 import Layout from '@/layouts/Pixverse.vue';
 import ConfigPanel from '@/components/pixverse/ConfigPanel.vue';
-import { pixverseOperator } from '@/operators';
+import { buildPixverseRequest, pixverseOperator } from '@/operators/pixverse';
 import { instrumentGeneration } from '@/plugins/telemetry';
-import { IPixverseGenerateRequest, Status } from '@/models';
-import { ElMessage } from 'element-plus';
+import { Status } from '@/models';
+import { ElMessage, ElMessageBox } from 'element-plus';
 import { ERROR_CODE_USED_UP } from '@/constants';
 import RecentPanel from '@/components/pixverse/RecentPanel.vue';
 import { IPixverseTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
 import { uploadTrackerProviderMixin, ensureNoPendingUpload, ensureLoggedIn } from '@/utils';
+import { isScenarioX402Enabled, scenarioPaymentState } from '@/utils/x402/scenarioPayment';
+import { X402PaymentCancelledError, type X402PaymentQuote, type X402WalletContext } from '@/operators/x402';
 
 interface IData {
   task: IPixverseTask | undefined;
   job: number;
   loadingMore: boolean;
   fetchingTasks: boolean;
+  walletTaskIds: string[];
 }
 
 export default defineComponent({
@@ -44,7 +47,8 @@ export default defineComponent({
       task: undefined,
       job: 0,
       loadingMore: false,
-      fetchingTasks: false
+      fetchingTasks: false,
+      walletTaskIds: []
     };
   },
   computed: {
@@ -62,9 +66,27 @@ export default defineComponent({
     },
     tasks() {
       return this.$store.state.pixverse.tasks;
+    },
+    walletMode(): boolean {
+      return isScenarioX402Enabled() && scenarioPaymentState('pixverse').mode === 'wallet';
     }
   },
   watch: {
+    walletMode: {
+      async handler(value: boolean, oldValue: boolean | undefined) {
+        if (oldValue === undefined || value === oldValue) return;
+        this.$store.commit('pixverse/setTasks', undefined);
+        if (value && !this.job) this.job = window.setInterval(this.onGetTasks, 5000);
+        if (!value && !this.credential?.token) {
+          window.clearInterval(this.job);
+          this.job = 0;
+          await this.onScrollDown();
+          return;
+        }
+        await this.onGetTasks();
+        await this.onScrollDown();
+      }
+    },
     tasks: {
       handler(value, oldValue) {
         // scroll down if new tasks are added
@@ -81,9 +103,7 @@ export default defineComponent({
           console.debug('layout initialized');
           await this.onGetTasks();
           await this.onScrollDown();
-          this.job = window.setInterval(() => {
-            this.onGetTasks();
-          }, 5000);
+          if (!this.job) this.job = window.setInterval(this.onGetTasks, 5000);
         }
       },
       immediate: true
@@ -141,7 +161,8 @@ export default defineComponent({
         await this.$store.dispatch('pixverse/getTasks', {
           limit,
           createdAtMin,
-          createdAtMax
+          createdAtMax,
+          ...(this.walletMode && !this.credential?.token ? { mode: 'x402', ids: this.walletTaskIds } : {})
         });
       } finally {
         this.fetchingTasks = false;
@@ -157,27 +178,44 @@ export default defineComponent({
       ) {
         return;
       }
-      const request = {
-        ...this.config,
-        async: true
-      } as IPixverseGenerateRequest;
-      if (!ensureLoggedIn()) {
-        return;
-      }
-      const token = this.credential?.token;
-      if (!token) {
-        console.error('no token specified');
-        return;
+      const request = buildPixverseRequest(this.config);
+      let operation: Promise<unknown>;
+      if (this.walletMode) {
+        const wallet = this.getWalletContext();
+        if (!wallet) {
+          ElMessage.warning(this.$t('common.x402Scenario.connectWalletFirst'));
+          return;
+        }
+        operation = pixverseOperator.generate(request, {
+          mode: 'x402',
+          x402: {
+            wallet,
+            confirm: (quote) => this.confirmWalletPayment(quote),
+            identityToken: this.credential?.token
+          }
+        });
+      } else {
+        if (!ensureLoggedIn()) return;
+        const token = this.credential?.token;
+        if (!token) return;
+        operation = pixverseOperator.generate(request, { token });
       }
       ElMessage.info(this.$t('pixverse.message.startingTask'));
-      instrumentGeneration('pixverse', pixverseOperator.generate(request, { token }))
-        .then(() => {
+      instrumentGeneration('pixverse', operation)
+        .then((response: any) => {
+          const taskId = response?.data?.task_id;
+          if (this.walletMode && !this.credential?.token && taskId && !this.walletTaskIds.includes(taskId)) {
+            this.walletTaskIds.unshift(taskId);
+          }
           ElMessage.success(this.$t('pixverse.message.startTaskSuccess'));
         })
         .catch((error) => {
           const response = error?.response?.data;
+          if (error instanceof X402PaymentCancelledError) return;
           if (response?.error?.code === ERROR_CODE_USED_UP) {
             ElMessage.error(this.$t('pixverse.message.usedUp'));
+          } else if (this.walletMode) {
+            ElMessage.error(`${this.$t('common.x402Scenario.paymentFailed')} ${error?.message || ''}`.trim());
           } else {
             ElMessage.error(this.$t('pixverse.message.startTaskFailed'));
           }
@@ -188,6 +226,26 @@ export default defineComponent({
             await this.onScrollDown();
           }, 1000);
         });
+    },
+    getWalletContext(): X402WalletContext | undefined {
+      const walletApi = (this as any).$wallet;
+      const publicKey = walletApi?.publicKey?.value;
+      const adapter = walletApi?.wallet?.value?.adapter;
+      if (!publicKey || !adapter?.signTransaction) return undefined;
+      return { publicKey, signTransaction: adapter.signTransaction.bind(adapter) };
+    },
+    async confirmWalletPayment(quote: X402PaymentQuote): Promise<boolean> {
+      return ElMessageBox.confirm(
+        this.$t('common.x402Scenario.confirmPayment', { amount: quote.amountUsdc }),
+        this.$t('order.message.x402ConfirmTitle'),
+        {
+          confirmButtonText: this.$t('order.message.x402WalletPayCta'),
+          cancelButtonText: this.$t('common.button.cancel'),
+          type: 'warning'
+        }
+      )
+        .then(() => true)
+        .catch(() => false);
     },
     getTasksScrollElement(): HTMLElement | undefined {
       const panel = this.$refs.recentPanel as any;

--- a/src/pages/seedance/Index.vue
+++ b/src/pages/seedance/Index.vue
@@ -14,21 +14,24 @@ import { defineComponent } from 'vue';
 import Layout from '@/layouts/Seedance.vue';
 import ConfigPanel from '@/components/seedance/ConfigPanel.vue';
 import RecentPanel from '@/components/seedance/RecentPanel.vue';
-import { seedanceOperator } from '@/operators';
+import { seedanceOperator } from '@/operators/seedance';
 import { instrumentGeneration } from '@/plugins/telemetry';
 import { Status } from '@/models';
-import { ElMessage } from 'element-plus';
+import { ElMessage, ElMessageBox } from 'element-plus';
 import { ERROR_CODE_USED_UP } from '@/constants';
 import { ISeedanceTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
 import { normalizeSeedanceRequest } from '@/utils/seedance';
 import { uploadTrackerProviderMixin, ensureNoPendingUpload, ensureLoggedIn } from '@/utils';
+import { isScenarioX402Enabled, scenarioPaymentState } from '@/utils/x402/scenarioPayment';
+import { X402PaymentCancelledError, type X402PaymentQuote, type X402WalletContext } from '@/operators/x402';
 
 interface IData {
   task: ISeedanceTask | undefined;
   job: number;
   loadingMore: boolean;
   fetchingTasks: boolean;
+  walletTaskIds: string[];
 }
 
 export default defineComponent({
@@ -45,7 +48,8 @@ export default defineComponent({
       task: undefined,
       job: 0,
       loadingMore: false,
-      fetchingTasks: false
+      fetchingTasks: false,
+      walletTaskIds: []
     };
   },
   computed: {
@@ -63,17 +67,33 @@ export default defineComponent({
     },
     tasks() {
       return this.$store.state.seedance?.tasks;
+    },
+    walletMode(): boolean {
+      return isScenarioX402Enabled() && scenarioPaymentState('seedance').mode === 'wallet';
     }
   },
   watch: {
+    walletMode: {
+      async handler(value: boolean, oldValue: boolean | undefined) {
+        if (oldValue === undefined || value === oldValue) return;
+        this.$store.commit('seedance/setTasks', undefined);
+        if (value && !this.job) this.job = window.setInterval(this.onGetTasks, 5000);
+        if (!value && !this.credential?.token) {
+          window.clearInterval(this.job);
+          this.job = 0;
+          await this.onScrollDown();
+          return;
+        }
+        await this.onGetTasks();
+        await this.onScrollDown();
+      }
+    },
     initialized: {
       async handler(newValue) {
         if (newValue) {
           await this.onGetTasks();
           await this.onScrollDown();
-          this.job = window.setInterval(() => {
-            this.onGetTasks();
-          }, 5000);
+          if (!this.job) this.job = window.setInterval(this.onGetTasks, 5000);
         }
       },
       immediate: true
@@ -119,7 +139,8 @@ export default defineComponent({
         await this.$store.dispatch('seedance/getTasks', {
           limit,
           createdAtMin,
-          createdAtMax
+          createdAtMax,
+          ...(this.walletMode && !this.credential?.token ? { mode: 'x402', ids: this.walletTaskIds } : {})
         });
       } finally {
         this.fetchingTasks = false;
@@ -144,23 +165,43 @@ export default defineComponent({
         return;
       }
 
-      if (!ensureLoggedIn()) {
-        return;
-      }
-      const token = this.credential?.token;
-      if (!token) {
-        console.error('no token specified');
-        return;
+      let operation: Promise<unknown>;
+      if (this.walletMode) {
+        const wallet = this.getWalletContext();
+        if (!wallet) {
+          ElMessage.warning(this.$t('common.x402Scenario.connectWalletFirst'));
+          return;
+        }
+        operation = seedanceOperator.generate(request, {
+          mode: 'x402',
+          x402: {
+            wallet,
+            confirm: (quote) => this.confirmWalletPayment(quote),
+            identityToken: this.credential?.token
+          }
+        });
+      } else {
+        if (!ensureLoggedIn()) return;
+        const token = this.credential?.token;
+        if (!token) return;
+        operation = seedanceOperator.generate(request, { token });
       }
       ElMessage.info(this.$t('seedance.message.startingTask'));
-      instrumentGeneration('seedance', seedanceOperator.generate(request, { token }))
-        .then(() => {
+      instrumentGeneration('seedance', operation)
+        .then((response: any) => {
+          const taskId = response?.data?.task_id;
+          if (this.walletMode && !this.credential?.token && taskId && !this.walletTaskIds.includes(taskId)) {
+            this.walletTaskIds.unshift(taskId);
+          }
           ElMessage.success(this.$t('seedance.message.startTaskSuccess'));
         })
         .catch((error) => {
           const response = error?.response?.data;
+          if (error instanceof X402PaymentCancelledError) return;
           if (response?.error?.code === ERROR_CODE_USED_UP) {
             ElMessage.error(this.$t('seedance.message.usedUp'));
+          } else if (this.walletMode) {
+            ElMessage.error(`${this.$t('common.x402Scenario.paymentFailed')} ${error?.message || ''}`.trim());
           } else {
             ElMessage.error(this.$t('seedance.message.startTaskFailed') + (response?.error?.message || ''));
           }
@@ -171,6 +212,26 @@ export default defineComponent({
             await this.onScrollDown();
           }, 1000);
         });
+    },
+    getWalletContext(): X402WalletContext | undefined {
+      const walletApi = (this as any).$wallet;
+      const publicKey = walletApi?.publicKey?.value;
+      const adapter = walletApi?.wallet?.value?.adapter;
+      if (!publicKey || !adapter?.signTransaction) return undefined;
+      return { publicKey, signTransaction: adapter.signTransaction.bind(adapter) };
+    },
+    async confirmWalletPayment(quote: X402PaymentQuote): Promise<boolean> {
+      return ElMessageBox.confirm(
+        this.$t('common.x402Scenario.confirmPayment', { amount: quote.amountUsdc }),
+        this.$t('order.message.x402ConfirmTitle'),
+        {
+          confirmButtonText: this.$t('order.message.x402WalletPayCta'),
+          cancelButtonText: this.$t('common.button.cancel'),
+          type: 'warning'
+        }
+      )
+        .then(() => true)
+        .catch(() => false);
     },
     getTasksScrollElement(): HTMLElement | undefined {
       const panel = this.$refs.recentPanel as any;

--- a/src/pages/sora/Index.vue
+++ b/src/pages/sora/Index.vue
@@ -13,21 +13,24 @@
 import { defineComponent } from 'vue';
 import Layout from '@/layouts/Sora.vue';
 import ConfigPanel from '@/components/sora/ConfigPanel.vue';
-import { soraOperator } from '@/operators';
+import { buildSoraRequest, soraOperator } from '@/operators/sora';
 import { instrumentGeneration } from '@/plugins/telemetry';
-import { ISoraGenerateRequest, Status } from '@/models';
-import { ElMessage } from 'element-plus';
+import { Status } from '@/models';
+import { ElMessage, ElMessageBox } from 'element-plus';
 import { ERROR_CODE_USED_UP } from '@/constants';
 import RecentPanel from '@/components/sora/RecentPanel.vue';
 import { ISoraTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
 import { uploadTrackerProviderMixin, ensureNoPendingUpload, ensureLoggedIn } from '@/utils';
+import { isScenarioX402Enabled, scenarioPaymentState } from '@/utils/x402/scenarioPayment';
+import { X402PaymentCancelledError, type X402PaymentQuote, type X402WalletContext } from '@/operators/x402';
 
 interface IData {
   task: ISoraTask | undefined;
   job: number;
   loadingMore: boolean;
   fetchingTasks: boolean;
+  walletTaskIds: string[];
 }
 
 export default defineComponent({
@@ -44,7 +47,8 @@ export default defineComponent({
       task: undefined,
       job: 0,
       loadingMore: false,
-      fetchingTasks: false
+      fetchingTasks: false,
+      walletTaskIds: []
     };
   },
   computed: {
@@ -62,9 +66,27 @@ export default defineComponent({
     },
     tasks() {
       return this.$store.state.sora.tasks;
+    },
+    walletMode(): boolean {
+      return isScenarioX402Enabled() && scenarioPaymentState('sora').mode === 'wallet';
     }
   },
   watch: {
+    walletMode: {
+      async handler(value: boolean, oldValue: boolean | undefined) {
+        if (oldValue === undefined || value === oldValue) return;
+        this.$store.commit('sora/setTasks', undefined);
+        if (value && !this.job) this.job = window.setInterval(this.onGetTasks, 5000);
+        if (!value && !this.credential?.token) {
+          window.clearInterval(this.job);
+          this.job = 0;
+          await this.onScrollDown();
+          return;
+        }
+        await this.onGetTasks();
+        await this.onScrollDown();
+      }
+    },
     tasks: {
       handler(value, oldValue) {
         // scroll down if new tasks are added
@@ -81,9 +103,7 @@ export default defineComponent({
           console.debug('layout initialized');
           await this.onGetTasks();
           await this.onScrollDown();
-          this.job = window.setInterval(() => {
-            this.onGetTasks();
-          }, 5000);
+          if (!this.job) this.job = window.setInterval(this.onGetTasks, 5000);
         }
       },
       immediate: true
@@ -141,7 +161,8 @@ export default defineComponent({
         await this.$store.dispatch('sora/getTasks', {
           limit,
           createdAtMin,
-          createdAtMax
+          createdAtMax,
+          ...(this.walletMode && !this.credential?.token ? { mode: 'x402', ids: this.walletTaskIds } : {})
         });
       } finally {
         this.fetchingTasks = false;
@@ -157,27 +178,44 @@ export default defineComponent({
       ) {
         return;
       }
-      const request = {
-        ...this.config,
-        async: true
-      } as ISoraGenerateRequest;
-      if (!ensureLoggedIn()) {
-        return;
-      }
-      const token = this.credential?.token;
-      if (!token) {
-        console.error('no token specified');
-        return;
+      const request = buildSoraRequest(this.config);
+      let operation: Promise<unknown>;
+      if (this.walletMode) {
+        const wallet = this.getWalletContext();
+        if (!wallet) {
+          ElMessage.warning(this.$t('common.x402Scenario.connectWalletFirst'));
+          return;
+        }
+        operation = soraOperator.generate(request, {
+          mode: 'x402',
+          x402: {
+            wallet,
+            confirm: (quote) => this.confirmWalletPayment(quote),
+            identityToken: this.credential?.token
+          }
+        });
+      } else {
+        if (!ensureLoggedIn()) return;
+        const token = this.credential?.token;
+        if (!token) return;
+        operation = soraOperator.generate(request, { token });
       }
       ElMessage.info(this.$t('sora.message.startingTask'));
-      instrumentGeneration('sora', soraOperator.generate(request, { token }))
-        .then(() => {
+      instrumentGeneration('sora', operation)
+        .then((response: any) => {
+          const taskId = response?.data?.task_id;
+          if (this.walletMode && !this.credential?.token && taskId && !this.walletTaskIds.includes(taskId)) {
+            this.walletTaskIds.unshift(taskId);
+          }
           ElMessage.success(this.$t('sora.message.startTaskSuccess'));
         })
         .catch((error) => {
           const response = error?.response?.data;
+          if (error instanceof X402PaymentCancelledError) return;
           if (response?.error?.code === ERROR_CODE_USED_UP) {
             ElMessage.error(this.$t('sora.message.usedUp'));
+          } else if (this.walletMode) {
+            ElMessage.error(`${this.$t('common.x402Scenario.paymentFailed')} ${error?.message || ''}`.trim());
           } else {
             ElMessage.error(this.$t('sora.message.startTaskFailed'));
           }
@@ -188,6 +226,26 @@ export default defineComponent({
             await this.onScrollDown();
           }, 1000);
         });
+    },
+    getWalletContext(): X402WalletContext | undefined {
+      const walletApi = (this as any).$wallet;
+      const publicKey = walletApi?.publicKey?.value;
+      const adapter = walletApi?.wallet?.value?.adapter;
+      if (!publicKey || !adapter?.signTransaction) return undefined;
+      return { publicKey, signTransaction: adapter.signTransaction.bind(adapter) };
+    },
+    async confirmWalletPayment(quote: X402PaymentQuote): Promise<boolean> {
+      return ElMessageBox.confirm(
+        this.$t('common.x402Scenario.confirmPayment', { amount: quote.amountUsdc }),
+        this.$t('order.message.x402ConfirmTitle'),
+        {
+          confirmButtonText: this.$t('order.message.x402WalletPayCta'),
+          cancelButtonText: this.$t('common.button.cancel'),
+          type: 'warning'
+        }
+      )
+        .then(() => true)
+        .catch(() => false);
     },
     getTasksScrollElement(): HTMLElement | undefined {
       const panel = this.$refs.recentPanel as any;

--- a/src/pages/veo/Index.vue
+++ b/src/pages/veo/Index.vue
@@ -13,22 +13,24 @@
 import { defineComponent } from 'vue';
 import Layout from '@/layouts/Veo.vue';
 import ConfigPanel from '@/components/veo/ConfigPanel.vue';
-import { veoOperator } from '@/operators';
+import { buildVeoRequest, veoOperator } from '@/operators/veo';
 import { instrumentGeneration } from '@/plugins/telemetry';
-import { IVeoGenerateRequest, Status } from '@/models';
-import { ElMessage } from 'element-plus';
+import { Status } from '@/models';
+import { ElMessage, ElMessageBox } from 'element-plus';
 import { ERROR_CODE_USED_UP } from '@/constants';
 import RecentPanel from '@/components/veo/RecentPanel.vue';
 import { IVeoTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
 import { uploadTrackerProviderMixin, ensureNoPendingUpload, ensureLoggedIn } from '@/utils';
-import { buildVeoGenerateRequest } from '@/utils/veo/config';
+import { isScenarioX402Enabled, scenarioPaymentState } from '@/utils/x402/scenarioPayment';
+import { X402PaymentCancelledError, type X402PaymentQuote, type X402WalletContext } from '@/operators/x402';
 
 interface IData {
   task: IVeoTask | undefined;
   job: number;
   loadingMore: boolean;
   fetchingTasks: boolean;
+  walletTaskIds: string[];
 }
 
 export default defineComponent({
@@ -45,7 +47,8 @@ export default defineComponent({
       task: undefined,
       job: 0,
       loadingMore: false,
-      fetchingTasks: false
+      fetchingTasks: false,
+      walletTaskIds: []
     };
   },
   computed: {
@@ -63,9 +66,27 @@ export default defineComponent({
     },
     tasks() {
       return this.$store.state.veo.tasks;
+    },
+    walletMode(): boolean {
+      return isScenarioX402Enabled() && scenarioPaymentState('veo').mode === 'wallet';
     }
   },
   watch: {
+    walletMode: {
+      async handler(value: boolean, oldValue: boolean | undefined) {
+        if (oldValue === undefined || value === oldValue) return;
+        this.$store.commit('veo/setTasks', undefined);
+        if (value && !this.job) this.job = window.setInterval(this.onGetTasks, 5000);
+        if (!value && !this.credential?.token) {
+          window.clearInterval(this.job);
+          this.job = 0;
+          await this.onScrollDown();
+          return;
+        }
+        await this.onGetTasks();
+        await this.onScrollDown();
+      }
+    },
     tasks: {
       handler(value, oldValue) {
         // scroll down if new tasks are added
@@ -82,9 +103,7 @@ export default defineComponent({
           console.debug('layout initialized');
           await this.onGetTasks();
           await this.onScrollDown();
-          this.job = window.setInterval(() => {
-            this.onGetTasks();
-          }, 5000);
+          if (!this.job) this.job = window.setInterval(this.onGetTasks, 5000);
         }
       },
       immediate: true
@@ -142,7 +161,8 @@ export default defineComponent({
         await this.$store.dispatch('veo/getTasks', {
           limit,
           createdAtMin,
-          createdAtMax
+          createdAtMax,
+          ...(this.walletMode && !this.credential?.token ? { mode: 'x402', ids: this.walletTaskIds } : {})
         });
       } finally {
         this.fetchingTasks = false;
@@ -158,15 +178,7 @@ export default defineComponent({
       ) {
         return;
       }
-      const request = buildVeoGenerateRequest(this.config) as IVeoGenerateRequest;
-      if (!ensureLoggedIn()) {
-        return;
-      }
-      const token = this.credential?.token;
-      if (!token) {
-        console.error('no token specified');
-        return;
-      }
+      const request = buildVeoRequest(this.config);
       // image2video requires at least one image; otherwise the upstream rejects with
       // "image_urls is invalid when generate videos". Validate client-side so the user
       // gets an actionable message instead of the generic failure toast.
@@ -177,15 +189,43 @@ export default defineComponent({
         ElMessage.warning(this.$t('veo.message.imageRequired'));
         return;
       }
+      let operation: Promise<unknown>;
+      if (this.walletMode) {
+        const wallet = this.getWalletContext();
+        if (!wallet) {
+          ElMessage.warning(this.$t('common.x402Scenario.connectWalletFirst'));
+          return;
+        }
+        operation = veoOperator.generate(request, {
+          mode: 'x402',
+          x402: {
+            wallet,
+            confirm: (quote) => this.confirmWalletPayment(quote),
+            identityToken: this.credential?.token
+          }
+        });
+      } else {
+        if (!ensureLoggedIn()) return;
+        const token = this.credential?.token;
+        if (!token) return;
+        operation = veoOperator.generate(request, { token });
+      }
       ElMessage.info(this.$t('veo.message.startingTask'));
-      instrumentGeneration('veo', veoOperator.generate(request, { token }))
-        .then(() => {
+      instrumentGeneration('veo', operation)
+        .then((response: any) => {
+          const taskId = response?.data?.task_id;
+          if (this.walletMode && !this.credential?.token && taskId && !this.walletTaskIds.includes(taskId)) {
+            this.walletTaskIds.unshift(taskId);
+          }
           ElMessage.success(this.$t('veo.message.startTaskSuccess'));
         })
         .catch((error) => {
           const response = error?.response?.data;
+          if (error instanceof X402PaymentCancelledError) return;
           if (response?.error?.code === ERROR_CODE_USED_UP) {
             ElMessage.error(this.$t('veo.message.usedUp'));
+          } else if (this.walletMode) {
+            ElMessage.error(`${this.$t('common.x402Scenario.paymentFailed')} ${error?.message || ''}`.trim());
           } else {
             ElMessage.error(this.$t('veo.message.startTaskFailed'));
           }
@@ -196,6 +236,26 @@ export default defineComponent({
             await this.onScrollDown();
           }, 1000);
         });
+    },
+    getWalletContext(): X402WalletContext | undefined {
+      const walletApi = (this as any).$wallet;
+      const publicKey = walletApi?.publicKey?.value;
+      const adapter = walletApi?.wallet?.value?.adapter;
+      if (!publicKey || !adapter?.signTransaction) return undefined;
+      return { publicKey, signTransaction: adapter.signTransaction.bind(adapter) };
+    },
+    async confirmWalletPayment(quote: X402PaymentQuote): Promise<boolean> {
+      return ElMessageBox.confirm(
+        this.$t('common.x402Scenario.confirmPayment', { amount: quote.amountUsdc }),
+        this.$t('order.message.x402ConfirmTitle'),
+        {
+          confirmButtonText: this.$t('order.message.x402WalletPayCta'),
+          cancelButtonText: this.$t('common.button.cancel'),
+          type: 'warning'
+        }
+      )
+        .then(() => true)
+        .catch(() => false);
     },
     getTasksScrollElement(): HTMLElement | undefined {
       const panel = this.$refs.recentPanel as any;

--- a/src/pages/wan/Index.vue
+++ b/src/pages/wan/Index.vue
@@ -13,21 +13,24 @@
 import { defineComponent } from 'vue';
 import Layout from '@/layouts/Wan.vue';
 import ConfigPanel from '@/components/wan/ConfigPanel.vue';
-import { wanOperator } from '@/operators';
+import { buildWanRequest, wanOperator } from '@/operators/wan';
 import { instrumentGeneration } from '@/plugins/telemetry';
-import { IWanGenerateRequest, Status } from '@/models';
-import { ElMessage } from 'element-plus';
+import { Status } from '@/models';
+import { ElMessage, ElMessageBox } from 'element-plus';
 import { ERROR_CODE_USED_UP } from '@/constants';
 import RecentPanel from '@/components/wan/RecentPanel.vue';
 import { IWanTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
 import { uploadTrackerProviderMixin, ensureNoPendingUpload, ensureLoggedIn } from '@/utils';
+import { isScenarioX402Enabled, scenarioPaymentState } from '@/utils/x402/scenarioPayment';
+import { X402PaymentCancelledError, type X402PaymentQuote, type X402WalletContext } from '@/operators/x402';
 
 interface IData {
   task: IWanTask | undefined;
   job: number;
   loadingMore: boolean;
   fetchingTasks: boolean;
+  walletTaskIds: string[];
 }
 
 export default defineComponent({
@@ -46,7 +49,8 @@ export default defineComponent({
       // @ts-ignore
       timer: undefined,
       loadingMore: false,
-      fetchingTasks: false
+      fetchingTasks: false,
+      walletTaskIds: []
     };
   },
   computed: {
@@ -67,9 +71,27 @@ export default defineComponent({
     },
     tasks() {
       return this.$store.state.wan.tasks;
+    },
+    walletMode(): boolean {
+      return isScenarioX402Enabled() && scenarioPaymentState('wan').mode === 'wallet';
     }
   },
   watch: {
+    walletMode: {
+      async handler(value: boolean, oldValue: boolean | undefined) {
+        if (oldValue === undefined || value === oldValue) return;
+        this.$store.commit('wan/setTasks', undefined);
+        if (value && !this.job) this.job = window.setInterval(this.onGetTasks, 5000);
+        if (!value && !this.credential?.token) {
+          window.clearInterval(this.job);
+          this.job = 0;
+          await this.onScrollDown();
+          return;
+        }
+        await this.onGetTasks();
+        await this.onScrollDown();
+      }
+    },
     tasks: {
       handler(value, oldValue) {
         // scroll down if new tasks are added
@@ -85,9 +107,7 @@ export default defineComponent({
           console.debug('layout initialized');
           await this.onGetTasks();
           await this.onScrollDown();
-          this.job = window.setInterval(() => {
-            this.onGetTasks();
-          }, 5000);
+          if (!this.job) this.job = window.setInterval(this.onGetTasks, 5000);
         }
       },
       immediate: true
@@ -145,7 +165,8 @@ export default defineComponent({
         await this.$store.dispatch('wan/getTasks', {
           limit,
           createdAtMin,
-          createdAtMax
+          createdAtMax,
+          ...(this.walletMode && !this.credential?.token ? { mode: 'x402', ids: this.walletTaskIds } : {})
         });
       } finally {
         this.fetchingTasks = false;
@@ -161,27 +182,44 @@ export default defineComponent({
       ) {
         return;
       }
-      const request = {
-        ...this.config,
-        async: true
-      } as IWanGenerateRequest;
-      if (!ensureLoggedIn()) {
-        return;
-      }
-      const token = this.credential?.token;
-      if (!token) {
-        console.error('no token specified');
-        return;
+      const request = buildWanRequest(this.config);
+      let operation: Promise<unknown>;
+      if (this.walletMode) {
+        const wallet = this.getWalletContext();
+        if (!wallet) {
+          ElMessage.warning(this.$t('common.x402Scenario.connectWalletFirst'));
+          return;
+        }
+        operation = wanOperator.generate(request, {
+          mode: 'x402',
+          x402: {
+            wallet,
+            confirm: (quote) => this.confirmWalletPayment(quote),
+            identityToken: this.credential?.token
+          }
+        });
+      } else {
+        if (!ensureLoggedIn()) return;
+        const token = this.credential?.token;
+        if (!token) return;
+        operation = wanOperator.generate(request, { token });
       }
       ElMessage.info(this.$t('wan.message.startingTask'));
-      instrumentGeneration('wan', wanOperator.generate(request, { token }))
-        .then(() => {
+      instrumentGeneration('wan', operation)
+        .then((response: any) => {
+          const taskId = response?.data?.task_id;
+          if (this.walletMode && !this.credential?.token && taskId && !this.walletTaskIds.includes(taskId)) {
+            this.walletTaskIds.unshift(taskId);
+          }
           ElMessage.success(this.$t('wan.message.startTaskSuccess'));
         })
         .catch((error) => {
           const response = error?.response?.data;
+          if (error instanceof X402PaymentCancelledError) return;
           if (response?.error?.code === ERROR_CODE_USED_UP) {
             ElMessage.error(this.$t('wan.message.usedUp'));
+          } else if (this.walletMode) {
+            ElMessage.error(`${this.$t('common.x402Scenario.paymentFailed')} ${error?.message || ''}`.trim());
           } else {
             ElMessage.error(this.$t('wan.message.startTaskFailed'));
           }
@@ -192,6 +230,26 @@ export default defineComponent({
             await this.onScrollDown();
           }, 1000);
         });
+    },
+    getWalletContext(): X402WalletContext | undefined {
+      const walletApi = (this as any).$wallet;
+      const publicKey = walletApi?.publicKey?.value;
+      const adapter = walletApi?.wallet?.value?.adapter;
+      if (!publicKey || !adapter?.signTransaction) return undefined;
+      return { publicKey, signTransaction: adapter.signTransaction.bind(adapter) };
+    },
+    async confirmWalletPayment(quote: X402PaymentQuote): Promise<boolean> {
+      return ElMessageBox.confirm(
+        this.$t('common.x402Scenario.confirmPayment', { amount: quote.amountUsdc }),
+        this.$t('order.message.x402ConfirmTitle'),
+        {
+          confirmButtonText: this.$t('order.message.x402WalletPayCta'),
+          cancelButtonText: this.$t('common.button.cancel'),
+          type: 'warning'
+        }
+      )
+        .then(() => true)
+        .catch(() => false);
     },
     getTasksScrollElement(): HTMLElement | undefined {
       const panel = this.$refs.recentPanel as any;


### PR DESCRIPTION
## Summary

- add Solana x402 wallet payment and server-authoritative quotes to 12 standard video scenarios: Luma, Pika, Pixverse, Hailuo, Veo, Seedance, Sora, Wan, Omni/Gemini Video, Grok Video, MiniMax, and Maestro
- keep each scenario's request builder authoritative for both quote and submit, including Veo action normalization, Seedance multimodal `content[]`, and Omni/Grok reference cleanup
- support authenticated identity sidecars and guest in-memory task polling without changing storage, delete behavior, shared task factories, or Credits flows

## Scope

Kling and Digital Human are intentionally excluded because they each have multiple independently priced endpoints and will be handled in a follow-up PR.

## Validation

- `npm run lint:check` — 0 errors (2 pre-existing warnings in `dropUploadMixin.test.ts`)
- `npx vue-tsc -b --pretty false`
- `npm run test:run` — 162 files / 1,287 tests passed
- `python3 scripts/check_i18n_coverage.py`
- `unset $(git rev-parse --local-env-vars); npm run verify`
- `npm run build:web`
- `npm run build:electron`
- `npm run compile:electron && node scripts/copy-renderer.js`
- `unset ELECTRON_RUN_AS_NODE; npm run test:e2e:desktop` — 3 passed
- `git diff --check`

## Rollout / rollback

- UI remains behind the existing web-only `x402` feature flag.
- Backend policy already marks these generation endpoints `exact`; Gateway remains fail-closed for unsupported payloads.
- Roll back this PR to remove the new UI entries; no database or API schema migration is involved.
- No billable generation, wallet signature, or chain payment was performed during validation.

## Review record

- Confirmed quote and submit use the same scenario-owned builder.
- Confirmed guest task IDs stay in page memory only and polling stops when a guest leaves Wallet mode.
- Confirmed no store factory, delete, RecentPanel, Preview, locale, or storage changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
