### PR TITLE
feat(x402): add Kling and Digital Human wallet payments

### DIFF
--- a/change/@acedatacloud-nexior-98c49df7-7810-43dd-b795-fbaad6e1e71d.json
+++ b/change/@acedatacloud-nexior-98c49df7-7810-43dd-b795-fbaad6e1e71d.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add Solana x402 wallet payments to Kling and Digital Human exact-priced flows.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "minor"
+}

--- a/src/components/digitalhuman/ConfigPanel.vue
+++ b/src/components/digitalhuman/ConfigPanel.vue
@@ -91,7 +91,8 @@
         <warning-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
         {{ missing[0].message }}
       </p>
-      <consumption :value="consumption" :service="service" />
+      <scenario-payment-mode scenario="digitalhuman" />
+      <consumption v-if="!walletMode" :value="consumption" :service="service" />
       <el-button type="primary" class="btn w-full" round @click="onGenerate">
         <magic-icon class="mr-2" :size="'1em' as any" aria-hidden="true" focusable="false" />
         {{ $t('digitalhuman.button.generateVideo') }}
@@ -120,7 +121,10 @@ import MediaInput from './config/MediaInput.vue';
 import TimbreSelector from './config/TimbreSelector.vue';
 import { getConsumption } from '@/utils';
 import { DIGITALHUMAN_AUDIO_ACCEPT, DIGITALHUMAN_IMAGE_ACCEPT, DIGITALHUMAN_VIDEO_ACCEPT } from '@/constants';
