### PR TITLE
feat(x402): add Suno wallet payments

### DIFF
--- a/change/@acedatacloud-nexior-39f62d29-44a8-4c87-bee5-172d69e728cb.json
+++ b/change/@acedatacloud-nexior-39f62d29-44a8-4c87-bee5-172d69e728cb.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add Solana x402 wallet payments to Suno generation and exact-priced secondary actions.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "minor"
+}

--- a/src/components/suno/ConfigPanel.vue
+++ b/src/components/suno/ConfigPanel.vue
@@ -39,7 +39,8 @@
       </el-tabs>
     </div>
     <div class="flex flex-col items-center justify-center px-5 pb-5 gap-2">
-      <consumption :value="consumption" :service="service" />
+      <scenario-payment-mode scenario="suno" />
+      <consumption v-if="!walletMode" :value="consumption" :service="service" />
       <div class="flex gap-2 w-full">
         <el-button class="flex-1" @click="onClearAll">
           <cleanup-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
@@ -76,6 +77,9 @@ import AdjustSpeedInput from './config/AdjustSpeedInput.vue';
 import PersonaInput from './config/PersonaInput.vue';
 import Consumption from '../common/Consumption.vue';
 import { getConsumption } from '@/utils';
+import ScenarioPaymentMode from '../common/ScenarioPaymentMode.vue';
+import { isScenarioX402Enabled, scenarioPaymentState } from '@/utils/x402/scenarioPayment';
+import { buildSunoAudioRequest, sunoOperator } from '@/operators/suno';
 
 export default defineComponent({
   name: 'PresetPanel',
@@ -101,9 +105,13 @@ export default defineComponent({
     ElButton,
     ElTabs,
     ElTabPane,
-    Consumption
+    Consumption,
+    ScenarioPaymentMode
   },
   emits: ['generate'],
+  data() {
+    return { quoteTimer: 0, quoteRunId: 0 };
+  },
   computed: {
     config() {
       return this.$store.state.suno?.config;
@@ -124,6 +132,9 @@ export default defineComponent({
     },
     service() {
       return this.$store.state.suno?.service;
+    },
+    walletMode(): boolean {
+      return isScenarioX402Enabled() && scenarioPaymentState('suno').mode === 'wallet';
     },
     supportsVocalGender() {
       const model = this.config?.model || '';
@@ -152,7 +163,43 @@ export default defineComponent({
       return this.$t('suno.button.generate');
     }
   },
+  watch: {
+    walletMode: {
+      handler(enabled: boolean) {
+        if (enabled) this.scheduleQuote();
+      },
+      immediate: true
+    },
+    config: {
+      handler() {
+        if (this.walletMode) this.scheduleQuote();
+      },
+      deep: true
+    }
+  },
+  beforeUnmount() {
+    window.clearTimeout(this.quoteTimer);
+    this.quoteRunId += 1;
+  },
   methods: {
+    scheduleQuote() {
+      window.clearTimeout(this.quoteTimer);
+      this.quoteTimer = window.setTimeout(this.refreshQuote, 350);
+    },
+    async refreshQuote() {
+      const state = scenarioPaymentState('suno');
+      const runId = ++this.quoteRunId;
+      state.quoteLoading = true;
+      state.quoteUsdc = undefined;
+      try {
+        const quote = await sunoOperator.quoteAudio(buildSunoAudioRequest(this.config));
+        if (runId === this.quoteRunId && state.mode === 'wallet') state.quoteUsdc = quote.amountUsdc;
+      } catch (error) {
+        console.warn('x402 quote failed', error);
+      } finally {
+        if (runId === this.quoteRunId) state.quoteLoading = false;
+      }
+    },
     onGenerate() {
       this.$emit('generate');
     },

--- a/src/components/suno/RecentPanel.vue
+++ b/src/components/suno/RecentPanel.vue
@@ -104,7 +104,13 @@
       :loading="loading"
       @reach-top="$emit('reach-top')"
     >
-      <task-preview v-for="(task, taskId) in filteredTasks" :key="taskId" :model-value="task" class="preview" />
+      <task-preview
+        v-for="(task, taskId) in filteredTasks"
+        :key="taskId"
+        :model-value="task"
+        class="preview"
+        @wallet-task="$emit('wallet-task', $event)"
+      />
     </scroll-list>
     <div
       v-else-if="!loading && searchQuery && tasks?.items?.length > 0"
@@ -189,7 +195,7 @@ export default defineComponent({
       default: false
     }
   },
-  emits: ['reach-top', 'load-all'],
+  emits: ['reach-top', 'load-all', 'wallet-task'],
   data() {
     return {
       job: 0,

--- a/src/components/suno/config/LyricInput.vue
+++ b/src/components/suno/config/LyricInput.vue
@@ -173,7 +173,9 @@ import { ClearIcon, FullscreenIcon, MagicIcon, UndoIcon } from '@acedatacloud/co
 import { defineComponent } from 'vue';
 import { ElInput, ElButton, ElMessage, ElMessageBox, ElTooltip, ElDialog } from 'element-plus';
 import InfoIcon from '@/components/common/InfoIcon.vue';
-import { sunoOperator } from '@/operators';
+import { sunoOperator } from '@/operators/suno';
+import { sunoPaymentOptions } from '@/utils/x402/sunoPayment';
+import { X402PaymentCancelledError } from '@/operators/x402';
 
 export const DEFAULT_LYRIC = '';
 
@@ -241,30 +243,31 @@ export default defineComponent({
       this.lyric = '';
     },
     async onEnhanceLyrics() {
-      const token = this.credential?.token;
-      if (!token || !this.lyric || !this.enhancePrompt) return;
+      const options = sunoPaymentOptions(this);
+      if (!options || !this.lyric || !this.enhancePrompt) return;
 
       this.pushHistory();
       this.enhancingLyrics = true;
       ElMessage.info(this.$t('suno.message.enhancingLyrics'));
       try {
         const prompt = `${this.enhancePrompt}\n\nOriginal lyrics:\n${this.lyric}`;
-        const response = await sunoOperator.lyric({ prompt }, { token });
+        const response = await sunoOperator.lyric({ prompt }, options);
         const data = response.data?.data;
         if (data?.text) {
           this.lyric = data.text;
           this.enhancePrompt = '';
           ElMessage.success(this.$t('suno.message.enhanceLyricsSuccess'));
         }
-      } catch {
+      } catch (error) {
+        if (error instanceof X402PaymentCancelledError) return;
         ElMessage.error(this.$t('suno.message.enhanceLyricsFailed'));
       } finally {
         this.enhancingLyrics = false;
       }
     },
     async onGenerateLyrics() {
-      const token = this.credential?.token;
-      if (!token) return;
+      const options = sunoPaymentOptions(this);
+      if (!options) return;
 
       let theme: string;
       try {
@@ -292,7 +295,7 @@ export default defineComponent({
       ElMessage.info(this.$t('suno.message.generatingLyrics'));
 
       try {
-        const response = await sunoOperator.lyric({ prompt: theme }, { token });
+        const response = await sunoOperator.lyric({ prompt: theme }, options);
         const data = response.data?.data;
         if (data?.text) {
           this.lyric = data.text;
@@ -305,7 +308,8 @@ export default defineComponent({
           }
           ElMessage.success(this.$t('suno.message.generateLyricsSuccess'));
         }
-      } catch {
+      } catch (error) {
+        if (error instanceof X402PaymentCancelledError) return;
         ElMessage.error(this.$t('suno.message.generateLyricsFailed'));
       } finally {
         this.generatingLyrics = false;

--- a/src/components/suno/config/StyleInput.vue
+++ b/src/components/suno/config/StyleInput.vue
@@ -36,7 +36,9 @@ import { MagicIcon, RefreshIcon } from '@acedatacloud/core/icons/components';
 import { defineComponent } from 'vue';
 import { ElInput, ElButton, ElMessage } from 'element-plus';
 import InfoIcon from '@/components/common/InfoIcon.vue';
-import { sunoOperator } from '@/operators';
+import { sunoOperator } from '@/operators/suno';
+import { sunoPaymentOptions } from '@/utils/x402/sunoPayment';
+import { X402PaymentCancelledError } from '@/operators/x402';
 
 const ALL_STYLE_TAGS = [
   'Pop',
@@ -146,19 +148,20 @@ export default defineComponent({
       this.shuffledTags = shuffleArray(ALL_STYLE_TAGS);
     },
     async onOptimizeStyle() {
-      const token = this.credential?.token;
-      if (!token || !this.style) return;
+      const options = sunoPaymentOptions(this);
+      if (!options || !this.style) return;
 
       this.optimizing = true;
       ElMessage.info(this.$t('suno.message.optimizingStyle'));
       try {
-        const response = await sunoOperator.style({ prompt: this.style }, { token });
+        const response = await sunoOperator.style({ prompt: this.style }, options);
         const text = response.data?.text || (response.data as any)?.data?.text;
         if (text) {
           this.style = text;
           ElMessage.success(this.$t('suno.message.optimizeStyleSuccess'));
         }
-      } catch {
+      } catch (error) {
+        if (error instanceof X402PaymentCancelledError) return;
         ElMessage.error(this.$t('suno.message.optimizeStyleFailed'));
       } finally {
         this.optimizing = false;

--- a/src/components/suno/task/Preview.vue
+++ b/src/components/suno/task/Preview.vue
@@ -346,7 +346,9 @@ import {
 import { PauseIcon as VideoPause, PlayIcon as VideoPlay } from '@acedatacloud/core/icons/components';
 import { ISunoMp4Request, ISunoAudioRequest, Status } from '@/models';
 import { saveAs } from 'file-saver';
-import { sunoOperator } from '@/operators';
+import { sunoOperator } from '@/operators/suno';
+import { sunoPaymentOptions } from '@/utils/x402/sunoPayment';
+import { X402PaymentCancelledError } from '@/operators/x402';
 import ApiCodeDialog from '@/components/common/ApiCodeDialog.vue';
 import ReportDialog from '@/components/common/ReportDialog.vue';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
@@ -401,6 +403,7 @@ export default defineComponent({
       required: true
     }
   },
+  emits: ['wallet-task'],
   data() {
     return {
       isFetchingVideoUrl: false,
@@ -760,15 +763,18 @@ export default defineComponent({
       ElMessage.success(this.$t('suno.message.reusePromptSuccess'));
     },
     async onExtractVocals(audioId: string) {
-      const token = this.credential?.token;
-      if (!token) return;
+      const options = sunoPaymentOptions(this);
+      if (!options) return;
       ElMessage.info(this.$t('suno.message.extractingVocals'));
       sunoOperator
-        .vox({ audio_id: audioId, async: true }, { token })
-        .then(() => {
+        .vox({ audio_id: audioId, async: true }, options)
+        .then((response) => {
+          const taskId = response?.data?.task_id;
+          if (taskId) this.$emit('wallet-task', taskId);
           ElMessage.success(this.$t('suno.message.extractVocalsSuccess'));
         })
         .catch((error) => {
+          if (error instanceof X402PaymentCancelledError) return;
           ElMessage.error(error?.response?.data?.error?.message || this.$t('suno.message.extractVocalsFailed'));
         })
         .finally(async () => {
@@ -777,26 +783,27 @@ export default defineComponent({
         });
     },
     async onGetTiming(audioId: string) {
-      const token = this.credential?.token;
-      if (!token) return;
+      const options = sunoPaymentOptions(this);
+      if (!options) return;
       ElMessage.info(this.$t('suno.message.fetchingTiming'));
       sunoOperator
-        .timing({ audio_id: audioId }, { token })
+        .timing({ audio_id: audioId }, options)
         .then(() => {
           ElMessage.success(this.$t('suno.message.fetchTimingSuccess'));
         })
         .catch((error) => {
+          if (error instanceof X402PaymentCancelledError) return;
           ElMessage.error(error?.response?.data?.error?.message || this.$t('suno.message.fetchTimingFailed'));
         });
     },
     async handleWavDownload(audio: ISunoAudio) {
       if (!audio?.id || this.isFetchingWav) return;
-      const token = this.credential?.token;
-      if (!token) return;
+      const options = sunoPaymentOptions(this);
+      if (!options) return;
       try {
         this.isFetchingWav = true;
         ElMessage.info(this.$t('suno.message.fetchingWav'));
-        const response = await sunoOperator.wav({ audio_id: audio.id }, { token });
+        const response = await sunoOperator.wav({ audio_id: audio.id }, options);
         // Worker returns `data: [{ file_url }]` (array, not an object).
         const wavUrl = response.data?.data?.[0]?.file_url;
         if (wavUrl) {
@@ -805,6 +812,7 @@ export default defineComponent({
           ElMessage.error(this.$t('suno.message.fetchWavFailed'));
         }
       } catch (error) {
+        if (error instanceof X402PaymentCancelledError) return;
         const message = (error as { response?: { data?: { error?: { message?: string } } } })?.response?.data?.error
           ?.message;
         ElMessage.error(message || this.$t('suno.message.fetchWavFailed'));
@@ -814,12 +822,12 @@ export default defineComponent({
     },
     async handleMidiDownload(audio: ISunoAudio) {
       if (!audio?.id || this.isFetchingMidi) return;
-      const token = this.credential?.token;
-      if (!token) return;
+      const options = sunoPaymentOptions(this);
+      if (!options) return;
       try {
         this.isFetchingMidi = true;
         ElMessage.info(this.$t('suno.message.fetchingMidi'));
-        const response = await sunoOperator.midi({ audio_id: audio.id }, { token });
+        const response = await sunoOperator.midi({ audio_id: audio.id }, options);
         // Worker returns structured note data, no URL — save raw JSON for the user.
         const data = response.data?.data;
         if (!data?.length) {
@@ -830,6 +838,7 @@ export default defineComponent({
         const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
         saveAs(blob, filename);
       } catch (error) {
+        if (error instanceof X402PaymentCancelledError) return;
         const message = (error as { response?: { data?: { error?: { message?: string } } } })?.response?.data?.error
           ?.message;
         ElMessage.error(message || this.$t('suno.message.fetchMidiFailed'));
@@ -843,20 +852,18 @@ export default defineComponent({
         audio_id: audioId,
         async: true
       } as ISunoAudioRequest;
-      const token = this.credential?.token;
-      if (!token) {
-        console.error('no token specified');
-        return;
-      }
+      const options = sunoPaymentOptions(this);
+      if (!options) return;
       ElMessage.info(this.$t('suno.message.startingTask'));
       sunoOperator
-        .audio(request, {
-          token
-        })
-        .then(() => {
+        .audio(request, options)
+        .then((response) => {
+          const taskId = response?.data?.task_id;
+          if (taskId) this.$emit('wallet-task', taskId);
           ElMessage.success(this.$t('suno.message.startTaskSuccess'));
         })
         .catch((error) => {
+          if (error instanceof X402PaymentCancelledError) return;
           ElMessage.error(error?.response?.data?.error?.message || this.$t('suno.message.startTaskFailed'));
         })
         .finally(async () => {

--- a/src/components/suno/voice/VoiceCreateDialog.vue
+++ b/src/components/suno/voice/VoiceCreateDialog.vue
@@ -44,7 +44,9 @@
 <script lang="ts">
 import { defineComponent } from 'vue';
 import { ElDialog, ElForm, ElFormItem, ElInput, ElButton, ElRadioGroup, ElRadio, ElMessage } from 'element-plus';
-import { sunoOperator } from '@/operators';
+import { sunoOperator } from '@/operators/suno';
+import { sunoPaymentOptions } from '@/utils/x402/sunoPayment';
+import { X402PaymentCancelledError } from '@/operators/x402';
 
 export default defineComponent({
   name: 'VoiceCreateDialog',
@@ -105,7 +107,8 @@ export default defineComponent({
       this.sourceType = 'song';
     },
     async onSubmit() {
-      if (!this.token) return;
+      const options = sunoPaymentOptions(this);
+      if (!options) return;
       this.loading = true;
       try {
         if (this.sourceType === 'song') {
@@ -115,7 +118,7 @@ export default defineComponent({
               name: this.form.name,
               description: this.form.description
             },
-            { token: this.token }
+            options
           );
         } else {
           await sunoOperator.voices(
@@ -124,13 +127,14 @@ export default defineComponent({
               name: this.form.name,
               description: this.form.description
             },
-            { token: this.token }
+            options
           );
         }
         ElMessage.success(this.$t('suno.voice.createSuccess'));
         this.$emit('created');
         this.onClose();
-      } catch {
+      } catch (error) {
+        if (error instanceof X402PaymentCancelledError) return;
         ElMessage.error(this.$t('suno.voice.createFailed'));
       } finally {
         this.loading = false;

--- a/src/components/x402SunoContract.test.ts
+++ b/src/components/x402SunoContract.test.ts
@@ -1,0 +1,49 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = (relativePath: string) => fs.readFileSync(path.resolve(process.cwd(), 'src', relativePath), 'utf8');
+
+describe('Suno x402 contract', () => {
+  it('registers Suno and shares the audio builder between quote and submit', () => {
+    expect(source('layouts/Main.vue')).toContain("'suno'");
+    expect(source('components/suno/ConfigPanel.vue')).toContain(
+      'sunoOperator.quoteAudio(buildSunoAudioRequest(this.config))'
+    );
+    expect(source('pages/suno/Index.vue')).toContain('buildSunoAudioRequest(this.config)');
+  });
+
+  it('uses endpoint-specific payment for every UI-used exact action', () => {
+    const lyrics = source('components/suno/config/LyricInput.vue');
+    const style = source('components/suno/config/StyleInput.vue');
+    const voice = source('components/suno/voice/VoiceCreateDialog.vue');
+    const preview = source('components/suno/task/Preview.vue');
+
+    expect(lyrics).toContain('sunoOperator.lyric({ prompt }, options)');
+    expect(lyrics).toContain('sunoOperator.lyric({ prompt: theme }, options)');
+    expect(style).toContain('sunoOperator.style({ prompt: this.style }, options)');
+    expect(voice).toContain('sunoOperator.persona(');
+    expect(voice).toContain('sunoOperator.voices(');
+    ['.vox(', '.timing(', '.wav(', '.midi(', '.audio('].forEach((call) => expect(preview).toContain(call));
+  });
+
+  it('keeps upload and persona reads/deletes authenticated Credits-only', () => {
+    const operator = source('operators/suno.ts');
+    expect(operator).toContain("return await axios.post('/suno/upload'");
+    expect(operator).toContain("return await axios.get('/suno/persona'");
+    expect(operator).toContain("return await axios.delete('/suno/persona'");
+  });
+
+  it('keeps guest task IDs in page memory and propagates secondary task IDs', () => {
+    const page = source('pages/suno/Index.vue');
+    const panel = source('components/suno/RecentPanel.vue');
+    const preview = source('components/suno/task/Preview.vue');
+    expect(page).toContain('walletTaskIds: string[]');
+    expect(page).toContain("mode: 'x402', ids: this.walletTaskIds");
+    expect(page).toContain('identityToken: this.credential?.token');
+    expect(panel).toContain('@wallet-task="$emit(\'wallet-task\', $event)"');
+    expect(preview).toContain("this.$emit('wallet-task', taskId)");
+    expect(page).not.toContain('localStorage');
+    expect(page).not.toContain('sessionStorage');
+  });
+});

--- a/src/layouts/Main.vue
+++ b/src/layouts/Main.vue
@@ -85,7 +85,8 @@ export default defineComponent({
           'maestro',
           'kling',
           'digitalhuman',
-          'serp'
+          'serp',
+          'suno'
         ].includes(String(this.appName)) && isScenarioX402Enabled()
       );
     },

--- a/src/operators/suno.ts
+++ b/src/operators/suno.ts
@@ -22,27 +22,32 @@ import {
   ISunoVoicesResponse,
   ISunoMashupLyricsRequest,
   ISunoMashupLyricsResponse,
-  ISunoPersonasListResponse
+  ISunoPersonasListResponse,
+  ISunoConfig
 } from '@/models';
-import { BASE_URL_API } from '@/constants';
+import { BASE_URL_API, BASE_URL_X402 } from '@/constants';
+import { postWithX402, quoteX402, type OperatorRequestOptions } from './x402';
+
+const HEADERS = { 'content-type': 'application/json', accept: 'application/json' };
+const TASK_HEADERS = { ...HEADERS, 'x-record-exempt': 'true' };
+
+export function buildSunoAudioRequest(config?: ISunoConfig): ISunoAudioRequest {
+  const request = { ...(config || {}), audio: undefined, async: true } as ISunoAudioRequest;
+  if (typeof request.prompt === 'string') request.prompt = request.prompt.trim();
+  return request;
+}
 
 class SunoOperator {
-  async task(id: string, options: { token: string }): Promise<AxiosResponse<ISunoTaskResponse>> {
+  async task(id: string, options: OperatorRequestOptions): Promise<AxiosResponse<ISunoTaskResponse>> {
     return await axios.post(
       `/suno/tasks`,
       {
         action: 'retrieve',
         id: id
       },
-      {
-        headers: {
-          accept: 'application/json',
-          'content-type': 'application/json',
-          authorization: `Bearer ${options.token}`,
-          'x-record-exempt': 'true'
-        },
-        baseURL: BASE_URL_API
-      }
+      options.mode === 'x402'
+        ? { headers: TASK_HEADERS, baseURL: BASE_URL_X402 }
+        : { headers: { ...TASK_HEADERS, authorization: `Bearer ${options.token}` }, baseURL: BASE_URL_API }
     );
   }
 
@@ -57,7 +62,7 @@ class SunoOperator {
       createdAtMax?: number;
       createdAtMin?: number;
     },
-    options: { token: string }
+    options: OperatorRequestOptions
   ): Promise<AxiosResponse<ISunoTasksResponse>> {
     return await axios.post(
       `/suno/tasks`,
@@ -104,46 +109,38 @@ class SunoOperator {
             }
           : {})
       },
-      {
-        headers: {
-          accept: 'application/json',
-          'content-type': 'application/json',
-          authorization: `Bearer ${options.token}`,
-          'x-record-exempt': 'true'
-        },
-        baseURL: BASE_URL_API
-      }
+      options.mode === 'x402'
+        ? { headers: TASK_HEADERS, baseURL: BASE_URL_X402 }
+        : { headers: { ...TASK_HEADERS, authorization: `Bearer ${options.token}` }, baseURL: BASE_URL_API }
     );
   }
-  // 生成歌曲
-  async audio(
-    data: ISunoAudioRequest,
-    options: {
-      token: string;
+  async quoteAudio(data: ISunoAudioRequest) {
+    return quoteX402('/suno/audios', data, HEADERS);
+  }
+
+  private async submitExact<T>(
+    path: string,
+    data: unknown,
+    options: OperatorRequestOptions
+  ): Promise<AxiosResponse<T>> {
+    if (options.mode === 'x402') {
+      if (!options.x402) throw new Error('x402 payment options are required');
+      return postWithX402<T>(path, data, options.x402, HEADERS);
     }
-  ): Promise<AxiosResponse<ISunoAudioResponse>> {
-    return await axios.post('/suno/audios', data, {
-      headers: {
-        authorization: `Bearer ${options.token}`,
-        'content-type': 'application/json'
-      },
+    return axios.post(path, data, {
+      headers: { ...HEADERS, authorization: `Bearer ${options.token}` },
       baseURL: BASE_URL_API
     });
   }
+
+  // 生成歌曲
+  async audio(data: ISunoAudioRequest, options: OperatorRequestOptions): Promise<AxiosResponse<ISunoAudioResponse>> {
+    return this.submitExact<ISunoAudioResponse>('/suno/audios', data, options);
+  }
+
   // 生成歌曲歌词
-  async lyric(
-    data: ISunoLyricRequest,
-    options: {
-      token: string;
-    }
-  ): Promise<AxiosResponse<ISunoLyricResponse>> {
-    return await axios.post('/suno/lyrics', data, {
-      headers: {
-        authorization: `Bearer ${options.token}`,
-        'content-type': 'application/json'
-      },
-      baseURL: BASE_URL_API
-    });
+  async lyric(data: ISunoLyricRequest, options: OperatorRequestOptions): Promise<AxiosResponse<ISunoLyricResponse>> {
+    return this.submitExact<ISunoLyricResponse>('/suno/lyrics', data, options);
   }
 
   // suno/upload
@@ -179,35 +176,16 @@ class SunoOperator {
   }
 
   // suno/style - optimize style description
-  async style(
-    data: ISunoStyleRequest,
-    options: {
-      token: string;
-    }
-  ): Promise<AxiosResponse<ISunoStyleResponse>> {
-    return await axios.post('/suno/style', data, {
-      headers: {
-        authorization: `Bearer ${options.token}`,
-        'content-type': 'application/json'
-      },
-      baseURL: BASE_URL_API
-    });
+  async style(data: ISunoStyleRequest, options: OperatorRequestOptions): Promise<AxiosResponse<ISunoStyleResponse>> {
+    return this.submitExact<ISunoStyleResponse>('/suno/style', data, options);
   }
 
   // suno/wav - get WAV format. Worker returns `data: [{ file_url }]`.
   async wav(
     data: { audio_id: string },
-    options: {
-      token: string;
-    }
+    options: OperatorRequestOptions
   ): Promise<AxiosResponse<{ data: Array<{ file_url: string }> }>> {
-    return await axios.post('/suno/wav', data, {
-      headers: {
-        authorization: `Bearer ${options.token}`,
-        'content-type': 'application/json'
-      },
-      baseURL: BASE_URL_API
-    });
+    return this.submitExact<{ data: Array<{ file_url: string }> }>('/suno/wav', data, options);
   }
 
   // suno/midi - get structured MIDI note data. Worker returns
@@ -215,9 +193,7 @@ class SunoOperator {
   // No URL — the caller is expected to assemble a .mid file client-side.
   async midi(
     data: { audio_id: string },
-    options: {
-      token: string;
-    }
+    options: OperatorRequestOptions
   ): Promise<
     AxiosResponse<{
       data: Array<{
@@ -229,77 +205,38 @@ class SunoOperator {
       }>;
     }>
   > {
-    return await axios.post('/suno/midi', data, {
-      headers: {
-        authorization: `Bearer ${options.token}`,
-        'content-type': 'application/json'
-      },
-      baseURL: BASE_URL_API
-    });
+    return this.submitExact<{
+      data: Array<{
+        state?: string;
+        instruments: Array<{
+          name?: string;
+          notes: Array<{ pitch: number; start: number; end: number; velocity: number }>;
+        }>;
+      }>;
+    }>('/suno/midi', data, options);
   }
 
   // suno/persona - create vocal persona
   async persona(
     data: ISunoPersonaRequest,
-    options: {
-      token: string;
-    }
+    options: OperatorRequestOptions
   ): Promise<AxiosResponse<ISunoPersonaResponse>> {
-    return await axios.post('/suno/persona', data, {
-      headers: {
-        authorization: `Bearer ${options.token}`,
-        'content-type': 'application/json'
-      },
-      baseURL: BASE_URL_API
-    });
+    return this.submitExact<ISunoPersonaResponse>('/suno/persona', data, options);
   }
 
   // suno/vox - extract vocals
-  async vox(
-    data: ISunoVoxRequest,
-    options: {
-      token: string;
-    }
-  ): Promise<AxiosResponse<ISunoVoxResponse>> {
-    return await axios.post('/suno/vox', data, {
-      headers: {
-        authorization: `Bearer ${options.token}`,
-        'content-type': 'application/json'
-      },
-      baseURL: BASE_URL_API
-    });
+  async vox(data: ISunoVoxRequest, options: OperatorRequestOptions): Promise<AxiosResponse<ISunoVoxResponse>> {
+    return this.submitExact<ISunoVoxResponse>('/suno/vox', data, options);
   }
 
   // suno/timing - get timing data
-  async timing(
-    data: ISunoTimingRequest,
-    options: {
-      token: string;
-    }
-  ): Promise<AxiosResponse<ISunoTimingResponse>> {
-    return await axios.post('/suno/timing', data, {
-      headers: {
-        authorization: `Bearer ${options.token}`,
-        'content-type': 'application/json'
-      },
-      baseURL: BASE_URL_API
-    });
+  async timing(data: ISunoTimingRequest, options: OperatorRequestOptions): Promise<AxiosResponse<ISunoTimingResponse>> {
+    return this.submitExact<ISunoTimingResponse>('/suno/timing', data, options);
   }
 
   // suno/voices - create custom voice
-  async voices(
-    data: ISunoVoicesRequest,
-    options: {
-      token: string;
-    }
-  ): Promise<AxiosResponse<ISunoVoicesResponse>> {
-    return await axios.post('/suno/voices', data, {
-      headers: {
-        authorization: `Bearer ${options.token}`,
-        'content-type': 'application/json'
-      },
-      baseURL: BASE_URL_API
-    });
+  async voices(data: ISunoVoicesRequest, options: OperatorRequestOptions): Promise<AxiosResponse<ISunoVoicesResponse>> {
+    return this.submitExact<ISunoVoicesResponse>('/suno/voices', data, options);
   }
 
   // suno/mashup-lyrics - generate mashup lyrics

--- a/src/operators/x402SunoRequests.test.ts
+++ b/src/operators/x402SunoRequests.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from 'vitest';
+import { buildSunoAudioRequest, sunoOperator } from './suno';
+
+const x402 = vi.hoisted(() => ({ quote: vi.fn(), post: vi.fn() }));
+vi.mock('./x402', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./x402')>()),
+  quoteX402: x402.quote,
+  postWithX402: x402.post
+}));
+
+describe('Suno x402 requests', () => {
+  it('builds the main audio request without preview-only audio state', () => {
+    expect(
+      buildSunoAudioRequest({ prompt: '  song  ', model: 'chirp-v5', audio: { id: 'preview' }, continue_at: 12 })
+    ).toEqual({ prompt: 'song', model: 'chirp-v5', audio: undefined, continue_at: 12, async: true });
+  });
+
+  it('routes all UI-used exact writes independently', async () => {
+    x402.quote.mockResolvedValue({ amountUsdc: '1' });
+    x402.post.mockResolvedValue({ data: { task_id: 'task-1' } });
+    const options = { mode: 'x402' as const, x402: { wallet: {} as never, confirm: async () => true } };
+
+    await sunoOperator.quoteAudio({ prompt: 'song' });
+    await sunoOperator.audio({ prompt: 'song' }, options);
+    await sunoOperator.lyric({ prompt: 'lyrics' }, options);
+    await sunoOperator.style({ prompt: 'style' }, options);
+    await sunoOperator.wav({ audio_id: 'audio-1' }, options);
+    await sunoOperator.midi({ audio_id: 'audio-1' }, options);
+    await sunoOperator.persona({ audio_id: 'audio-1', name: 'voice' }, options);
+    await sunoOperator.voices({ audio_url: 'voice.mp3' }, options);
+    await sunoOperator.vox({ audio_id: 'audio-1', async: true }, options);
+    await sunoOperator.timing({ audio_id: 'audio-1' }, options);
+
+    expect(x402.quote).toHaveBeenCalledWith('/suno/audios', { prompt: 'song' }, expect.any(Object));
+    expect(x402.post.mock.calls.map((call) => call[0])).toEqual([
+      '/suno/audios',
+      '/suno/lyrics',
+      '/suno/style',
+      '/suno/wav',
+      '/suno/midi',
+      '/suno/persona',
+      '/suno/voices',
+      '/suno/vox',
+      '/suno/timing'
+    ]);
+  });
+
+  it('keeps upload outside the x402 submit helper', () => {
+    expect(sunoOperator.upload).toBeTypeOf('function');
+  });
+});

--- a/src/pages/suno/Index.vue
+++ b/src/pages/suno/Index.vue
@@ -10,6 +10,7 @@
         :loading="loadingMore || loadingAll"
         @reach-top="onReachTop"
         @load-all="onLoadAll"
+        @wallet-task="onWalletTask"
       />
     </template>
     <template #preview>
@@ -21,9 +22,10 @@
 <script lang="ts">
 import { defineComponent } from 'vue';
 import Layout from '@/layouts/Suno.vue';
-import { applicationOperator, sunoOperator } from '@/operators';
+import { applicationOperator } from '@/operators';
+import { buildSunoAudioRequest, sunoOperator } from '@/operators/suno';
 import { IApplicationDetailResponse, ISunoAudioRequest, Status } from '@/models';
-import { ElMessage } from 'element-plus';
+import { ElMessage, ElMessageBox } from 'element-plus';
 import { ISunoTask } from '@/models';
 import { ERROR_CODE_DUPLICATION } from '@/constants';
 import { instrumentGeneration } from '@/plugins/telemetry';
@@ -32,6 +34,13 @@ import RecentPanel from '@/components/suno/RecentPanel.vue';
 import PreviewPanel from '@/components/suno/PreviewPanel.vue';
 import { loadPreviousPage } from '@/utils/pagination';
 import { uploadTrackerProviderMixin, ensureNoPendingUpload, ensureLoggedIn } from '@/utils';
+import { isScenarioX402Enabled, scenarioPaymentState } from '@/utils/x402/scenarioPayment';
+import {
+  X402PaymentCancelledError,
+  type OperatorRequestOptions,
+  type X402PaymentQuote,
+  type X402WalletContext
+} from '@/operators/x402';
 
 interface IData {
   task: ISunoTask | undefined;
@@ -39,6 +48,7 @@ interface IData {
   loadingMore: boolean;
   loadingAll: boolean;
   fetchingTasks: boolean;
+  walletTaskIds: string[];
 }
 
 export default defineComponent({
@@ -57,7 +67,8 @@ export default defineComponent({
       job: 0,
       loadingMore: false,
       loadingAll: false,
-      fetchingTasks: false
+      fetchingTasks: false,
+      walletTaskIds: []
     };
   },
   computed: {
@@ -90,9 +101,27 @@ export default defineComponent({
     },
     applications() {
       return this.$store.state.suno.applications;
+    },
+    walletMode(): boolean {
+      return isScenarioX402Enabled() && scenarioPaymentState('suno').mode === 'wallet';
     }
   },
   watch: {
+    walletMode: {
+      async handler(value: boolean, oldValue: boolean | undefined) {
+        if (oldValue === undefined || value === oldValue) return;
+        this.$store.commit('suno/setTasks', undefined);
+        if (value && !this.job) this.job = window.setInterval(this.onGetTasks, 5000);
+        if (!value && !this.credential?.token) {
+          window.clearInterval(this.job);
+          this.job = 0;
+          await this.onScrollDown();
+          return;
+        }
+        await this.onGetTasks();
+        await this.onScrollDown();
+      }
+    },
     tasks: {
       handler(value, oldValue) {
         // scroll down if new tasks are added
@@ -107,9 +136,7 @@ export default defineComponent({
         if (newValue) {
           await this.onGetTasks();
           await this.onScrollDown();
-          this.job = window.setInterval(() => {
-            this.onGetTasks();
-          }, 5000);
+          if (!this.job) this.job = window.setInterval(this.onGetTasks, 5000);
         }
       },
       immediate: true
@@ -140,6 +167,7 @@ export default defineComponent({
     // search/filter cover everything, not just the loaded pages. Triggered
     // once when the user first searches/filters.
     async onLoadAll() {
+      if (this.walletMode && !this.credential?.token) return;
       if (this.loadingAll) {
         return;
       }
@@ -213,7 +241,8 @@ export default defineComponent({
         await this.$store.dispatch('suno/getTasks', {
           limit,
           createdAtMin,
-          createdAtMax
+          createdAtMax,
+          ...(this.walletMode && !this.credential?.token ? { mode: 'x402', ids: this.walletTaskIds } : {})
         });
       } finally {
         this.fetchingTasks = false;
@@ -229,10 +258,7 @@ export default defineComponent({
       ) {
         return;
       }
-      const request = {
-        ...this.config,
-        async: true
-      } as ISunoAudioRequest;
+      const request = buildSunoAudioRequest(this.config);
       if (!this.hasSunoInput(request)) {
         ElMessage.error(this.$t('suno.message.promptRequired'));
         return;
@@ -240,28 +266,64 @@ export default defineComponent({
       if (this.hasText(request.prompt)) {
         request.prompt = request.prompt.trim();
       }
-      if (!ensureLoggedIn()) {
-        return;
-      }
-      const token = this.credential?.token;
-      if (!token) {
-        console.error('no token specified');
-        return;
-      }
+      const operation = this.createPaymentOperation((options) => sunoOperator.audio(request, options));
+      if (!operation) return;
       ElMessage.info(this.$t('suno.message.startingTask'));
-      instrumentGeneration('suno', sunoOperator.audio(request, { token }))
-        .then(() => {
-          ElMessage.success(this.$t('suno.message.startTaskSuccess'));
-        })
-        .catch((error) => {
-          ElMessage.error(error?.response?.data?.error?.message || this.$t('suno.message.startTaskFailed'));
-        })
-        .finally(async () => {
-          setTimeout(async () => {
-            await this.onGetTasks();
-            await this.onScrollDown();
-          }, 1000);
-        });
+      try {
+        const response = await instrumentGeneration('suno', operation);
+        this.onWalletTask(response?.data?.task_id);
+        ElMessage.success(this.$t('suno.message.startTaskSuccess'));
+      } catch (error: any) {
+        if (error instanceof X402PaymentCancelledError) return;
+        if (this.walletMode)
+          ElMessage.error(`${this.$t('common.x402Scenario.paymentFailed')} ${error?.message || ''}`.trim());
+        else ElMessage.error(error?.response?.data?.error?.message || this.$t('suno.message.startTaskFailed'));
+      } finally {
+        setTimeout(async () => {
+          await this.onGetTasks();
+          await this.onScrollDown();
+        }, 1000);
+      }
+    },
+    createPaymentOperation(submit: (options: OperatorRequestOptions) => Promise<any>): Promise<any> | undefined {
+      if (!this.walletMode) {
+        if (!ensureLoggedIn()) return undefined;
+        const token = this.credential?.token;
+        return token ? submit({ token }) : undefined;
+      }
+      const wallet = this.getWalletContext();
+      if (!wallet) {
+        ElMessage.warning(this.$t('common.x402Scenario.connectWalletFirst'));
+        return undefined;
+      }
+      return submit({
+        mode: 'x402',
+        x402: { wallet, confirm: (quote) => this.confirmWalletPayment(quote), identityToken: this.credential?.token }
+      });
+    },
+    onWalletTask(taskId: string | undefined) {
+      if (this.walletMode && !this.credential?.token && taskId && !this.walletTaskIds.includes(taskId))
+        this.walletTaskIds.unshift(taskId);
+    },
+    getWalletContext(): X402WalletContext | undefined {
+      const walletApi = (this as any).$wallet;
+      const publicKey = walletApi?.publicKey?.value;
+      const adapter = walletApi?.wallet?.value?.adapter;
+      if (!publicKey || !adapter?.signTransaction) return undefined;
+      return { publicKey, signTransaction: adapter.signTransaction.bind(adapter) };
+    },
+    async confirmWalletPayment(quote: X402PaymentQuote): Promise<boolean> {
+      return ElMessageBox.confirm(
+        this.$t('common.x402Scenario.confirmPayment', { amount: quote.amountUsdc }),
+        this.$t('order.message.x402ConfirmTitle'),
+        {
+          confirmButtonText: this.$t('order.message.x402WalletPayCta'),
+          cancelButtonText: this.$t('common.button.cancel'),
+          type: 'warning'
+        }
+      )
+        .then(() => true)
+        .catch(() => false);
     },
     getTasksScrollElement(): HTMLElement | undefined {
       const panel = this.$refs.recentPanel as any;

--- a/src/store/suno/actions.ts
+++ b/src/store/suno/actions.ts
@@ -144,27 +144,34 @@ export const getTasks = async (
     offset,
     limit,
     createdAtMin,
-    createdAtMax
-  }: { offset?: number; limit?: number; createdAtMin?: number; createdAtMax?: number }
+    createdAtMax,
+    mode = 'credits',
+    ids
+  }: {
+    offset?: number;
+    limit?: number;
+    createdAtMin?: number;
+    createdAtMax?: number;
+    mode?: 'credits' | 'x402';
+    ids?: string[];
+  }
 ): Promise<ISunoTask[]> => {
   return new Promise((resolve, reject) => {
     console.debug('start to get tasks', offset, limit, createdAtMax, createdAtMin);
     const credential = state.credential;
     const token = credential?.token;
-    if (!token) {
-      return reject('no token');
+    if (mode === 'credits' && !token) return reject('no token');
+    if (mode === 'x402' && !ids?.length) {
+      commit('setTasksItems', []);
+      commit('setTasksTotal', 0);
+      return resolve([]);
     }
     sunoOperator
       .tasks(
-        {
-          userId: rootState?.user?.id,
-          createdAtMin,
-          createdAtMax,
-          type: 'audios'
-        },
-        {
-          token
-        }
+        mode === 'x402'
+          ? { ids, createdAtMin, createdAtMax, type: 'audios' }
+          : { userId: rootState?.user?.id, createdAtMin, createdAtMax, type: 'audios' },
+        mode === 'x402' ? { mode: 'x402' } : { token }
       )
       .then((response) => {
         console.debug('get imagine tasks success', response.data.items);

--- a/src/store/suno/actions.x402.test.ts
+++ b/src/store/suno/actions.x402.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({ tasks: vi.fn() }));
+vi.mock('@/operators', () => ({
+  applicationOperator: {},
+  credentialOperator: {},
+  sunoOperator: { tasks: mocks.tasks },
+  serviceOperator: {}
+}));
+
+import { getTasks } from './actions';
+
+const state = () => ({ credential: { token: 'credits-token' }, tasks: { items: [], total: 0 } }) as any;
+const context = (value = state()) => ({ state: value, rootState: { user: { id: 'user-1' } }, commit: vi.fn() }) as any;
+
+describe('Suno x402 history', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('keeps Credits history user-scoped', async () => {
+    mocks.tasks.mockResolvedValueOnce({ data: { items: [], count: 0 } });
+    const ctx = context();
+    await getTasks(ctx, { limit: 5 });
+    expect(mocks.tasks).toHaveBeenCalledWith(expect.objectContaining({ userId: 'user-1', type: 'audios' }), {
+      token: 'credits-token'
+    });
+  });
+
+  it('uses only guest in-memory IDs', async () => {
+    mocks.tasks.mockResolvedValueOnce({ data: { items: [], count: 0 } });
+    const ctx = context({ ...state(), credential: undefined });
+    await getTasks(ctx, { mode: 'x402', ids: ['task-1'] });
+    expect(mocks.tasks).toHaveBeenCalledWith(expect.objectContaining({ ids: ['task-1'], type: 'audios' }), {
+      mode: 'x402'
+    });
+  });
+
+  it('does not query empty guest history', async () => {
+    const ctx = context({ ...state(), credential: undefined });
+    await getTasks(ctx, { mode: 'x402', ids: [] });
+    expect(mocks.tasks).not.toHaveBeenCalled();
+    expect(ctx.commit).toHaveBeenCalledWith('setTasksTotal', 0);
+  });
+});

--- a/src/utils/x402/sunoPayment.ts
+++ b/src/utils/x402/sunoPayment.ts
@@ -1,0 +1,52 @@
+import { ElMessage, ElMessageBox } from 'element-plus';
+import { isScenarioX402Enabled, scenarioPaymentState } from './scenarioPayment';
+import type { OperatorRequestOptions, X402PaymentQuote, X402WalletContext } from '@/operators/x402';
+
+interface SunoPaymentComponent {
+  $wallet?: any;
+  $store: any;
+  $t(key: string, values?: Record<string, unknown>): string;
+}
+
+export function isSunoWalletMode(): boolean {
+  return isScenarioX402Enabled() && scenarioPaymentState('suno').mode === 'wallet';
+}
+
+export function sunoPaymentOptions(component: SunoPaymentComponent): OperatorRequestOptions | undefined {
+  const token = component.$store.state.suno?.credential?.token;
+  if (!isSunoWalletMode()) return token ? { token } : undefined;
+  const wallet = sunoWalletContext(component);
+  if (!wallet) {
+    ElMessage.warning(component.$t('common.x402Scenario.connectWalletFirst'));
+    return undefined;
+  }
+  return {
+    mode: 'x402',
+    x402: {
+      wallet,
+      confirm: (quote) => confirmSunoPayment(component, quote),
+      identityToken: token
+    }
+  };
+}
+
+function sunoWalletContext(component: SunoPaymentComponent): X402WalletContext | undefined {
+  const publicKey = component.$wallet?.publicKey?.value;
+  const adapter = component.$wallet?.wallet?.value?.adapter;
+  if (!publicKey || !adapter?.signTransaction) return undefined;
+  return { publicKey, signTransaction: adapter.signTransaction.bind(adapter) };
+}
+
+function confirmSunoPayment(component: SunoPaymentComponent, quote: X402PaymentQuote): Promise<boolean> {
+  return ElMessageBox.confirm(
+    component.$t('common.x402Scenario.confirmPayment', { amount: quote.amountUsdc }),
+    component.$t('order.message.x402ConfirmTitle'),
+    {
+      confirmButtonText: component.$t('order.message.x402WalletPayCta'),
+      cancelButtonText: component.$t('common.button.cancel'),
+      type: 'warning'
+    }
+  )
+    .then(() => true)
+    .catch(() => false);
+}


### PR DESCRIPTION
## Summary
- add Solana x402 wallet quote and signed submit flows for Suno audio generation
- support endpoint-specific payments for `/suno/audios`, `/suno/lyrics`, `/suno/style`, `/suno/wav`, `/suno/midi`, `/suno/persona`, `/suno/voices`, `/suno/vox`, and `/suno/timing`
- keep `/suno/upload` and persona reads/deletes on the existing authenticated Credits path
- keep guest wallet task IDs in page memory only and attach the signed-retry identity sidecar for authenticated users
- use one Suno-owned request builder for both the server quote and main audio submission

## Validation
- focused x402 tests: 14 passed
- full unit suite: 174 files / 1,328 tests passed
- `npx vue-tsc -b --pretty false`
- `npm run lint:check` (0 errors)
- `python3 scripts/check_i18n_coverage.py`
- `npm run build:web`
- `unset ELECTRON_RUN_AS_NODE && npm run test:e2e:desktop` (3/3 passed)
- worktree-safe `npm run verify` / Beachball check
- `git diff --check`

## Release notes
- no storage-backed guest history, delete changes, or shared polling architecture added
- no billable generation, signature, or real on-chain payment was executed during validation
- production validation after an authorized merge should use unsigned quotes and read-only UI checks only

🤖 Generated with [Claude Code](https://claude.com/claude-code)