### PR TITLE
feat(x402): add Base wallet generation payments

### DIFF
--- a/change/@acedatacloud-nexior-0a89175f-a2eb-4bef-9e6a-7f0b9a7d81b0.json
+++ b/change/@acedatacloud-nexior-0a89175f-a2eb-4bef-9e6a-7f0b9a7d81b0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add Base wallet payments for x402 generation flows",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/application/Status.vue
+++ b/src/components/application/Status.vue
@@ -28,17 +28,43 @@
       </div>
 
       <div v-else-if="paymentMode === 'wallet'" class="wallet-mode">
-        <template v-if="solanaConnected && solanaAddress">
-          <div class="wallet-connected">
-            <el-tag type="success">{{ $t('order.message.x402WalletConnected') }}</el-tag>
-            <span class="wallet-address">{{ shortSolanaAddress }}</span>
-          </div>
-          <el-button @click="disconnectSolanaWallet">{{ $t('coin.button.disconnect') }}</el-button>
+        <el-radio-group v-model="walletRail" size="small">
+          <el-radio-button value="base">Base</el-radio-button>
+          <el-radio-button value="solana">Solana</el-radio-button>
+        </el-radio-group>
+        <template v-if="walletRail === 'base'">
+          <template v-if="evmAddress">
+            <div class="wallet-connected">
+              <el-tag type="success">{{ $t('order.message.x402WalletConnected') }}</el-tag>
+              <span class="wallet-address">{{ shortEvmAddress }}</span>
+            </div>
+            <el-button @click="disconnectEvmWallet">{{ $t('coin.button.disconnect') }}</el-button>
+          </template>
+          <el-button v-else type="primary" @click="openEvmWalletPicker">
+            {{ $t('order.message.x402ConnectWallet') }}
+          </el-button>
         </template>
-        <el-button v-else type="primary" @click="walletPickerVisible = true">
-          {{ $t('order.message.x402ConnectWallet') }}
-        </el-button>
+        <template v-else>
+          <template v-if="solanaConnected && solanaAddress">
+            <div class="wallet-connected">
+              <el-tag type="success">{{ $t('order.message.x402WalletConnected') }}</el-tag>
+              <span class="wallet-address">{{ shortSolanaAddress }}</span>
+            </div>
+            <el-button @click="disconnectSolanaWallet">{{ $t('coin.button.disconnect') }}</el-button>
+          </template>
+          <el-button v-else type="primary" @click="walletPickerVisible = true">
+            {{ $t('order.message.x402ConnectWallet') }}
+          </el-button>
+        </template>
         <p class="wallet-hint">{{ $t('common.x402Scenario.quoteBeforeSigning') }}</p>
+      </div>
+    </el-dialog>
+    <el-dialog v-model="evmWalletPickerVisible" title="Base" width="420px">
+      <div class="flex flex-col gap-2">
+        <el-button v-for="wallet in evmWallets" :key="wallet.id" @click="connectEvmWallet(wallet)">
+          {{ wallet.name }}
+        </el-button>
+        <p v-if="!evmWallets.length" class="wallet-hint">{{ $t('order.message.x402ConnectWallet') }}</p>
       </div>
     </el-dialog>
     <solana-wallet-picker-dialog
@@ -58,7 +84,7 @@
 <script lang="ts">
 import { WalletIcon } from '@acedatacloud/core/icons/components';
 import { defineComponent, nextTick } from 'vue';
-import { ElButton, ElDialog, ElMessage, ElTabPane, ElTabs, ElTag } from 'element-plus';
+import { ElButton, ElDialog, ElMessage, ElRadioButton, ElRadioGroup, ElTabPane, ElTabs, ElTag } from 'element-plus';
 import { IApplicationType, IApplication, IService } from '@/models';
 import { ROUTE_CONSOLE_APPLICATION_EXTRA, ROUTE_CONSOLE_USAGE_LIST } from '@/router';
 import ApplicationInfo from './Info.vue';
@@ -70,9 +96,20 @@ import {
   setScenarioPaymentMode,
   type ScenarioPaymentMode
 } from '@/utils/x402/scenarioPayment';
+import {
+  activeEvmWallet,
+  activeWalletRail,
+  connectBaseWallet,
+  discoverEvmWallets,
+  setActiveEvmWallet,
+  setActiveWalletRail,
+  type EvmWalletInfo
+} from '@/utils/x402/evmWallet';
 export interface IData {
   visible: boolean;
   walletPickerVisible: boolean;
+  evmWalletPickerVisible: boolean;
+  evmWallets: EvmWalletInfo[];
   walletConnecting: boolean;
   applicationType: typeof IApplicationType;
 }
