### PR TITLE
refactor(coding): reuse shared agent contracts

### DIFF
--- a/change/@acedatacloud-nexior-coding-agent-core.json
+++ b/change/@acedatacloud-nexior-coding-agent-core.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Reuse shared coding-agent contracts and transcript helpers.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.359.0",
       "license": "MIT",
       "dependencies": {
-        "@acedatacloud/core": "^0.19.1",
+        "@acedatacloud/core": "^0.20.1",
         "@acedatacloud/x402-client": "^2026.726.1",
         "@capacitor-community/apple-sign-in": "^7.1.0",
         "@capacitor-community/stripe": "^8.1.1",
@@ -128,9 +128,9 @@
       }
     },
     "node_modules/@acedatacloud/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@acedatacloud/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-ucJMqJMnCrsLWTnmOMogiZ6RLxBWv6hDJptgKIfs+t9fqbn7vvdUJFCnMkq/Q7ggJkm2dY3NvpWAatefnZHjQw==",
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@acedatacloud/core/-/core-0.20.1.tgz",
+      "integrity": "sha512-0asg4N+aO9yrj+IbAVl3DlXZ7C3zFgeTwLx/dxTRqX5fzb8rtTIqkMOlmDmYrnNLvkQHXicI8r/wVf99fRZJvw==",
       "license": "UNLICENSED",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "build:ssg": "cross-env VITE_SURFACE=web vite-ssg build"
   },
   "dependencies": {
-    "@acedatacloud/core": "^0.19.1",
+    "@acedatacloud/core": "^0.20.1",
     "@acedatacloud/x402-client": "^2026.726.1",
     "@capacitor-community/apple-sign-in": "^7.1.0",
     "@capacitor-community/stripe": "^8.1.1",

--- a/src/constants/codingBridge.ts
+++ b/src/constants/codingBridge.ts
@@ -1,3 +1,5 @@
+import { CODING_AGENT_ACTION, CODING_AGENT_EVENT, CODING_AGENT_HISTORY_LIMIT } from '@acedatacloud/core/coding-agent';
+
 /**
  * Wire protocol shared with the `coding-bridge` relay and the node daemon.
  *
@@ -24,58 +26,45 @@ export const CB_NODE_NAME_MAX_LENGTH = 64;
 export const CB_ERROR = 'error';
 
 // --- Inner actions: browser -> node ----------------------------------------
-export const CB_ACTION_SESSION_START = 'session.start';
-export const CB_ACTION_SESSION_SEND = 'session.send';
-// Edit a past prompt: fork the conversation at `cut_uuid` and re-run it.
-export const CB_ACTION_SESSION_EDIT = 'session.edit';
-export const CB_ACTION_SESSION_INTERRUPT = 'session.interrupt';
-export const CB_ACTION_SESSION_CLOSE = 'session.close';
-export const CB_ACTION_PERMISSION_RESOLVE = 'permission.resolve';
-// Reconnect / followed a notification: re-fetch every pending permission prompt.
-export const CB_ACTION_PERMISSIONS_LIST = 'permissions.list';
-export const CB_ACTION_SESSIONS_LIST = 'sessions.list';
-export const CB_ACTION_HISTORY_LIST = 'history.list';
-export const CB_ACTION_HISTORY_GET = 'history.get';
-// Clear a session's unread dot. The node answers with a refreshed history
-// snapshot, so no dedicated reply event is needed.
-export const CB_ACTION_HISTORY_MARK_READ = 'history.mark_read';
-// Page size for the history drawer. mark_read echoes it so its refreshed
-// listing covers the same rows the drawer is showing.
-export const CB_HISTORY_LIMIT = 200;
+export const CB_ACTION_SESSION_START = CODING_AGENT_ACTION.sessionStart;
+export const CB_ACTION_SESSION_SEND = CODING_AGENT_ACTION.sessionSend;
+export const CB_ACTION_SESSION_EDIT = CODING_AGENT_ACTION.sessionEdit;
+export const CB_ACTION_SESSION_INTERRUPT = CODING_AGENT_ACTION.sessionInterrupt;
+export const CB_ACTION_SESSION_CLOSE = CODING_AGENT_ACTION.sessionClose;
+export const CB_ACTION_PERMISSION_RESOLVE = CODING_AGENT_ACTION.permissionResolve;
+export const CB_ACTION_PERMISSIONS_LIST = CODING_AGENT_ACTION.permissionsList;
+export const CB_ACTION_SESSIONS_LIST = CODING_AGENT_ACTION.sessionsList;
+export const CB_ACTION_HISTORY_LIST = CODING_AGENT_ACTION.historyList;
+export const CB_ACTION_HISTORY_GET = CODING_AGENT_ACTION.historyGet;
+export const CB_ACTION_HISTORY_MARK_READ = CODING_AGENT_ACTION.historyMarkRead;
+export const CB_HISTORY_LIMIT = CODING_AGENT_HISTORY_LIMIT;
 export const CB_ACTION_FS_LIST = 'fs.list';
-export const CB_ACTION_CAPABILITIES_GET = 'capabilities.get';
-export const CB_ACTION_PING = 'ping';
+export const CB_ACTION_CAPABILITIES_GET = CODING_AGENT_ACTION.capabilitiesGet;
+export const CB_ACTION_PING = CODING_AGENT_ACTION.ping;
 
 // --- Inner events: node -> browser -----------------------------------------
-export const CB_EVENT_SESSION_STARTED = 'session.started';
-// The provider's real (SDK) session id is known: re-key the session from the
-// provisional id (`session_id`) to the canonical one (`sdk_session_id`).
-export const CB_EVENT_SESSION_IDENTIFIED = 'session.identified';
-export const CB_EVENT_SESSION_TEXT = 'session.text';
-export const CB_EVENT_SESSION_TEXT_DELTA = 'session.text_delta';
-export const CB_EVENT_SESSION_THINKING = 'session.thinking';
-export const CB_EVENT_SESSION_TOOL_USE = 'session.tool_use';
-export const CB_EVENT_SESSION_TOOL_RESULT = 'session.tool_result';
-export const CB_EVENT_PERMISSION_REQUEST = 'permission.request';
-export const CB_EVENT_PERMISSION_RESOLVED = 'permission.resolved';
-// Reply to permissions.list: every still-pending request across all sessions.
-export const CB_EVENT_PERMISSIONS_SNAPSHOT = 'permissions.snapshot';
-export const CB_EVENT_SESSION_RESULT = 'session.result';
-export const CB_EVENT_SESSION_NOTICE = 'session.notice';
-export const CB_EVENT_SESSION_ERROR = 'session.error';
-export const CB_EVENT_SESSION_CLOSED = 'session.closed';
-// A past prompt was edited: the conversation forked at `cut_uuid`. The browser
-// folds this into a transcript truncation (rewind), live and on replay.
-export const CB_EVENT_SESSION_REWOUND = 'session.rewound';
-// The live stream lost events that could not be replayed (cursor too old /
-// outbox overflow); resync the session from history.
-export const CB_EVENT_SESSION_STREAM_TRUNCATED = 'session.stream_truncated';
-export const CB_EVENT_SESSIONS_SNAPSHOT = 'sessions.snapshot';
-export const CB_EVENT_HISTORY_SNAPSHOT = 'history.snapshot';
-export const CB_EVENT_HISTORY_DETAIL = 'history.detail';
+export const CB_EVENT_SESSION_STARTED = CODING_AGENT_EVENT.sessionStarted;
+export const CB_EVENT_SESSION_IDENTIFIED = CODING_AGENT_EVENT.sessionIdentified;
+export const CB_EVENT_SESSION_TEXT = CODING_AGENT_EVENT.sessionText;
+export const CB_EVENT_SESSION_TEXT_DELTA = CODING_AGENT_EVENT.sessionTextDelta;
+export const CB_EVENT_SESSION_THINKING = CODING_AGENT_EVENT.sessionThinking;
+export const CB_EVENT_SESSION_TOOL_USE = CODING_AGENT_EVENT.sessionToolUse;
+export const CB_EVENT_SESSION_TOOL_RESULT = CODING_AGENT_EVENT.sessionToolResult;
+export const CB_EVENT_PERMISSION_REQUEST = CODING_AGENT_EVENT.permissionRequest;
+export const CB_EVENT_PERMISSION_RESOLVED = CODING_AGENT_EVENT.permissionResolved;
+export const CB_EVENT_PERMISSIONS_SNAPSHOT = CODING_AGENT_EVENT.permissionsSnapshot;
+export const CB_EVENT_SESSION_RESULT = CODING_AGENT_EVENT.sessionResult;
+export const CB_EVENT_SESSION_NOTICE = CODING_AGENT_EVENT.sessionNotice;
+export const CB_EVENT_SESSION_ERROR = CODING_AGENT_EVENT.sessionError;
+export const CB_EVENT_SESSION_CLOSED = CODING_AGENT_EVENT.sessionClosed;
+export const CB_EVENT_SESSION_REWOUND = CODING_AGENT_EVENT.sessionRewound;
+export const CB_EVENT_SESSION_STREAM_TRUNCATED = CODING_AGENT_EVENT.sessionStreamTruncated;
+export const CB_EVENT_SESSIONS_SNAPSHOT = CODING_AGENT_EVENT.sessionsSnapshot;
+export const CB_EVENT_HISTORY_SNAPSHOT = CODING_AGENT_EVENT.historySnapshot;
+export const CB_EVENT_HISTORY_DETAIL = CODING_AGENT_EVENT.historyDetail;
 export const CB_EVENT_FS_LIST = 'fs.list';
-export const CB_EVENT_CAPABILITIES = 'capabilities';
-export const CB_EVENT_PONG = 'pong';
+export const CB_EVENT_CAPABILITIES = CODING_AGENT_EVENT.capabilities;
+export const CB_EVENT_PONG = CODING_AGENT_EVENT.pong;
 
 // Reconnect backoff for the browser WebSocket (milliseconds).
 export const CB_RECONNECT_MIN_MS = 1000;

--- a/src/models/codingBridge.ts
+++ b/src/models/codingBridge.ts
@@ -1,11 +1,20 @@
-/**
- * Coding Bridge lets a signed-in user drive a Claude Code / Codex / Copilot
- * agent that runs on their own machine (a "node" daemon) from the web UI. The browser
- * never executes anything: it only relays JSON envelopes to the node through
- * the stateful `coding-bridge` relay over a single authenticated WebSocket.
- */
+import type {
+  CodingAgentAttachment,
+  CodingAgentCapabilities,
+  CodingAgentEvent,
+  CodingAgentEventKind,
+  CodingAgentHistoryDetail,
+  CodingAgentHistorySummary,
+  CodingAgentModelOption,
+  CodingAgentPermissionRequest,
+  CodingAgentProvider,
+  CodingAgentProviderCapability,
+  CodingAgentSession,
+  CodingAgentSessionStatus,
+  CodingAgentSlashCommand
+} from '@acedatacloud/core/coding-agent';
 
-/** A node daemon owned by the current user, as returned by `GET /api/nodes`. */
+/** A local node daemon owned by the current user. */
 export interface ICodingBridgeNode {
   node_id: string;
   name: string;
@@ -14,21 +23,20 @@ export interface ICodingBridgeNode {
   last_seen?: number;
 }
 
-export type ICodingBridgeSessionStatus = 'starting' | 'running' | 'idle' | 'closed' | 'error';
+export type ICodingBridgeSessionStatus = CodingAgentSessionStatus;
+export type ICodingBridgeHistoryProvider = CodingAgentProvider;
+export type ICodingBridgeModelOption = CodingAgentModelOption;
+export type ICodingBridgeProviderCapability = CodingAgentProviderCapability;
+export type ICodingBridgeSlashCommand = CodingAgentSlashCommand;
+export type ICodingBridgeCapabilities = CodingAgentCapabilities;
+export type ICodingBridgeSession = CodingAgentSession & { node_id: string };
+export type ICodingBridgeHistorySummary = CodingAgentHistorySummary;
+export type ICodingBridgeHistoryDetail = CodingAgentHistoryDetail;
+export type ICodingBridgeEventKind = CodingAgentEventKind;
+export type ICodingBridgeEvent = CodingAgentEvent;
+export type ICodingBridgeAttachment = CodingAgentAttachment;
+export type ICodingBridgePermissionRequest = CodingAgentPermissionRequest & { node_id: string };
 
-export type ICodingBridgeHistoryProvider = 'claude' | 'codex' | 'copilot';
-
-/** One selectable model offered by a provider, as reported by the node. */
-export interface ICodingBridgeModelOption {
-  value: string;
-  label: string;
-}
-
-/**
- * Last composer setup used on a node, so a new session pre-fills it instead of
- * resetting to defaults every time. Node-scoped because cwd / provider / model
- * are all device-specific. Persisted to localStorage.
- */
 export interface ICodingBridgeComposerPrefs {
   cwd?: string;
   provider?: string;
@@ -37,169 +45,12 @@ export interface ICodingBridgeComposerPrefs {
   effort?: string;
 }
 
-/**
- * What one backend on a node can do, reported by the node's `capabilities.get`.
- * The UI renders dropdowns from this instead of hard-coding models / efforts,
- * so a new model only needs a node update (or a typed-in custom value).
- */
-export interface ICodingBridgeProviderCapability {
-  name: string;
-  label: string;
-  available: boolean;
-  models: ICodingBridgeModelOption[];
-  // Effort tokens ('' = backend default); the UI localizes known ones.
-  efforts: string[];
-  permission_modes: string[];
-  allow_custom_model: boolean;
-  // Whether a past prompt can be edited (the conversation forked at that turn).
-  // Claude supports it; Codex does not. Absent on older nodes → treat as false.
-  supports_edit?: boolean;
-  // Whether editing can also roll back on-disk file changes, so the UI can
-  // offer a "restore code" choice. Absent on older nodes → treat as false.
-  supports_code_restore?: boolean;
-  // Slash commands this backend can actually run in a remote session, used to
-  // drive the composer autocomplete. Absent on older nodes.
-  commands?: ICodingBridgeSlashCommand[];
-}
-
-/** One slash command a backend advertises as runnable in a remote session. */
-export interface ICodingBridgeSlashCommand {
-  name: string;
-  description?: string;
-  argument_hint?: string;
-  aliases?: string[];
-}
-
-/** The full capabilities descriptor a node advertises. */
-export interface ICodingBridgeCapabilities {
-  providers: ICodingBridgeProviderCapability[];
-}
-
-/** A live agent session running inside one node. */
-export interface ICodingBridgeSession {
-  session_id: string;
-  node_id: string;
-  status: ICodingBridgeSessionStatus;
-  cwd?: string;
-  /** Exact client selector used to launch/switch the agent, e.g. `opus[1m]`. */
-  model?: string;
-  /** Provider-reported identity for display/audit; never used to resume. */
-  resolved_model?: string;
-  // Reasoning-effort tier and permission/edit mode the session is running with.
-  // Transcripts don't record these, so a history replay seeds them from the
-  // node's last composer prefs; a sent turn keeps them current. Both stay
-  // editable per query (the node applies them on each turn).
-  effort?: string;
-  permission_mode?: string;
-  cost_usd?: number;
-  // Which backend this session targets; defaults to Claude Code.
-  provider?: ICodingBridgeHistoryProvider;
-  // `session_id` IS the canonical identity. A new session opens under a
-  // provisional id and is re-keyed to the provider's real (SDK/transcript) id on
-  // `session.identified`, so the same id resumes it and matches its history entry.
-  // A live turn has been started on the node for this session.
-  started?: boolean;
-  // Replay of past history that cannot be continued (e.g. Codex).
-  readonly?: boolean;
-  // Trace id of the most recent turn, threaded browser → relay → node and back
-  // for end-to-end correlation in logs.
-  trace_id?: string;
-}
-
-/** One past on-device session as listed by `history.list`. */
-export interface ICodingBridgeHistorySummary {
-  provider: ICodingBridgeHistoryProvider;
-  session_id: string;
-  title: string;
-  cwd?: string;
-  git_branch?: string;
-  updated_at?: number;
-  message_count?: number;
-  // True when this transcript is a session live on the node right now, so the
-  // drawer can flag it and opening it reattaches instead of replaying a copy.
-  running?: boolean;
-  // Finished since the user last opened it. The read watermark lives on the node,
-  // so a session read on the phone is read on the desktop too.
-  unread?: boolean;
-}
-
-/** A normalised transcript returned by `history.get`. */
-export interface ICodingBridgeHistoryDetail {
-  provider: ICodingBridgeHistoryProvider;
-  session_id: string;
-  title?: string;
-  cwd?: string;
-  git_branch?: string;
-  /** Exact launch model restored from the versioned node sidecar. */
-  model?: string;
-  resolved_model?: string;
-  events: Array<Partial<ICodingBridgeEvent> & { kind: ICodingBridgeEventKind }>;
-}
-
-/**
- * A single rendered item in a session transcript. We flatten every node event
- * (and the locally-echoed user prompt) into this one shape so the transcript
- * view can render a uniform, append-only list.
- */
-export type ICodingBridgeEventKind =
-  | 'prompt'
-  | 'text'
-  | 'thinking'
-  | 'tool_use'
-  | 'tool_result'
-  | 'result'
-  | 'notice'
-  | 'error';
-
-export interface ICodingBridgeEvent {
-  id: string;
-  session_id: string;
-  kind: ICodingBridgeEventKind;
-  ts: number;
-  text?: string;
-  tool?: string;
-  tool_use_id?: string;
-  input?: Record<string, any>;
-  content?: string;
-  is_error?: boolean;
-  subtype?: string;
-  cost_usd?: number;
-  // Result events only: the fork point for editing the NEXT prompt — the uuid
-  // of the last kept transcript message — and the session to resume from.
-  cut_uuid?: string;
-  sdk_session_id?: string;
-  // Notice events: a machine code (e.g. 'slash_unavailable') and the command
-  // the user typed, so the UI can render a localized message.
-  command?: string;
-  level?: string;
-  // Streaming assistant text: `stream_id` ties text_delta chunks to their
-  // final `session.text` commit; `streaming` stays true while deltas arrive.
-  stream_id?: string;
-  streaming?: boolean;
-  // Legacy data-URL previews of images the user attached to a prompt turn.
-  images?: string[];
-  attachments?: ICodingBridgeAttachment[];
-  // Trace id correlating this event with the turn that produced it.
-  trace_id?: string;
-}
-
-/** One browser-uploaded file/image attached to a prompt turn. */
-export interface ICodingBridgeAttachment {
-  type: 'image' | 'file';
-  url: string;
-  name?: string;
-  mime_type?: string;
-  size?: number;
-}
-
-/** One entry returned by a node's `fs.list` directory listing. */
 export interface ICodingBridgeDirEntry {
   name: string;
   path: string;
   type: 'dir' | 'file';
 }
 
-/** A directory snapshot from a node, used by the working-directory picker. */
 export interface ICodingBridgeDirListing {
   path: string;
   parent: string | null;
@@ -209,27 +60,13 @@ export interface ICodingBridgeDirListing {
   error?: string;
 }
 
-/** A pending tool-permission request awaiting the user's approval. */
-export interface ICodingBridgePermissionRequest {
-  request_id: string;
-  session_id: string;
-  node_id: string;
-  tool: string;
-  title?: string;
-  display_name?: string;
-  description?: string;
-  input?: Record<string, any>;
-}
-
 export type ICodingBridgeConnectionStatus = 'disconnected' | 'connecting' | 'connected' | 'error';
 
-/** Response of `POST /pair/claim`. */
 export interface ICodingBridgeClaimResponse {
   ok: boolean;
   node_name: string;
 }
 
-/** Push capability advertised by the relay (`GET /api/push/config`). */
 export interface ICodingBridgePushConfig {
   enabled: boolean;
   web_push_enabled: boolean;

--- a/src/store/codingBridge/mutations.ts
+++ b/src/store/codingBridge/mutations.ts
@@ -1,3 +1,12 @@
+import {
+  appendCodingAgentDelta,
+  appendCodingAgentEvent,
+  finalizeAllCodingAgentStreams,
+  finalizeCodingAgentStream,
+  renameCodingAgentSession,
+  rewindCodingAgentEvents,
+  upsertCodingAgentSession
+} from '@acedatacloud/core/coding-agent';
 import initialState from './state';
 import { ICodingBridgeHistoryRef, ICodingBridgeState } from './models';
 import {
@@ -78,10 +87,7 @@ export const setCurrentSession = (state: ICodingBridgeState, payload: string | u
 };
 
 export const upsertSession = (state: ICodingBridgeState, payload: ICodingBridgeSession): void => {
-  state.sessions[payload.session_id] = { ...state.sessions[payload.session_id], ...payload };
-  if (!state.events[payload.session_id]) {
-    state.events[payload.session_id] = [];
-  }
+  upsertCodingAgentSession(state, payload);
 };
 
 export const updateSession = (
@@ -101,52 +107,14 @@ export const updateSession = (
 // (e.g. a snapshot stub); its transcript is only carried over when non-empty so
 // a reattach never blows away events already loaded under the real id.
 export const renameSession = (state: ICodingBridgeState, payload: { from: string; to: string }): void => {
-  const { from, to } = payload;
-  if (from === to || !state.sessions[from]) {
-    return;
-  }
-  state.sessions[to] = { ...state.sessions[to], ...state.sessions[from], session_id: to };
-  delete state.sessions[from];
-  const moving = state.events[from];
-  if (moving && (moving.length || !state.events[to]?.length)) {
-    state.events[to] = moving;
-  }
-  delete state.events[from];
-  // Do NOT carry the provisional id's seq cursor onto the real id. The relay
-  // numbers `seq` PER session_id, so once the node re-tags events to the real id
-  // that id begins a FRESH seq space (1, 2, 3…). Inheriting the provisional
-  // cursor made the dedup in `applyNodeEvent` drop the real id's first events as
-  // "already seen" — e.g. a codex turn's first reply (low seq) silently vanished
-  // while a later turn (higher seq) showed. Leave the real id with NO cursor:
-  // it is brand-new to this tab, so it accepts its whole stream, and
-  // `reattachSession` reads absent-cursor as "never followed" and skips the
-  // resume (a cursor of 0 would instead ask the relay for the entire buffer).
-  delete state.lastSeq[from];
-  delete state.seqChecked[from];
-  // `to` may already carry a cursor from an earlier life in this tab (reopened
-  // history entry, LRU-evicted relay log). Its space restarts under us here, so
-  // drop the validation that would otherwise short-circuit the re-baseline in
-  // `applyNodeEvent` and swallow the real id's first events. The cursor itself
-  // stays: the re-baseline needs it to notice the restart at all.
-  delete state.seqChecked[to];
-  for (const request of state.permissions) {
-    if (request.session_id === from) {
-      request.session_id = to;
-    }
-  }
-  if (state.currentSessionId === from) {
-    state.currentSessionId = to;
-  }
-  if (state.historyRef?.session_id === from) {
-    state.historyRef = { ...state.historyRef, session_id: to };
+  renameCodingAgentSession(state, payload.from, payload.to);
+  if (state.historyRef?.session_id === payload.from) {
+    state.historyRef = { ...state.historyRef, session_id: payload.to };
   }
 };
 
 export const appendEvent = (state: ICodingBridgeState, payload: ICodingBridgeEvent): void => {
-  if (!state.events[payload.session_id]) {
-    state.events[payload.session_id] = [];
-  }
-  state.events[payload.session_id].push(payload);
+  appendCodingAgentEvent(state, payload);
 };
 
 // Drop the event with `event_id` and everything after it. Used when editing a
@@ -172,18 +140,7 @@ export const truncateEventsBefore = (
 // the whole transcript is cleared. This is what makes a reconnect-after-edit
 // rebuild the correct branch from the log instead of replaying the old turns.
 export const rewindToCut = (state: ICodingBridgeState, payload: { session_id: string; cut_uuid?: string }): void => {
-  const events = state.events[payload.session_id];
-  if (!events) {
-    return;
-  }
-  if (!payload.cut_uuid) {
-    state.events[payload.session_id] = [];
-    return;
-  }
-  const index = events.findIndex((event) => event.kind === 'result' && event.cut_uuid === payload.cut_uuid);
-  if (index >= 0) {
-    state.events[payload.session_id] = events.slice(0, index + 1);
-  }
+  rewindCodingAgentEvents(state, payload.session_id, payload.cut_uuid);
 };
 
 // Remember the highest event seq applied for a session (reconnect cursor).
@@ -226,14 +183,7 @@ export const appendDelta = (
   state: ICodingBridgeState,
   payload: { session_id: string; stream_id: string; text: string }
 ): void => {
-  const events = state.events[payload.session_id];
-  if (!events) {
-    return;
-  }
-  const target = events.find((item) => item.kind === 'text' && item.stream_id === payload.stream_id);
-  if (target) {
-    target.text = (target.text ?? '') + (payload.text ?? '');
-  }
+  appendCodingAgentDelta(state, payload.session_id, payload.stream_id, payload.text);
 };
 
 // Streaming: close the bubble matching `stream_id`, optionally replacing its
@@ -242,30 +192,12 @@ export const finalizeStream = (
   state: ICodingBridgeState,
   payload: { session_id: string; stream_id: string; text?: string }
 ): void => {
-  const events = state.events[payload.session_id];
-  if (!events) {
-    return;
-  }
-  const target = events.find((item) => item.kind === 'text' && item.stream_id === payload.stream_id);
-  if (target) {
-    if (typeof payload.text === 'string') {
-      target.text = payload.text;
-    }
-    target.streaming = false;
-  }
+  finalizeCodingAgentStream(state, payload.session_id, payload.stream_id, payload.text);
 };
 
 // Streaming: close every still-open bubble in a session (turn ended / errored).
 export const finalizeAllStreams = (state: ICodingBridgeState, payload: { session_id: string }): void => {
-  const events = state.events[payload.session_id];
-  if (!events) {
-    return;
-  }
-  for (const item of events) {
-    if (item.streaming) {
-      item.streaming = false;
-    }
-  }
+  finalizeAllCodingAgentStreams(state, payload.session_id);
 };
 
 // Replace a session's transcript wholesale (used when replaying history).


### PR DESCRIPTION
## Dependency node

3/6 for debug-agent. Depends on `@acedatacloud/core@0.20.1` from CommonFrontend PRs 26-28.

## Summary

- replace local Coding Bridge DTOs with aliases to `@acedatacloud/core/coding-agent`
- source inner action/event constants from core
- delegate session re-key, event append, stream delta/finalize, and rewind mutations to shared helpers
- retain node pairing, directories, push, store, router, and native workflows in Nexior
- net remove 242 lines of duplicated contract logic

## Validation

- Coding Bridge focused tests: 28 passed
- web production build passed with core 0.20.1 tarball
- ESLint: 0 errors (2 pre-existing warnings in dropUploadMixin.test.ts)
- beachball check: no change file required for dependency-only refactor
- `git diff --check`

## Rollout / rollback

Behavior-preserving consumer migration. Rollback by reverting imports/helpers and returning to core 0.19.1.

## Review

The downstream tests found a real `streaming: undefined` compatibility bug in core 0.20.0; CommonFrontend PR 28 fixed and released it as 0.20.1 before this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)