### PR TITLE
feat(x402): add SERP wallet payments

### DIFF
--- a/change/@acedatacloud-nexior-62baa00e-71fd-4404-a8ce-f6c960bf0f3a.json
+++ b/change/@acedatacloud-nexior-62baa00e-71fd-4404-a8ce-f6c960bf0f3a.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add Solana x402 wallet payments to SERP search.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "minor"
+}

--- a/src/components/serp/SearchPanel.vue
+++ b/src/components/serp/SearchPanel.vue
@@ -7,7 +7,8 @@
       <language-input class="mb-4" />
     </div>
     <div class="flex flex-col items-center justify-center px-5 pb-5">
-      <consumption :value="consumption" :service="service" />
+      <scenario-payment-mode scenario="serp" />
+      <consumption v-if="!walletMode" :value="consumption" :service="service" />
       <el-button type="primary" class="btn w-full" round :loading="searching" @click="onSearch">
         <search-icon class="mr-2" :size="'1em' as any" aria-hidden="true" focusable="false" />
         {{ $t('serp.button.search') }}
@@ -27,6 +28,9 @@ import LanguageInput from './config/LanguageInput.vue';
 import Consumption from '../common/Consumption.vue';
 import { getConsumption } from '@/utils';
 import { Status } from '@/models';