@@ -83,6 +120,8 @@ export default defineComponent({
     WalletIcon,
     ElButton,
     ElDialog,
+    ElRadioButton,
+    ElRadioGroup,
     ElTabPane,
     ElTabs,
     ElTag,
@@ -112,6 +151,8 @@ export default defineComponent({
     return {
       visible: false,
       walletPickerVisible: false,
+      evmWalletPickerVisible: false,
+      evmWallets: [],
       walletConnecting: false,
       applicationType: IApplicationType
     };
@@ -127,8 +168,28 @@ export default defineComponent({
       set(value: ScenarioPaymentMode) {
         if (!this.scenario) return;
         setScenarioPaymentMode(this.scenario, value);
-        if (value === 'wallet' && !this.solanaConnected) this.walletPickerVisible = true;
+        if (value === 'wallet') setActiveWalletRail(this.walletRail);
+        if (value === 'wallet' && this.walletRail === 'base' && !this.evmAddress) void this.openEvmWalletPicker();
+        if (value === 'wallet' && this.walletRail === 'solana' && !this.solanaConnected)
+          this.walletPickerVisible = true;
       }
+    },
+    walletRail: {
+      get(): 'base' | 'solana' {
+        return activeWalletRail();
+      },
+      set(value: 'base' | 'solana') {
+        setActiveWalletRail(value);
+        if (value === 'base' && !this.evmAddress) void this.openEvmWalletPicker();
+        if (value === 'solana' && !this.solanaConnected) this.walletPickerVisible = true;
+      }
+    },
+    evmAddress(): string | undefined {
+      return activeEvmWallet()?.address;
+    },
+    shortEvmAddress(): string {
+      const address = this.evmAddress || '';
+      return address ? `${address.slice(0, 6)}…${address.slice(-4)}` : '';
     },
     solanaConnected(): boolean {
       return Boolean((this as any).$wallet?.connected?.value);
@@ -155,13 +216,18 @@ export default defineComponent({
       return Number(this.application?.remaining_amount ?? 0);
     },
     balanceUnit(): string {
-      if (this.paymentMode === 'wallet') return this.solanaConnected ? '' : this.$t('common.x402Scenario.wallet');
+      if (this.paymentMode === 'wallet') return this.walletConnected ? '' : this.$t('common.x402Scenario.wallet');
       const unit = this.application?.service?.unit || 'credit';
       const key = `service.unit.${unit}` + (this.balanceAmount === 1 ? '' : 's');
       return this.$t(key);
     },
+    walletConnected(): boolean {
+      return this.walletRail === 'base' ? Boolean(this.evmAddress) : this.solanaConnected;
+    },
     balanceText(): string {
-      if (this.paymentMode === 'wallet') return this.solanaConnected ? this.shortSolanaAddress : '';
+      if (this.paymentMode === 'wallet') {
+        return this.walletRail === 'base' ? this.shortEvmAddress : this.solanaConnected ? this.shortSolanaAddress : '';
+      }
       const value = this.balanceAmount;
       if (!Number.isFinite(value)) return '0';
       if (value >= 1000) return Math.round(value).toLocaleString();
@@ -173,6 +239,27 @@ export default defineComponent({
     }
   },
   methods: {
+    async openEvmWalletPicker() {
+      this.evmWallets = await discoverEvmWallets();
+      this.evmWalletPickerVisible = true;
+    },
+    async connectEvmWallet(wallet: EvmWalletInfo) {
+      if (this.walletConnecting) return;
+      this.walletConnecting = true;
+      try {
+        await connectBaseWallet(wallet.provider);
+        setActiveWalletRail('base');
+        this.evmWalletPickerVisible = false;
+      } catch (error) {
+        console.warn('Base wallet connect failed', error);
+        ElMessage.error(String(this.$t('coin.message.connectError')));
+      } finally {
+        this.walletConnecting = false;
+      }
+    },
+    disconnectEvmWallet() {
+      setActiveEvmWallet(undefined);
+    },
     async connectSolanaWallet(wallet: any) {
       const walletApi = (this as any).$wallet;
       const adapterName = wallet?.adapter?.name;
@@ -182,6 +269,7 @@ export default defineComponent({
         walletApi.select(adapterName);
         await nextTick();
         await walletApi.connect();
+        setActiveWalletRail('solana');
         this.walletPickerVisible = false;
       } catch (error) {
         console.warn('wallet connect failed', error);

--- a/src/components/digitalhuman/config/VoiceCloneDialog.vue
+++ b/src/components/digitalhuman/config/VoiceCloneDialog.vue
@@ -91,7 +91,8 @@ import {
   X402PaymentCancelledError,
   type OperatorRequestOptions,
   type X402PaymentQuote,
-  type X402WalletContext
+  type X402WalletContext,
+  resolveX402WalletContext
 } from '@/operators/x402';
 import { IDigitalHumanLang } from '@/models';
 
@@ -297,11 +298,7 @@ export default defineComponent({
       throw new Error('timeout');
     },
     getWalletContext(): X402WalletContext | undefined {
-      const walletApi = (this as any).$wallet;
-      const publicKey = walletApi?.publicKey?.value;
-      const adapter = walletApi?.wallet?.value?.adapter;
-      if (!publicKey || !adapter?.signTransaction) return undefined;
-      return { publicKey, signTransaction: adapter.signTransaction.bind(adapter) };
+      return resolveX402WalletContext((this as any).$wallet);
     },
     async confirmWalletPayment(quote: X402PaymentQuote): Promise<boolean> {
       return ElMessageBox.confirm(

--- a/src/components/producer/config/LyricInput.vue
+++ b/src/components/producer/config/LyricInput.vue
@@ -46,7 +46,8 @@ import {
   X402PaymentCancelledError,
   type OperatorRequestOptions,
   type X402PaymentQuote,
-  type X402WalletContext
+  type X402WalletContext,
+  resolveX402WalletContext
 } from '@/operators/x402';
 
 export const DEFAULT_LYRIC = '';
@@ -140,11 +141,7 @@ export default defineComponent({
       }
     },
     getWalletContext(): X402WalletContext | undefined {
-      const walletApi = (this as any).$wallet;
-      const publicKey = walletApi?.publicKey?.value;
-      const adapter = walletApi?.wallet?.value?.adapter;
-      if (!publicKey || !adapter?.signTransaction) return undefined;
-      return { publicKey, signTransaction: adapter.signTransaction.bind(adapter) };
+      return resolveX402WalletContext((this as any).$wallet);
     },
     async confirmWalletPayment(quote: X402PaymentQuote): Promise<boolean> {
       return ElMessageBox.confirm(

--- a/src/components/producer/task/Preview.vue
+++ b/src/components/producer/task/Preview.vue
@@ -206,7 +206,8 @@ import {
   X402PaymentCancelledError,
   type OperatorRequestOptions,
   type X402PaymentQuote,
-  type X402WalletContext
+  type X402WalletContext,
+  resolveX402WalletContext
 } from '@/operators/x402';
 import ApiCodeDialog from '@/components/common/ApiCodeDialog.vue';
 import ReportDialog from '@/components/common/ReportDialog.vue';
@@ -321,11 +322,7 @@ export default defineComponent({
       };
     },
     getWalletContext(): X402WalletContext | undefined {
-      const walletApi = (this as any).$wallet;
-      const publicKey = walletApi?.publicKey?.value;
-      const adapter = walletApi?.wallet?.value?.adapter;
-      if (!publicKey || !adapter?.signTransaction) return undefined;
-      return { publicKey, signTransaction: adapter.signTransaction.bind(adapter) };
+      return resolveX402WalletContext((this as any).$wallet);
     },
     async confirmWalletPayment(quote: X402PaymentQuote): Promise<boolean> {
       return ElMessageBox.confirm(

--- a/src/components/x402ScenarioContract.test.ts
+++ b/src/components/x402ScenarioContract.test.ts
@@ -11,6 +11,9 @@ describe('x402 image scenario contract', () => {
     expect(status).toContain('scenarioPaymentState(this.scenario)');
     expect(status).toContain('setScenarioPaymentMode(this.scenario, value)');
     expect(status).toContain('solana-wallet-picker-dialog');
+    expect(status).toContain('value="base"');
+    expect(status).toContain('value="solana"');
+    expect(status).toContain('discoverEvmWallets');
     expect(source('components/order/X402Pay.vue')).toContain('solana-wallet-picker-dialog');
     expect(selector).not.toContain('solana-wallet-picker-dialog');
     expect(selector).not.toContain('el-radio');
@@ -50,6 +53,23 @@ describe('x402 image scenario contract', () => {
     expect(operator).not.toContain('signSolanaPayment');
     expect(operator).not.toContain('signAndSendTransaction');
     expect(operator).not.toContain('localStorage');
+  });
+
+  it('uses one shared wallet resolver and prefers Base EIP-3009', () => {
+    const operator = source('operators/x402.ts');
+    expect(operator).toContain('signEVMPayment');
+    expect(operator).toContain("BASE_NETWORK = 'eip155:8453'");
+    expect(operator).toContain('resolveX402WalletContext');
+    const roots = ['pages', 'components'];
+    const legacy = roots.flatMap((root) =>
+      fs
+        .readdirSync(path.resolve(process.cwd(), 'src', root), { recursive: true })
+        .filter((name) => String(name).endsWith('.vue'))
+        .map((name) => path.join(root, String(name)))
+        .filter((name) => source(name).includes('getWalletContext(): X402WalletContext'))
+    );
+    expect(legacy.length).toBeGreaterThan(0);
+    expect(legacy.every((name) => source(name).includes('resolveX402WalletContext'))).toBe(true);
   });
 
   it('attaches platform identity only to the signed retry', () => {

--- a/src/operators/x402.test.ts
+++ b/src/operators/x402.test.ts
@@ -7,7 +7,14 @@ const mocks = vi.hoisted(() => ({
     x402Version: 2,
     accepted: requirement,
     payload: { transaction: 'signed-transaction' }
-  }))
+  })),
+  signEVMPayment: vi.fn(async (requirement: unknown) => ({
+    x402Version: 2,
+    accepted: requirement,
+    payload: { authorization: { from: '0xpayer' }, signature: '0xsigned' }
+  })),
+  activeEvmWallet: vi.fn(),
+  activeWalletRail: vi.fn()
 }));
 
 vi.mock('axios', () => ({
@@ -18,6 +25,11 @@ vi.mock('axios', () => ({
   }
 }));
 vi.mock('@acedatacloud/x402-client/solana', () => ({ buildSolanaPayment: mocks.buildSolanaPayment }));
+vi.mock('@acedatacloud/x402-client', () => ({ signEVMPayment: mocks.signEVMPayment }));
+vi.mock('@/utils/x402/evmWallet', () => ({
+  activeEvmWallet: mocks.activeEvmWallet,
+  activeWalletRail: mocks.activeWalletRail
+}));
 
 import { formatAtomicUsdc, postWithX402, quoteX402, X402PaymentCancelledError } from './x402';
 
@@ -37,8 +49,17 @@ const wallet = {
   signTransaction: vi.fn()
 };
 
-function challengeError(withHeader = false) {
-  const body = { x402Version: 2, accepts: [requirement], error: 'PAYMENT-SIGNATURE header is required' };
+const baseRequirement = {
+  ...requirement,
+  network: 'eip155:8453',
+  maxTimeoutSeconds: 3600,
+  payTo: '0x1111111111111111111111111111111111111111',
+  asset: '0x2222222222222222222222222222222222222222',
+  extra: { name: 'USD Coin', version: '2', chainId: 8453 }
+};
+
+function challengeError(withHeader = false, accepts = [requirement]) {
+  const body = { x402Version: 2, accepts, error: 'PAYMENT-SIGNATURE header is required' };
   return {
     isAxiosError: true,
     response: {
@@ -52,6 +73,8 @@ function challengeError(withHeader = false) {
 describe('postWithX402', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.activeEvmWallet.mockReturnValue(undefined);
+    mocks.activeWalletRail.mockReturnValue('solana');
     mocks.get.mockResolvedValue({ data: { blockhash: 'fresh-blockhash' } });
   });
 
@@ -120,6 +143,29 @@ describe('postWithX402', () => {
     const envelope = JSON.parse(Buffer.from(retryConfig.headers['PAYMENT-SIGNATURE'], 'base64').toString('utf8'));
     expect(envelope).toEqual(expect.objectContaining({ x402Version: 2, accepted: requirement }));
     expect(mocks.post).toHaveBeenCalledTimes(2);
+  });
+
+  it('prefers Base exact when an EVM wallet is connected', async () => {
+    const provider = { request: vi.fn() };
+    mocks.activeWalletRail.mockReturnValue('base');
+    mocks.activeEvmWallet.mockReturnValue({ address: '0xpayer', provider });
+    mocks.post
+      .mockRejectedValueOnce(challengeError(true, [requirement, baseRequirement]))
+      .mockResolvedValueOnce({ data: { task_id: 'base-task' } });
+
+    const response = await postWithX402<{ task_id: string }>(
+      '/openai/images/generations',
+      { model: 'gpt-image-2', async: true },
+      { wallet, confirm: async () => true }
+    );
+
+    expect(response.data.task_id).toBe('base-task');
+    expect(mocks.signEVMPayment).toHaveBeenCalledWith(baseRequirement, provider, '0xpayer');
+    expect(mocks.buildSolanaPayment).not.toHaveBeenCalled();
+    expect(mocks.get).not.toHaveBeenCalled();
+    const retryConfig = mocks.post.mock.calls[1][2];
+    const envelope = JSON.parse(Buffer.from(retryConfig.headers['PAYMENT-SIGNATURE'], 'base64').toString('utf8'));
+    expect(envelope).toEqual(expect.objectContaining({ x402Version: 2, accepted: baseRequirement }));
   });
 
   it('uses the 402 body when browsers cannot expose PAYMENT-REQUIRED', async () => {

--- a/src/operators/x402.ts
+++ b/src/operators/x402.ts
@@ -1,7 +1,9 @@
 import axios, { AxiosResponse } from 'axios';
 import type { PaymentRequirement } from '@acedatacloud/x402-client';
 import { BASE_URL_PLATFORM, BASE_URL_X402 } from '@/constants';
+import { activeEvmWallet, activeWalletRail } from '@/utils/x402/evmWallet';
 
+const BASE_NETWORK = 'eip155:8453';
 const SOLANA_NETWORK = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp';
 const USDC_DECIMALS = 6;
 
@@ -10,6 +12,23 @@ export type PaymentMode = 'credits' | 'x402';
 export interface X402WalletContext {
   publicKey: { toBase58(): string; toString(): string };
   signTransaction(tx: unknown): Promise<unknown>;
+}
+
+export function resolveX402WalletContext(walletApi: any): X402WalletContext | undefined {
+  if (activeWalletRail() === 'base') {
+    const evm = activeEvmWallet();
+    if (!evm) return undefined;
+    return {
+      publicKey: { toBase58: () => evm.address, toString: () => evm.address },
+      signTransaction: async () => {
+        throw new Error('Solana signing is unavailable while Base is selected');
+      }
+    };
+  }
+  const publicKey = walletApi?.publicKey?.value;
+  const adapter = walletApi?.wallet?.value?.adapter;
+  if (!publicKey || !adapter?.signTransaction) return undefined;
+  return { publicKey, signTransaction: adapter.signTransaction.bind(adapter) };
 }
 
 export interface X402PaymentQuote {
@@ -39,8 +58,9 @@ export class X402PaymentCancelledError extends Error {
   }
 }
 
-function selectSolanaExact(accepts: PaymentRequirement[]): PaymentRequirement | undefined {
-  return accepts.find((item) => item.network === SOLANA_NETWORK && item.scheme === 'exact');
+function selectExact(accepts: PaymentRequirement[], rail: 'base' | 'solana' = 'base'): PaymentRequirement | undefined {
+  const network = rail === 'base' ? BASE_NETWORK : SOLANA_NETWORK;
+  return accepts.find((item) => item.network === network && item.scheme === 'exact');
 }
 
 export function formatAtomicUsdc(value: string, decimals = USDC_DECIMALS): string {
@@ -66,9 +86,9 @@ function paymentRequired(error: unknown): { accepts: PaymentRequirement[] } {
 }
 
 function quoteFromChallenge(challenge: { accepts: PaymentRequirement[] }): X402PaymentQuote {
-  const requirement = selectSolanaExact(challenge.accepts || []);
+  const requirement = selectExact(challenge.accepts || [], activeWalletRail());
   const amountAtomic = requirement?.amount || requirement?.maxAmountRequired;
-  if (!requirement || !amountAtomic) throw new Error('No Solana exact payment option is available');
+  if (!requirement || !amountAtomic) throw new Error('No supported exact payment option is available');
   return {
     amountAtomic,
     amountUsdc: formatAtomicUsdc(amountAtomic),
@@ -118,19 +138,34 @@ export async function postWithX402<T>(
       }
     });
   } catch (error) {
-    const quote = quoteFromChallenge(paymentRequired(error));
-    const { requirement } = quote;
+    const challenge = paymentRequired(error);
+    const evmWallet = activeEvmWallet();
+    const rail = activeWalletRail();
+    const requirement = selectExact(challenge.accepts || [], rail);
+    const amountAtomic = requirement?.amount || requirement?.maxAmountRequired;
+    if (!requirement || !amountAtomic) throw new Error('No supported exact payment option is available');
+    const quote: X402PaymentQuote = {
+      amountAtomic,
+      amountUsdc: formatAtomicUsdc(amountAtomic),
+      network: requirement.network,
+      requirement
+    };
 
     const approved = await options.confirm(quote);
     if (!approved) throw new X402PaymentCancelledError();
 
-    const [{ Buffer }, { buildSolanaPayment }] = await Promise.all([
-      import('buffer'),
-      import('@acedatacloud/x402-client/solana')
-    ]);
+    const { Buffer } = await import('buffer');
     if (!(globalThis as any).Buffer) (globalThis as any).Buffer = Buffer;
-    const blockhash = await fetchSolanaBlockhash(requirement.network);
-    const envelope = await buildSolanaPayment(requirement, options.wallet, blockhash);
+    let envelope: unknown;
+    if (rail === 'base') {
+      if (!evmWallet) throw new Error('Connect a Base wallet before signing');
+      const { signEVMPayment } = await import('@acedatacloud/x402-client');
+      envelope = await signEVMPayment(requirement, evmWallet.provider, evmWallet.address);
+    } else {
+      const { buildSolanaPayment } = await import('@acedatacloud/x402-client/solana');
+      const blockhash = await fetchSolanaBlockhash(requirement.network);
+      envelope = await buildSolanaPayment(requirement, options.wallet, blockhash);
+    }
     const paymentSignature = Buffer.from(JSON.stringify(envelope), 'utf8').toString('base64');
     return axios.post<T>(path, data, {
       baseURL: BASE_URL_X402,

--- a/src/pages/digitalhuman/Index.vue
+++ b/src/pages/digitalhuman/Index.vue
@@ -22,7 +22,12 @@ import { ElMessage, ElMessageBox } from 'element-plus';
 import { ERROR_CODE_USED_UP } from '@/constants';
 import { loadPreviousPage } from '@/utils/pagination';
 import { isScenarioX402Enabled, scenarioPaymentState } from '@/utils/x402/scenarioPayment';
-import { X402PaymentCancelledError, type X402PaymentQuote, type X402WalletContext } from '@/operators/x402';
+import {
+  X402PaymentCancelledError,
+  type X402PaymentQuote,
+  type X402WalletContext,
+  resolveX402WalletContext
+} from '@/operators/x402';
 
 interface IData {
   job: number;
@@ -192,11 +197,7 @@ export default defineComponent({
         });
     },
     getWalletContext(): X402WalletContext | undefined {
-      const walletApi = (this as any).$wallet;
-      const publicKey = walletApi?.publicKey?.value;
-      const adapter = walletApi?.wallet?.value?.adapter;
-      if (!publicKey || !adapter?.signTransaction) return undefined;
-      return { publicKey, signTransaction: adapter.signTransaction.bind(adapter) };
+      return resolveX402WalletContext((this as any).$wallet);
     },
     async confirmWalletPayment(quote: X402PaymentQuote): Promise<boolean> {
       return ElMessageBox.confirm(

--- a/src/pages/flux/Index.vue
+++ b/src/pages/flux/Index.vue
@@ -23,7 +23,12 @@ import { IFluxTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
 import { uploadTrackerProviderMixin, ensureNoPendingUpload, ensureLoggedIn } from '@/utils';
 import { isScenarioX402Enabled, scenarioPaymentState } from '@/utils/x402/scenarioPayment';
-import { X402PaymentCancelledError, type X402PaymentQuote, type X402WalletContext } from '@/operators/x402';
+import {
+  X402PaymentCancelledError,
+  type X402PaymentQuote,
+  type X402WalletContext,
+  resolveX402WalletContext
+} from '@/operators/x402';
 
 interface IData {
   task: IFluxTask | undefined;
@@ -226,11 +231,7 @@ export default defineComponent({
         });
     },
     getWalletContext(): X402WalletContext | undefined {
-      const walletApi = (this as any).$wallet;
-      const publicKey = walletApi?.publicKey?.value;
-      const adapter = walletApi?.wallet?.value?.adapter;
-      if (!publicKey || !adapter?.signTransaction) return undefined;
-      return { publicKey, signTransaction: adapter.signTransaction.bind(adapter) };
+      return resolveX402WalletContext((this as any).$wallet);
     },
     async confirmWalletPayment(quote: X402PaymentQuote): Promise<boolean> {
       return ElMessageBox.confirm(

--- a/src/pages/grokvideo/Index.vue
+++ b/src/pages/grokvideo/Index.vue
@@ -22,7 +22,12 @@ import { ERROR_CODE_USED_UP, isGrokVideoImageOnlyModel } from '@/constants';
 import { loadPreviousPage } from '@/utils/pagination';
 import { uploadTrackerProviderMixin, ensureNoPendingUpload, ensureLoggedIn } from '@/utils';
 import { isScenarioX402Enabled, scenarioPaymentState } from '@/utils/x402/scenarioPayment';
-import { X402PaymentCancelledError, type X402PaymentQuote, type X402WalletContext } from '@/operators/x402';
+import {
+  X402PaymentCancelledError,
+  type X402PaymentQuote,
+  type X402WalletContext,
+  resolveX402WalletContext
+} from '@/operators/x402';
 
 interface IData {
   task: IGrokVideoTask | undefined;
@@ -216,11 +221,7 @@ export default defineComponent({
         });
     },
     getWalletContext(): X402WalletContext | undefined {
-      const walletApi = (this as any).$wallet;
-      const publicKey = walletApi?.publicKey?.value;
-      const adapter = walletApi?.wallet?.value?.adapter;
-      if (!publicKey || !adapter?.signTransaction) return undefined;
-      return { publicKey, signTransaction: adapter.signTransaction.bind(adapter) };
+      return resolveX402WalletContext((this as any).$wallet);
     },
     async confirmWalletPayment(quote: X402PaymentQuote): Promise<boolean> {
       return ElMessageBox.confirm(

--- a/src/pages/hailuo/Index.vue
+++ b/src/pages/hailuo/Index.vue
@@ -23,7 +23,12 @@ import { IHailuoTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
 import { uploadTrackerProviderMixin, ensureNoPendingUpload, ensureLoggedIn } from '@/utils';
 import { isScenarioX402Enabled, scenarioPaymentState } from '@/utils/x402/scenarioPayment';
-import { X402PaymentCancelledError, type X402PaymentQuote, type X402WalletContext } from '@/operators/x402';
+import {
+  X402PaymentCancelledError,
+  type X402PaymentQuote,
+  type X402WalletContext,
+  resolveX402WalletContext
+} from '@/operators/x402';
 
 interface IData {
   task: IHailuoTask | undefined;
@@ -233,11 +238,7 @@ export default defineComponent({
         });
     },
     getWalletContext(): X402WalletContext | undefined {
-      const walletApi = (this as any).$wallet;
-      const publicKey = walletApi?.publicKey?.value;
-      const adapter = walletApi?.wallet?.value?.adapter;
-      if (!publicKey || !adapter?.signTransaction) return undefined;
-      return { publicKey, signTransaction: adapter.signTransaction.bind(adapter) };
+      return resolveX402WalletContext((this as any).$wallet);
     },
     async confirmWalletPayment(quote: X402PaymentQuote): Promise<boolean> {
       return ElMessageBox.confirm(

--- a/src/pages/kling/Index.vue
+++ b/src/pages/kling/Index.vue
@@ -37,7 +37,8 @@ import {
   X402PaymentCancelledError,
   type OperatorRequestOptions,
   type X402PaymentQuote,
-  type X402WalletContext
+  type X402WalletContext,
+  resolveX402WalletContext
 } from '@/operators/x402';
 
 interface IData {
@@ -279,11 +280,7 @@ export default defineComponent({
       }
     },
     getWalletContext(): X402WalletContext | undefined {
-      const walletApi = (this as any).$wallet;
-      const publicKey = walletApi?.publicKey?.value;
-      const adapter = walletApi?.wallet?.value?.adapter;
-      if (!publicKey || !adapter?.signTransaction) return undefined;
-      return { publicKey, signTransaction: adapter.signTransaction.bind(adapter) };
+      return resolveX402WalletContext((this as any).$wallet);
     },
     async confirmWalletPayment(quote: X402PaymentQuote): Promise<boolean> {
       return ElMessageBox.confirm(

--- a/src/pages/luma/Index.vue
+++ b/src/pages/luma/Index.vue
@@ -23,7 +23,12 @@ import { ILumaTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
 import { uploadTrackerProviderMixin, ensureNoPendingUpload, ensureLoggedIn } from '@/utils';
 import { isScenarioX402Enabled, scenarioPaymentState } from '@/utils/x402/scenarioPayment';
-import { X402PaymentCancelledError, type X402PaymentQuote, type X402WalletContext } from '@/operators/x402';
+import {
+  X402PaymentCancelledError,
+  type X402PaymentQuote,
+  type X402WalletContext,
+  resolveX402WalletContext
+} from '@/operators/x402';
 
 interface IData {
   task: ILumaTask | undefined;
@@ -238,11 +243,7 @@ export default defineComponent({
         });
     },
     getWalletContext(): X402WalletContext | undefined {
-      const walletApi = (this as any).$wallet;
-      const publicKey = walletApi?.publicKey?.value;
-      const adapter = walletApi?.wallet?.value?.adapter;
-      if (!publicKey || !adapter?.signTransaction) return undefined;
-      return { publicKey, signTransaction: adapter.signTransaction.bind(adapter) };
+      return resolveX402WalletContext((this as any).$wallet);
     },
     async confirmWalletPayment(quote: X402PaymentQuote): Promise<boolean> {
       return ElMessageBox.confirm(

--- a/src/pages/maestro/Index.vue
+++ b/src/pages/maestro/Index.vue
@@ -22,7 +22,12 @@ import { ElMessage, ElMessageBox } from 'element-plus';
 import { ERROR_CODE_USED_UP } from '@/constants';
 import { loadPreviousPage } from '@/utils/pagination';
 import { isScenarioX402Enabled, scenarioPaymentState } from '@/utils/x402/scenarioPayment';
-import { X402PaymentCancelledError, type X402PaymentQuote, type X402WalletContext } from '@/operators/x402';
+import {
+  X402PaymentCancelledError,
+  type X402PaymentQuote,
+  type X402WalletContext,
+  resolveX402WalletContext
+} from '@/operators/x402';
 
 interface IData {
   job: number;
@@ -190,11 +195,7 @@ export default defineComponent({
         });
     },
     getWalletContext(): X402WalletContext | undefined {
-      const walletApi = (this as any).$wallet;
-      const publicKey = walletApi?.publicKey?.value;
-      const adapter = walletApi?.wallet?.value?.adapter;
-      if (!publicKey || !adapter?.signTransaction) return undefined;
-      return { publicKey, signTransaction: adapter.signTransaction.bind(adapter) };
+      return resolveX402WalletContext((this as any).$wallet);
     },
     async confirmWalletPayment(quote: X402PaymentQuote): Promise<boolean> {
       return ElMessageBox.confirm(

--- a/src/pages/midjourney/Index.vue
+++ b/src/pages/midjourney/Index.vue
@@ -39,7 +39,8 @@ import {
   X402PaymentCancelledError,
   type OperatorRequestOptions,
   type X402PaymentQuote,
-  type X402WalletContext
+  type X402WalletContext,
+  resolveX402WalletContext
 } from '@/operators/x402';
 
 interface IData {
@@ -278,11 +279,7 @@ export default defineComponent({
       }
     },
     getWalletContext(): X402WalletContext | undefined {
-      const walletApi = (this as any).$wallet;
-      const publicKey = walletApi?.publicKey?.value;
-      const adapter = walletApi?.wallet?.value?.adapter;
-      if (!publicKey || !adapter?.signTransaction) return undefined;
-      return { publicKey, signTransaction: adapter.signTransaction.bind(adapter) };
+      return resolveX402WalletContext((this as any).$wallet);
     },
     async confirmWalletPayment(quote: X402PaymentQuote): Promise<boolean> {
       return ElMessageBox.confirm(

--- a/src/pages/minimax/Index.vue
+++ b/src/pages/minimax/Index.vue
@@ -23,7 +23,12 @@ import { IMinimaxTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
 import { uploadTrackerProviderMixin, ensureNoPendingUpload, ensureLoggedIn } from '@/utils';
 import { isScenarioX402Enabled, scenarioPaymentState } from '@/utils/x402/scenarioPayment';
-import { X402PaymentCancelledError, type X402PaymentQuote, type X402WalletContext } from '@/operators/x402';
+import {
+  X402PaymentCancelledError,
+  type X402PaymentQuote,
+  type X402WalletContext,
+  resolveX402WalletContext
+} from '@/operators/x402';
 
 interface IData {
   task: IMinimaxTask | undefined;
@@ -233,11 +238,7 @@ export default defineComponent({
         });
     },
     getWalletContext(): X402WalletContext | undefined {
-      const walletApi = (this as any).$wallet;
-      const publicKey = walletApi?.publicKey?.value;
-      const adapter = walletApi?.wallet?.value?.adapter;
-      if (!publicKey || !adapter?.signTransaction) return undefined;
-      return { publicKey, signTransaction: adapter.signTransaction.bind(adapter) };
+      return resolveX402WalletContext((this as any).$wallet);
     },
     async confirmWalletPayment(quote: X402PaymentQuote): Promise<boolean> {
       return ElMessageBox.confirm(

--- a/src/pages/nanobanana/Index.vue
+++ b/src/pages/nanobanana/Index.vue
@@ -23,7 +23,12 @@ import { INanobananaTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
 import { uploadTrackerProviderMixin, ensureNoPendingUpload, ensureLoggedIn } from '@/utils';
 import { isScenarioX402Enabled, scenarioPaymentState } from '@/utils/x402/scenarioPayment';
-import { X402PaymentCancelledError, type X402PaymentQuote, type X402WalletContext } from '@/operators/x402';
+import {
+  X402PaymentCancelledError,
+  type X402PaymentQuote,
+  type X402WalletContext,
+  resolveX402WalletContext
+} from '@/operators/x402';
 import { buildNanobananaRequest } from '@/utils/x402/imageRequests';
 
 interface IData {
@@ -217,14 +222,7 @@ export default defineComponent({
         });
     },
     getWalletContext(): X402WalletContext | undefined {
-      const walletApi = (this as any).$wallet;
-      const publicKey = walletApi?.publicKey?.value;
-      const adapter = walletApi?.wallet?.value?.adapter;
-      if (!publicKey || !adapter?.signTransaction) return undefined;
-      return {
-        publicKey,
-        signTransaction: adapter.signTransaction.bind(adapter)
-      };
+      return resolveX402WalletContext((this as any).$wallet);
     },
     async confirmWalletPayment(quote: X402PaymentQuote): Promise<boolean> {
       return ElMessageBox.confirm(

--- a/src/pages/omni/Index.vue
+++ b/src/pages/omni/Index.vue
@@ -22,7 +22,12 @@ import { ERROR_CODE_USED_UP } from '@/constants';
 import { loadPreviousPage } from '@/utils/pagination';
 import { uploadTrackerProviderMixin, ensureNoPendingUpload, ensureLoggedIn } from '@/utils';
 import { isScenarioX402Enabled, scenarioPaymentState } from '@/utils/x402/scenarioPayment';
-import { X402PaymentCancelledError, type X402PaymentQuote, type X402WalletContext } from '@/operators/x402';
+import {
+  X402PaymentCancelledError,
+  type X402PaymentQuote,
+  type X402WalletContext,
+  resolveX402WalletContext
+} from '@/operators/x402';
 
 interface IData {
   task: IOmniTask | undefined;
@@ -215,11 +220,7 @@ export default defineComponent({
         });
     },
     getWalletContext(): X402WalletContext | undefined {
-      const walletApi = (this as any).$wallet;
-      const publicKey = walletApi?.publicKey?.value;
-      const adapter = walletApi?.wallet?.value?.adapter;
-      if (!publicKey || !adapter?.signTransaction) return undefined;
-      return { publicKey, signTransaction: adapter.signTransaction.bind(adapter) };
+      return resolveX402WalletContext((this as any).$wallet);
     },
     async confirmWalletPayment(quote: X402PaymentQuote): Promise<boolean> {
       return ElMessageBox.confirm(

--- a/src/pages/openaiimage/Index.vue
+++ b/src/pages/openaiimage/Index.vue
@@ -23,7 +23,12 @@ import { loadPreviousPage } from '@/utils/pagination';
 import { uploadTrackerProviderMixin, ensureNoPendingUpload, ensureLoggedIn } from '@/utils';
 import { IOpenAIImageTask } from '@/models';
 import { isScenarioX402Enabled, scenarioPaymentState } from '@/utils/x402/scenarioPayment';
-import { X402PaymentCancelledError, type X402PaymentQuote, type X402WalletContext } from '@/operators/x402';
+import {
+  X402PaymentCancelledError,
+  type X402PaymentQuote,
+  type X402WalletContext,
+  resolveX402WalletContext
+} from '@/operators/x402';
 import { buildOpenAIImageGenerateRequest } from '@/utils/x402/imageRequests';
 
 interface IData {
@@ -250,14 +255,7 @@ export default defineComponent({
         });
     },
     getWalletContext(): X402WalletContext | undefined {
-      const walletApi = (this as any).$wallet;
-      const publicKey = walletApi?.publicKey?.value;
-      const adapter = walletApi?.wallet?.value?.adapter;
-      if (!publicKey || !adapter?.signTransaction) return undefined;
-      return {
-        publicKey,
-        signTransaction: adapter.signTransaction.bind(adapter)
-      };
+      return resolveX402WalletContext((this as any).$wallet);
     },
     async confirmWalletPayment(quote: X402PaymentQuote): Promise<boolean> {
       return ElMessageBox.confirm(

--- a/src/pages/pika/Index.vue
+++ b/src/pages/pika/Index.vue
@@ -24,7 +24,12 @@ import { IPikaTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
 import { uploadTrackerProviderMixin, ensureNoPendingUpload, ensureLoggedIn } from '@/utils';
 import { isScenarioX402Enabled, scenarioPaymentState } from '@/utils/x402/scenarioPayment';
-import { X402PaymentCancelledError, type X402PaymentQuote, type X402WalletContext } from '@/operators/x402';
+import {
+  X402PaymentCancelledError,
+  type X402PaymentQuote,
+  type X402WalletContext,
+  resolveX402WalletContext
+} from '@/operators/x402';
 
 interface IData {
   task: IPikaTask | undefined;
@@ -263,11 +268,7 @@ export default defineComponent({
         });
     },
     getWalletContext(): X402WalletContext | undefined {
-      const walletApi = (this as any).$wallet;
-      const publicKey = walletApi?.publicKey?.value;
-      const adapter = walletApi?.wallet?.value?.adapter;
-      if (!publicKey || !adapter?.signTransaction) return undefined;
-      return { publicKey, signTransaction: adapter.signTransaction.bind(adapter) };
+      return resolveX402WalletContext((this as any).$wallet);
     },
     async confirmWalletPayment(quote: X402PaymentQuote): Promise<boolean> {
       return ElMessageBox.confirm(

--- a/src/pages/pixverse/Index.vue
+++ b/src/pages/pixverse/Index.vue
@@ -23,7 +23,12 @@ import { IPixverseTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
 import { uploadTrackerProviderMixin, ensureNoPendingUpload, ensureLoggedIn } from '@/utils';
 import { isScenarioX402Enabled, scenarioPaymentState } from '@/utils/x402/scenarioPayment';
-import { X402PaymentCancelledError, type X402PaymentQuote, type X402WalletContext } from '@/operators/x402';
+import {
+  X402PaymentCancelledError,
+  type X402PaymentQuote,
+  type X402WalletContext,
+  resolveX402WalletContext
+} from '@/operators/x402';
 
 interface IData {
   task: IPixverseTask | undefined;
@@ -228,11 +233,7 @@ export default defineComponent({
         });
     },
     getWalletContext(): X402WalletContext | undefined {
-      const walletApi = (this as any).$wallet;
-      const publicKey = walletApi?.publicKey?.value;
-      const adapter = walletApi?.wallet?.value?.adapter;
-      if (!publicKey || !adapter?.signTransaction) return undefined;
-      return { publicKey, signTransaction: adapter.signTransaction.bind(adapter) };
+      return resolveX402WalletContext((this as any).$wallet);
     },
     async confirmWalletPayment(quote: X402PaymentQuote): Promise<boolean> {
       return ElMessageBox.confirm(

--- a/src/pages/producer/Index.vue
+++ b/src/pages/producer/Index.vue
@@ -38,7 +38,8 @@ import {
   X402PaymentCancelledError,
   type OperatorRequestOptions,
   type X402PaymentQuote,
-  type X402WalletContext
+  type X402WalletContext,
+  resolveX402WalletContext
 } from '@/operators/x402';
 
 interface IData {
@@ -272,11 +273,7 @@ export default defineComponent({
       else ElMessage.error(error?.response?.data?.error?.message || this.$t('producer.message.startTaskFailed'));
     },
     getWalletContext(): X402WalletContext | undefined {
-      const walletApi = (this as any).$wallet;
-      const publicKey = walletApi?.publicKey?.value;
-      const adapter = walletApi?.wallet?.value?.adapter;
-      if (!publicKey || !adapter?.signTransaction) return undefined;
-      return { publicKey, signTransaction: adapter.signTransaction.bind(adapter) };
+      return resolveX402WalletContext((this as any).$wallet);
     },
     async confirmWalletPayment(quote: X402PaymentQuote): Promise<boolean> {
       return ElMessageBox.confirm(

--- a/src/pages/qrart/Index.vue
+++ b/src/pages/qrart/Index.vue
@@ -35,7 +35,12 @@ import { IQrartTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
 import { uploadTrackerProviderMixin, ensureNoPendingUpload, ensureLoggedIn } from '@/utils';
 import { isScenarioX402Enabled, scenarioPaymentState } from '@/utils/x402/scenarioPayment';
-import { X402PaymentCancelledError, type X402PaymentQuote, type X402WalletContext } from '@/operators/x402';
+import {
+  X402PaymentCancelledError,
+  type X402PaymentQuote,
+  type X402WalletContext,
+  resolveX402WalletContext
+} from '@/operators/x402';
 
 interface IData {
   task: IQrartTask | undefined;
@@ -267,11 +272,7 @@ export default defineComponent({
         });
     },
     getWalletContext(): X402WalletContext | undefined {
-      const walletApi = (this as any).$wallet;
-      const publicKey = walletApi?.publicKey?.value;
-      const adapter = walletApi?.wallet?.value?.adapter;
-      if (!publicKey || !adapter?.signTransaction) return undefined;
-      return { publicKey, signTransaction: adapter.signTransaction.bind(adapter) };
+      return resolveX402WalletContext((this as any).$wallet);
     },
     async confirmWalletPayment(quote: X402PaymentQuote): Promise<boolean> {
       return ElMessageBox.confirm(

--- a/src/pages/seedance/Index.vue
+++ b/src/pages/seedance/Index.vue
@@ -24,7 +24,12 @@ import { loadPreviousPage } from '@/utils/pagination';
 import { normalizeSeedanceRequest } from '@/utils/seedance';
 import { uploadTrackerProviderMixin, ensureNoPendingUpload, ensureLoggedIn } from '@/utils';
 import { isScenarioX402Enabled, scenarioPaymentState } from '@/utils/x402/scenarioPayment';
-import { X402PaymentCancelledError, type X402PaymentQuote, type X402WalletContext } from '@/operators/x402';
+import {
+  X402PaymentCancelledError,
+  type X402PaymentQuote,
+  type X402WalletContext,
+  resolveX402WalletContext
+} from '@/operators/x402';
 
 interface IData {
   task: ISeedanceTask | undefined;
@@ -214,11 +219,7 @@ export default defineComponent({
         });
     },
     getWalletContext(): X402WalletContext | undefined {
-      const walletApi = (this as any).$wallet;
-      const publicKey = walletApi?.publicKey?.value;
-      const adapter = walletApi?.wallet?.value?.adapter;
-      if (!publicKey || !adapter?.signTransaction) return undefined;
-      return { publicKey, signTransaction: adapter.signTransaction.bind(adapter) };
+      return resolveX402WalletContext((this as any).$wallet);
     },
     async confirmWalletPayment(quote: X402PaymentQuote): Promise<boolean> {
       return ElMessageBox.confirm(

--- a/src/pages/serp/Index.vue
+++ b/src/pages/serp/Index.vue
@@ -18,7 +18,12 @@ import { ElMessage, ElMessageBox } from 'element-plus';
 import { ERROR_CODE_USED_UP } from '@/constants';
 import { ensureLoggedIn } from '@/utils';
 import { isScenarioX402Enabled, scenarioPaymentState } from '@/utils/x402/scenarioPayment';
-import { X402PaymentCancelledError, type X402PaymentQuote, type X402WalletContext } from '@/operators/x402';
+import {
+  X402PaymentCancelledError,
+  type X402PaymentQuote,
+  type X402WalletContext,
+  resolveX402WalletContext
+} from '@/operators/x402';
 
 export default defineComponent({
   name: 'SerpIndex',
@@ -80,11 +85,7 @@ export default defineComponent({
       }
     },
     getWalletContext(): X402WalletContext | undefined {
-      const walletApi = (this as any).$wallet;
-      const publicKey = walletApi?.publicKey?.value;
-      const adapter = walletApi?.wallet?.value?.adapter;
-      if (!publicKey || !adapter?.signTransaction) return undefined;
-      return { publicKey, signTransaction: adapter.signTransaction.bind(adapter) };
+      return resolveX402WalletContext((this as any).$wallet);
     },
     async confirmWalletPayment(quote: X402PaymentQuote): Promise<boolean> {
       return ElMessageBox.confirm(

--- a/src/pages/sora/Index.vue
+++ b/src/pages/sora/Index.vue
@@ -23,7 +23,12 @@ import { ISoraTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
 import { uploadTrackerProviderMixin, ensureNoPendingUpload, ensureLoggedIn } from '@/utils';
 import { isScenarioX402Enabled, scenarioPaymentState } from '@/utils/x402/scenarioPayment';
-import { X402PaymentCancelledError, type X402PaymentQuote, type X402WalletContext } from '@/operators/x402';
+import {
+  X402PaymentCancelledError,
+  type X402PaymentQuote,
+  type X402WalletContext,
+  resolveX402WalletContext
+} from '@/operators/x402';
 
 interface IData {
   task: ISoraTask | undefined;
@@ -228,11 +233,7 @@ export default defineComponent({
         });
     },
     getWalletContext(): X402WalletContext | undefined {
-      const walletApi = (this as any).$wallet;
-      const publicKey = walletApi?.publicKey?.value;
-      const adapter = walletApi?.wallet?.value?.adapter;
-      if (!publicKey || !adapter?.signTransaction) return undefined;
-      return { publicKey, signTransaction: adapter.signTransaction.bind(adapter) };
+      return resolveX402WalletContext((this as any).$wallet);
     },
     async confirmWalletPayment(quote: X402PaymentQuote): Promise<boolean> {
       return ElMessageBox.confirm(

--- a/src/pages/suno/Index.vue
+++ b/src/pages/suno/Index.vue
@@ -39,7 +39,8 @@ import {
   X402PaymentCancelledError,
   type OperatorRequestOptions,
   type X402PaymentQuote,
-  type X402WalletContext
+  type X402WalletContext,
+  resolveX402WalletContext
 } from '@/operators/x402';
 
 interface IData {
@@ -306,11 +307,7 @@ export default defineComponent({
         this.walletTaskIds.unshift(taskId);
     },
     getWalletContext(): X402WalletContext | undefined {
-      const walletApi = (this as any).$wallet;
-      const publicKey = walletApi?.publicKey?.value;
-      const adapter = walletApi?.wallet?.value?.adapter;
-      if (!publicKey || !adapter?.signTransaction) return undefined;
-      return { publicKey, signTransaction: adapter.signTransaction.bind(adapter) };
+      return resolveX402WalletContext((this as any).$wallet);
     },
     async confirmWalletPayment(quote: X402PaymentQuote): Promise<boolean> {
       return ElMessageBox.confirm(

--- a/src/pages/veo/Index.vue
+++ b/src/pages/veo/Index.vue
@@ -23,7 +23,12 @@ import { IVeoTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
 import { uploadTrackerProviderMixin, ensureNoPendingUpload, ensureLoggedIn } from '@/utils';
 import { isScenarioX402Enabled, scenarioPaymentState } from '@/utils/x402/scenarioPayment';
-import { X402PaymentCancelledError, type X402PaymentQuote, type X402WalletContext } from '@/operators/x402';
+import {
+  X402PaymentCancelledError,
+  type X402PaymentQuote,
+  type X402WalletContext,
+  resolveX402WalletContext
+} from '@/operators/x402';
 
 interface IData {
   task: IVeoTask | undefined;
@@ -238,11 +243,7 @@ export default defineComponent({
         });
     },
     getWalletContext(): X402WalletContext | undefined {
-      const walletApi = (this as any).$wallet;
-      const publicKey = walletApi?.publicKey?.value;
-      const adapter = walletApi?.wallet?.value?.adapter;
-      if (!publicKey || !adapter?.signTransaction) return undefined;
-      return { publicKey, signTransaction: adapter.signTransaction.bind(adapter) };
+      return resolveX402WalletContext((this as any).$wallet);
     },
     async confirmWalletPayment(quote: X402PaymentQuote): Promise<boolean> {
       return ElMessageBox.confirm(

--- a/src/pages/wan/Index.vue
+++ b/src/pages/wan/Index.vue
@@ -23,7 +23,12 @@ import { IWanTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
 import { uploadTrackerProviderMixin, ensureNoPendingUpload, ensureLoggedIn } from '@/utils';
 import { isScenarioX402Enabled, scenarioPaymentState } from '@/utils/x402/scenarioPayment';
-import { X402PaymentCancelledError, type X402PaymentQuote, type X402WalletContext } from '@/operators/x402';
+import {
+  X402PaymentCancelledError,
+  type X402PaymentQuote,
+  type X402WalletContext,
+  resolveX402WalletContext
+} from '@/operators/x402';
 
 interface IData {
   task: IWanTask | undefined;
@@ -232,11 +237,7 @@ export default defineComponent({
         });
     },
     getWalletContext(): X402WalletContext | undefined {
-      const walletApi = (this as any).$wallet;
-      const publicKey = walletApi?.publicKey?.value;
-      const adapter = walletApi?.wallet?.value?.adapter;
-      if (!publicKey || !adapter?.signTransaction) return undefined;
-      return { publicKey, signTransaction: adapter.signTransaction.bind(adapter) };
+      return resolveX402WalletContext((this as any).$wallet);
     },
     async confirmWalletPayment(quote: X402PaymentQuote): Promise<boolean> {
       return ElMessageBox.confirm(

--- a/src/utils/x402/evmWallet.test.ts
+++ b/src/utils/x402/evmWallet.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { activeEvmWallet, connectBaseWallet, setActiveEvmWallet } from './evmWallet';
+
+describe('Base EVM wallet', () => {
+  beforeEach(() => setActiveEvmWallet(undefined));
+
+  it('switches to Base and stores the connected account', async () => {
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce(['0x1234567890abcdef'])
+      .mockResolvedValueOnce('0x1')
+      .mockResolvedValueOnce(null);
+
+    const connection = await connectBaseWallet({ request });
+
+    expect(connection.address).toBe('0x1234567890abcdef');
+    expect(activeEvmWallet()?.address).toBe('0x1234567890abcdef');
+    expect(request).toHaveBeenNthCalledWith(3, {
+      method: 'wallet_switchEthereumChain',
+      params: [{ chainId: '0x2105' }]
+    });
+  });
+
+  it('tracks account changes and clears a wallet that leaves Base', async () => {
+    const listeners: Record<string, (...args: any[]) => void> = {};
+    const provider = {
+      request: vi.fn().mockResolvedValueOnce(['0xpayer']).mockResolvedValueOnce('0x2105'),
+      on: vi.fn((event: string, listener: (...args: any[]) => void) => {
+        listeners[event] = listener;
+      })
+    };
+    await connectBaseWallet(provider);
+
+    listeners.accountsChanged(['0xnext']);
+    expect(activeEvmWallet()?.address).toBe('0xnext');
+    listeners.chainChanged('0x1');
+    expect(activeEvmWallet()).toBeUndefined();
+  });
+
+  it('does not switch when the wallet is already on Base', async () => {
+    const request = vi.fn().mockResolvedValueOnce(['0xpayer']).mockResolvedValueOnce('0x2105');
+
+    await connectBaseWallet({ request });
+
+    expect(request).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/utils/x402/evmWallet.ts
+++ b/src/utils/x402/evmWallet.ts
@@ -1,0 +1,97 @@
+import { shallowRef } from 'vue';
+
+export interface Eip1193Provider {
+  request(args: { method: string; params?: unknown[] }): Promise<unknown>;
+  on?(event: string, listener: (...args: any[]) => void): void;
+}
+
+export interface EvmWalletConnection {
+  address: string;
+  provider: Eip1193Provider;
+}
+
+export interface EvmWalletInfo {
+  id: string;
+  name: string;
+  icon?: string;
+  provider: Eip1193Provider;
+}
+
+const connection = shallowRef<EvmWalletConnection>();
+const watchedProviders = new WeakSet<object>();
+const rail = shallowRef<'base' | 'solana'>('base');
+
+export function activeWalletRail(): 'base' | 'solana' {
+  return rail.value;
+}
+
+export function setActiveWalletRail(value: 'base' | 'solana'): void {
+  rail.value = value;
+}
+
+export function activeEvmWallet(): EvmWalletConnection | undefined {
+  return connection.value;
+}
+
+export function setActiveEvmWallet(value: EvmWalletConnection | undefined): void {
+  connection.value = value;
+}
+
+export async function discoverEvmWallets(): Promise<EvmWalletInfo[]> {
+  const found = new Map<string, EvmWalletInfo>();
+  if (typeof window !== 'undefined') {
+    const handler = (event: Event) => {
+      const detail = (event as CustomEvent).detail || {};
+      const provider = detail.provider as Eip1193Provider | undefined;
+      if (!provider) return;
+      const id = String(detail.info?.uuid || detail.info?.rdns || detail.info?.name || found.size);
+      found.set(id, { id, name: String(detail.info?.name || 'Wallet'), icon: detail.info?.icon, provider });
+    };
+    window.addEventListener('eip6963:announceProvider', handler);
+    window.dispatchEvent(new Event('eip6963:requestProvider'));
+    await new Promise((resolve) => window.setTimeout(resolve, 120));
+    window.removeEventListener('eip6963:announceProvider', handler);
+  }
+  const injected = (globalThis as any).ethereum as Eip1193Provider | undefined;
+  if (injected && found.size === 0)
+    found.set('injected', { id: 'injected', name: 'Injected Wallet', provider: injected });
+  return Array.from(found.values());
+}
+
+export async function connectBaseWallet(provider: Eip1193Provider): Promise<EvmWalletConnection> {
+  const accounts = (await provider.request({ method: 'eth_requestAccounts' })) as string[];
+  const address = accounts?.[0];
+  if (!address) throw new Error('No EVM wallet account is available');
+  const baseChainId = '0x2105';
+  const chainId = String(await provider.request({ method: 'eth_chainId' })).toLowerCase();
+  if (chainId !== baseChainId) {
+    try {
+      await provider.request({ method: 'wallet_switchEthereumChain', params: [{ chainId: baseChainId }] });
+    } catch {
+      await provider.request({
+        method: 'wallet_addEthereumChain',
+        params: [
+          {
+            chainId: baseChainId,
+            chainName: 'Base',
+            nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
+            rpcUrls: ['https://mainnet.base.org'],
+            blockExplorerUrls: ['https://basescan.org']
+          }
+        ]
+      });
+    }
+  }
+  connection.value = { address, provider };
+  if (provider.on && !watchedProviders.has(provider as object)) {
+    watchedProviders.add(provider as object);
+    provider.on('accountsChanged', (...args: any[]) => {
+      const accounts = args[0] as string[] | undefined;
+      connection.value = accounts?.[0] ? { address: accounts[0], provider } : undefined;
+    });
+    provider.on('chainChanged', (...args: any[]) => {
+      if (String(args[0]).toLowerCase() !== baseChainId) connection.value = undefined;
+    });
+  }
+  return connection.value;
+}


### PR DESCRIPTION
## Summary
- add Base as the default wallet rail for every x402-enabled generation scenario
- discover injected EVM wallets through EIP-6963 with an injected-provider fallback
- switch/add Base mainnet and track account/chain changes
- sign the server quote with the shipped `@acedatacloud/x402-client` EIP-3009 V2 signer
- send canonical `PAYMENT-SIGNATURE` envelopes and keep platform identity on quote + retry
- retain Solana as an explicitly selectable fallback; it is not removed in this PR
- replace 25 duplicated Solana-only wallet context implementations with one shared resolver

## Billing semantics
Base exact signs an EIP-3009 authorization valid for the server-provided 3600 seconds. Gateway continues settling only after a successful API response, so provider 4xx/403/5xx remains uncharged. The facilitator pays gas; the wallet needs Base USDC but does not need ETH for this signature.

## Existing backend support verified
- Gateway live quote advertises `exact / eip155:8453`, discounted amount `9635`, timeout `3600`
- Facilitator live `/supported` advertises Base exact + upto
- installed SDK smoke produced V2 `eth_signTypedData_v4` envelope on chainId 8453
- usage explorer already maps `eip155:8453` to Basescan

## Verification
- ESLint: no errors
- Vue type-check: passed
- full Vitest: 181 files / 1350 tests passed
- production web build: passed
- focused Base/Solana rail tests: passed
- Beachball check: passed manually; GitHub CI reruns it

## Rollout
Deploy Nexior only. No Gateway/Facilitator change is required for Base. After production validation, Solana removal can be a separate explicit change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)