### PR TITLE
fix(android): avoid network-blocked startup

### DIFF
--- a/change/@acedatacloud-nexior-android-startup-load.json
+++ b/change/@acedatacloud-nexior-android-startup-load.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Prevent Android startup from waiting on remote initialization and acknowledge the native update watchdog immediately.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/main.startup.test.ts
+++ b/src/main.startup.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(new URL('./main.ts', import.meta.url), 'utf8');
+
+describe('native startup', () => {
+  it('acknowledges the native updater before background API initialization', () => {
+    expect(source.indexOf('void runLiveUpdate();')).toBeGreaterThan(-1);
+    expect(source.indexOf('startPostMountBoot(')).toBeGreaterThan(source.indexOf('void runLiveUpdate();'));
+  });
+
+  it('exchanges an SSO callback code before the callback component can redirect', () => {
+    expect(source.indexOf('if (isSsoCallback) {\n    await initializeToken();')).toBeGreaterThan(-1);
+    expect(source.indexOf('if (isSsoCallback) {\n    await initializeToken();')).toBeLessThan(
+      source.indexOf('startPostMountBoot(')
+    );
+  });
+
+  it('re-evaluates the root redirect after site features load', () => {
+    expect(source).toContain('await router.replace({ ...getDefaultRoute(), query: router.currentRoute.value.query });');
+  });
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,8 @@
 import { ViteSSG } from 'vite-ssg';
 import { Capacitor } from '@capacitor/core';
 import App from './App.vue';
-import { routes, setupRouterGuards, setActiveRouter } from './router';
+import { getDefaultRoute, routes, setupRouterGuards, setActiveRouter } from './router';
+import { ROUTE_CHATGPT_CONVERSATION_NEW } from './router/constants';
 import store from './store';
 import i18n, { setI18nLanguage, getLocale } from './i18n';
 import { I18N_DEFAULT_LOCALE } from '@/constants/i18n';
@@ -25,6 +26,7 @@ import { resolveBootLocale } from '@/utils/siteLocales';
 import { syncFeaturesFromUrl } from '@/utils/featureFlag';
 import { runVersionGate } from '@/utils/versionGate';
 import { runLiveUpdate } from '@/utils/liveUpdate';
+import { startPostMountBoot } from '@/utils/postMountBoot';
 import {
   initializeCookies,
   initializeDescription,
@@ -105,41 +107,62 @@ export const createApp = ViteSSG(App, { routes, base: import.meta.env.BASE_URL }
     const { installMobileLocalExec } = await import('@/utils/mobileLocalExec');
     installMobileLocalExec();
   }
-  await initializeCookies();
-  await resolveDeferredInviterId();
-  await initializeToken();
-  await Promise.all([initializeUser(), initializeSite(), initializeConfig()]);
-  // Resolve against the saved LOCALE cookie, not `i18n.global.locale`: the
-  // router guard that applies the cookie runs after this hook, so the live
-  // locale is still the vue-i18n default and we'd clobber the user's choice.
-  const savedLocale = getLocale(getCookie('LOCALE') || I18N_DEFAULT_LOCALE);
-  const siteLocale = resolveBootLocale(savedLocale, store.state.site);
-  if (siteLocale !== savedLocale) {
-    await setI18nLanguage(siteLocale);
-    setCookie('LOCALE', siteLocale, { path: '/', domain: getDomain() });
-  }
-
-  if (isNative() || isDesktop()) {
-    const blocked = await runVersionGate();
-    if (blocked) return;
-  }
+  void initializeCookies();
+  // Capgo starts a 10-second readiness watchdog as soon as the native shell
+  // opens. A slow API must never make it reload the WebView during boot.
   void runLiveUpdate();
-
-  void initTelemetry({
-    uin: store.getters.user?.id,
-    // __APP_VERSION__ is injected by vite.config `define` for all surfaces.
-    // (Previously this read import.meta.env.VITE_APP_VERSION, which was never
-    // defined anywhere → the telemetry release tag was always undefined.)
-    release: typeof __APP_VERSION__ === 'string' ? __APP_VERSION__ : undefined
-  });
-
   initializeCurrency();
   initializeTheme();
-  initializeExchangeRate();
-  initializeTitle();
-  initializeDescription();
-  initializeKeywords();
-  initializeFavicon();
+  const bootedAtRoot = router.currentRoute.value.path === '/' || window.location.pathname === '/';
+
+  // The callback route immediately returns users to the protected destination
+  // from its mounted hook. Exchange its one-time SSO code before that hook
+  // gets a chance to run, while ordinary startup remains non-blocking.
+  const isSsoCallback =
+    window.location.pathname.endsWith('/auth/callback') && new URLSearchParams(window.location.search).has('code');
+  if (isSsoCallback) {
+    await initializeToken();
+  }
+
+  startPostMountBoot(
+    async () => {
+      await Promise.all([resolveDeferredInviterId(), isSsoCallback ? Promise.resolve() : initializeToken()]);
+      await Promise.all([initializeUser(), initializeSite(), initializeConfig()]);
+
+      // Root redirects run before the site request completes. Re-evaluate the
+      // fallback route once the site feature configuration arrives.
+      if (bootedAtRoot && router.currentRoute.value.name === ROUTE_CHATGPT_CONVERSATION_NEW) {
+        await router.replace({ ...getDefaultRoute(), query: router.currentRoute.value.query });
+      }
+
+      // Resolve against the saved LOCALE cookie, not `i18n.global.locale`: the
+      // router guard that applies the cookie runs after this hook, so the live
+      // locale is still the vue-i18n default and we'd clobber the user's choice.
+      const savedLocale = getLocale(getCookie('LOCALE') || I18N_DEFAULT_LOCALE);
+      const siteLocale = resolveBootLocale(savedLocale, store.state.site);
+      if (siteLocale !== savedLocale) {
+        await setI18nLanguage(siteLocale);
+        setCookie('LOCALE', siteLocale, { path: '/', domain: getDomain() });
+      }
+
+      if (isNative() || isDesktop()) {
+        await runVersionGate();
+      }
+
+      void initTelemetry({
+        uin: store.getters.user?.id,
+        release: typeof __APP_VERSION__ === 'string' ? __APP_VERSION__ : undefined
+      });
+
+      initializeTheme();
+      initializeExchangeRate();
+      initializeTitle();
+      initializeDescription();
+      initializeKeywords();
+      initializeFavicon();
+    },
+    (error) => captureError(error, { source: 'postMountBoot' })
+  );
 
   window.addEventListener('unhandledrejection', (event) => {
     captureError(event.reason, { source: 'unhandledrejection' });

--- a/src/utils/postMountBoot.test.ts
+++ b/src/utils/postMountBoot.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from 'vitest';
+import { startPostMountBoot } from './postMountBoot';
+
+describe('startPostMountBoot', () => {
+  it('starts asynchronous work without delaying the caller', () => {
+    let finish!: () => void;
+    const task = vi.fn(() => new Promise<void>((resolve) => (finish = resolve)));
+    const onError = vi.fn();
+
+    startPostMountBoot(task, onError);
+
+    expect(task).toHaveBeenCalledOnce();
+    expect(onError).not.toHaveBeenCalled();
+    finish();
+  });
+
+  it('reports a failed background task', async () => {
+    const error = new Error('offline');
+    const onError = vi.fn();
+
+    startPostMountBoot(async () => {
+      throw error;
+    }, onError);
+    await Promise.resolve();
+
+    expect(onError).toHaveBeenCalledWith(error);
+  });
+});

--- a/src/utils/postMountBoot.ts
+++ b/src/utils/postMountBoot.ts
@@ -1,0 +1,3 @@
+export const startPostMountBoot = (task: () => Promise<void>, onError: (error: unknown) => void): void => {
+  void task().catch(onError);
+};


### PR DESCRIPTION
## Summary
- Mount the Nexior UI before remote user/site/config initialization.
- Acknowledge the Capgo native-update readiness watchdog immediately on app startup.
- Move non-critical boot work behind a safe post-mount error boundary.

## Google Play issue addressed
Google Play rejected 3.358.0 (versionCode 65800) under **Broken Functionality**: "Your app doesn't open or load." The old build waited for several remote initialization calls before mounting Vue; an unavailable network could hold the app on its loading screen for 20+ seconds. It also delayed Capgo `notifyAppReady()` beyond the 10-second watchdog, allowing the WebView to reload.

## Validation
- `npm run test:run -- src/utils/postMountBoot.test.ts src/main.startup.test.ts`
- `npx vue-tsc --noEmit`
- `npx eslint src/main.ts src/main.startup.test.ts src/utils/postMountBoot.ts src/utils/postMountBoot.test.ts`
- `npx beachball check --branch origin/main`
- `git diff --check`
- Built Play debug APK and release AAB locally.
- API 34 Google Play ARM64 emulator, cold launch with an unreachable proxy: full chat UI was visible at 5s and remained usable at 10/20/30/45s; no fatal exception, ANR, process death, or Capgo watchdog reload.

## Rollout / rollback
The release pipeline will create 3.358.1 (expected versionCode 65801). Upload initially targets the existing production release path. If post-upload validation shows a regression, halt the rollout and revert this commit before resubmitting.