-import { IDigitalHumanConfig, IDigitalHumanGenerateRequest } from '@/models';
+import { IDigitalHumanConfig } from '@/models';
+import ScenarioPaymentMode from '../common/ScenarioPaymentMode.vue';
+import { isScenarioX402Enabled, scenarioPaymentState } from '@/utils/x402/scenarioPayment';
+import { buildDigitalHumanVideoRequest, digitalHumanOperator } from '@/operators/digitalhuman';
 
 interface IMissing {
   key: string;
@@ -134,6 +138,8 @@ interface IData {
   DIGITALHUMAN_VIDEO_ACCEPT: string;
   DIGITALHUMAN_IMAGE_ACCEPT: string;
   DIGITALHUMAN_AUDIO_ACCEPT: string;
+  quoteTimer: number;
+  quoteRunId: number;
 }
 
 export default defineComponent({
@@ -151,7 +157,8 @@ export default defineComponent({
     MediaInput,
     PromptTextarea,
     TimbreSelector,
-    WarningIcon
+    WarningIcon,
+    ScenarioPaymentMode
   },
   emits: ['generate'],
   data(): IData {
@@ -161,7 +168,9 @@ export default defineComponent({
       advancedOpen: [],
       DIGITALHUMAN_VIDEO_ACCEPT,
       DIGITALHUMAN_IMAGE_ACCEPT,
-      DIGITALHUMAN_AUDIO_ACCEPT
+      DIGITALHUMAN_AUDIO_ACCEPT,
+      quoteTimer: 0,
+      quoteRunId: 0
     };
   },
   computed: {
@@ -220,6 +229,29 @@ export default defineComponent({
       set(val: number) {
         this.update({ speed: val });
       }
+    },
+    walletMode(): boolean {
+      return isScenarioX402Enabled() && scenarioPaymentState('digitalhuman').mode === 'wallet';
+    }
+  },
+  watch: {
+    walletMode: {
+      handler(enabled: boolean) {
+        if (enabled) this.scheduleQuote();
+      },
+      immediate: true
+    },
+    config: {
+      handler() {
+        if (this.walletMode) this.scheduleQuote();
+      },
+      deep: true
+    },
+    faceMode() {
+      if (this.walletMode) this.scheduleQuote();
+    },
+    voiceMode() {
+      if (this.walletMode) this.scheduleQuote();
     }
   },
   mounted() {
@@ -231,7 +263,30 @@ export default defineComponent({
       this.voiceMode = 'audio';
     }
   },
+  beforeUnmount() {
+    window.clearTimeout(this.quoteTimer);
+    this.quoteRunId += 1;
+  },
   methods: {
+    scheduleQuote() {
+      window.clearTimeout(this.quoteTimer);
+      this.quoteTimer = window.setTimeout(this.refreshQuote, 350);
+    },
+    async refreshQuote() {
+      const state = scenarioPaymentState('digitalhuman');
+      const runId = ++this.quoteRunId;
+      state.quoteLoading = true;
+      state.quoteUsdc = undefined;
+      try {
+        const request = buildDigitalHumanVideoRequest(this.config, this.faceMode, this.voiceMode);
+        const quote = await digitalHumanOperator.quote(request);
+        if (runId === this.quoteRunId && state.mode === 'wallet') state.quoteUsdc = quote.amountUsdc;
+      } catch (error) {
+        console.warn('x402 quote failed', error);
+      } finally {
+        if (runId === this.quoteRunId) state.quoteLoading = false;
+      }
+    },
     isMissing(key: string): boolean {
       return this.missing.some((item) => item.key === key);
     },
@@ -267,23 +322,7 @@ export default defineComponent({
         (this.$refs[anchor] as HTMLElement | undefined)?.scrollIntoView?.({ behavior: 'smooth', block: 'center' });
         return;
       }
-      // Build a clean request from the active modes only — never leak the
-      // inactive face/voice fields into the payload. A photo travels in
-      // video_url: that is the single face field the API reads.
-      const c = this.config || {};
-      const request: IDigitalHumanGenerateRequest = {
-        video_url: this.faceMode === 'video' ? c.video_url : c.image_url
-      };
-      if (this.voiceMode === 'audio') {
-        request.audio_url = c.audio_url;
-      } else {
-        request.text = c.text;
-        request.voice_id = c.voice_id;
-      }
-      if (c.speed && c.speed !== 1) {
-        request.speed = c.speed;
-      }
-      this.$emit('generate', request);
+      this.$emit('generate', buildDigitalHumanVideoRequest(this.config, this.faceMode, this.voiceMode));
     }
   }
 });

--- a/src/components/digitalhuman/config/VoiceCloneDialog.vue
+++ b/src/components/digitalhuman/config/VoiceCloneDialog.vue
@@ -43,7 +43,16 @@
 
     <template #footer>
       <div class="footer">
-        <consumption :value="DIGITALHUMAN_VOICE_CLONE_CONSUMPTION" :service="service" class="cost" />
+        <span v-if="walletMode" class="cost text-xs text-[var(--el-text-color-secondary)]">
+          {{
+            voiceQuoteLoading
+              ? '…'
+              : voiceQuoteUsdc
+                ? `${voiceQuoteUsdc} USDC`
+                : $t('common.x402Scenario.quoteBeforeSigning')
+          }}
+        </span>
+        <consumption v-else :value="DIGITALHUMAN_VOICE_CLONE_CONSUMPTION" :service="service" class="cost" />
         <div>
           <el-button :disabled="cloning" @click="onVisible(false)">{{ $t('common.button.cancel') }}</el-button>
           <el-button type="primary" :loading="cloning" :disabled="!sampleUrl || cloning" @click="onClone">
@@ -57,10 +66,19 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElAlert, ElButton, ElDialog, ElInput, ElMessage, ElRadioButton, ElRadioGroup } from 'element-plus';
+import {
+  ElAlert,
+  ElButton,
+  ElDialog,
+  ElInput,
+  ElMessage,
+  ElMessageBox,
+  ElRadioButton,
+  ElRadioGroup
+} from 'element-plus';
 import Consumption from '@/components/common/Consumption.vue';
 import MediaInput from './MediaInput.vue';
-import { digitalHumanOperator } from '@/operators';
+import { buildDigitalHumanVoiceRequest, digitalHumanOperator } from '@/operators/digitalhuman';
 import {
   DIGITALHUMAN_ALLOWED_LANGS,
   DIGITALHUMAN_AUDIO_ACCEPT,
@@ -68,6 +86,13 @@ import {
   DIGITALHUMAN_VOICE_CLONE_CONSUMPTION
 } from '@/constants';
 import { addVoice, nextVoiceName } from '@/utils/digitalhumanVoices';
+import { isScenarioX402Enabled, scenarioPaymentState } from '@/utils/x402/scenarioPayment';
+import {
+  X402PaymentCancelledError,
+  type OperatorRequestOptions,
+  type X402PaymentQuote,
+  type X402WalletContext
+} from '@/operators/x402';
 import { IDigitalHumanLang } from '@/models';
 
 const POLL_INTERVAL = 3000;
@@ -82,6 +107,9 @@ interface IData {
   runId: number;
   DIGITALHUMAN_AUDIO_ACCEPT: string;
   DIGITALHUMAN_VOICE_CLONE_CONSUMPTION: number;
+  voiceQuoteUsdc: string | undefined;
+  voiceQuoteLoading: boolean;
+  quoteRunId: number;
 }
 
 export default defineComponent({
@@ -112,7 +140,10 @@ export default defineComponent({
       destroyed: false,
       runId: 0,
       DIGITALHUMAN_AUDIO_ACCEPT,
-      DIGITALHUMAN_VOICE_CLONE_CONSUMPTION
+      DIGITALHUMAN_VOICE_CLONE_CONSUMPTION,
+      voiceQuoteUsdc: undefined,
+      voiceQuoteLoading: false,
+      quoteRunId: 0
     };
   },
   computed: {
@@ -122,6 +153,9 @@ export default defineComponent({
     credentialToken(): string | undefined {
       return this.$store.state.digitalhuman?.credential?.token;
     },
+    walletMode(): boolean {
+      return isScenarioX402Enabled() && scenarioPaymentState('digitalhuman').mode === 'wallet';
+    },
     langOptions(): { value: string; label: string }[] {
       return DIGITALHUMAN_ALLOWED_LANGS.map((value) => ({
         value,
@@ -130,6 +164,10 @@ export default defineComponent({
     }
   },
   watch: {
+    walletMode(enabled: boolean) {
+      this.voiceQuoteUsdc = undefined;
+      if (enabled && this.visible && this.sampleUrl) this.refreshVoiceQuote();
+    },
     visible(open: boolean) {
       if (open) {
         this.sampleUrl = undefined;
@@ -138,13 +176,16 @@ export default defineComponent({
       } else {
         // abandon any in-flight poll so a reopened dialog never adopts it
         this.runId++;
+        this.quoteRunId++;
         this.cloning = false;
+        this.voiceQuoteLoading = false;
       }
     }
   },
   beforeUnmount() {
     this.destroyed = true;
     this.runId++;
+    this.quoteRunId++;
   },
   methods: {
     onVisible(open: boolean) {
@@ -155,6 +196,8 @@ export default defineComponent({
     },
     onSampleChange(url: string | undefined) {
       this.sampleUrl = url;
+      this.voiceQuoteUsdc = undefined;
+      if (url && this.walletMode) this.refreshVoiceQuote();
     },
     isStale(runId: number): boolean {
       return this.destroyed || runId !== this.runId;
@@ -162,18 +205,50 @@ export default defineComponent({
     sleep(ms: number): Promise<void> {
       return new Promise((resolve) => setTimeout(resolve, ms));
     },
-    async onClone() {
-      const token = this.credentialToken;
-      if (!this.sampleUrl || !token) {
-        return;
+    async refreshVoiceQuote() {
+      if (!this.sampleUrl) return;
+      const runId = ++this.quoteRunId;
+      this.voiceQuoteLoading = true;
+      try {
+        const quote = await digitalHumanOperator.quoteVoice(this.voiceRequest());
+        if (runId === this.quoteRunId && this.walletMode) this.voiceQuoteUsdc = quote.amountUsdc;
+      } catch (error) {
+        console.warn('x402 voice quote failed', error);
+      } finally {
+        if (runId === this.quoteRunId) this.voiceQuoteLoading = false;
       }
+    },
+    voiceRequest() {
+      return buildDigitalHumanVoiceRequest({
+        audio_url: this.sampleUrl || '',
+        lang: this.lang,
+        name: this.name || undefined
+      });
+    },
+    paymentOptions(): OperatorRequestOptions | undefined {
+      if (!this.walletMode) return this.credentialToken ? { token: this.credentialToken } : undefined;
+      const wallet = this.getWalletContext();
+      if (!wallet) {
+        ElMessage.warning(this.$t('common.x402Scenario.connectWalletFirst'));
+        return undefined;
+      }
+      return {
+        mode: 'x402',
+        x402: {
+          wallet,
+          confirm: (quote) => this.confirmWalletPayment(quote),
+          identityToken: this.credentialToken
+        }
+      };
+    },
+    async onClone() {
+      if (!this.sampleUrl) return;
+      const options = this.paymentOptions();
+      if (!options) return;
       const runId = ++this.runId;
       this.cloning = true;
       try {
-        const { data } = await digitalHumanOperator.cloneVoice(
-          { audio_url: this.sampleUrl, lang: this.lang, name: this.name || undefined },
-          { token }
-        );
+        const { data } = await digitalHumanOperator.cloneVoice(this.voiceRequest(), options);
         if (this.isStale(runId)) {
           return;
         }
@@ -182,11 +257,12 @@ export default defineComponent({
           return;
         }
         if (data?.task_id) {
-          await this.pollVoice(data.task_id, token, runId);
+          await this.pollVoice(data.task_id, runId);
         } else {
           throw new Error('no task');
         }
-      } catch (_e) {
+      } catch (error) {
+        if (error instanceof X402PaymentCancelledError) return;
         if (!this.isStale(runId)) {
           ElMessage.error(this.$t('digitalhuman.message.voiceCloneFailed'));
         }
@@ -196,7 +272,7 @@ export default defineComponent({
         }
       }
     },
-    async pollVoice(taskId: string, token: string, runId: number) {
+    async pollVoice(taskId: string, runId: number) {
       for (let i = 0; i < POLL_MAX; i++) {
         if (this.isStale(runId)) {
           return;
@@ -205,7 +281,8 @@ export default defineComponent({
         if (this.isStale(runId)) {
           return;
         }
-        const { data } = await digitalHumanOperator.pollTask(taskId, { token });
+        const token = this.credentialToken;
+        const { data } = await digitalHumanOperator.pollTask(taskId, token ? { token } : { mode: 'x402' });
         if (this.isStale(runId)) {
           return;
         }
@@ -218,6 +295,26 @@ export default defineComponent({
         }
       }
       throw new Error('timeout');
+    },
+    getWalletContext(): X402WalletContext | undefined {
+      const walletApi = (this as any).$wallet;
+      const publicKey = walletApi?.publicKey?.value;
+      const adapter = walletApi?.wallet?.value?.adapter;
+      if (!publicKey || !adapter?.signTransaction) return undefined;
+      return { publicKey, signTransaction: adapter.signTransaction.bind(adapter) };
+    },
+    async confirmWalletPayment(quote: X402PaymentQuote): Promise<boolean> {
+      return ElMessageBox.confirm(
+        this.$t('common.x402Scenario.confirmPayment', { amount: quote.amountUsdc }),
+        this.$t('order.message.x402ConfirmTitle'),
+        {
+          confirmButtonText: this.$t('order.message.x402WalletPayCta'),
+          cancelButtonText: this.$t('common.button.cancel'),
+          type: 'warning'
+        }
+      )
+        .then(() => true)
+        .catch(() => false);
     },
     onCloned(voiceId: string) {
       addVoice({

--- a/src/components/kling/ConfigPanel.vue
+++ b/src/components/kling/ConfigPanel.vue
@@ -17,7 +17,8 @@
     </div>
     <div class="flex flex-col items-center justify-center px-5 pb-5">
       <summary-chip />
-      <consumption :value="consumption" :service="service" />
+      <scenario-payment-mode scenario="kling" />
+      <consumption v-if="!walletMode" :value="consumption" :service="service" />
       <el-button
         v-if="config?.video_url !== undefined || config?.custom"
         type="primary"
@@ -59,6 +60,9 @@ import InspirationDrawer from './inspiration/InspirationDrawer.vue';
 import SummaryChip from './SummaryChip.vue';
 import { getConsumption } from '@/utils';
 import { getKlingCapabilities } from '@/utils/kling/capabilities';
+import ScenarioPaymentMode from '../common/ScenarioPaymentMode.vue';
+import { isScenarioX402Enabled, scenarioPaymentState } from '@/utils/x402/scenarioPayment';
+import { buildKlingVideoRequest, klingOperator } from '@/operators/kling';
 
 export default defineComponent({
   name: 'ConfigPanel',
@@ -80,12 +84,15 @@ export default defineComponent({
     SummaryChip,
     EndImage,
     ReferenceImages,
-    ReferenceVideo
+    ReferenceVideo,
+    ScenarioPaymentMode
   },
   emits: ['generate'],
   data() {
     return {
-      inspirationOpen: false
+      inspirationOpen: false,
+      quoteTimer: 0,
+      quoteRunId: 0
     };
   },
   computed: {
@@ -105,9 +112,48 @@ export default defineComponent({
     },
     service() {
       return this.$store.state.kling?.service;
+    },
+    walletMode(): boolean {
+      return isScenarioX402Enabled() && scenarioPaymentState('kling').mode === 'wallet';
     }
   },
+  watch: {
+    walletMode: {
+      handler(enabled: boolean) {
+        if (enabled) this.scheduleQuote();
+      },
+      immediate: true
+    },
+    config: {
+      handler() {
+        if (this.walletMode) this.scheduleQuote();
+      },
+      deep: true
+    }
+  },
+  beforeUnmount() {
+    window.clearTimeout(this.quoteTimer);
+    this.quoteRunId += 1;
+  },
   methods: {
+    scheduleQuote() {
+      window.clearTimeout(this.quoteTimer);
+      this.quoteTimer = window.setTimeout(this.refreshQuote, 350);
+    },
+    async refreshQuote() {
+      const state = scenarioPaymentState('kling');
+      const runId = ++this.quoteRunId;
+      state.quoteLoading = true;
+      state.quoteUsdc = undefined;
+      try {
+        const quote = await klingOperator.quote(buildKlingVideoRequest(this.config));
+        if (runId === this.quoteRunId && state.mode === 'wallet') state.quoteUsdc = quote.amountUsdc;
+      } catch (error) {
+        console.warn('x402 quote failed', error);
+      } finally {
+        if (runId === this.quoteRunId) state.quoteLoading = false;
+      }
+    },
     onGenerate() {
       this.$emit('generate');
     }

--- a/src/components/kling/TalkingPhotoPanel.vue
+++ b/src/components/kling/TalkingPhotoPanel.vue
@@ -90,7 +90,8 @@
     </div>
 
     <div class="flex flex-col items-center justify-center px-5 pb-5">
-      <consumption :value="consumption" :service="service" />
+      <scenario-payment-mode scenario="kling" />
+      <consumption v-if="!walletMode" :value="consumption" :service="service" />
       <el-button type="primary" class="btn w-full" round :disabled="!canGenerate" @click="onGenerate">
         <magic-icon class="mr-2" :size="'1em' as any" aria-hidden="true" focusable="false" />
         {{ $t('kling.button.generateTalkingPhoto') }}
@@ -110,11 +111,16 @@ import ModelSelector from './talking-photo/ModelSelector.vue';
 import ModeSelector from './talking-photo/ModeSelector.vue';
 import { getBaseUrlPlatform, getConsumption, uploadTrackerMixin, uploadSizeGuardMixin } from '@/utils';
 import { IKlingTalkingPhotoConfig } from '@/models';
+import ScenarioPaymentMode from '../common/ScenarioPaymentMode.vue';
+import { isScenarioX402Enabled, scenarioPaymentState } from '@/utils/x402/scenarioPayment';
+import { buildKlingTalkingPhotoRequest, klingOperator } from '@/operators/kling';
 
 interface IData {
   imageFiles: UploadFiles;
   audioFiles: UploadFiles;
   uploadUrl: string;
+  quoteTimer: number;
+  quoteRunId: number;
 }
 
 export default defineComponent({
@@ -129,7 +135,8 @@ export default defineComponent({
     InfoIcon,
     ImagePreview,
     ModelSelector,
-    ModeSelector
+    ModeSelector,
+    ScenarioPaymentMode
   },
   mixins: [uploadTrackerMixin, uploadSizeGuardMixin],
   emits: ['generate'],
@@ -137,7 +144,9 @@ export default defineComponent({
     return {
       imageFiles: [],
       audioFiles: [],
-      uploadUrl: getBaseUrlPlatform() + '/api/v1/files/'
+      uploadUrl: getBaseUrlPlatform() + '/api/v1/files/',
+      quoteTimer: 0,
+      quoteRunId: 0
     };
   },
   computed: {
@@ -160,9 +169,48 @@ export default defineComponent({
     },
     canGenerate(): boolean {
       return Boolean(this.config.image_url && this.config.audio_url);
+    },
+    walletMode(): boolean {
+      return isScenarioX402Enabled() && scenarioPaymentState('kling').mode === 'wallet';
     }
   },
+  watch: {
+    walletMode: {
+      handler(enabled: boolean) {
+        if (enabled) this.scheduleQuote();
+      },
+      immediate: true
+    },
+    config: {
+      handler() {
+        if (this.walletMode) this.scheduleQuote();
+      },
+      deep: true
+    }
+  },
+  beforeUnmount() {
+    window.clearTimeout(this.quoteTimer);
+    this.quoteRunId += 1;
+  },
   methods: {
+    scheduleQuote() {
+      window.clearTimeout(this.quoteTimer);
+      this.quoteTimer = window.setTimeout(this.refreshQuote, 350);
+    },
+    async refreshQuote() {
+      const state = scenarioPaymentState('kling');
+      const runId = ++this.quoteRunId;
+      state.quoteLoading = true;
+      state.quoteUsdc = undefined;
+      try {
+        const quote = await klingOperator.quoteTalkingPhoto(buildKlingTalkingPhotoRequest(this.config));
+        if (runId === this.quoteRunId && state.mode === 'wallet') state.quoteUsdc = quote.amountUsdc;
+      } catch (error) {
+        console.warn('x402 quote failed', error);
+      } finally {
+        if (runId === this.quoteRunId) state.quoteLoading = false;
+      }
+    },
     commit(patch: Partial<IKlingTalkingPhotoConfig>) {
       this.$store.commit('kling/setTalkingPhotoConfig', { ...this.config, ...patch });
     },

--- a/src/components/x402SpecialVideoContract.test.ts
+++ b/src/components/x402SpecialVideoContract.test.ts
@@ -1,0 +1,55 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = (relativePath: string) => fs.readFileSync(path.resolve(process.cwd(), 'src', relativePath), 'utf8');
+
+describe('special video x402 contract', () => {
+  it('registers Kling and Digital Human while disabling wallet mode for Kling Motion', () => {
+    const main = source('layouts/Main.vue');
+    const klingPage = source('pages/kling/Index.vue');
+
+    expect(main).toContain("'kling'");
+    expect(main).toContain("'digitalhuman'");
+    expect(main).toContain("this.appName === 'kling'");
+    expect(main).toContain("taskType === 'motion'");
+    expect(klingPage).toContain("if (value === 'motion') setScenarioPaymentMode('kling', 'credits')");
+    expect(source('components/kling/MotionPanel.vue')).not.toContain('ScenarioPaymentMode');
+    expect(klingPage).toContain('klingOperator.motion(request, { token })');
+  });
+
+  it('keeps Kling video and talking-photo quote/submit endpoints separate', () => {
+    const videoPanel = source('components/kling/ConfigPanel.vue');
+    const talkingPanel = source('components/kling/TalkingPhotoPanel.vue');
+    const page = source('pages/kling/Index.vue');
+
+    expect(videoPanel).toContain('klingOperator.quote(buildKlingVideoRequest(this.config))');
+    expect(talkingPanel).toContain('klingOperator.quoteTalkingPhoto(buildKlingTalkingPhotoRequest(this.config))');
+    expect(page).toContain('klingOperator.generate(request, options)');
+    expect(page).toContain('klingOperator.talkingPhoto(request, options)');
+    expect(page).toContain('identityToken: this.credential?.token');
+    expect(page).toContain("mode: 'x402', ids: this.walletTaskIds");
+  });
+
+  it('keeps Digital Human video and voice clone payment state independent', () => {
+    const config = source('components/digitalhuman/ConfigPanel.vue');
+    const dialog = source('components/digitalhuman/config/VoiceCloneDialog.vue');
+    const page = source('pages/digitalhuman/Index.vue');
+
+    expect(config).toContain('digitalHumanOperator.quote(request)');
+    expect(config).toContain('buildDigitalHumanVideoRequest(this.config, this.faceMode, this.voiceMode)');
+    expect(dialog).toContain('digitalHumanOperator.quoteVoice(this.voiceRequest())');
+    expect(dialog).toContain('voiceQuoteUsdc');
+    expect(dialog).not.toContain("scenarioPaymentState('digitalhuman').quoteUsdc");
+    expect(dialog).toContain("token ? { token } : { mode: 'x402' }");
+    expect(page).toContain("mode: 'x402', ids: this.walletTaskIds");
+    expect(page).toContain('identityToken: this.credential?.token');
+  });
+
+  it('does not add persistent task history or change shared delete behavior', () => {
+    ['pages/kling/Index.vue', 'pages/digitalhuman/Index.vue'].forEach((file) => {
+      expect(source(file)).not.toContain('localStorage');
+      expect(source(file)).not.toContain('sessionStorage');
+    });
+  });
+});

--- a/src/layouts/Main.vue
+++ b/src/layouts/Main.vue
@@ -3,14 +3,14 @@
     <router-view class="main" />
     <navigator class="navigator" :direction="mobile ? 'row' : 'column'" />
     <application-status
-      v-if="application || x402ScenarioEnabled"
+      v-if="application || x402Scenario"
       class="status-floating fixed right-2 z-[200]"
       :application="application"
       :applications="applications"
       :show-price="false"
       :authenticated="!!$store.state.token.access"
       :service="service"
-      :scenario="appName"
+      :scenario="x402Scenario"
       @select="$store.dispatch(`${appName}/setApplication`, $event)"
     />
     <application-confirm v-model.visible="applying" @apply="onApply" />
@@ -60,6 +60,10 @@ export default defineComponent({
     appName(): keyof IAppState {
       return this.$route.meta.appName as keyof IAppState;
     },
+    x402Scenario(): string | undefined {
+      if (this.appName === 'kling' && this.$store.state.kling?.taskType === 'motion') return undefined;
+      return this.x402ScenarioEnabled ? String(this.appName) : undefined;
+    },
     x402ScenarioEnabled(): boolean {
       return (
         [
@@ -78,7 +82,9 @@ export default defineComponent({
           'omni',
           'grokvideo',
           'minimax',
-          'maestro'
+          'maestro',
+          'kling',
+          'digitalhuman'
         ].includes(String(this.appName)) && isScenarioX402Enabled()
       );
     },

--- a/src/operators/digitalhuman.ts
+++ b/src/operators/digitalhuman.ts
@@ -1,6 +1,7 @@
 import axios, { AxiosResponse } from 'axios';
-import { BASE_URL_API } from '@/constants';
+import { BASE_URL_API, BASE_URL_X402 } from '@/constants';
 import {
+  IDigitalHumanConfig,
   IDigitalHumanGenerateRequest,
   IDigitalHumanGenerateResponse,
   IDigitalHumanTaskResponse,
@@ -9,6 +10,32 @@ import {
   IDigitalHumanVoiceResponse
 } from '@/models';
 import { BaseTaskOperator, ITaskListFilter } from './baseTaskOperator';
+import { postWithX402, quoteX402, type OperatorRequestOptions } from './x402';
+
+const VOICE_HEADERS = { 'content-type': 'application/json', accept: 'application/json' };
+
+export function buildDigitalHumanVideoRequest(
+  config: IDigitalHumanConfig | undefined,
+  faceMode: 'video' | 'photo',
+  voiceMode: 'audio' | 'text'
+): IDigitalHumanGenerateRequest {
+  const source = config || {};
+  const request: IDigitalHumanGenerateRequest = {
+    video_url: faceMode === 'video' ? source.video_url : source.image_url,
+    async: true
+  };
+  if (voiceMode === 'audio') request.audio_url = source.audio_url;
+  else {
+    request.text = source.text;
+    request.voice_id = source.voice_id;
+  }
+  if (source.speed && source.speed !== 1) request.speed = source.speed;
+  return request;
+}
+
+export function buildDigitalHumanVoiceRequest(data: IDigitalHumanVoiceRequest): IDigitalHumanVoiceRequest {
+  return { ...data, async: true };
+}
 
 class DigitalHumanOperator extends BaseTaskOperator<
   IDigitalHumanGenerateRequest,
@@ -21,35 +48,41 @@ class DigitalHumanOperator extends BaseTaskOperator<
     super({ tasksPath: '/digital-human/tasks', generatePath: '/digital-human/videos' });
   }
 
-  /** Clone a voice sample into a reusable voice_id (async — poll with `pollTask`). */
+  async quoteVoice(data: IDigitalHumanVoiceRequest) {
+    return quoteX402('/digital-human/voices', data, VOICE_HEADERS);
+  }
+
   async cloneVoice(
     data: IDigitalHumanVoiceRequest,
-    options: { token: string }
+    options: OperatorRequestOptions
   ): Promise<AxiosResponse<IDigitalHumanVoiceResponse>> {
+    if (options.mode === 'x402') {
+      if (!options.x402) throw new Error('x402 payment options are required');
+      return postWithX402<IDigitalHumanVoiceResponse>('/digital-human/voices', data, options.x402, VOICE_HEADERS);
+    }
     return axios.post('/digital-human/voices', data, {
       baseURL: BASE_URL_API,
-      headers: {
-        'content-type': 'application/json',
-        accept: 'application/json',
-        authorization: `Bearer ${options.token}`
-      }
+      headers: { ...VOICE_HEADERS, authorization: `Bearer ${options.token}` }
     });
   }
 
-  /** Poll a single task (voice clone or video) by task_id — the flat external shape. */
-  async pollTask(taskId: string, options: { token: string }): Promise<AxiosResponse<IDigitalHumanGenerateResponse>> {
+  async pollTask(
+    taskId: string,
+    options: OperatorRequestOptions
+  ): Promise<AxiosResponse<IDigitalHumanGenerateResponse>> {
     return axios.post(
       '/digital-human/tasks',
       { task_id: taskId },
-      {
-        baseURL: BASE_URL_API,
-        headers: {
-          'content-type': 'application/json',
-          accept: 'application/json',
-          'x-record-exempt': 'true',
-          authorization: `Bearer ${options.token}`
-        }
-      }
+      options.mode === 'x402'
+        ? { baseURL: BASE_URL_X402, headers: { ...VOICE_HEADERS, 'x-record-exempt': 'true' } }
+        : {
+            baseURL: BASE_URL_API,
+            headers: {
+              ...VOICE_HEADERS,
+              'x-record-exempt': 'true',
+              authorization: `Bearer ${options.token}`
+            }
+          }
     );
   }
 }

--- a/src/operators/kling.ts
+++ b/src/operators/kling.ts
@@ -1,14 +1,56 @@
 import axios, { AxiosResponse } from 'axios';
 import {
+  IKlingConfig,
   IKlingGenerateRequest,
   IKlingGenerateResponse,
   IKlingMotionRequest,
+  IKlingTalkingPhotoConfig,
   IKlingTalkingPhotoRequest,
   IKlingTaskResponse,
   IKlingTasksResponse
 } from '@/models';
-import { BASE_URL_API } from '@/constants';
+import { BASE_URL_API, KLING_TALKING_PHOTO_DEFAULT_MODEL, KLING_TALKING_PHOTO_DEFAULT_MODE } from '@/constants';
 import { BaseTaskOperator, ITaskListFilter } from './baseTaskOperator';
+import { postWithX402, quoteX402, type OperatorRequestOptions } from './x402';
+
+const X402_HEADERS = { 'content-type': 'application/json', accept: 'application/x-ndjson' };
+
+export function buildKlingVideoRequest(config?: IKlingConfig): IKlingGenerateRequest {
+  const { camera_control, ...rest } = config || {};
+  const request: IKlingGenerateRequest = { ...rest, async: true };
+  if (!request.action) {
+    if (request.video_id || request.video_url) request.action = 'extend';
+    else if (request.start_image_url) request.action = 'image2video';
+    else request.action = 'text2video';
+  }
+  if (request.action === 'text2video') delete request.end_image_url;
+  if (camera_control?.type) {
+    request.camera_control = {
+      type: camera_control.type,
+      ...(camera_control.type === 'simple' && camera_control.config
+        ? {
+            config: Object.fromEntries(
+              Object.entries(camera_control.config).filter(([, value]) => value !== undefined && value !== null)
+            )
+          }
+        : {})
+    };
+  }
+  return request;
+}
+
+export function buildKlingTalkingPhotoRequest(config?: IKlingTalkingPhotoConfig): IKlingTalkingPhotoRequest {
+  const source = config || {};
+  return {
+    image_url: source.image_url || '',
+    audio_url: source.audio_url || '',
+    model: source.model || KLING_TALKING_PHOTO_DEFAULT_MODEL,
+    mode: source.mode || KLING_TALKING_PHOTO_DEFAULT_MODE,
+    ...(source.prompt ? { prompt: source.prompt } : {}),
+    ...(source.duration ? { duration: source.duration } : {}),
+    async: true
+  };
+}
 
 class KlingOperator extends BaseTaskOperator<
   IKlingGenerateRequest,
@@ -24,25 +66,25 @@ class KlingOperator extends BaseTaskOperator<
   async motion(data: IKlingMotionRequest, options: { token: string }): Promise<AxiosResponse<IKlingGenerateResponse>> {
     return axios.post('/kling/motion', data, {
       baseURL: BASE_URL_API,
-      headers: {
-        authorization: `Bearer ${options.token}`,
-        'content-type': 'application/json',
-        accept: 'application/x-ndjson'
-      }
+      headers: { ...X402_HEADERS, authorization: `Bearer ${options.token}` }
     });
+  }
+
+  async quoteTalkingPhoto(data: IKlingTalkingPhotoRequest) {
+    return quoteX402('/kling/talking-photo', data, X402_HEADERS);
   }
 
   async talkingPhoto(
     data: IKlingTalkingPhotoRequest,
-    options: { token: string }
+    options: OperatorRequestOptions
   ): Promise<AxiosResponse<IKlingGenerateResponse>> {
+    if (options.mode === 'x402') {
+      if (!options.x402) throw new Error('x402 payment options are required');
+      return postWithX402<IKlingGenerateResponse>('/kling/talking-photo', data, options.x402, X402_HEADERS);
+    }
     return axios.post('/kling/talking-photo', data, {
       baseURL: BASE_URL_API,
-      headers: {
-        authorization: `Bearer ${options.token}`,
-        'content-type': 'application/json',
-        accept: 'application/x-ndjson'
-      }
+      headers: { ...X402_HEADERS, authorization: `Bearer ${options.token}` }
     });
   }
 }

--- a/src/operators/x402SpecialVideoRequests.test.ts
+++ b/src/operators/x402SpecialVideoRequests.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from 'vitest';
+import { buildKlingTalkingPhotoRequest, buildKlingVideoRequest, klingOperator } from './kling';
+import { buildDigitalHumanVideoRequest, buildDigitalHumanVoiceRequest, digitalHumanOperator } from './digitalhuman';
+
+const x402 = vi.hoisted(() => ({ quote: vi.fn(), post: vi.fn() }));
+const axios = vi.hoisted(() => ({ post: vi.fn() }));
+
+vi.mock('./x402', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./x402')>()),
+  quoteX402: x402.quote,
+  postWithX402: x402.post
+}));
+vi.mock('axios', () => ({ default: { post: axios.post } }));
+
+describe('special video x402 requests', () => {
+  it('normalizes Kling video and talking-photo requests independently', () => {
+    expect(
+      buildKlingVideoRequest({
+        model: 'kling-v3',
+        mode: 'std',
+        duration: 10,
+        start_image_url: 'start.png',
+        camera_control: { type: 'simple', config: { horizontal: 1, pan: undefined } }
+      })
+    ).toEqual({
+      model: 'kling-v3',
+      mode: 'std',
+      duration: 10,
+      start_image_url: 'start.png',
+      action: 'image2video',
+      camera_control: { type: 'simple', config: { horizontal: 1 } },
+      async: true
+    });
+    expect(
+      buildKlingTalkingPhotoRequest({ image_url: 'face.png', audio_url: 'voice.mp3', duration: 10 })
+    ).toMatchObject({
+      image_url: 'face.png',
+      audio_url: 'voice.mp3',
+      duration: 10,
+      async: true
+    });
+  });
+
+  it('routes Kling talking-photo quote and payment to its own endpoint', async () => {
+    x402.quote.mockResolvedValueOnce({ amountUsdc: '1' });
+    x402.post.mockResolvedValueOnce({ data: { task_id: 'talk-1' } });
+    const request = buildKlingTalkingPhotoRequest({ image_url: 'face.png', audio_url: 'voice.mp3' });
+
+    await klingOperator.quoteTalkingPhoto(request);
+    await klingOperator.talkingPhoto(request, {
+      mode: 'x402',
+      x402: { wallet: {} as never, confirm: async () => true }
+    });
+
+    expect(x402.quote).toHaveBeenCalledWith('/kling/talking-photo', request, expect.any(Object));
+    expect(x402.post).toHaveBeenCalledWith('/kling/talking-photo', request, expect.any(Object), expect.any(Object));
+  });
+
+  it('normalizes Digital Human video and voice payloads independently', () => {
+    expect(
+      buildDigitalHumanVideoRequest(
+        { image_url: 'face.png', text: 'hello', voice_id: 'voice-1', speed: 1.2 },
+        'photo',
+        'text'
+      )
+    ).toEqual({ video_url: 'face.png', text: 'hello', voice_id: 'voice-1', speed: 1.2, async: true });
+    expect(buildDigitalHumanVoiceRequest({ audio_url: 'voice.mp3', lang: 'en', name: 'Voice' })).toEqual({
+      audio_url: 'voice.mp3',
+      lang: 'en',
+      name: 'Voice',
+      async: true
+    });
+  });
+
+  it('routes voice quote/payment separately and keeps x402 polling free', async () => {
+    x402.quote.mockResolvedValueOnce({ amountUsdc: '1' });
+    x402.post.mockResolvedValueOnce({ data: { task_id: 'voice-1' } });
+    axios.post.mockResolvedValueOnce({ data: { voice_id: 'ready' } });
+    const request = buildDigitalHumanVoiceRequest({ audio_url: 'voice.mp3' });
+
+    await digitalHumanOperator.quoteVoice(request);
+    await digitalHumanOperator.cloneVoice(request, {
+      mode: 'x402',
+      x402: { wallet: {} as never, confirm: async () => true }
+    });
+    await digitalHumanOperator.pollTask('voice-1', { mode: 'x402' });
+
+    expect(x402.quote).toHaveBeenCalledWith('/digital-human/voices', request, expect.any(Object));
+    expect(x402.post).toHaveBeenCalledWith('/digital-human/voices', request, expect.any(Object), expect.any(Object));
+    expect(axios.post).toHaveBeenCalledWith(
+      '/digital-human/tasks',
+      { task_id: 'voice-1' },
+      expect.objectContaining({
+        baseURL: 'https://x402.acedata.cloud',
+        headers: expect.not.objectContaining({ authorization: expect.anything() })
+      })
+    );
+  });
+});

--- a/src/pages/digitalhuman/Index.vue
+++ b/src/pages/digitalhuman/Index.vue
@@ -14,18 +14,21 @@ import { defineComponent } from 'vue';
 import Layout from '@/layouts/DigitalHuman.vue';
 import ConfigPanel from '@/components/digitalhuman/ConfigPanel.vue';
 import RecentPanel from '@/components/digitalhuman/RecentPanel.vue';
-import { digitalHumanOperator } from '@/operators';
+import { digitalHumanOperator } from '@/operators/digitalhuman';
 import { ensureLoggedIn, ensureNoPendingUpload, uploadTrackerProviderMixin } from '@/utils';
 import { instrumentGeneration } from '@/plugins/telemetry';
 import { IDigitalHumanGenerateRequest, Status } from '@/models';
-import { ElMessage } from 'element-plus';
+import { ElMessage, ElMessageBox } from 'element-plus';
 import { ERROR_CODE_USED_UP } from '@/constants';
 import { loadPreviousPage } from '@/utils/pagination';
+import { isScenarioX402Enabled, scenarioPaymentState } from '@/utils/x402/scenarioPayment';
+import { X402PaymentCancelledError, type X402PaymentQuote, type X402WalletContext } from '@/operators/x402';
 
 interface IData {
   job: number;
   loadingMore: boolean;
   fetchingTasks: boolean;
+  walletTaskIds: string[];
 }
 
 export default defineComponent({
@@ -41,7 +44,8 @@ export default defineComponent({
     return {
       job: 0,
       loadingMore: false,
-      fetchingTasks: false
+      fetchingTasks: false,
+      walletTaskIds: []
     };
   },
   computed: {
@@ -59,18 +63,34 @@ export default defineComponent({
     },
     tasks() {
       return this.$store.state.digitalhuman.tasks;
+    },
+    walletMode(): boolean {
+      return isScenarioX402Enabled() && scenarioPaymentState('digitalhuman').mode === 'wallet';
     }
   },
   watch: {
+    walletMode: {
+      async handler(value: boolean, oldValue: boolean | undefined) {
+        if (oldValue === undefined || value === oldValue) return;
+        this.$store.commit('digitalhuman/setTasks', undefined);
+        if (value && !this.job) this.job = window.setInterval(this.onGetTasks, 5000);
+        if (!value && !this.credential?.token) {
+          window.clearInterval(this.job);
+          this.job = 0;
+          await this.onScrollDown();
+          return;
+        }
+        await this.onGetTasks();
+        await this.onScrollDown();
+      }
+    },
     initialized: {
       async handler(newValue) {
         window.clearInterval(this.job);
         if (newValue) {
           await this.onGetTasks();
           await this.onScrollDown();
-          this.job = window.setInterval(() => {
-            this.onGetTasks();
-          }, 5000);
+          if (!this.job) this.job = window.setInterval(this.onGetTasks, 5000);
         }
       },
       immediate: true
@@ -111,7 +131,12 @@ export default defineComponent({
       const { limit = 5, createdAtMin, createdAtMax } = payload || {};
       this.fetchingTasks = true;
       try {
-        await this.$store.dispatch('digitalhuman/getTasks', { limit, createdAtMin, createdAtMax });
+        await this.$store.dispatch('digitalhuman/getTasks', {
+          limit,
+          createdAtMin,
+          createdAtMax,
+          ...(this.walletMode && !this.credential?.token ? { mode: 'x402', ids: this.walletTaskIds } : {})
+        });
       } finally {
         this.fetchingTasks = false;
       }
@@ -126,26 +151,38 @@ export default defineComponent({
       ) {
         return;
       }
-      if (!ensureLoggedIn()) {
-        return;
-      }
-      const token = this.credential?.token;
-      if (!token) {
-        console.error('no token specified');
-        return;
+      let operation: Promise<unknown>;
+      if (this.walletMode) {
+        const wallet = this.getWalletContext();
+        if (!wallet) {
+          ElMessage.warning(this.$t('common.x402Scenario.connectWalletFirst'));
+          return;
+        }
+        operation = digitalHumanOperator.generate(request, {
+          mode: 'x402',
+          x402: { wallet, confirm: (quote) => this.confirmWalletPayment(quote), identityToken: this.credential?.token }
+        });
+      } else {
+        if (!ensureLoggedIn()) return;
+        const token = this.credential?.token;
+        if (!token) return;
+        operation = digitalHumanOperator.generate(request, { token });
       }
       ElMessage.info(this.$t('digitalhuman.message.startingTask'));
-      instrumentGeneration('digitalhuman', digitalHumanOperator.generate(request, { token }))
-        .then(() => {
+      instrumentGeneration('digitalhuman', operation)
+        .then((response: any) => {
+          const taskId = response?.data?.task_id;
+          if (this.walletMode && !this.credential?.token && taskId && !this.walletTaskIds.includes(taskId))
+            this.walletTaskIds.unshift(taskId);
           ElMessage.success(this.$t('digitalhuman.message.startTaskSuccess'));
         })
         .catch((error) => {
+          if (error instanceof X402PaymentCancelledError) return;
           const response = error?.response?.data;
-          if (response?.error?.code === ERROR_CODE_USED_UP) {
-            ElMessage.error(this.$t('digitalhuman.message.usedUp'));
-          } else {
-            ElMessage.error(this.$t('digitalhuman.message.startTaskFailed'));
-          }
+          if (response?.error?.code === ERROR_CODE_USED_UP) ElMessage.error(this.$t('digitalhuman.message.usedUp'));
+          else if (this.walletMode)
+            ElMessage.error(`${this.$t('common.x402Scenario.paymentFailed')} ${error?.message || ''}`.trim());
+          else ElMessage.error(this.$t('digitalhuman.message.startTaskFailed'));
         })
         .finally(async () => {
           setTimeout(async () => {
@@ -153,6 +190,26 @@ export default defineComponent({
             await this.onScrollDown();
           }, 1000);
         });
+    },
+    getWalletContext(): X402WalletContext | undefined {
+      const walletApi = (this as any).$wallet;
+      const publicKey = walletApi?.publicKey?.value;
+      const adapter = walletApi?.wallet?.value?.adapter;
+      if (!publicKey || !adapter?.signTransaction) return undefined;
+      return { publicKey, signTransaction: adapter.signTransaction.bind(adapter) };
+    },
+    async confirmWalletPayment(quote: X402PaymentQuote): Promise<boolean> {
+      return ElMessageBox.confirm(
+        this.$t('common.x402Scenario.confirmPayment', { amount: quote.amountUsdc }),
+        this.$t('order.message.x402ConfirmTitle'),
+        {
+          confirmButtonText: this.$t('order.message.x402WalletPayCta'),
+          cancelButtonText: this.$t('common.button.cancel'),
+          type: 'warning'
+        }
+      )
+        .then(() => true)
+        .catch(() => false);
     },
     getTasksScrollElement(): HTMLElement | undefined {
       const panel = this.$refs.recentPanel as any;

--- a/src/pages/kling/Index.vue
+++ b/src/pages/kling/Index.vue
@@ -23,27 +23,29 @@ import ConfigPanel from '@/components/kling/ConfigPanel.vue';
 import MotionPanel from '@/components/kling/MotionPanel.vue';
 import TabSwitcher from '@/components/kling/TabSwitcher.vue';
 import TalkingPhotoPanel from '@/components/kling/TalkingPhotoPanel.vue';
-import { klingOperator } from '@/operators';
+import { buildKlingTalkingPhotoRequest, buildKlingVideoRequest, klingOperator } from '@/operators/kling';
 import { instrumentGeneration } from '@/plugins/telemetry';
-import {
-  IKlingGenerateRequest,
-  IKlingMotionRequest,
-  IKlingTalkingPhotoRequest,
-  IKlingTaskType,
-  Status
-} from '@/models';
-import { ElMessage } from 'element-plus';
-import { ERROR_CODE_USED_UP, KLING_TALKING_PHOTO_DEFAULT_MODEL, KLING_TALKING_PHOTO_DEFAULT_MODE } from '@/constants';
+import { IKlingMotionRequest, IKlingTaskType, Status } from '@/models';
+import { ElMessage, ElMessageBox } from 'element-plus';
+import { ERROR_CODE_USED_UP } from '@/constants';
 import RecentPanel from '@/components/kling/RecentPanel.vue';
 import { IKlingTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
 import { uploadTrackerProviderMixin, ensureNoPendingUpload, ensureLoggedIn } from '@/utils';
+import { isScenarioX402Enabled, scenarioPaymentState, setScenarioPaymentMode } from '@/utils/x402/scenarioPayment';
+import {
+  X402PaymentCancelledError,
+  type OperatorRequestOptions,
+  type X402PaymentQuote,
+  type X402WalletContext
+} from '@/operators/x402';
 
 interface IData {
   task: IKlingTask | undefined;
   job: number;
   loadingMore: boolean;
   fetchingTasks: boolean;
+  walletTaskIds: string[];
 }
 
 export default defineComponent({
@@ -63,7 +65,8 @@ export default defineComponent({
       task: undefined,
       job: 0,
       loadingMore: false,
-      fetchingTasks: false
+      fetchingTasks: false,
+      walletTaskIds: []
     };
   },
   computed: {
@@ -90,9 +93,27 @@ export default defineComponent({
     },
     tasks() {
       return this.$store.state.kling.tasks;
+    },
+    walletMode(): boolean {
+      return this.taskType !== 'motion' && isScenarioX402Enabled() && scenarioPaymentState('kling').mode === 'wallet';
     }
   },
   watch: {
+    walletMode: {
+      async handler(value: boolean, oldValue: boolean | undefined) {
+        if (oldValue === undefined || value === oldValue) return;
+        this.$store.commit('kling/setTasks', undefined);
+        if (value && !this.job) this.job = window.setInterval(this.onGetTasks, 5000);
+        if (!value && !this.credential?.token) {
+          window.clearInterval(this.job);
+          this.job = 0;
+          await this.onScrollDown();
+          return;
+        }
+        await this.onGetTasks();
+        await this.onScrollDown();
+      }
+    },
     tasks: {
       handler(value, oldValue) {
         // scroll down if new tasks are added
@@ -109,9 +130,7 @@ export default defineComponent({
           console.debug('layout initialized');
           await this.onGetTasks();
           await this.onScrollDown();
-          this.job = window.setInterval(() => {
-            this.onGetTasks();
-          }, 5000);
+          if (!this.job) this.job = window.setInterval(this.onGetTasks, 5000);
         }
       },
       immediate: true
@@ -168,7 +187,8 @@ export default defineComponent({
         await this.$store.dispatch('kling/getTasks', {
           limit,
           createdAtMin,
-          createdAtMax
+          createdAtMax,
+          ...(this.walletMode && !this.credential?.token ? { mode: 'x402', ids: this.walletTaskIds } : {})
         });
       } finally {
         this.fetchingTasks = false;
@@ -184,11 +204,7 @@ export default defineComponent({
       ) {
         return;
       }
-      const { camera_control, ...rest } = this.config || {};
-      const request = {
-        ...rest,
-        async: true
-      } as IKlingGenerateRequest;
+      const request = buildKlingVideoRequest(this.config);
       const frameCount = Number(Boolean(request.start_image_url)) + Number(Boolean(request.end_image_url));
       const referenceImageCount = request.image_list?.length || 0;
       const maxReferenceImages = request.video_list?.length ? 4 : 7;
@@ -203,62 +219,19 @@ export default defineComponent({
         ElMessage.warning(this.$t('kling.message.baseVideoFrameConflict'));
         return;
       }
-      // Reject "only end frame, no start frame" — Kling can't anchor an
-      // end-frame without a starting reference.
-      if (!request.video_id && !(rest as any).video_url && !request.start_image_url && request.end_image_url) {
+      if (!request.video_id && !request.video_url && !request.start_image_url && request.end_image_url) {
         ElMessage.warning(this.$t('kling.message.endImageRequiresStart'));
         return;
       }
-      // Derive `action` from inputs if the user did not set one explicitly.
-      // Upstream Kling worker requires `action` and defaults to `text2video`,
-      // which rejects `start_image_url`/`end_image_url` (#bug: image refs ignored).
-      if (!request.action) {
-        if (request.video_id || (rest as any).video_url) {
-          request.action = 'extend';
-        } else if (request.start_image_url) {
-          request.action = 'image2video';
-        } else {
-          request.action = 'text2video';
-        }
-      }
-      // text2video does not accept end_image_url; strip it to avoid a 400.
-      if (request.action === 'text2video' && request.end_image_url) {
-        delete request.end_image_url;
-      }
-      // Only include camera_control when a type is set; clean empty config blocks.
-      if (camera_control?.type) {
-        request.camera_control = {
-          type: camera_control.type,
-          ...(camera_control.type === 'simple' && camera_control.config
-            ? {
-                config: Object.fromEntries(
-                  Object.entries(camera_control.config).filter(([, v]) => v !== undefined && v !== null)
-                )
-              }
-            : {})
-        };
-      }
-      if (!ensureLoggedIn()) {
-        return;
-      }
-      const token = this.credential?.token;
-      if (!token) {
-        console.error('no token specified');
-        return;
-      }
+      const operation = this.createPaymentOperation((options) => klingOperator.generate(request, options));
+      if (!operation) return;
       ElMessage.info(this.$t('kling.message.startingTask'));
-      instrumentGeneration('kling', klingOperator.generate(request, { token }))
-        .then(() => {
+      instrumentGeneration('kling', operation)
+        .then((response: any) => {
+          this.recordWalletTask(response);
           ElMessage.success(this.$t('kling.message.startTaskSuccess'));
         })
-        .catch((error) => {
-          const response = error?.response?.data;
-          if (response?.error?.code === ERROR_CODE_USED_UP) {
-            ElMessage.error(this.$t('kling.message.usedUp'));
-          } else {
-            ElMessage.error(this.$t('kling.message.startTaskFailed'));
-          }
-        })
+        .catch((error) => this.handleGenerationError(error))
         .finally(async () => {
           setTimeout(async () => {
             await this.onGetTasks();
@@ -266,12 +239,72 @@ export default defineComponent({
           }, 1000);
         });
     },
+    createPaymentOperation(
+      submit: (options: OperatorRequestOptions) => Promise<unknown>
+    ): Promise<unknown> | undefined {
+      if (!this.walletMode) {
+        if (!ensureLoggedIn()) return undefined;
+        const token = this.credential?.token;
+        return token ? submit({ token }) : undefined;
+      }
+      const wallet = this.getWalletContext();
+      if (!wallet) {
+        ElMessage.warning(this.$t('common.x402Scenario.connectWalletFirst'));
+        return undefined;
+      }
+      return submit({
+        mode: 'x402',
+        x402: {
+          wallet,
+          confirm: (quote) => this.confirmWalletPayment(quote),
+          identityToken: this.credential?.token
+        }
+      });
+    },
+    recordWalletTask(response: any) {
+      const taskId = response?.data?.task_id;
+      if (this.walletMode && !this.credential?.token && taskId && !this.walletTaskIds.includes(taskId)) {
+        this.walletTaskIds.unshift(taskId);
+      }
+    },
+    handleGenerationError(error: any) {
+      if (error instanceof X402PaymentCancelledError) return;
+      const response = error?.response?.data;
+      if (response?.error?.code === ERROR_CODE_USED_UP) {
+        ElMessage.error(this.$t('kling.message.usedUp'));
+      } else if (this.walletMode) {
+        ElMessage.error(`${this.$t('common.x402Scenario.paymentFailed')} ${error?.message || ''}`.trim());
+      } else {
+        ElMessage.error(this.$t('kling.message.startTaskFailed'));
+      }
+    },
+    getWalletContext(): X402WalletContext | undefined {
+      const walletApi = (this as any).$wallet;
+      const publicKey = walletApi?.publicKey?.value;
+      const adapter = walletApi?.wallet?.value?.adapter;
+      if (!publicKey || !adapter?.signTransaction) return undefined;
+      return { publicKey, signTransaction: adapter.signTransaction.bind(adapter) };
+    },
+    async confirmWalletPayment(quote: X402PaymentQuote): Promise<boolean> {
+      return ElMessageBox.confirm(
+        this.$t('common.x402Scenario.confirmPayment', { amount: quote.amountUsdc }),
+        this.$t('order.message.x402ConfirmTitle'),
+        {
+          confirmButtonText: this.$t('order.message.x402WalletPayCta'),
+          cancelButtonText: this.$t('common.button.cancel'),
+          type: 'warning'
+        }
+      )
+        .then(() => true)
+        .catch(() => false);
+    },
     getTasksScrollElement(): HTMLElement | undefined {
       const panel = this.$refs.recentPanel as any;
       return panel?.getScrollElement?.();
     },
     async onTabChange(value: IKlingTaskType) {
       if (value === this.taskType) return;
+      if (value === 'motion') setScenarioPaymentMode('kling', 'credits');
       await this.$store.dispatch('kling/setTaskType', value);
       // taskType change clears tasks; re-fetch.
       await this.onGetTasks();
@@ -345,37 +378,16 @@ export default defineComponent({
         ElMessage.warning(this.$t('kling.message.talkingPhotoMissingInputs'));
         return;
       }
-      const request: IKlingTalkingPhotoRequest = {
-        image_url: cfg.image_url,
-        audio_url: cfg.audio_url,
-        // Upstream requires `model`; always send a supported default if unset.
-        model: cfg.model || KLING_TALKING_PHOTO_DEFAULT_MODEL,
-        mode: cfg.mode || KLING_TALKING_PHOTO_DEFAULT_MODE,
-        ...(cfg.prompt ? { prompt: cfg.prompt } : {}),
-        ...(cfg.duration ? { duration: cfg.duration } : {}),
-        async: true
-      };
-      if (!ensureLoggedIn()) {
-        return;
-      }
-      const token = this.credential?.token;
-      if (!token) {
-        console.error('no token specified');
-        return;
-      }
+      const request = buildKlingTalkingPhotoRequest(cfg);
+      const operation = this.createPaymentOperation((options) => klingOperator.talkingPhoto(request, options));
+      if (!operation) return;
       ElMessage.info(this.$t('kling.message.startingTask'));
-      instrumentGeneration('kling', klingOperator.talkingPhoto(request, { token }))
-        .then(() => {
+      instrumentGeneration('kling', operation)
+        .then((response: any) => {
+          this.recordWalletTask(response);
           ElMessage.success(this.$t('kling.message.startTaskSuccess'));
         })
-        .catch((error) => {
-          const response = error?.response?.data;
-          if (response?.error?.code === ERROR_CODE_USED_UP) {
-            ElMessage.error(this.$t('kling.message.usedUp'));
-          } else {
-            ElMessage.error(this.$t('kling.message.startTaskFailed'));
-          }
-        })
+        .catch((error) => this.handleGenerationError(error))
         .finally(async () => {
           setTimeout(async () => {
             await this.onGetTasks();


### PR DESCRIPTION
## Summary

- add Solana x402 wallet payments to Kling video generation, Kling talking-photo, Digital Human video generation, and Digital Human voice cloning
- keep each endpoint's quote and submit payload independent; voice clone has its own local quote state and free guest polling
- keep Kling Motion Credits-only because its final output duration is unknown before generation

## Safety dependency

Depends on https://github.com/AceDataCloud/PlatformBackend/pull/1371 being merged, deployed, synced, and production-validated before this PR is merged. That PR removes the unsafe `/kling/motion` Solana exact challenge. The frontend also forces Kling Motion to Credits and hides the wallet selector on that tab.

## Validation

- `npm run lint:check` — 0 errors (2 pre-existing warnings)
- `npx vue-tsc -b --pretty false`
- `npm run test:run` — 167 files / 1,306 tests passed
- `python3 scripts/check_i18n_coverage.py`
- `unset $(git rev-parse --local-env-vars); npm run verify`
- `npm run build:web`
- `npm run build:electron`
- `npm run compile:electron && node scripts/copy-renderer.js`
- `unset ELECTRON_RUN_AS_NODE; npm run test:e2e:desktop` — 3 passed
- `git diff --check`

## Scope controls

- no local/session storage task history
- no delete, RecentPanel, Preview, shared task factory, or locale changes
- no x402 support for Kling Motion
- no billable generation, signature, or payment performed during validation

## Rollback

Revert this PR to remove the special-flow wallet UI. No schema migration is involved. Keep the Backend Kling Motion policy fix even if this UI is rolled back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
