### PR TITLE
feat(x402): add Midjourney wallet payments

### DIFF
--- a/change/@acedatacloud-nexior-cdd1c69d-8727-416d-930b-554fb0361d01.json
+++ b/change/@acedatacloud-nexior-cdd1c69d-8727-416d-930b-554fb0361d01.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add Solana x402 wallet payments to Midjourney image, video, describe, and custom actions.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "minor"
+}

--- a/src/components/midjourney/ConfigPanel.vue
+++ b/src/components/midjourney/ConfigPanel.vue
@@ -40,7 +40,8 @@
       </el-tabs>
     </div>
     <div class="flex flex-col px-5 pb-5">
-      <consumption :value="consumption" :service="service" />
+      <scenario-payment-mode scenario="midjourney" />
+      <consumption v-if="!walletMode" :value="consumption" :service="service" />
       <div class="flex gap-1">
         <mode-selector v-if="type !== 'describe'" />
         <el-button v-if="config.action === 'extend'" type="primary" class="btn w-full" round @click="$emit('generate')">
@@ -81,6 +82,14 @@ import { ElButton, ElTabs, ElTabPane } from 'element-plus';
 import Consumption from '../common/Consumption.vue';
 import { getConsumption } from '@/utils';
 import { MIDJOURNEY_DEFAULT_TYPE } from '@/constants';
