### PR TITLE
feat(x402): add Producer wallet payments

### DIFF
--- a/change/@acedatacloud-nexior-25acb0ba-3b03-4fc9-9abc-b732defa910f.json
+++ b/change/@acedatacloud-nexior-25acb0ba-3b03-4fc9-9abc-b732defa910f.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add Solana x402 wallet payments to Producer audio, lyrics, video, and WAV actions.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "minor"
+}

--- a/src/components/producer/ConfigPanel.vue
+++ b/src/components/producer/ConfigPanel.vue
@@ -30,7 +30,8 @@
       </el-tabs>
     </div>
     <div class="flex flex-col items-center justify-center px-5 pb-5 gap-2">
-      <consumption :value="consumption" :service="service" />
+      <scenario-payment-mode scenario="producer" />
+      <consumption v-if="!walletMode" :value="consumption" :service="service" />
       <div class="flex gap-2 w-full">
         <el-button class="flex-1" @click="onClearAll">
           <cleanup-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
@@ -62,6 +63,9 @@ import AdvancedParams from './config/AdvancedParams.vue';
 import ReplaceSectionInput from './config/ReplaceSectionInput.vue';
 import Consumption from '../common/Consumption.vue';
 import { getConsumption } from '@/utils';
+import ScenarioPaymentMode from '../common/ScenarioPaymentMode.vue';
+import { isScenarioX402Enabled, scenarioPaymentState } from '@/utils/x402/scenarioPayment';
+import { buildProducerAudioRequest, producerOperator } from '@/operators/producer';
 
 export default defineComponent({
   name: 'PresetPanel',
@@ -82,9 +86,13 @@ export default defineComponent({
     ElButton,
     ElTabs,
     ElTabPane,
-    Consumption
+    Consumption,
+    ScenarioPaymentMode
   },
   emits: ['generate'],
+  data() {
+    return { quoteTimer: 0, quoteRunId: 0 };
+  },
   computed: {
     config() {
       return this.$store.state.producer?.config;
@@ -106,6 +114,9 @@ export default defineComponent({
     service() {
       return this.$store.state.producer?.service;
     },
+    walletMode(): boolean {
+      return isScenarioX402Enabled() && scenarioPaymentState('producer').mode === 'wallet';
+    },
     generateButtonText() {
       const action = this.config?.action;
       if (action === 'extend' || action === 'upload_extend') return this.$t('producer.button.extend');
@@ -118,7 +129,43 @@ export default defineComponent({
       return this.$t('producer.button.generate');
     }
   },
+  watch: {
+    walletMode: {
+      handler(enabled: boolean) {
+        if (enabled) this.scheduleQuote();
+      },
+      immediate: true
+    },
+    config: {
+      handler() {
+        if (this.walletMode) this.scheduleQuote();
+      },
+      deep: true
+    }
+  },
+  beforeUnmount() {
+    window.clearTimeout(this.quoteTimer);
+    this.quoteRunId += 1;
+  },
   methods: {
+    scheduleQuote() {
+      window.clearTimeout(this.quoteTimer);
+      this.quoteTimer = window.setTimeout(this.refreshQuote, 350);
+    },
+    async refreshQuote() {
+      const state = scenarioPaymentState('producer');
+      const runId = ++this.quoteRunId;
+      state.quoteLoading = true;
+      state.quoteUsdc = undefined;
+      try {
+        const quote = await producerOperator.quoteAudio(buildProducerAudioRequest(this.config));
+        if (runId === this.quoteRunId && state.mode === 'wallet') state.quoteUsdc = quote.amountUsdc;
+      } catch (error) {
+        console.warn('x402 quote failed', error);
+      } finally {
+        if (runId === this.quoteRunId) state.quoteLoading = false;
+      }
+    },
     onGenerate() {
       this.$emit('generate');
     },

--- a/src/components/producer/RecentPanel.vue
+++ b/src/components/producer/RecentPanel.vue
@@ -25,7 +25,13 @@
     :loading="loading"
     @reach-top="$emit('reach-top')"
   >
-    <task-preview v-for="(task, taskId) in tasks?.items" :key="taskId" :model-value="task" class="preview" />
+    <task-preview
+      v-for="(task, taskId) in tasks?.items"
+      :key="taskId"
+      :model-value="task"
+      class="preview"
+      @wallet-task="$emit('wallet-task', $event)"
+    />
   </scroll-list>
   <div v-if="tasks?.items?.length === 0" class="w-full flex-1 flex items-center justify-center">
     <no-tasks />
@@ -59,7 +65,7 @@ export default defineComponent({
       default: false
     }
   },
-  emits: ['reach-top'],
+  emits: ['reach-top', 'wallet-task'],
   data() {
     return {
       job: 0

--- a/src/components/producer/config/LyricInput.vue
+++ b/src/components/producer/config/LyricInput.vue
@@ -38,9 +38,16 @@
 <script lang="ts">
 import { MagicIcon } from '@acedatacloud/core/icons/components';
 import { defineComponent } from 'vue';
-import { ElInput, ElButton, ElMessage } from 'element-plus';
+import { ElInput, ElButton, ElMessage, ElMessageBox } from 'element-plus';
 import InfoIcon from '@/components/common/InfoIcon.vue';
-import { producerOperator } from '@/operators';
+import { producerOperator } from '@/operators/producer';
+import { isScenarioX402Enabled, scenarioPaymentState } from '@/utils/x402/scenarioPayment';
+import {
+  X402PaymentCancelledError,
+  type OperatorRequestOptions,
+  type X402PaymentQuote,
+  type X402WalletContext
+} from '@/operators/x402';
 
 export const DEFAULT_LYRIC = '';
 
@@ -74,6 +81,9 @@ export default defineComponent({
     },
     credential() {
       return this.$store.state.producer?.credential;
+    },
+    walletMode(): boolean {
+      return isScenarioX402Enabled() && scenarioPaymentState('producer').mode === 'wallet';
     }
   },
   mounted() {
@@ -82,16 +92,34 @@ export default defineComponent({
     }
   },
   methods: {
+    paymentOptions(): OperatorRequestOptions | undefined {
+      if (!this.walletMode) {
+        const token = this.credential?.token;
+        return token ? { token } : undefined;
+      }
+      const wallet = this.getWalletContext();
+      if (!wallet) {
+        ElMessage.warning(this.$t('common.x402Scenario.connectWalletFirst'));
+        return undefined;
+      }
+      return {
+        mode: 'x402',
+        x402: {
+          wallet,
+          confirm: (quote) => this.confirmWalletPayment(quote),
+          identityToken: this.credential?.token
+        }
+      };
+    },
     async onGenerateLyrics() {
-      const token = this.credential?.token;
-      if (!token) return;
-
+      const options = this.paymentOptions();
+      if (!options) return;
       const prompt = this.config?.style || this.config?.title || 'a beautiful song';
       this.generatingLyrics = true;
       ElMessage.info(this.$t('producer.message.generatingLyrics'));
 
       try {
-        const response = await producerOperator.lyric({ prompt }, { token });
+        const response = await producerOperator.lyric({ prompt }, options);
         const data = response.data?.data;
         if (data?.text) {
           this.lyric = data.text;
@@ -104,11 +132,32 @@ export default defineComponent({
           }
           ElMessage.success(this.$t('producer.message.generateLyricsSuccess'));
         }
-      } catch {
+      } catch (error) {
+        if (error instanceof X402PaymentCancelledError) return;
         ElMessage.error(this.$t('producer.message.generateLyricsFailed'));
       } finally {
         this.generatingLyrics = false;
       }
+    },
+    getWalletContext(): X402WalletContext | undefined {
+      const walletApi = (this as any).$wallet;
+      const publicKey = walletApi?.publicKey?.value;
+      const adapter = walletApi?.wallet?.value?.adapter;
+      if (!publicKey || !adapter?.signTransaction) return undefined;
+      return { publicKey, signTransaction: adapter.signTransaction.bind(adapter) };
+    },
+    async confirmWalletPayment(quote: X402PaymentQuote): Promise<boolean> {
+      return ElMessageBox.confirm(
+        this.$t('common.x402Scenario.confirmPayment', { amount: quote.amountUsdc }),
+        this.$t('order.message.x402ConfirmTitle'),
+        {
+          confirmButtonText: this.$t('order.message.x402WalletPayCta'),
+          cancelButtonText: this.$t('common.button.cancel'),
+          type: 'warning'
+        }
+      )
+        .then(() => true)
+        .catch(() => false);
     }
   }
 });

--- a/src/components/producer/task/Preview.vue
+++ b/src/components/producer/task/Preview.vue
@@ -194,12 +194,20 @@ import {
   ElDropdown,
   ElDropdownMenu,
   ElDropdownItem,
-  ElMessage
+  ElMessage,
+  ElMessageBox
 } from 'element-plus';
 
 import { IProducerVideoRequest, IProducerAudioRequest, Status } from '@/models';
 import { saveAs } from 'file-saver';
-import { producerOperator } from '@/operators';
+import { producerOperator } from '@/operators/producer';
+import { isScenarioX402Enabled, scenarioPaymentState } from '@/utils/x402/scenarioPayment';
+import {
+  X402PaymentCancelledError,
+  type OperatorRequestOptions,
+  type X402PaymentQuote,
+  type X402WalletContext
+} from '@/operators/x402';
 import ApiCodeDialog from '@/components/common/ApiCodeDialog.vue';
 import ReportDialog from '@/components/common/ReportDialog.vue';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
@@ -235,6 +243,7 @@ export default defineComponent({
       required: true
     }
   },
+  emits: ['wallet-task'],
   data() {
     return {
       isFetchingVideoUrl: false,
@@ -256,6 +265,9 @@ export default defineComponent({
     },
     credential() {
       return this.$store.state.producer.credential;
+    },
+    walletMode(): boolean {
+      return isScenarioX402Enabled() && scenarioPaymentState('producer').mode === 'wallet';
     },
     config() {
       return this.$store.state.producer.config;
@@ -289,6 +301,45 @@ export default defineComponent({
     }
   },
   methods: {
+    paymentOptions(): OperatorRequestOptions | undefined {
+      if (!this.walletMode) {
+        const token = this.credential?.token;
+        return token ? { token } : undefined;
+      }
+      const wallet = this.getWalletContext();
+      if (!wallet) {
+        ElMessage.warning(this.$t('common.x402Scenario.connectWalletFirst'));
+        return undefined;
+      }
+      return {
+        mode: 'x402',
+        x402: {
+          wallet,
+          confirm: (quote) => this.confirmWalletPayment(quote),
+          identityToken: this.credential?.token
+        }
+      };
+    },
+    getWalletContext(): X402WalletContext | undefined {
+      const walletApi = (this as any).$wallet;
+      const publicKey = walletApi?.publicKey?.value;
+      const adapter = walletApi?.wallet?.value?.adapter;
+      if (!publicKey || !adapter?.signTransaction) return undefined;
+      return { publicKey, signTransaction: adapter.signTransaction.bind(adapter) };
+    },
+    async confirmWalletPayment(quote: X402PaymentQuote): Promise<boolean> {
+      return ElMessageBox.confirm(
+        this.$t('common.x402Scenario.confirmPayment', { amount: quote.amountUsdc }),
+        this.$t('order.message.x402ConfirmTitle'),
+        {
+          confirmButtonText: this.$t('order.message.x402WalletPayCta'),
+          cancelButtonText: this.$t('common.button.cancel'),
+          type: 'warning'
+        }
+      )
+        .then(() => true)
+        .catch(() => false);
+    },
     onReport(audio: any) {
       this.reportTargetId = audio?.id || '';
       this.reportSnapshot = { prompt: audio?.prompt, title: audio?.title };
@@ -377,6 +428,7 @@ export default defineComponent({
         audio.video_url = videoUrl;
         this.onDownload(null, videoUrl);
       } catch (error) {
+        if (error instanceof X402PaymentCancelledError) return;
         console.error('get videoUrl failed:', error);
         ElMessage.error(this.$t('producer.message.getVideoUrlFailed'));
       } finally {
@@ -385,17 +437,11 @@ export default defineComponent({
     },
     async fetchVideoUrlFromApi(audioId: string): Promise<string> {
       return new Promise((resolve, reject) => {
-        const request = {
-          audio_id: audioId
-        } as IProducerVideoRequest;
-        const token = this.credential?.token;
-        if (!token) {
-          console.error('no token specified');
-          reject(new Error('No token specified'));
-          return;
-        }
+        const request = { audio_id: audioId } as IProducerVideoRequest;
+        const options = this.paymentOptions();
+        if (!options) return reject(new X402PaymentCancelledError());
         producerOperator
-          .video(request, { token })
+          .video(request, options)
           .then((response) => {
             const videoUrl = response.data?.data?.video_url;
             if (videoUrl) {
@@ -464,12 +510,12 @@ export default defineComponent({
     },
     async handleWavDownload(audio: IProducerAudio) {
       if (!audio?.id || this.isFetchingWav) return;
-      const token = this.credential?.token;
-      if (!token) return;
+      const options = this.paymentOptions();
+      if (!options) return;
       try {
         this.isFetchingWav = true;
         ElMessage.info(this.$t('producer.message.fetchingWav'));
-        const response = await producerOperator.wav({ audio_id: audio.id }, { token });
+        const response = await producerOperator.wav({ audio_id: audio.id }, options);
         // Upstream returns { data: [{ file_url }] } — read the first entry's file_url
         const data = response.data?.data;
         const wavUrl = Array.isArray(data) ? data[0]?.file_url : data?.file_url || data?.audio_url;
@@ -478,7 +524,8 @@ export default defineComponent({
         } else {
           ElMessage.error(this.$t('producer.message.fetchWavFailed'));
         }
-      } catch {
+      } catch (error) {
+        if (error instanceof X402PaymentCancelledError) return;
         ElMessage.error(this.$t('producer.message.fetchWavFailed'));
       } finally {
         this.isFetchingWav = false;
@@ -490,25 +537,19 @@ export default defineComponent({
         audio_id: audioId,
         async: true
       } as IProducerAudioRequest;
-      const token = this.credential?.token;
-      if (!token) {
-        console.error('no token specified');
-        return;
-      }
+      const options = this.paymentOptions();
+      if (!options) return;
       ElMessage.info(this.$t('producer.message.startingTask'));
       producerOperator
-        .audio(request, {
-          token
-        })
-        .then(() => {
+        .audio(request, options)
+        .then((response) => {
+          const taskId = response?.data?.task_id;
+          if (this.walletMode && !this.credential?.token && taskId) this.$emit('wallet-task', taskId);
           ElMessage.success(this.$t('producer.message.startTaskSuccess'));
         })
         .catch((error) => {
+          if (error instanceof X402PaymentCancelledError) return;
           ElMessage.error(error?.response?.data?.error?.message || this.$t('producer.message.startTaskFailed'));
-        })
-        .finally(async () => {
-          await this.onGetTasks();
-          await this.onScrollDown();
         });
     },
     async onScrollDown() {

--- a/src/components/x402ProducerContract.test.ts
+++ b/src/components/x402ProducerContract.test.ts
@@ -1,0 +1,41 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = (relativePath: string) => fs.readFileSync(path.resolve(process.cwd(), 'src', relativePath), 'utf8');
+
+describe('Producer x402 contract', () => {
+  it('registers Producer and shares the audio builder between quote and submit', () => {
+    expect(source('layouts/Main.vue')).toContain("'producer'");
+    expect(source('components/producer/ConfigPanel.vue')).toContain(
+      'producerOperator.quoteAudio(buildProducerAudioRequest(this.config))'
+    );
+    expect(source('pages/producer/Index.vue')).toContain('buildProducerAudioRequest(this.config)');
+  });
+
+  it('keeps lyrics, wav, video, and upload endpoint semantics separate', () => {
+    const lyrics = source('components/producer/config/LyricInput.vue');
+    const preview = source('components/producer/task/Preview.vue');
+    const operator = source('operators/producer.ts');
+
+    expect(lyrics).toContain('producerOperator.lyric({ prompt }, options)');
+    expect(preview).toContain('producerOperator.wav({ audio_id: audio.id }, options)');
+    expect(preview).toContain('.video(request, options)');
+    expect(operator).toContain("return axios.post('/producer/upload', data");
+    expect(operator).not.toContain("postWithX402<IProducerUploadResponse>('/producer/upload'");
+  });
+
+  it('tracks guest main and secondary tasks in page memory only', () => {
+    const page = source('pages/producer/Index.vue');
+    const panel = source('components/producer/RecentPanel.vue');
+    const preview = source('components/producer/task/Preview.vue');
+
+    expect(page).toContain('walletTaskIds: string[]');
+    expect(page).toContain("mode: 'x402', ids: this.walletTaskIds");
+    expect(page).toContain('identityToken: this.credential?.token');
+    expect(panel).toContain('@wallet-task="$emit(\'wallet-task\', $event)"');
+    expect(preview).toContain("this.$emit('wallet-task', taskId)");
+    expect(page).not.toContain('localStorage');
+    expect(page).not.toContain('sessionStorage');
+  });
+});

--- a/src/layouts/Main.vue
+++ b/src/layouts/Main.vue
@@ -87,7 +87,8 @@ export default defineComponent({
           'digitalhuman',
           'serp',
           'suno',
-          'midjourney'
+          'midjourney',
+          'producer'
         ].includes(String(this.appName)) && isScenarioX402Enabled()
       );
     },

--- a/src/operators/producer.ts
+++ b/src/operators/producer.ts
@@ -2,34 +2,34 @@ import axios, { AxiosResponse } from 'axios';
 import {
   IProducerAudioRequest,
   IProducerAudioResponse,
+  IProducerConfig,
   IProducerLyricRequest,
   IProducerLyricResponse,
   IProducerTaskResponse,
   IProducerTasksResponse,
-  IProducerUploadResponse,
   IProducerUploadRequest,
+  IProducerUploadResponse,
   IProducerVideoRequest,
   IProducerVideoResponse
 } from '@/models';
-import { BASE_URL_API } from '@/constants';
+import { BASE_URL_API, BASE_URL_X402 } from '@/constants';
+import { postWithX402, quoteX402, type OperatorRequestOptions } from './x402';
+
+const HEADERS = { 'content-type': 'application/json', accept: 'application/json' };
+const TASK_HEADERS = { ...HEADERS, 'x-record-exempt': 'true' };
+
+export function buildProducerAudioRequest(config?: IProducerConfig): IProducerAudioRequest {
+  return { ...(config || {}), audio: undefined, async: true } as IProducerAudioRequest;
+}
 
 class ProducerOperator {
-  async task(id: string, options: { token: string }): Promise<AxiosResponse<IProducerTaskResponse>> {
-    return await axios.post(
-      `/producer/tasks`,
-      {
-        action: 'retrieve',
-        id: id
-      },
-      {
-        headers: {
-          accept: 'application/json',
-          'content-type': 'application/json',
-          authorization: `Bearer ${options.token}`,
-          'x-record-exempt': 'true'
-        },
-        baseURL: BASE_URL_API
-      }
+  async task(id: string, options: OperatorRequestOptions): Promise<AxiosResponse<IProducerTaskResponse>> {
+    return axios.post(
+      '/producer/tasks',
+      { action: 'retrieve', id },
+      options.mode === 'x402'
+        ? { headers: TASK_HEADERS, baseURL: BASE_URL_X402 }
+        : { headers: { ...TASK_HEADERS, authorization: `Bearer ${options.token}` }, baseURL: BASE_URL_API }
     );
   }
 
@@ -44,138 +44,77 @@ class ProducerOperator {
       createdAtMax?: number;
       createdAtMin?: number;
     },
-    options: { token: string }
+    options: OperatorRequestOptions
   ): Promise<AxiosResponse<IProducerTasksResponse>> {
-    return await axios.post(
-      `/producer/tasks`,
+    return axios.post(
+      '/producer/tasks',
       {
         action: 'retrieve_batch',
-        ...(filter.ids
-          ? {
-              ids: filter.ids
-            }
-          : {}),
-        ...(filter.userId
-          ? {
-              user_id: filter.userId
-            }
-          : {}),
-        ...(filter.type
-          ? {
-              type: filter.type
-            }
-          : {}),
-        ...(filter.applicationId
-          ? {
-              application_id: filter.applicationId
-            }
-          : {}),
-        ...(filter.limit !== undefined
-          ? {
-              limit: filter.limit
-            }
-          : {}),
-        ...(filter.offset !== undefined
-          ? {
-              offset: filter.offset
-            }
-          : {}),
-        ...(filter.createdAtMax !== undefined
-          ? {
-              created_at_max: filter.createdAtMax
-            }
-          : {}),
-        ...(filter.createdAtMin !== undefined
-          ? {
-              created_at_min: filter.createdAtMin
-            }
-          : {})
+        ...(filter.ids ? { ids: filter.ids } : {}),
+        ...(filter.userId ? { user_id: filter.userId } : {}),
+        ...(filter.type ? { type: filter.type } : {}),
+        ...(filter.applicationId ? { application_id: filter.applicationId } : {}),
+        ...(filter.limit !== undefined ? { limit: filter.limit } : {}),
+        ...(filter.offset !== undefined ? { offset: filter.offset } : {}),
+        ...(filter.createdAtMax !== undefined ? { created_at_max: filter.createdAtMax } : {}),
+        ...(filter.createdAtMin !== undefined ? { created_at_min: filter.createdAtMin } : {})
       },
-      {
-        headers: {
-          accept: 'application/json',
-          'content-type': 'application/json',
-          authorization: `Bearer ${options.token}`,
-          'x-record-exempt': 'true'
-        },
-        baseURL: BASE_URL_API
-      }
+      options.mode === 'x402'
+        ? { headers: TASK_HEADERS, baseURL: BASE_URL_X402 }
+        : { headers: { ...TASK_HEADERS, authorization: `Bearer ${options.token}` }, baseURL: BASE_URL_API }
     );
   }
 
-  async audio(
-    data: IProducerAudioRequest,
-    options: {
-      token: string;
+  async quoteAudio(data: IProducerAudioRequest) {
+    return quoteX402('/producer/audios', data, HEADERS);
+  }
+  async quoteLyric(data: IProducerLyricRequest) {
+    return quoteX402('/producer/lyrics', data, HEADERS);
+  }
+  async quoteWav(data: { audio_id: string }) {
+    return quoteX402('/producer/wav', data, HEADERS);
+  }
+  async quoteVideo(data: IProducerVideoRequest) {
+    return quoteX402('/producer/videos', data, HEADERS);
+  }
+
+  private async submit<T>(path: string, data: unknown, options: OperatorRequestOptions): Promise<AxiosResponse<T>> {
+    if (options.mode === 'x402') {
+      if (!options.x402) throw new Error('x402 payment options are required');
+      return postWithX402<T>(path, data, options.x402, HEADERS);
     }
-  ): Promise<AxiosResponse<IProducerAudioResponse>> {
-    return await axios.post('/producer/audios', data, {
-      headers: {
-        authorization: `Bearer ${options.token}`,
-        'content-type': 'application/json'
-      },
+    return axios.post(path, data, {
+      headers: { ...HEADERS, authorization: `Bearer ${options.token}` },
       baseURL: BASE_URL_API
     });
   }
 
-  async lyric(
-    data: IProducerLyricRequest,
-    options: {
-      token: string;
-    }
-  ): Promise<AxiosResponse<IProducerLyricResponse>> {
-    return await axios.post('/producer/lyrics', data, {
-      headers: {
-        authorization: `Bearer ${options.token}`,
-        'content-type': 'application/json'
-      },
-      baseURL: BASE_URL_API
-    });
+  async audio(data: IProducerAudioRequest, options: OperatorRequestOptions) {
+    return this.submit<IProducerAudioResponse>('/producer/audios', data, options);
+  }
+  async lyric(data: IProducerLyricRequest, options: OperatorRequestOptions) {
+    return this.submit<IProducerLyricResponse>('/producer/lyrics', data, options);
+  }
+  async wav(data: { audio_id: string }, options: OperatorRequestOptions) {
+    return this.submit<{ data: Array<{ file_url?: string }> | { file_url?: string; audio_url?: string } }>(
+      '/producer/wav',
+      data,
+      options
+    );
   }
 
   async upload(
     data: IProducerUploadRequest,
-    options: {
-      token: string;
-    }
+    options: { token: string }
   ): Promise<AxiosResponse<IProducerUploadResponse>> {
-    return await axios.post('/producer/upload', data, {
-      headers: {
-        authorization: `Bearer ${options.token}`,
-        'content-type': 'application/json'
-      },
+    return axios.post('/producer/upload', data, {
+      headers: { ...HEADERS, authorization: `Bearer ${options.token}` },
       baseURL: BASE_URL_API
     });
   }
 
-  async video(
-    data: IProducerVideoRequest,
-    options: {
-      token: string;
-    }
-  ): Promise<AxiosResponse<IProducerVideoResponse>> {
-    return await axios.post('/producer/videos', data, {
-      headers: {
-        authorization: `Bearer ${options.token}`,
-        'content-type': 'application/json'
-      },
-      baseURL: BASE_URL_API
-    });
-  }
-
-  async wav(
-    data: { audio_id: string },
-    options: {
-      token: string;
-    }
-  ): Promise<AxiosResponse<{ data: Array<{ file_url?: string }> | { file_url?: string; audio_url?: string } }>> {
-    return await axios.post('/producer/wav', data, {
-      headers: {
-        authorization: `Bearer ${options.token}`,
-        'content-type': 'application/json'
-      },
-      baseURL: BASE_URL_API
-    });
+  async video(data: IProducerVideoRequest, options: OperatorRequestOptions) {
+    return this.submit<IProducerVideoResponse>('/producer/videos', data, options);
   }
 }
 

--- a/src/operators/x402ProducerRequests.test.ts
+++ b/src/operators/x402ProducerRequests.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from 'vitest';
+import { buildProducerAudioRequest, producerOperator } from './producer';
+
+const x402 = vi.hoisted(() => ({ quote: vi.fn(), post: vi.fn() }));
+vi.mock('./x402', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./x402')>()),
+  quoteX402: x402.quote,
+  postWithX402: x402.post
+}));
+
+describe('Producer x402 requests', () => {
+  it('builds the audio request without persisted preview data', () => {
+    expect(
+      buildProducerAudioRequest({
+        action: 'generate',
+        model: 'producer-v1',
+        prompt: 'song',
+        custom: true,
+        audio: { id: 'preview-only' },
+        continue_at: 12
+      })
+    ).toEqual({
+      action: 'generate',
+      model: 'producer-v1',
+      prompt: 'song',
+      custom: true,
+      audio: undefined,
+      continue_at: 12,
+      async: true
+    });
+  });
+
+  it('routes audio, lyrics, and wav quotes/submits independently', async () => {
+    x402.quote.mockResolvedValue({ amountUsdc: '1' });
+    x402.post.mockResolvedValue({ data: { task_id: 'task-1' } });
+    const options = { mode: 'x402' as const, x402: { wallet: {} as never, confirm: async () => true } };
+
+    await producerOperator.quoteAudio({ prompt: 'song' });
+    await producerOperator.quoteLyric({ prompt: 'lyrics' });
+    await producerOperator.quoteWav({ audio_id: 'audio-1' });
+    await producerOperator.quoteVideo({ audio_id: 'audio-1' });
+    await producerOperator.audio({ prompt: 'song' }, options);
+    await producerOperator.lyric({ prompt: 'lyrics' }, options);
+    await producerOperator.wav({ audio_id: 'audio-1' }, options);
+    await producerOperator.video({ audio_id: 'audio-1' }, options);
+
+    expect(x402.quote.mock.calls.map((call) => call[0])).toEqual([
+      '/producer/audios',
+      '/producer/lyrics',
+      '/producer/wav',
+      '/producer/videos'
+    ]);
+    expect(x402.post.mock.calls.map((call) => call[0])).toEqual([
+      '/producer/audios',
+      '/producer/lyrics',
+      '/producer/wav',
+      '/producer/videos'
+    ]);
+  });
+});

--- a/src/pages/producer/Index.vue
+++ b/src/pages/producer/Index.vue
@@ -4,7 +4,13 @@
       <config-panel @generate="onGenerateAudio" />
     </template>
     <template #result>
-      <recent-panel ref="recentPanel" class="panel recent" :loading="loadingMore" @reach-top="onReachTop" />
+      <recent-panel
+        ref="recentPanel"
+        class="panel recent"
+        :loading="loadingMore"
+        @reach-top="onReachTop"
+        @wallet-task="onWalletTask"
+      />
     </template>
     <template #preview>
       <preview-panel />
@@ -15,10 +21,11 @@
 <script lang="ts">
 import { defineComponent } from 'vue';
 import Layout from '@/layouts/Producer.vue';
-import { applicationOperator, producerOperator } from '@/operators';
+import { applicationOperator } from '@/operators';
+import { buildProducerAudioRequest, producerOperator } from '@/operators/producer';
 import { instrumentGeneration } from '@/plugins/telemetry';
-import { IApplicationDetailResponse, IProducerAudioRequest, Status } from '@/models';
-import { ElMessage } from 'element-plus';
+import { IApplicationDetailResponse, Status } from '@/models';
+import { ElMessage, ElMessageBox } from 'element-plus';
 import { IProducerTask } from '@/models';
 import { ERROR_CODE_DUPLICATION } from '@/constants';
 import ConfigPanel from '@/components/producer/ConfigPanel.vue';
@@ -26,12 +33,20 @@ import RecentPanel from '@/components/producer/RecentPanel.vue';
 import PreviewPanel from '@/components/producer/PreviewPanel.vue';
 import { loadPreviousPage } from '@/utils/pagination';
 import { uploadTrackerProviderMixin, ensureNoPendingUpload, ensureLoggedIn } from '@/utils';
+import { isScenarioX402Enabled, scenarioPaymentState } from '@/utils/x402/scenarioPayment';
+import {
+  X402PaymentCancelledError,
+  type OperatorRequestOptions,
+  type X402PaymentQuote,
+  type X402WalletContext
+} from '@/operators/x402';
 
 interface IData {
   task: IProducerTask | undefined;
   job: number;
   loadingMore: boolean;
   fetchingTasks: boolean;
+  walletTaskIds: string[];
 }
 
 export default defineComponent({
@@ -49,7 +64,8 @@ export default defineComponent({
       task: undefined,
       job: 0,
       loadingMore: false,
-      fetchingTasks: false
+      fetchingTasks: false,
+      walletTaskIds: []
     };
   },
   computed: {
@@ -82,9 +98,27 @@ export default defineComponent({
     },
     applications() {
       return this.$store.state.producer.applications;
+    },
+    walletMode(): boolean {
+      return isScenarioX402Enabled() && scenarioPaymentState('producer').mode === 'wallet';
     }
   },
   watch: {
+    walletMode: {
+      async handler(value: boolean, oldValue: boolean | undefined) {
+        if (oldValue === undefined || value === oldValue) return;
+        this.$store.commit('producer/setTasks', undefined);
+        if (value && !this.job) this.job = window.setInterval(this.onGetTasks, 5000);
+        if (!value && !this.credential?.token) {
+          window.clearInterval(this.job);
+          this.job = 0;
+          await this.onScrollDown();
+          return;
+        }
+        await this.onGetTasks();
+        await this.onScrollDown();
+      }
+    },
     tasks: {
       handler(value, oldValue) {
         if (value?.items?.length > oldValue?.items?.length) {
@@ -99,9 +133,7 @@ export default defineComponent({
           console.debug('layout initialized');
           await this.onGetTasks();
           await this.onScrollDown();
-          this.job = window.setInterval(() => {
-            this.onGetTasks();
-          }, 5000);
+          if (!this.job) this.job = window.setInterval(this.onGetTasks, 5000);
         }
       },
       immediate: true
@@ -175,7 +207,8 @@ export default defineComponent({
         await this.$store.dispatch('producer/getTasks', {
           limit,
           createdAtMin,
-          createdAtMax
+          createdAtMax,
+          ...(this.walletMode && !this.credential?.token ? { mode: 'x402', ids: this.walletTaskIds } : {})
         });
       } finally {
         this.fetchingTasks = false;
@@ -191,32 +224,72 @@ export default defineComponent({
       ) {
         return;
       }
-      const request = {
-        ...this.config,
-        async: true
-      } as IProducerAudioRequest;
-      if (!ensureLoggedIn()) {
-        return;
-      }
-      const token = this.credential?.token;
-      if (!token) {
-        console.error('no token specified');
-        return;
-      }
+      const request = buildProducerAudioRequest(this.config);
+      const operation = this.createPaymentOperation((options) => producerOperator.audio(request, options));
+      if (!operation) return;
       ElMessage.info(this.$t('producer.message.startingTask'));
-      instrumentGeneration('producer', producerOperator.audio(request, { token }))
-        .then(() => {
-          ElMessage.success(this.$t('producer.message.startTaskSuccess'));
-        })
-        .catch((error) => {
-          ElMessage.error(error?.response?.data?.error?.message || this.$t('producer.message.startTaskFailed'));
-        })
-        .finally(async () => {
-          setTimeout(async () => {
-            await this.onGetTasks();
-            await this.onScrollDown();
-          }, 1000);
-        });
+      try {
+        const response = await instrumentGeneration('producer', operation);
+        this.recordWalletTask(response);
+        ElMessage.success(this.$t('producer.message.startTaskSuccess'));
+      } catch (error) {
+        this.handlePaymentError(error);
+      } finally {
+        setTimeout(async () => {
+          await this.onGetTasks();
+          await this.onScrollDown();
+        }, 1000);
+      }
+    },
+    createPaymentOperation(submit: (options: OperatorRequestOptions) => Promise<any>): Promise<any> | undefined {
+      if (!this.walletMode) {
+        if (!ensureLoggedIn()) return undefined;
+        const token = this.credential?.token;
+        return token ? submit({ token }) : undefined;
+      }
+      const wallet = this.getWalletContext();
+      if (!wallet) {
+        ElMessage.warning(this.$t('common.x402Scenario.connectWalletFirst'));
+        return undefined;
+      }
+      return submit({
+        mode: 'x402',
+        x402: { wallet, confirm: (quote) => this.confirmWalletPayment(quote), identityToken: this.credential?.token }
+      });
+    },
+    recordWalletTask(response: any) {
+      this.onWalletTask(response?.data?.task_id);
+    },
+    onWalletTask(taskId: string | undefined) {
+      if (this.walletMode && !this.credential?.token && taskId && !this.walletTaskIds.includes(taskId)) {
+        this.walletTaskIds.unshift(taskId);
+      }
+    },
+    handlePaymentError(error: any) {
+      if (error instanceof X402PaymentCancelledError) return;
+      if (this.walletMode)
+        ElMessage.error(`${this.$t('common.x402Scenario.paymentFailed')} ${error?.message || ''}`.trim());
+      else ElMessage.error(error?.response?.data?.error?.message || this.$t('producer.message.startTaskFailed'));
+    },
+    getWalletContext(): X402WalletContext | undefined {
+      const walletApi = (this as any).$wallet;
+      const publicKey = walletApi?.publicKey?.value;
+      const adapter = walletApi?.wallet?.value?.adapter;
+      if (!publicKey || !adapter?.signTransaction) return undefined;
+      return { publicKey, signTransaction: adapter.signTransaction.bind(adapter) };
+    },
+    async confirmWalletPayment(quote: X402PaymentQuote): Promise<boolean> {
+      return ElMessageBox.confirm(
+        this.$t('common.x402Scenario.confirmPayment', { amount: quote.amountUsdc }),
+        this.$t('order.message.x402ConfirmTitle'),
+        {
+          confirmButtonText: this.$t('order.message.x402WalletPayCta'),
+          cancelButtonText: this.$t('common.button.cancel'),
+          type: 'warning'
+        }
+      )
+        .then(() => true)
+        .catch(() => false);
     },
     getTasksScrollElement(): HTMLElement | undefined {
       const panel = this.$refs.recentPanel as any;

--- a/src/store/producer/actions.ts
+++ b/src/store/producer/actions.ts
@@ -142,27 +142,34 @@ export const getTasks = async (
     offset,
     limit,
     createdAtMin,
-    createdAtMax
-  }: { offset?: number; limit?: number; createdAtMin?: number; createdAtMax?: number }
+    createdAtMax,
+    mode = 'credits',
+    ids
+  }: {
+    offset?: number;
+    limit?: number;
+    createdAtMin?: number;
+    createdAtMax?: number;
+    mode?: 'credits' | 'x402';
+    ids?: string[];
+  }
 ): Promise<IProducerTask[]> => {
   return new Promise((resolve, reject) => {
     console.debug('start to get tasks', offset, limit, createdAtMax, createdAtMin);
     const credential = state.credential;
     const token = credential?.token;
-    if (!token) {
-      return reject('no token');
+    if (mode === 'credits' && !token) return reject('no token');
+    if (mode === 'x402' && !ids?.length) {
+      commit('setTasksItems', []);
+      commit('setTasksTotal', 0);
+      return resolve([]);
     }
     producerOperator
       .tasks(
-        {
-          userId: rootState?.user?.id,
-          createdAtMin,
-          createdAtMax,
-          type: 'audios'
-        },
-        {
-          token
-        }
+        mode === 'x402'
+          ? { ids, createdAtMin, createdAtMax, type: 'audios' }
+          : { userId: rootState?.user?.id, createdAtMin, createdAtMax, type: 'audios' },
+        mode === 'x402' ? { mode: 'x402' } : { token }
       )
       .then((response) => {
         console.debug('get producer tasks success', response.data.items);

--- a/src/store/producer/actions.x402.test.ts
+++ b/src/store/producer/actions.x402.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({ tasks: vi.fn() }));
+vi.mock('@/operators', () => ({
+  applicationOperator: {},
+  credentialOperator: {},
+  producerOperator: { tasks: mocks.tasks },
+  serviceOperator: {}
+}));
+
+import { getTasks } from './actions';
+
+const state = () => ({ credential: { token: 'credits-token' }, tasks: { items: [], total: 0 } }) as any;
+const context = (value = state()) => ({ state: value, rootState: { user: { id: 'user-1' } }, commit: vi.fn() }) as any;
+
+describe('Producer x402 history', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('keeps Credits history scoped to the user', async () => {
+    mocks.tasks.mockResolvedValueOnce({ data: { items: [], count: 0 } });
+    const ctx = context();
+    await getTasks(ctx, { limit: 5 });
+    expect(mocks.tasks).toHaveBeenCalledWith(expect.objectContaining({ userId: 'user-1', type: 'audios' }), {
+      token: 'credits-token'
+    });
+  });
+
+  it('queries guest history only by in-memory IDs', async () => {
+    mocks.tasks.mockResolvedValueOnce({ data: { items: [], count: 0 } });
+    const ctx = context({ ...state(), credential: undefined });
+    await getTasks(ctx, { mode: 'x402', ids: ['task-1'] });
+    expect(mocks.tasks).toHaveBeenCalledWith(expect.objectContaining({ ids: ['task-1'], type: 'audios' }), {
+      mode: 'x402'
+    });
+  });
+
+  it('does not send an empty guest history request', async () => {
+    const ctx = context({ ...state(), credential: undefined });
+    await getTasks(ctx, { mode: 'x402', ids: [] });
+    expect(mocks.tasks).not.toHaveBeenCalled();
+    expect(ctx.commit).toHaveBeenCalledWith('setTasksTotal', 0);
+  });
+});


### PR DESCRIPTION
## Summary

- add Solana x402 wallet payments to Producer audio generation and secondary audio actions
- add endpoint-specific wallet payment for lyrics, video export, and WAV export while keeping upload Credits-only
- preserve guest-generated task visibility through page-memory task IDs and a local Preview → RecentPanel → page event

## Validation

- `npm run lint:check` — 0 errors (2 pre-existing warnings)
- `npx vue-tsc -b --pretty false`
- `npm run test:run` — 172 files / 1,321 tests passed
- `python3 scripts/check_i18n_coverage.py`
- `unset $(git rev-parse --local-env-vars); npm run verify`
- `npm run build:web`
- `npm run build:electron`
- `npm run compile:electron && node scripts/copy-renderer.js`
- `unset ELECTRON_RUN_AS_NODE; npm run test:e2e:desktop` — 3 passed
- `git diff --check`

## Scope

- enabled exact endpoints: `/producer/audios`, `/producer/lyrics`, `/producer/videos`, `/producer/wav`
- `/producer/upload` remains authenticated Credits-only
- no persistent task storage, delete, locale, or shared task-factory changes
- no billable generation, signature, or payment performed during validation

## Rollback

Revert this PR to remove Producer wallet behavior. No schema migration is involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