+import ScenarioPaymentMode from '../common/ScenarioPaymentMode.vue';
+import { isScenarioX402Enabled, scenarioPaymentState } from '@/utils/x402/scenarioPayment';
+import { buildSerpRequest, serpOperator } from '@/operators/serp';
 
 export default defineComponent({
   name: 'SearchPanel',
@@ -37,9 +41,13 @@ export default defineComponent({
     TypeSelector,
     CountryInput,
     LanguageInput,
-    Consumption
+    Consumption,
+    ScenarioPaymentMode
   },
   emits: ['search'],
+  data() {
+    return { quoteTimer: 0, quoteRunId: 0 };
+  },
   computed: {
     config() {
       return this.$store.state.serp?.config;
@@ -52,9 +60,48 @@ export default defineComponent({
     },
     searching() {
       return this.$store.state.serp?.status?.search === Status.Request;
+    },
+    walletMode(): boolean {
+      return isScenarioX402Enabled() && scenarioPaymentState('serp').mode === 'wallet';
     }
   },
+  watch: {
+    walletMode: {
+      handler(enabled: boolean) {
+        if (enabled) this.scheduleQuote();
+      },
+      immediate: true
+    },
+    config: {
+      handler() {
+        if (this.walletMode) this.scheduleQuote();
+      },
+      deep: true
+    }
+  },
+  beforeUnmount() {
+    window.clearTimeout(this.quoteTimer);
+    this.quoteRunId += 1;
+  },
   methods: {
+    scheduleQuote() {
+      window.clearTimeout(this.quoteTimer);
+      this.quoteTimer = window.setTimeout(this.refreshQuote, 350);
+    },
+    async refreshQuote() {
+      const state = scenarioPaymentState('serp');
+      const runId = ++this.quoteRunId;
+      state.quoteLoading = true;
+      state.quoteUsdc = undefined;
+      try {
+        const quote = await serpOperator.quote(buildSerpRequest(this.config));
+        if (runId === this.quoteRunId && state.mode === 'wallet') state.quoteUsdc = quote.amountUsdc;
+      } catch (error) {
+        console.warn('x402 quote failed', error);
+      } finally {
+        if (runId === this.quoteRunId) state.quoteLoading = false;
+      }
+    },
     onSearch() {
       this.$emit('search');
     }

--- a/src/components/x402SerpContract.test.ts
+++ b/src/components/x402SerpContract.test.ts
@@ -1,0 +1,23 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = (relativePath: string) => fs.readFileSync(path.resolve(process.cwd(), 'src', relativePath), 'utf8');
+
+describe('SERP x402 contract', () => {
+  it('registers SERP and uses one request builder for quote and search', () => {
+    expect(source('layouts/Main.vue')).toContain("'serp'");
+    expect(source('components/serp/SearchPanel.vue')).toContain('serpOperator.quote(buildSerpRequest(this.config))');
+    expect(source('store/serp/actions.ts')).toContain('const request = buildSerpRequest(state.config)');
+  });
+
+  it('supports wallet identity and cancellation without task history', () => {
+    const page = source('pages/serp/Index.vue');
+    expect(page).toContain("mode: 'x402'");
+    expect(page).toContain('identityToken: this.credential?.token');
+    expect(page).toContain('error instanceof X402PaymentCancelledError');
+    expect(page).not.toContain('walletTaskIds');
+    expect(page).not.toContain('localStorage');
+    expect(page).not.toContain('sessionStorage');
+  });
+});

--- a/src/layouts/Main.vue
+++ b/src/layouts/Main.vue
@@ -84,7 +84,8 @@ export default defineComponent({
           'minimax',
           'maestro',
           'kling',
-          'digitalhuman'
+          'digitalhuman',
+          'serp'
         ].includes(String(this.appName)) && isScenarioX402Enabled()
       );
     },

--- a/src/operators/serp.ts
+++ b/src/operators/serp.ts
@@ -1,20 +1,34 @@
 import axios, { AxiosResponse } from 'axios';
-import { ISerpSearchRequest, ISerpSearchResponse } from '@/models';
+import { ISerpConfig, ISerpSearchRequest, ISerpSearchResponse } from '@/models';
 import { BASE_URL_API } from '@/constants';
+import { postWithX402, quoteX402, type OperatorRequestOptions } from './x402';
+
+const HEADERS = { 'content-type': 'application/json', accept: 'application/json' };
+
+export function buildSerpRequest(config?: ISerpConfig): ISerpSearchRequest {
+  return {
+    query: config?.query?.trim(),
+    type: config?.type,
+    number: config?.number,
+    page: config?.page,
+    country: config?.country,
+    language: config?.language,
+    range: config?.range
+  };
+}
 
 class SerpOperator {
-  async search(
-    data: ISerpSearchRequest,
-    options: {
-      token: string;
+  async quote(data: ISerpSearchRequest) {
+    return quoteX402('/serp/google', data, HEADERS);
+  }
+
+  async search(data: ISerpSearchRequest, options: OperatorRequestOptions): Promise<AxiosResponse<ISerpSearchResponse>> {
+    if (options.mode === 'x402') {
+      if (!options.x402) throw new Error('x402 payment options are required');
+      return postWithX402<ISerpSearchResponse>('/serp/google', data, options.x402, HEADERS);
     }
-  ): Promise<AxiosResponse<ISerpSearchResponse>> {
-    return await axios.post('/serp/google', data, {
-      headers: {
-        authorization: `Bearer ${options.token}`,
-        'content-type': 'application/json',
-        accept: 'application/json'
-      },
+    return axios.post('/serp/google', data, {
+      headers: { ...HEADERS, authorization: `Bearer ${options.token}` },
       baseURL: BASE_URL_API
     });
   }

--- a/src/pages/serp/Index.vue
+++ b/src/pages/serp/Index.vue
@@ -14,9 +14,11 @@ import { defineComponent } from 'vue';
 import Layout from '@/layouts/Serp.vue';
 import SearchPanel from '@/components/serp/SearchPanel.vue';
 import ResultPanel from '@/components/serp/ResultPanel.vue';
-import { ElMessage } from 'element-plus';
+import { ElMessage, ElMessageBox } from 'element-plus';
 import { ERROR_CODE_USED_UP } from '@/constants';
 import { ensureLoggedIn } from '@/utils';
+import { isScenarioX402Enabled, scenarioPaymentState } from '@/utils/x402/scenarioPayment';
+import { X402PaymentCancelledError, type X402PaymentQuote, type X402WalletContext } from '@/operators/x402';
 
 export default defineComponent({
   name: 'SerpIndex',
@@ -26,6 +28,14 @@ export default defineComponent({
     ResultPanel
   },
   inject: ['initialized'],
+  computed: {
+    credential() {
+      return this.$store.state.serp?.credential;
+    },
+    walletMode(): boolean {
+      return isScenarioX402Enabled() && scenarioPaymentState('serp').mode === 'wallet';
+    }
+  },
   async mounted() {
     await this.onGetService();
   },
@@ -36,26 +46,58 @@ export default defineComponent({
       console.debug('end onGetService');
     },
     async onSearch() {
-      // Deferred auth: guests compose a query freely; running it triggers login.
-      if (!ensureLoggedIn()) {
-        return;
-      }
       const config = this.$store.state.serp?.config;
-      if (!config?.query) {
+      if (!config?.query) return;
+      let options;
+      if (this.walletMode) {
+        const wallet = this.getWalletContext();
+        if (!wallet) {
+          ElMessage.warning(this.$t('common.x402Scenario.connectWalletFirst'));
+          return;
+        }
+        options = {
+          mode: 'x402',
+          x402: {
+            wallet,
+            confirm: (quote: X402PaymentQuote) => this.confirmWalletPayment(quote),
+            identityToken: this.credential?.token
+          }
+        };
+      } else if (!ensureLoggedIn()) {
         return;
       }
       ElMessage.info(this.$t('serp.message.searching'));
       try {
-        await this.$store.dispatch('serp/search');
+        await this.$store.dispatch('serp/search', options);
         ElMessage.success(this.$t('serp.message.searchSuccess'));
       } catch (error: any) {
+        if (error instanceof X402PaymentCancelledError) return;
         const response = error?.response?.data;
-        if (response?.error?.code === ERROR_CODE_USED_UP) {
-          ElMessage.error(this.$t('serp.message.usedUp'));
-        } else {
-          ElMessage.error(this.$t('serp.message.searchFailed'));
-        }
+        if (response?.error?.code === ERROR_CODE_USED_UP) ElMessage.error(this.$t('serp.message.usedUp'));
+        else if (this.walletMode) {
+          ElMessage.error(`${this.$t('common.x402Scenario.paymentFailed')} ${error?.message || ''}`.trim());
+        } else ElMessage.error(this.$t('serp.message.searchFailed'));
       }
+    },
+    getWalletContext(): X402WalletContext | undefined {
+      const walletApi = (this as any).$wallet;
+      const publicKey = walletApi?.publicKey?.value;
+      const adapter = walletApi?.wallet?.value?.adapter;
+      if (!publicKey || !adapter?.signTransaction) return undefined;
+      return { publicKey, signTransaction: adapter.signTransaction.bind(adapter) };
+    },
+    async confirmWalletPayment(quote: X402PaymentQuote): Promise<boolean> {
+      return ElMessageBox.confirm(
+        this.$t('common.x402Scenario.confirmPayment', { amount: quote.amountUsdc }),
+        this.$t('order.message.x402ConfirmTitle'),
+        {
+          confirmButtonText: this.$t('order.message.x402WalletPayCta'),
+          cancelButtonText: this.$t('common.button.cancel'),
+          type: 'warning'
+        }
+      )
+        .then(() => true)
+        .catch(() => false);
     },
     async onRelatedSearch(query: string) {
       this.$store.commit('serp/setConfig', {

--- a/src/store/serp/actions.ts
+++ b/src/store/serp/actions.ts
@@ -1,4 +1,6 @@
-import { applicationOperator, credentialOperator, serpOperator, serviceOperator } from '@/operators';
+import { applicationOperator, credentialOperator, serviceOperator } from '@/operators';
+import { buildSerpRequest, serpOperator } from '@/operators/serp';
+import type { OperatorRequestOptions } from '@/operators/x402';
 import { ISerpState } from './models';
 import { ActionContext } from 'vuex';
 import { IRootState } from '../common/models';
@@ -113,38 +115,24 @@ export const setConfig = ({ commit }: any, payload: ISerpConfig) => {
   commit('setConfig', payload);
 };
 
-export const search = async ({ commit, state }: ActionContext<ISerpState, IRootState>): Promise<void> => {
-  const credential = state.credential;
-  const token = credential?.token;
-  if (!token) {
-    console.error('no token specified');
-    return;
-  }
-  const config = state.config;
-  if (!config?.query) {
-    console.error('no query specified');
-    return;
-  }
+export const search = async (
+  { commit, state }: ActionContext<ISerpState, IRootState>,
+  options?: OperatorRequestOptions
+): Promise<void> => {
+  const requestOptions = options || { token: state.credential?.token };
+  if (requestOptions.mode !== 'x402' && !requestOptions.token) throw new Error('no token specified');
+  const request = buildSerpRequest(state.config);
+  if (!request.query) throw new Error('no query specified');
   state.status.search = Status.Request;
   try {
-    const { data } = await serpOperator.search(
-      {
-        query: config.query,
-        type: config.type,
-        number: config.number,
-        page: config.page,
-        country: config.country,
-        language: config.language,
-        range: config.range
-      },
-      { token }
-    );
+    const { data } = await serpOperator.search(request, requestOptions);
     state.status.search = Status.Success;
     commit('setResults', data);
   } catch (error) {
     console.error('search failed', error);
     state.status.search = Status.Error;
     commit('setResults', undefined);
+    throw error;
   }
 };
 

--- a/src/store/serp/actions.x402.test.ts
+++ b/src/store/serp/actions.x402.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Status } from '@/models';
+
+const mocks = vi.hoisted(() => ({ search: vi.fn() }));
+vi.mock('@/operators/serp', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/operators/serp')>()),
+  serpOperator: { search: mocks.search }
+}));
+
+import { search } from './actions';
+
+const state = () =>
+  ({
+    credential: { token: 'credits-token' },
+    config: { query: '  ace data  ', type: 'search', number: 10 },
+    results: undefined,
+    status: { search: Status.None }
+  }) as any;
+
+const context = (value = state()) => ({ state: value, commit: vi.fn() }) as any;
+
+describe('SERP x402 search action', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('keeps the existing credential path and normalized request', async () => {
+    mocks.search.mockResolvedValueOnce({ data: { organic: [] } });
+    const ctx = context();
+
+    await search(ctx);
+
+    expect(mocks.search).toHaveBeenCalledWith(
+      expect.objectContaining({ query: 'ace data', type: 'search', number: 10 }),
+      { token: 'credits-token' }
+    );
+    expect(ctx.state.status.search).toBe(Status.Success);
+    expect(ctx.commit).toHaveBeenCalledWith('setResults', { organic: [] });
+  });
+
+  it('allows guest wallet search options without a credential', async () => {
+    mocks.search.mockResolvedValueOnce({ data: { images: [] } });
+    const ctx = context({ ...state(), credential: undefined });
+    const options = { mode: 'x402' as const, x402: { wallet: {} as never, confirm: async () => true } };
+
+    await search(ctx, options);
+
+    expect(mocks.search).toHaveBeenCalledWith(expect.objectContaining({ query: 'ace data' }), options);
+  });
+
+  it('preserves error state and rethrows failures to the page', async () => {
+    const error = new Error('search failed');
+    mocks.search.mockRejectedValueOnce(error);
+    const ctx = context();
+
+    await expect(search(ctx)).rejects.toBe(error);
+    expect(ctx.state.status.search).toBe(Status.Error);
+    expect(ctx.commit).toHaveBeenCalledWith('setResults', undefined);
+  });
+});


### PR DESCRIPTION
## Summary

- add Solana x402 wallet quotes and signed search to the synchronous SERP scenario
- keep quote and submit on one normalized request builder, including result-count pricing
- preserve Vuex status/result mutations while rethrowing failures so payment cancellation and errors are handled correctly by the page

## Validation

- `npm run lint:check` — 0 errors (2 pre-existing warnings)
- `npx vue-tsc -b --pretty false`
- `npm run test:run` — 167 files / 1,305 tests passed
- `python3 scripts/check_i18n_coverage.py`
- `unset $(git rev-parse --local-env-vars); npm run verify`
- `npm run build:web`
- `npm run build:electron`
- `npm run compile:electron && node scripts/copy-renderer.js`
- `unset ELECTRON_RUN_AS_NODE; npm run test:e2e:desktop` — 3 passed
- `git diff --check`

## Scope

- no task history or polling (SERP is synchronous)
- no storage, delete, locale, or result-renderer changes
- no billable search, signature, or payment performed during validation

## Rollback

Revert this PR to remove the SERP wallet UI. No schema migration is involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