+import ScenarioPaymentMode from '../common/ScenarioPaymentMode.vue';
+import { isScenarioX402Enabled, scenarioPaymentState } from '@/utils/x402/scenarioPayment';
+import {
+  buildMidjourneyDescribeRequest,
+  buildMidjourneyImagineRequest,
+  buildMidjourneyVideosRequest,
+  midjourneyOperator
+} from '@/operators/midjourney';
 
 export default defineComponent({
   name: 'ConfigPanel',
@@ -109,9 +118,13 @@ export default defineComponent({
     Consumption,
     VideoFromInput,
     ElTabs,
-    ElTabPane
+    ElTabPane,
+    ScenarioPaymentMode
   },
   emits: ['generate'],
+  data() {
+    return { quoteTimer: 0, quoteRunId: 0 };
+  },
   computed: {
     config() {
       return this.$store.state.midjourney.config;
@@ -139,11 +152,55 @@ export default defineComponent({
     },
     service() {
       return this.$store.state.midjourney?.service;
+    },
+    walletMode(): boolean {
+      return isScenarioX402Enabled() && scenarioPaymentState('midjourney').mode === 'wallet';
+    }
+  },
+  watch: {
+    walletMode: {
+      handler(enabled: boolean) {
+        if (enabled) this.scheduleQuote();
+      },
+      immediate: true
+    },
+    config: {
+      handler() {
+        if (this.walletMode) this.scheduleQuote();
+      },
+      deep: true
     }
   },
   mounted() {
-    if (!this.config.type) {
-      this.type = MIDJOURNEY_DEFAULT_TYPE;
+    if (!this.config.type) this.type = MIDJOURNEY_DEFAULT_TYPE;
+  },
+  beforeUnmount() {
+    window.clearTimeout(this.quoteTimer);
+    this.quoteRunId += 1;
+  },
+  methods: {
+    scheduleQuote() {
+      window.clearTimeout(this.quoteTimer);
+      this.quoteTimer = window.setTimeout(this.refreshQuote, 350);
+    },
+    async refreshQuote() {
+      const state = scenarioPaymentState('midjourney');
+      const runId = ++this.quoteRunId;
+      state.quoteLoading = true;
+      state.quoteUsdc = undefined;
+      try {
+        const quote =
+          this.type === 'videos'
+            ? await midjourneyOperator.quoteVideos(buildMidjourneyVideosRequest(this.config))
+            : this.type === 'describe'
+              ? await midjourneyOperator.quoteDescribe(buildMidjourneyDescribeRequest(this.config))
+              : await midjourneyOperator.quoteImagine(buildMidjourneyImagineRequest(this.config));
+        if (runId === this.quoteRunId && state.mode === 'wallet') state.quoteUsdc = quote.amountUsdc;
+      } catch (error) {
+        console.warn('x402 quote failed', error);
+      } finally {
+        if (runId === this.quoteRunId) state.quoteLoading = false;
+      }
     }
   }
 });

--- a/src/components/midjourney/v81Capabilities.test.ts
+++ b/src/components/midjourney/v81Capabilities.test.ts
@@ -10,7 +10,7 @@ describe('Midjourney V8.1 capability controls', () => {
   const versionSelector = source('./config/VersionSelector.vue');
   const modeSelector = source('./config/ModeSelector2.vue');
   const qualitySelector = source('./config/QualitySelector.vue');
-  const page = source('../../pages/midjourney/Index.vue');
+  const operator = source('../../operators/midjourney.ts');
 
   it('hides the unsupported Quality control', () => {
     expect(panel).toContain('<quality-selector v-if="config?.version !== \'8.1\'"');
@@ -32,8 +32,8 @@ describe('Midjourney V8.1 capability controls', () => {
   it('keeps video Turbo available and omits Quality from V8.1 requests', () => {
     expect(modeSelector).toContain("return this.$store.state.midjourney.config.type || 'imagine'");
     expect(qualitySelector).toContain("return this.version === '8'");
-    expect(page).toContain("this.config?.version !== '8.1' &&");
-    expect(page.match(/\.\.\.\(!isV81 \? \{ quality:/g)).toHaveLength(2);
-    expect(page).toContain('mode: isV81 ? MIDJOURNEY_DEFAULT_MODE : this.config?.mode || MIDJOURNEY_DEFAULT_MODE');
+    expect(operator).toContain("const isV81 = config.version === '8.1'");
+    expect(operator.match(/\.\.\.\(!isV81 \? \{ quality:/g)).toHaveLength(2);
+    expect(operator).toContain('mode: isV81 ? MIDJOURNEY_DEFAULT_MODE : config.mode || MIDJOURNEY_DEFAULT_MODE');
   });
 });

--- a/src/components/x402MidjourneyContract.test.ts
+++ b/src/components/x402MidjourneyContract.test.ts
@@ -1,0 +1,37 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = (relativePath: string) => fs.readFileSync(path.resolve(process.cwd(), 'src', relativePath), 'utf8');
+
+describe('Midjourney x402 contract', () => {
+  it('registers Midjourney and quotes each selected endpoint with its builder', () => {
+    const main = source('layouts/Main.vue');
+    const panel = source('components/midjourney/ConfigPanel.vue');
+    expect(main).toContain("'midjourney'");
+    expect(panel).toContain('quoteImagine(buildMidjourneyImagineRequest(this.config))');
+    expect(panel).toContain('quoteVideos(buildMidjourneyVideosRequest(this.config))');
+    expect(panel).toContain('quoteDescribe(buildMidjourneyDescribeRequest(this.config))');
+  });
+
+  it('submits imagine, videos, describe, and custom actions through authoritative builders', () => {
+    const page = source('pages/midjourney/Index.vue');
+    expect(page).toContain('buildMidjourneyCustomRequest(this.config, payload)');
+    expect(page).toContain('buildMidjourneyImagineRequest(this.config)');
+    expect(page).toContain('buildMidjourneyVideosRequest(this.config)');
+    expect(page).toContain('buildMidjourneyDescribeRequest(this.config)');
+    expect(page).toContain('midjourneyOperator.imagine(request, options)');
+    expect(page).toContain('midjourneyOperator.videos(request, options)');
+    expect(page).toContain('midjourneyOperator.describe(request, options)');
+  });
+
+  it('keeps guest task history in memory and attaches authenticated identity', () => {
+    const page = source('pages/midjourney/Index.vue');
+    expect(page).toContain('walletTaskIds: string[]');
+    expect(page).toContain("mode: 'x402', ids: this.walletTaskIds");
+    expect(page).toContain('identityToken: this.credential?.token');
+    expect(page).toContain('error instanceof X402PaymentCancelledError');
+    expect(page).not.toContain('localStorage');
+    expect(page).not.toContain('sessionStorage');
+  });
+});

--- a/src/layouts/Main.vue
+++ b/src/layouts/Main.vue
@@ -86,7 +86,8 @@ export default defineComponent({
           'kling',
           'digitalhuman',
           'serp',
-          'suno'
+          'suno',
+          'midjourney'
         ].includes(String(this.appName)) && isScenarioX402Enabled()
       );
     },

--- a/src/operators/midjourney.ts
+++ b/src/operators/midjourney.ts
@@ -1,33 +1,148 @@
 import axios, { AxiosResponse } from 'axios';
 import {
+  IMidjourneyConfig,
+  IMidjourneyDescribeRequest,
+  IMidjourneyDescribeResponse,
   IMidjourneyImagineRequest,
-  IMidjourneyVideosRequest,
   IMidjourneyImagineResponse,
-  IMidjourneyVideosResponse,
   IMidjourneyTaskResponse,
   IMidjourneyTasksResponse,
-  IMidjourneyDescribeResponse,
-  IMidjourneyDescribeRequest
+  IMidjourneyVideosRequest,
+  IMidjourneyVideosResponse,
+  MidjourneyImagineAction,
+  MidjourneyVideosAction
 } from '@/models';
-import { BASE_URL_API } from '@/constants';
+import {
+  BASE_URL_API,
+  BASE_URL_X402,
+  MIDJOURNEY_DEFAULT_IMAGE_WEIGHT,
+  MIDJOURNEY_DEFAULT_MODE,
+  MIDJOURNEY_DEFAULT_QUALITY,
+  MIDJOURNEY_DEFAULT_RATIO,
+  MIDJOURNEY_DEFAULT_STYLIZE,
+  MIDJOURNEY_DEFAULT_WIRED
+} from '@/constants';
+import { postWithX402, quoteX402, type OperatorRequestOptions } from './x402';
+
+const HEADERS = { 'content-type': 'application/json', accept: 'application/x-ndjson' };
+const TASK_HEADERS = { 'content-type': 'application/json', accept: 'application/json', 'x-record-exempt': 'true' };
+
+function buildFinalPrompt(config: IMidjourneyConfig): string {
+  let content = '';
+  if (config.references?.length) content += `${config.references.join(' ')} `;
+  if (config.prompt) content += config.prompt;
+  if (config.elements?.length) content += `,${config.elements.map((item) => item.value).join(',')}`;
+  const isNiji = config.model?.includes('niji');
+  if (config.model && !content.includes(`--${config.model}`)) content += ` --${config.model}`;
+  if (!isNiji && config.version && !content.includes('--version ') && !content.includes('--v ')) {
+    content += ` --version ${config.version}`;
+  }
+  if (config.chaos && config.advanced && !content.includes('--chaos ')) content += ` --chaos ${config.chaos}`;
+  if (
+    config.version !== '8.1' &&
+    config.quality &&
+    !content.includes('--quality ') &&
+    !content.includes('--q ') &&
+    config.quality !== MIDJOURNEY_DEFAULT_QUALITY
+  ) {
+    content += ` --quality ${config.quality}`;
+  }
+  if (
+    config.ratio &&
+    !content.includes('--aspect ') &&
+    !content.includes('--ar ') &&
+    config.ratio !== MIDJOURNEY_DEFAULT_RATIO
+  ) {
+    content += ` --aspect ${config.ratio}`;
+  }
+  if (
+    config.stylize &&
+    !content.includes('--stylize ') &&
+    !content.includes('--s ') &&
+    config.advanced &&
+    config.stylize !== MIDJOURNEY_DEFAULT_STYLIZE
+  ) {
+    content += ` --stylize ${config.stylize}`;
+  }
+  if (
+    config.weird &&
+    !content.includes('--weird ') &&
+    !content.includes('--w ') &&
+    config.advanced &&
+    config.weird !== MIDJOURNEY_DEFAULT_WIRED
+  ) {
+    content += ` --weird ${config.weird}`;
+  }
+  if (config.ignore && !content.includes('--no ')) content += ` --no ${config.ignore}`;
+  if (config.iw && !content.includes('--iw ') && config.advanced && config.iw !== MIDJOURNEY_DEFAULT_IMAGE_WEIGHT) {
+    content += ` --iw ${config.iw}`;
+  }
+  if (config.style && config.advanced && !content.includes('--style')) content += ` --style ${config.style}`;
+  if (!isNiji && config.hd && !content.includes('--hd')) content += ' --hd';
+  content = content.replace(/--(fast|relax|turbo) /g, '');
+  return config.prompt || config.references?.length ? content : '';
+}
+
+export function buildMidjourneyImagineRequest(config: IMidjourneyConfig): IMidjourneyImagineRequest {
+  const isV81 = config.version === '8.1';
+  const isV8 = config.version === '8' || isV81;
+  const prompt = buildFinalPrompt(config);
+  return {
+    mode: config.mode || MIDJOURNEY_DEFAULT_MODE,
+    prompt,
+    action: MidjourneyImagineAction.GENERATE,
+    translation: config.translation,
+    async: true,
+    version: config.version,
+    hd: config.hd || false,
+    ...(!isV81 ? { quality: config.quality || MIDJOURNEY_DEFAULT_QUALITY } : {}),
+    style_reference: prompt.includes('--sref'),
+    moodboard: Boolean(isV8 && config.references?.length)
+  };
+}
+
+export function buildMidjourneyCustomRequest(
+  config: IMidjourneyConfig,
+  payload: { image_id: string; action: MidjourneyImagineAction }
+): IMidjourneyImagineRequest {
+  const isV81 = config.version === '8.1';
+  return {
+    image_id: payload.image_id,
+    action: payload.action,
+    mode: isV81 ? MIDJOURNEY_DEFAULT_MODE : config.mode || MIDJOURNEY_DEFAULT_MODE,
+    async: true,
+    version: config.version,
+    hd: config.hd || false,
+    ...(!isV81 ? { quality: config.quality || MIDJOURNEY_DEFAULT_QUALITY } : {})
+  };
+}
+
+export function buildMidjourneyVideosRequest(config: IMidjourneyConfig): IMidjourneyVideosRequest {
+  return {
+    video_id: config.video_id,
+    image_url: config.image_url,
+    action: config.action as MidjourneyVideosAction,
+    prompt: config.prompt,
+    end_image_url: config.end_image_url,
+    resolution: config.resolution,
+    loop: config.loop,
+    mode: config.mode || MIDJOURNEY_DEFAULT_MODE,
+    async: true
+  };
+}
+
+export function buildMidjourneyDescribeRequest(config: IMidjourneyConfig): IMidjourneyDescribeRequest {
+  return { image_url: config.image_url || '' };
+}
 
 class MidjourneyOperator {
-  async task(id: string, options: { token: string }): Promise<AxiosResponse<IMidjourneyTaskResponse>> {
-    return await axios.post(
-      `/midjourney/tasks`,
-      {
-        action: 'retrieve',
-        id: id
-      },
-      {
-        headers: {
-          accept: 'application/json',
-          'content-type': 'application/json',
-          authorization: `Bearer ${options.token}`,
-          'x-record-exempt': 'true'
-        },
-        baseURL: BASE_URL_API
-      }
+  async task(id: string, options: OperatorRequestOptions): Promise<AxiosResponse<IMidjourneyTaskResponse>> {
+    return axios.post(
+      '/midjourney/tasks',
+      { action: 'retrieve', id },
+      options.mode === 'x402'
+        ? { headers: TASK_HEADERS, baseURL: BASE_URL_X402 }
+        : { headers: { ...TASK_HEADERS, authorization: `Bearer ${options.token}` }, baseURL: BASE_URL_API }
     );
   }
 
@@ -42,111 +157,56 @@ class MidjourneyOperator {
       createdAtMax?: number;
       createdAtMin?: number;
     },
-    options: { token: string }
+    options: OperatorRequestOptions
   ): Promise<AxiosResponse<IMidjourneyTasksResponse>> {
-    return await axios.post(
-      `/midjourney/tasks`,
+    return axios.post(
+      '/midjourney/tasks',
       {
         action: 'retrieve_batch',
-        ...(filter.ids
-          ? {
-              ids: filter.ids
-            }
-          : {}),
-        ...(filter.applicationId
-          ? {
-              application_id: filter.applicationId
-            }
-          : {}),
-        ...(filter.userId
-          ? {
-              user_id: filter.userId
-            }
-          : {}),
-        ...(filter.type
-          ? {
-              type: filter.type
-            }
-          : {}),
-        ...(filter.limit !== undefined
-          ? {
-              limit: filter.limit
-            }
-          : {}),
-        ...(filter.offset !== undefined
-          ? {
-              offset: filter.offset
-            }
-          : {}),
-        ...(filter.createdAtMax !== undefined
-          ? {
-              created_at_max: filter.createdAtMax
-            }
-          : {}),
-        ...(filter.createdAtMin !== undefined
-          ? {
-              created_at_min: filter.createdAtMin
-            }
-          : {})
+        ...(filter.ids ? { ids: filter.ids } : {}),
+        ...(filter.applicationId ? { application_id: filter.applicationId } : {}),
+        ...(filter.userId ? { user_id: filter.userId } : {}),
+        ...(filter.type ? { type: filter.type } : {}),
+        ...(filter.limit !== undefined ? { limit: filter.limit } : {}),
+        ...(filter.offset !== undefined ? { offset: filter.offset } : {}),
+        ...(filter.createdAtMax !== undefined ? { created_at_max: filter.createdAtMax } : {}),
+        ...(filter.createdAtMin !== undefined ? { created_at_min: filter.createdAtMin } : {})
       },
-      {
-        headers: {
-          accept: 'application/json',
-          'content-type': 'application/json',
-          authorization: `Bearer ${options.token}`,
-          'x-record-exempt': 'true'
-        },
-        baseURL: BASE_URL_API
-      }
+      options.mode === 'x402'
+        ? { headers: TASK_HEADERS, baseURL: BASE_URL_X402 }
+        : { headers: { ...TASK_HEADERS, authorization: `Bearer ${options.token}` }, baseURL: BASE_URL_API }
     );
   }
 
-  async imagine(
-    data: IMidjourneyImagineRequest,
-    options: {
-      token: string;
+  async quoteImagine(data: IMidjourneyImagineRequest) {
+    return quoteX402('/midjourney/imagine', data, HEADERS);
+  }
+  async quoteVideos(data: IMidjourneyVideosRequest) {
+    return quoteX402('/midjourney/videos', data, HEADERS);
+  }
+  async quoteDescribe(data: IMidjourneyDescribeRequest) {
+    return quoteX402('/midjourney/describe', data, HEADERS);
+  }
+
+  private async submit<T>(path: string, data: unknown, options: OperatorRequestOptions): Promise<AxiosResponse<T>> {
+    if (options.mode === 'x402') {
+      if (!options.x402) throw new Error('x402 payment options are required');
+      return postWithX402<T>(path, data, options.x402, HEADERS);
     }
-  ): Promise<AxiosResponse<IMidjourneyImagineResponse>> {
-    return await axios.post('/midjourney/imagine', data, {
-      headers: {
-        authorization: `Bearer ${options.token}`,
-        'content-type': 'application/json',
-        accept: 'application/x-ndjson'
-      },
+    return axios.post(path, data, {
+      headers: { ...HEADERS, authorization: `Bearer ${options.token}` },
       baseURL: BASE_URL_API
     });
   }
 
-  async videos(
-    data: IMidjourneyVideosRequest,
-    options: {
-      token: string;
-    }
-  ): Promise<AxiosResponse<IMidjourneyVideosResponse>> {
-    return await axios.post('/midjourney/videos', data, {
-      headers: {
-        authorization: `Bearer ${options.token}`,
-        'content-type': 'application/json',
-        accept: 'application/x-ndjson'
-      },
-      baseURL: BASE_URL_API
-    });
+  async imagine(data: IMidjourneyImagineRequest, options: OperatorRequestOptions) {
+    return this.submit<IMidjourneyImagineResponse>('/midjourney/imagine', data, options);
   }
-
-  async describe(
-    data: IMidjourneyDescribeRequest,
-    options: {
-      token: string;
-    }
-  ): Promise<AxiosResponse<IMidjourneyDescribeResponse>> {
-    return await axios.post('/midjourney/describe', data, {
-      headers: {
-        authorization: `Bearer ${options.token}`,
-        'content-type': 'application/json',
-        accept: 'application/x-ndjson'
-      },
-      baseURL: BASE_URL_API
-    });
+  async videos(data: IMidjourneyVideosRequest, options: OperatorRequestOptions) {
+    return this.submit<IMidjourneyVideosResponse>('/midjourney/videos', data, options);
+  }
+  async describe(data: IMidjourneyDescribeRequest, options: OperatorRequestOptions) {
+    return this.submit<IMidjourneyDescribeResponse>('/midjourney/describe', data, options);
   }
 }
 

--- a/src/operators/x402MidjourneyRequests.test.ts
+++ b/src/operators/x402MidjourneyRequests.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  buildMidjourneyCustomRequest,
+  buildMidjourneyDescribeRequest,
+  buildMidjourneyImagineRequest,
+  buildMidjourneyVideosRequest,
+  midjourneyOperator
+} from './midjourney';
+import { MidjourneyImagineAction, MidjourneyVideosAction } from '@/models';
+
+const x402 = vi.hoisted(() => ({ quote: vi.fn(), post: vi.fn() }));
+vi.mock('./x402', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./x402')>()),
+  quoteX402: x402.quote,
+  postWithX402: x402.post
+}));
+
+describe('Midjourney x402 requests', () => {
+  it('builds one authoritative imagine prompt with V8 pricing flags', () => {
+    expect(
+      buildMidjourneyImagineRequest({
+        type: 'imagine',
+        prompt: 'cat',
+        references: ['https://example.com/ref.png'],
+        model: 'v8',
+        version: '8',
+        hd: true,
+        quality: '2',
+        advanced: true,
+        chaos: 10,
+        ratio: '16:9'
+      })
+    ).toMatchObject({
+      action: MidjourneyImagineAction.GENERATE,
+      version: '8',
+      hd: true,
+      quality: '2',
+      moodboard: true,
+      async: true,
+      prompt: expect.stringContaining('cat --v8 --version 8 --chaos 10 --quality 2 --aspect 16:9 --hd')
+    });
+  });
+
+  it('builds custom, videos, and describe payloads without crossing endpoints', () => {
+    expect(
+      buildMidjourneyCustomRequest(
+        { version: '8.1', mode: 'relax', quality: '2' },
+        { image_id: 'image-1', action: MidjourneyImagineAction.UPSCALE1 }
+      )
+    ).toEqual({
+      image_id: 'image-1',
+      action: MidjourneyImagineAction.UPSCALE1,
+      mode: 'fast',
+      async: true,
+      version: '8.1',
+      hd: false
+    });
+    expect(buildMidjourneyVideosRequest({ action: 'extend', video_id: 'video-1', resolution: '720p' })).toMatchObject({
+      action: MidjourneyVideosAction.EXTEND,
+      video_id: 'video-1',
+      resolution: '720p',
+      async: true
+    });
+    expect(buildMidjourneyDescribeRequest({ image_url: 'image.png' })).toEqual({ image_url: 'image.png' });
+  });
+
+  it('routes each quote and signed submit to its exact endpoint', async () => {
+    x402.quote.mockResolvedValue({ amountUsdc: '1' });
+    x402.post.mockResolvedValue({ data: { task_id: 'task-1' } });
+    const options = { mode: 'x402' as const, x402: { wallet: {} as never, confirm: async () => true } };
+    const imagine = buildMidjourneyImagineRequest({ prompt: 'cat' });
+    const videos = buildMidjourneyVideosRequest({ image_url: 'image.png' });
+    const describe = buildMidjourneyDescribeRequest({ image_url: 'image.png' });
+
+    await midjourneyOperator.quoteImagine(imagine);
+    await midjourneyOperator.quoteVideos(videos);
+    await midjourneyOperator.quoteDescribe(describe);
+    await midjourneyOperator.imagine(imagine, options);
+    await midjourneyOperator.videos(videos, options);
+    await midjourneyOperator.describe(describe, options);
+
+    expect(x402.quote.mock.calls.map((call) => call[0])).toEqual([
+      '/midjourney/imagine',
+      '/midjourney/videos',
+      '/midjourney/describe'
+    ]);
+    expect(x402.post.mock.calls.map((call) => call[0])).toEqual([
+      '/midjourney/imagine',
+      '/midjourney/videos',
+      '/midjourney/describe'
+    ]);
+  });
+});

--- a/src/pages/midjourney/Index.vue
+++ b/src/pages/midjourney/Index.vue
@@ -13,8 +13,14 @@
 import { defineComponent } from 'vue';
 import Layout from '@/layouts/Midjourney.vue';
 import ConfigPanel from '@/components/midjourney/ConfigPanel.vue';
-import { ElMessage } from 'element-plus';
-import { midjourneyOperator } from '@/operators';
+import { ElMessage, ElMessageBox } from 'element-plus';
+import {
+  buildMidjourneyCustomRequest,
+  buildMidjourneyDescribeRequest,
+  buildMidjourneyImagineRequest,
+  buildMidjourneyVideosRequest,
+  midjourneyOperator
+} from '@/operators/midjourney';
 import { instrumentGeneration } from '@/plugins/telemetry';
 import TaskList from '@/components/midjourney/tasks/TaskList.vue';
 import { ERROR_CODE_USED_UP } from '@/constants/errorCode';
@@ -25,22 +31,23 @@ import {
   MidjourneyImagineAction,
   IMidjourneyDescribeRequest
 } from '@/models';
-import {
-  MIDJOURNEY_DEFAULT_IMAGE_WEIGHT,
-  MIDJOURNEY_DEFAULT_RATIO,
-  MIDJOURNEY_DEFAULT_STYLIZE,
-  MIDJOURNEY_DEFAULT_WIRED,
-  MIDJOURNEY_DEFAULT_MODE,
-  MIDJOURNEY_DEFAULT_QUALITY
-} from '@/constants';
+
 import { loadPreviousPage } from '@/utils/pagination';
 import { uploadTrackerProviderMixin, ensureNoPendingUpload, ensureLoggedIn } from '@/utils';
+import { isScenarioX402Enabled, scenarioPaymentState } from '@/utils/x402/scenarioPayment';
+import {
+  X402PaymentCancelledError,
+  type OperatorRequestOptions,
+  type X402PaymentQuote,
+  type X402WalletContext
+} from '@/operators/x402';
 
 interface IData {
   operating: boolean;
   job: number;
   loadingMore: boolean;
   fetchingTasks: boolean;
+  walletTaskIds: string[];
 }
 
 export default defineComponent({
@@ -57,7 +64,8 @@ export default defineComponent({
       operating: false,
       job: 0,
       loadingMore: false,
-      fetchingTasks: false
+      fetchingTasks: false,
+      walletTaskIds: []
     };
   },
   computed: {
@@ -79,87 +87,26 @@ export default defineComponent({
     application() {
       return this.$store.state.midjourney.application;
     },
-    finalPrompt(): string {
-      let content = '';
-      if (this.config.references && this.config.references?.length > 0) {
-        content += `${this.config.references.join(' ')} `;
-      }
-      if (this.config.prompt) {
-        content += this.config.prompt;
-      }
-      if (this.config.elements && this.config.elements.length > 0) {
-        content += ',' + this.config.elements.map((item) => item.value).join(',');
-      }
-      const isNiji = this.config?.model?.includes('niji');
-      if (this.config?.model && !content.includes(`--${this.config.model}`)) {
-        content += ` --${this.config.model}`;
-      }
-      // niji models carry their own version (e.g. `niji 5`) and reject --version
-      if (!isNiji && this.config?.version && !content.includes(`--version `) && !content.includes(`--v `)) {
-        content += ` --version ${this.config.version}`;
-      }
-      if (this.config?.chaos && this.config?.advanced && !content.includes(`--chaos `)) {
-        content += ` --chaos ${this.config.chaos}`;
-      }
-      if (
-        this.config?.version !== '8.1' &&
-        this.config?.quality &&
-        !content.includes(`--quality `) &&
-        !content.includes(`--q `) &&
-        this.config?.quality !== MIDJOURNEY_DEFAULT_QUALITY
-      ) {
-        content += ` --quality ${this.config.quality}`;
-      }
-      if (
-        this.config?.ratio &&
-        !content.includes(`--aspect `) &&
-        !content.includes(`--ar `) &&
-        this.config?.ratio !== MIDJOURNEY_DEFAULT_RATIO
-      ) {
-        content += ` --aspect ${this.config.ratio}`;
-      }
-      if (
-        this.config?.stylize &&
-        !content.includes(`--stylize `) &&
-        !content.includes(`--s `) &&
-        this.config?.advanced &&
-        this.config?.stylize !== MIDJOURNEY_DEFAULT_STYLIZE
-      ) {
-        content += ` --stylize ${this.config?.stylize}`;
-      }
-      if (
-        this.config?.weird &&
-        !content.includes(`--weird `) &&
-        !content.includes(`--w `) &&
-        this.config?.advanced &&
-        this.config?.weird !== MIDJOURNEY_DEFAULT_WIRED
-      ) {
-        content += ` --weird ${this.config.weird}`;
-      }
-      if (this.config.ignore && !content.includes(`--no `)) {
-        content += ` --no ${this.config.ignore}`;
-      }
-      if (
-        this.config?.iw &&
-        !content.includes(`--iw `) &&
-        this.config?.advanced &&
-        this.config?.iw !== MIDJOURNEY_DEFAULT_IMAGE_WEIGHT
-      ) {
-        content += ` --iw ${this.config.iw}`;
-      }
-      if (this.config?.style && this.config?.advanced && !content.includes(`--style`)) {
-        content += ` --style ${this.config?.style}`;
-      }
-      // V8 --hd parameter (not supported by niji models)
-      if (!isNiji && this.config?.hd && !content.includes(`--hd`)) {
-        content += ` --hd`;
-      }
-      // remove `--fast`, `--relax`, `--turbo`
-      content = content.replace(/--(fast|relax|turbo) /g, '');
-      return this.config.prompt || (this.config.references && this.config.references?.length > 0) ? content : '';
+    walletMode(): boolean {
+      return isScenarioX402Enabled() && scenarioPaymentState('midjourney').mode === 'wallet';
     }
   },
   watch: {
+    walletMode: {
+      async handler(value: boolean, oldValue: boolean | undefined) {
+        if (oldValue === undefined || value === oldValue) return;
+        this.$store.commit('midjourney/setTasks', undefined);
+        if (value && !this.job) this.job = window.setInterval(this.onGetTasks, 5000);
+        if (!value && !this.credential?.token) {
+          window.clearInterval(this.job);
+          this.job = 0;
+          await this.onScrollDown();
+          return;
+        }
+        await this.onGetTasks();
+        await this.onScrollDown();
+      }
+    },
     tasks: {
       handler(value, oldValue) {
         // scroll down if new tasks are added
@@ -176,9 +123,7 @@ export default defineComponent({
           console.debug('layout initialized');
           await this.onGetTasks();
           await this.onScrollDown();
-          this.job = window.setInterval(() => {
-            this.onGetTasks();
-          }, 5000);
+          if (!this.job) this.job = window.setInterval(this.onGetTasks, 5000);
         }
       },
       immediate: true
@@ -217,49 +162,17 @@ export default defineComponent({
       await this.onGetTasks();
     },
     async onStartImagineTask(request: IMidjourneyImagineRequest) {
-      // Deferred auth: guests compose freely; hitting generate sends them to login.
-      if (!ensureLoggedIn()) {
-        return;
-      }
-      const token = this.credential?.token;
-      if (!token) {
-        console.error('no token specified');
-        return;
-      }
       if (!request.prompt && request.action === MidjourneyImagineAction.GENERATE) {
         ElMessage.error(this.$t('midjourney.message.promptRequired'));
         return;
       }
-      ElMessage.info(this.$t('midjourney.message.startingTask'));
-      instrumentGeneration('midjourney', midjourneyOperator.imagine(request, { token }))
-        .then(() => {
-          ElMessage.success(this.$t('midjourney.message.startTaskSuccess'));
-        })
-        .catch((error) => {
-          const response = error?.response?.data;
-          if (response?.error?.code === ERROR_CODE_USED_UP) {
-            ElMessage.error(this.$t('midjourney.message.usedUp'));
-          } else {
-            ElMessage.error(this.$t('midjourney.message.startTaskFailed') + error.response?.data?.error?.message);
-          }
-        })
-        .finally(async () => {
-          setTimeout(async () => {
-            await this.onGetTasks();
-            await this.onScrollDown();
-          }, 1000);
-        });
+      await this.startPaidTask(
+        (options) => midjourneyOperator.imagine(request, options),
+        'midjourney.message.startTaskSuccess',
+        'midjourney.message.startTaskFailed'
+      );
     },
     async onStartVideosTask(request: IMidjourneyVideosRequest) {
-      // Deferred auth: guests compose freely; hitting generate sends them to login.
-      if (!ensureLoggedIn()) {
-        return;
-      }
-      const token = this.credential?.token;
-      if (!token) {
-        console.error('no token specified');
-        return;
-      }
       if (!request.prompt) {
         ElMessage.error(this.$t('midjourney.message.promptRequired'));
         return;
@@ -270,69 +183,21 @@ export default defineComponent({
         ElMessage.error(this.$t('midjourney.message.imageUrlRequired'));
         return;
       }
-      ElMessage.info(this.$t('midjourney.message.startingTask'));
-      instrumentGeneration('midjourney', midjourneyOperator.videos(request, { token }))
-        .then(() => {
-          ElMessage.success(this.$t('midjourney.message.startVideosTaskSuccess'));
-        })
-        .catch((error) => {
-          const response = error?.response?.data;
-          if (response?.error?.code === ERROR_CODE_USED_UP) {
-            ElMessage.error(this.$t('midjourney.message.usedUp'));
-          } else {
-            ElMessage.error(this.$t('midjourney.message.startVideosTaskFailed') + error.response?.data?.error?.message);
-          }
-        })
-        .finally(async () => {
-          setTimeout(async () => {
-            await this.onGetTasks();
-            await this.onScrollDown();
-          }, 1000);
-        });
+      await this.startPaidTask(
+        (options) => midjourneyOperator.videos(request, options),
+        'midjourney.message.startVideosTaskSuccess',
+        'midjourney.message.startVideosTaskFailed'
+      );
     },
     async onStartDescribeTask(request: IMidjourneyDescribeRequest) {
-      // Deferred auth: guests compose freely; hitting describe sends them to login.
-      if (!ensureLoggedIn()) {
-        return;
-      }
-      const token = this.credential?.token;
-      if (!token) {
-        console.error('no token specified');
-        return;
-      }
-      ElMessage.info(this.$t('midjourney.message.startingTask'));
-      instrumentGeneration('midjourney', midjourneyOperator.describe(request, { token }))
-        .then(() => {
-          ElMessage.success(this.$t('midjourney.message.startDescribeTaskSuccess'));
-        })
-        .catch((error) => {
-          const response = error?.response?.data;
-          if (response?.error?.code === ERROR_CODE_USED_UP) {
-            ElMessage.error(this.$t('midjourney.message.usedUp'));
-          } else {
-            ElMessage.error(
-              this.$t('midjourney.message.startDescribeTaskFailed') + error.response?.data?.error?.message
-            );
-          }
-        })
-        .finally(async () => {
-          setTimeout(async () => {
-            await this.onGetTasks();
-            await this.onScrollDown();
-          }, 1000);
-        });
+      await this.startPaidTask(
+        (options) => midjourneyOperator.describe(request, options),
+        'midjourney.message.startDescribeTaskSuccess',
+        'midjourney.message.startDescribeTaskFailed'
+      );
     },
     async onCustom(payload: { image_id: string; action: MidjourneyImagineAction }) {
-      const isV81 = this.config?.version === '8.1';
-      const request = {
-        image_id: payload.image_id,
-        action: payload.action,
-        mode: isV81 ? MIDJOURNEY_DEFAULT_MODE : this.config?.mode || MIDJOURNEY_DEFAULT_MODE,
-        async: true,
-        version: this.config?.version,
-        hd: this.config?.hd || false,
-        ...(!isV81 ? { quality: this.config?.quality || MIDJOURNEY_DEFAULT_QUALITY } : {})
-      };
+      const request = buildMidjourneyCustomRequest(this.config, payload);
       this.onStartImagineTask(request);
     },
     async onGenerate() {
@@ -347,47 +212,90 @@ export default defineComponent({
       }
       console.debug('onGenerate', this.config);
       if (this.config?.type === 'videos') {
-        const request = {
-          video_id: this.config?.video_id,
-          image_url: this.config?.image_url,
-          action: this.config?.action as MidjourneyVideosAction,
-          prompt: this.config?.prompt,
-          end_image_url: this.config?.end_image_url,
-          resolution: this.config?.resolution,
-          loop: this.config?.loop,
-          mode: this.config?.mode || MIDJOURNEY_DEFAULT_MODE,
-          async: true
-        };
+        const request = buildMidjourneyVideosRequest(this.config);
         await this.onStartVideosTask(request);
       } else if (this.config?.type === 'imagine') {
-        const isV81 = this.config?.version === '8.1';
-        const isV8 = this.config?.version === '8' || this.config?.version === '8.1';
-        const hasSref = !!(this.finalPrompt && this.finalPrompt.includes('--sref'));
-        const hasMoodboard = !!(isV8 && this.config?.references && this.config.references.length > 0);
-        const request = {
-          mode: this.config?.mode || MIDJOURNEY_DEFAULT_MODE,
-          prompt: this.finalPrompt,
-          action: MidjourneyImagineAction.GENERATE,
-          translation: this.config?.translation,
-          async: true,
-          version: this.config?.version,
-          hd: this.config?.hd || false,
-          ...(!isV81 ? { quality: this.config?.quality || MIDJOURNEY_DEFAULT_QUALITY } : {}),
-          style_reference: hasSref,
-          moodboard: hasMoodboard
-        };
+        const request = buildMidjourneyImagineRequest(this.config);
         await this.onStartImagineTask(request);
       } else if (this.config?.type === 'describe') {
         if (!this.config?.image_url) {
           ElMessage.error(this.$t('midjourney.message.imageUrlRequired'));
           return;
         }
-        const request = {
-          image_url: this.config?.image_url,
-          async: true
-        };
+        const request = buildMidjourneyDescribeRequest(this.config);
         await this.onStartDescribeTask(request);
       }
+    },
+    paymentOptions(): OperatorRequestOptions | undefined {
+      if (!this.walletMode) {
+        if (!ensureLoggedIn()) return undefined;
+        const token = this.credential?.token;
+        return token ? { token } : undefined;
+      }
+      const wallet = this.getWalletContext();
+      if (!wallet) {
+        ElMessage.warning(this.$t('common.x402Scenario.connectWalletFirst'));
+        return undefined;
+      }
+      return {
+        mode: 'x402',
+        x402: {
+          wallet,
+          confirm: (quote) => this.confirmWalletPayment(quote),
+          identityToken: this.credential?.token
+        }
+      };
+    },
+    async startPaidTask(
+      submit: (options: OperatorRequestOptions) => Promise<unknown>,
+      successKey: string,
+      failureKey: string
+    ) {
+      const options = this.paymentOptions();
+      if (!options) return;
+      ElMessage.info(this.$t('midjourney.message.startingTask'));
+      try {
+        const response: any = await instrumentGeneration('midjourney', submit(options));
+        const taskId = response?.data?.task_id;
+        if (this.walletMode && !this.credential?.token && taskId && !this.walletTaskIds.includes(taskId)) {
+          this.walletTaskIds.unshift(taskId);
+        }
+        ElMessage.success(this.$t(successKey));
+      } catch (error: any) {
+        if (error instanceof X402PaymentCancelledError) return;
+        if (error?.response?.data?.error?.code === ERROR_CODE_USED_UP) {
+          ElMessage.error(this.$t('midjourney.message.usedUp'));
+        } else if (this.walletMode) {
+          ElMessage.error(`${this.$t('common.x402Scenario.paymentFailed')} ${error?.message || ''}`.trim());
+        } else {
+          ElMessage.error(this.$t(failureKey) + (error?.response?.data?.error?.message || ''));
+        }
+      } finally {
+        setTimeout(async () => {
+          await this.onGetTasks();
+          await this.onScrollDown();
+        }, 1000);
+      }
+    },
+    getWalletContext(): X402WalletContext | undefined {
+      const walletApi = (this as any).$wallet;
+      const publicKey = walletApi?.publicKey?.value;
+      const adapter = walletApi?.wallet?.value?.adapter;
+      if (!publicKey || !adapter?.signTransaction) return undefined;
+      return { publicKey, signTransaction: adapter.signTransaction.bind(adapter) };
+    },
+    async confirmWalletPayment(quote: X402PaymentQuote): Promise<boolean> {
+      return ElMessageBox.confirm(
+        this.$t('common.x402Scenario.confirmPayment', { amount: quote.amountUsdc }),
+        this.$t('order.message.x402ConfirmTitle'),
+        {
+          confirmButtonText: this.$t('order.message.x402WalletPayCta'),
+          cancelButtonText: this.$t('common.button.cancel'),
+          type: 'warning'
+        }
+      )
+        .then(() => true)
+        .catch(() => false);
     },
     async onScrollDown() {
       await this.$nextTick();
@@ -409,7 +317,8 @@ export default defineComponent({
         await this.$store.dispatch('midjourney/getTasks', {
           limit,
           createdAtMin,
-          createdAtMax
+          createdAtMax,
+          ...(this.walletMode && !this.credential?.token ? { mode: 'x402', ids: this.walletTaskIds } : {})
         });
       } finally {
         this.fetchingTasks = false;

--- a/src/store/midjourney/actions.ts
+++ b/src/store/midjourney/actions.ts
@@ -138,27 +138,35 @@ export const getTasks = async (
     offset,
     limit,
     createdAtMin,
-    createdAtMax
-  }: { offset?: number; limit?: number; createdAtMin?: number; createdAtMax?: number }
+    createdAtMax,
+    mode = 'credits',
+    ids
+  }: {
+    offset?: number;
+    limit?: number;
+    createdAtMin?: number;
+    createdAtMax?: number;
+    mode?: 'credits' | 'x402';
+    ids?: string[];
+  }
 ): Promise<IMidjourneyTask[]> => {
   return new Promise((resolve, reject) => {
     console.debug('start to get tasks', offset, limit, createdAtMax, createdAtMin);
     const credential = state.credential;
     console.debug('current credential', credential);
     const token = credential?.token;
-    if (!token) {
-      return reject('no token');
+    if (mode === 'credits' && !token) return reject('no token');
+    if (mode === 'x402' && !ids?.length) {
+      commit('setTasksItems', []);
+      commit('setTasksTotal', 0);
+      return resolve([]);
     }
     midjourneyOperator
       .tasks(
-        {
-          userId: rootState?.user?.id,
-          createdAtMin,
-          createdAtMax
-        },
-        {
-          token
-        }
+        mode === 'x402'
+          ? { ids, createdAtMin, createdAtMax }
+          : { userId: rootState?.user?.id, createdAtMin, createdAtMax },
+        mode === 'x402' ? { mode: 'x402' } : { token }
       )
       .then((response) => {
         console.debug('get imagine tasks success', response.data.items);

--- a/src/store/midjourney/actions.x402.test.ts
+++ b/src/store/midjourney/actions.x402.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({ tasks: vi.fn() }));
+vi.mock('@/operators', () => ({
+  applicationOperator: {},
+  credentialOperator: {},
+  midjourneyOperator: { tasks: mocks.tasks },
+  serviceOperator: {}
+}));
+
+import { getTasks } from './actions';
+
+const state = () => ({ credential: { token: 'credits-token' }, tasks: { items: [], total: 0 } }) as any;
+const context = (value = state()) => ({ state: value, rootState: { user: { id: 'user-1' } }, commit: vi.fn() }) as any;
+
+describe('Midjourney x402 history', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('keeps Credits history scoped to the authenticated user', async () => {
+    mocks.tasks.mockResolvedValueOnce({ data: { items: [], count: 0 } });
+    const ctx = context();
+    await getTasks(ctx, { limit: 5 });
+    expect(mocks.tasks).toHaveBeenCalledWith(expect.objectContaining({ userId: 'user-1' }), { token: 'credits-token' });
+  });
+
+  it('queries guest wallet history only by in-memory task IDs', async () => {
+    mocks.tasks.mockResolvedValueOnce({ data: { items: [], count: 0 } });
+    const ctx = context({ ...state(), credential: undefined });
+    await getTasks(ctx, { mode: 'x402', ids: ['task-1'], limit: 5 });
+    expect(mocks.tasks).toHaveBeenCalledWith(expect.objectContaining({ ids: ['task-1'] }), { mode: 'x402' });
+  });
+
+  it('does not send an empty guest history request', async () => {
+    const ctx = context({ ...state(), credential: undefined });
+    await getTasks(ctx, { mode: 'x402', ids: [] });
+    expect(mocks.tasks).not.toHaveBeenCalled();
+    expect(ctx.commit).toHaveBeenCalledWith('setTasksItems', []);
+    expect(ctx.commit).toHaveBeenCalledWith('setTasksTotal', 0);
+  });
+});


### PR DESCRIPTION
## Summary

- add Solana x402 wallet quotes and signed submit for Midjourney imagine/custom actions, videos, and describe
- centralize the complex V8/Niji prompt and pricing flags into authoritative request builders shared by quote and submit
- support guest in-memory task polling and authenticated identity sidecars without changing task cards or delete behavior

## Validation

- `npm run lint:check` — 0 errors (2 pre-existing warnings)
- `npx vue-tsc -b --pretty false`
- `npm run test:run` — 172 files / 1,322 tests passed
- `python3 scripts/check_i18n_coverage.py`
- `unset $(git rev-parse --local-env-vars); npm run verify`
- `npm run build:web`
- `npm run build:electron`
- `npm run compile:electron && node scripts/copy-renderer.js`
- `unset ELECTRON_RUN_AS_NODE; npm run test:e2e:desktop` — 3 passed
- `git diff --check`

## Scope

- wallet support is limited to the existing exact-enabled `/midjourney/imagine`, `/midjourney/videos`, and `/midjourney/describe` endpoints
- no storage, delete, task-card, Preview, or locale changes
- no billable generation, signature, or payment performed during validation

## Rollback

Revert this PR to remove Midjourney wallet UI. No schema migration is involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
