### PR TITLE
fix(fish): keep voice clone submission state

### DIFF
--- a/change/@acedatacloud-nexior-89c6f705-708b-469d-9ba0-30074e63ddb2.json
+++ b/change/@acedatacloud-nexior-89c6f705-708b-469d-9ba0-30074e63ddb2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Keep Fish voice clone submissions pending until completion and preserve failed form input",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/fish/ModelConfigPanel.test.ts
+++ b/src/components/fish/ModelConfigPanel.test.ts
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+import { shallowMount } from '@vue/test-utils';
+import { nextTick } from 'vue';
+import { describe, expect, it } from 'vitest';
+
+import ModelConfigPanel from './ModelConfigPanel.vue';
+
+const mountPanel = () =>
+  shallowMount(ModelConfigPanel, {
+    global: {
+      mocks: {
+        $t: (key: string) => key,
+        $store: { state: { token: { access: 'access-token' } } }
+      }
+    }
+  });
+
+const fillForm = async (wrapper: ReturnType<typeof mountPanel>) => {
+  await wrapper.setData({
+    form: {
+      title: ' My voice ',
+      description: ' Description ',
+      texts: ' Transcript ',
+      voicesUrl: 'https://cdn.acedata.cloud/audio.mp3',
+      visibility: 'private',
+      enhanceAudio: true,
+      generateSample: false
+    },
+    fileList: [{ name: 'audio.mp3' }]
+  });
+};
+
+describe('fish/ModelConfigPanel', () => {
+  it('keeps the form pending until the parent resolves and then resets it', async () => {
+    const wrapper = mountPanel();
+    await fillForm(wrapper);
+
+    const submission = (wrapper.vm as any).onCreate();
+    await nextTick();
+
+    const [payload, callbacks] = wrapper.emitted('create')?.[0] as any;
+    expect(payload).toMatchObject({
+      title: 'My voice',
+      voices: 'https://cdn.acedata.cloud/audio.mp3',
+      description: 'Description',
+      texts: ['Transcript'],
+      train_mode: 'fast'
+    });
+    expect((wrapper.vm as any).creating).toBe(true);
+    expect((wrapper.vm as any).form.title).toBe(' My voice ');
+
+    callbacks.resolve();
+    await submission;
+
+    expect((wrapper.vm as any).creating).toBe(false);
+    expect((wrapper.vm as any).form.title).toBe('');
+    expect((wrapper.vm as any).form.voicesUrl).toBe('');
+    expect((wrapper.vm as any).fileList).toEqual([]);
+  });
+
+  it('restores the button but preserves the form when creation fails', async () => {
+    const wrapper = mountPanel();
+    await fillForm(wrapper);
+
+    const submission = (wrapper.vm as any).onCreate();
+    await nextTick();
+    const [, callbacks] = wrapper.emitted('create')?.[0] as any;
+
+    callbacks.reject(new Error('creation failed'));
+    await submission;
+
+    expect((wrapper.vm as any).creating).toBe(false);
+    expect((wrapper.vm as any).form.title).toBe(' My voice ');
+    expect((wrapper.vm as any).form.voicesUrl).toBe('https://cdn.acedata.cloud/audio.mp3');
+    expect((wrapper.vm as any).fileList).toHaveLength(1);
+  });
+
+  it('ignores extra clicks while a submission is still in flight', async () => {
+    const wrapper = mountPanel();
+    await fillForm(wrapper);
+
+    const submission = (wrapper.vm as any).onCreate();
+    await nextTick();
+    await (wrapper.vm as any).onCreate();
+    await nextTick();
+
+    expect(wrapper.emitted('create')).toHaveLength(1);
+    expect((wrapper.vm as any).canCreate).toBe(false);
+
+    const [, callbacks] = wrapper.emitted('create')?.[0] as any;
+    callbacks.resolve();
+    await submission;
+  });
+
+  it('does not expose the unsupported precise training mode', async () => {
+    const wrapper = mountPanel();
+    await fillForm(wrapper);
+
+    const submission = (wrapper.vm as any).onCreate();
+    await nextTick();
+    const [payload, callbacks] = wrapper.emitted('create')?.[0] as any;
+
+    expect(wrapper.text()).not.toContain('fish.value.trainModePrecise');
+    expect(payload.train_mode).toBe('fast');
+
+    callbacks.resolve();
+    await submission;
+  });
+});

--- a/src/components/fish/ModelConfigPanel.vue
+++ b/src/components/fish/ModelConfigPanel.vue
@@ -98,15 +98,6 @@
         />
       </div>
 
-      <!-- Train mode -->
-      <div class="field-block mb-4">
-        <h2 class="title font-bold">{{ $t('fish.name.trainMode') }}</h2>
-        <el-radio-group v-model="form.trainMode">
-          <el-radio-button label="fast" value="fast">{{ $t('fish.value.trainModeFast') }}</el-radio-button>
-          <el-radio-button label="precise" value="precise">{{ $t('fish.value.trainModePrecise') }}</el-radio-button>
-        </el-radio-group>
-      </div>
-
       <!-- Toggles -->
       <div class="field-block mb-3">
         <div class="field-row">
@@ -144,17 +135,7 @@
 <script lang="ts">
 import { MagicIcon, MicrophoneIcon, UndoIcon, UploadIcon } from '@acedatacloud/core/icons/components';
 import { defineComponent } from 'vue';
-import {
-  ElButton,
-  ElInput,
-  ElMessage,
-  ElRadioButton,
-  ElRadioGroup,
-  ElSwitch,
-  ElUpload,
-  UploadFile,
-  UploadFiles
-} from 'element-plus';
+import { ElButton, ElInput, ElMessage, ElSwitch, ElUpload, UploadFile, UploadFiles } from 'element-plus';
 import { getBaseUrlPlatform, uploadTrackerMixin } from '@/utils';
 import Recorder from './model/Recorder.vue';
 
@@ -165,14 +146,13 @@ export interface IFishCreatePayload {
   voices: string;
   description?: string;
   visibility: 'public' | 'unlist' | 'private';
-  train_mode: 'fast' | 'precise';
+  train_mode: 'fast';
   texts?: string[];
   enhance_audio_quality?: boolean;
   generate_sample?: boolean;
 }
 
 type Visibility = 'public' | 'unlist' | 'private';
-type TrainMode = 'fast' | 'precise';
 
 interface IForm {
   title: string;
@@ -180,7 +160,6 @@ interface IForm {
   texts: string;
   voicesUrl: string;
   visibility: Visibility;
-  trainMode: TrainMode;
   enhanceAudio: boolean;
   generateSample: boolean;
 }
@@ -200,7 +179,6 @@ const defaultForm = (): IForm => ({
   texts: '',
   voicesUrl: '',
   visibility: 'private',
-  trainMode: 'fast',
   enhanceAudio: true,
   generateSample: false
 });
@@ -214,8 +192,6 @@ export default defineComponent({
     UploadIcon,
     ElButton,
     ElInput,
-    ElRadioButton,
-    ElRadioGroup,
     ElSwitch,
     ElUpload,
     Recorder
@@ -307,7 +283,8 @@ export default defineComponent({
       this.form.voicesUrl = '';
       this.fileList = [];
     },
-    onCreate() {
+    async onCreate() {
+      if (this.creating) return;
       const title = this.form.title.trim();
       if (!title) {
         ElMessage.warning(this.$t('fish.message.titleRequired'));
@@ -321,7 +298,7 @@ export default defineComponent({
         title,
         voices: this.form.voicesUrl,
         visibility: this.form.visibility,
-        train_mode: this.form.trainMode,
+        train_mode: 'fast',
         enhance_audio_quality: this.form.enhanceAudio,
         generate_sample: this.form.generateSample
       };
@@ -329,14 +306,17 @@ export default defineComponent({
       if (this.form.texts.trim()) payload.texts = [this.form.texts.trim()];
 
       this.creating = true;
-      this.$emit('create', payload);
-      // Re-enable the form shortly after so the spinner is visible but the
-      // user can keep working while the create call runs in the background.
-      setTimeout(() => {
-        this.creating = false;
+      try {
+        await new Promise<void>((resolve, reject) => {
+          this.$emit('create', payload, { resolve, reject });
+        });
         this.form = defaultForm();
         this.fileList = [];
-      }, 600);
+      } catch {
+        // The parent displays the request error; keep the form ready to retry.
+      } finally {
+        this.creating = false;
+      }
     }
   }
 });

--- a/src/operators/fish.ts
+++ b/src/operators/fish.ts
@@ -2,7 +2,6 @@ import axios, { AxiosResponse } from 'axios';
 import { BASE_URL_API } from '@/constants';
 import {
   IFishModelListResponse,
-  IFishTask,
   IFishTaskResponse,
   IFishTasksResponse,
   IFishTtsRequest,
@@ -94,18 +93,14 @@ class FishOperator extends BaseTaskOperator<
     });
   }
 
-  /**
-   * POST /fish/model — create a voice clone. The platform's JSON-with-URL
-   * variant (`voices` is a single https URL pointing at the reference audio).
-   * Async-only when `callback_url` is supplied.
-   */
+  /** POST /fish/model — synchronously create and return a voice model. */
   async createModel(
     data: {
       title: string;
       voices: string;
       description?: string;
       cover_image?: string;
-      train_mode?: 'fast' | 'precise';
+      train_mode?: 'fast';
       type?: 'tts';
       visibility?: 'public' | 'unlist' | 'private';
       tags?: string[];
@@ -115,7 +110,7 @@ class FishOperator extends BaseTaskOperator<
       callback_url?: string;
     },
     options: { token: string }
-  ): Promise<AxiosResponse<IFishTask & { id?: string }>> {
+  ): Promise<AxiosResponse<IFishVoiceModel>> {
     return axios.post(
       '/fish/model',
       { type: 'tts', ...data },

--- a/src/pages/fish/Model.test.ts
+++ b/src/pages/fish/Model.test.ts
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+import { shallowMount } from '@vue/test-utils';
+import { ElMessage } from 'element-plus';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import Model from './Model.vue';
+
+const mocks = vi.hoisted(() => ({
+  createModel: vi.fn(),
+  ensureLoggedIn: vi.fn(() => true)
+}));
+
+vi.mock('@/operators', () => ({
+  fishOperator: { createModel: mocks.createModel }
+}));
+
+vi.mock('@/utils', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/utils')>()),
+  ensureLoggedIn: mocks.ensureLoggedIn
+}));
+
+const payload = {
+  title: 'My voice',
+  voices: 'https://cdn.acedata.cloud/audio.mp3',
+  visibility: 'private' as const,
+  train_mode: 'fast' as const
+};
+
+const mountPage = (token: string | null = 'credential-token') => {
+  const dispatch = vi.fn().mockResolvedValue(undefined);
+  const wrapper = shallowMount(Model, {
+    global: {
+      provide: { initialized: false },
+      mocks: {
+        $t: (key: string) => key,
+        $store: {
+          state: { fish: { credential: token ? { token } : undefined } },
+          dispatch
+        }
+      }
+    }
+  });
+  return { wrapper, dispatch };
+};
+
+const callbacks = () => ({ resolve: vi.fn(), reject: vi.fn() });
+
+describe('fish/Model', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.ensureLoggedIn.mockReturnValue(true);
+    mocks.createModel.mockResolvedValue({ data: { id: 'voice-id' } });
+    vi.spyOn(ElMessage, 'info').mockImplementation(() => undefined as never);
+    vi.spyOn(ElMessage, 'success').mockImplementation(() => undefined as never);
+    vi.spyOn(ElMessage, 'error').mockImplementation(() => undefined as never);
+  });
+
+  it('resolves after creating the model and refreshing the voice list', async () => {
+    const { wrapper, dispatch } = mountPage();
+    const result = callbacks();
+
+    await (wrapper.vm as any).onCreate(payload, result);
+
+    expect(mocks.createModel).toHaveBeenCalledWith(payload, { token: 'credential-token' });
+    expect(dispatch).toHaveBeenCalledWith('fish/getVoices');
+    expect(result.resolve).toHaveBeenCalledOnce();
+    expect(result.reject).not.toHaveBeenCalled();
+    expect((wrapper.vm as any).loading).toBe(false);
+  });
+
+  it('rejects without submitting when login is required', async () => {
+    mocks.ensureLoggedIn.mockReturnValue(false);
+    const { wrapper } = mountPage();
+    const result = callbacks();
+
+    await (wrapper.vm as any).onCreate(payload, result);
+
+    expect(mocks.createModel).not.toHaveBeenCalled();
+    expect(result.reject).toHaveBeenCalledOnce();
+    expect(result.resolve).not.toHaveBeenCalled();
+  });
+
+  it('shows an error and rejects when the credential is unavailable', async () => {
+    const { wrapper } = mountPage(null);
+    const result = callbacks();
+
+    await (wrapper.vm as any).onCreate(payload, result);
+
+    expect(ElMessage.error).toHaveBeenCalledWith('fish.message.createModelFailed');
+    expect(mocks.createModel).not.toHaveBeenCalled();
+    expect(result.reject).toHaveBeenCalledOnce();
+  });
+
+  it('preserves the server error and rejects a failed request', async () => {
+    const error = { response: { data: { error: { message: 'Audio is invalid' } } } };
+    mocks.createModel.mockRejectedValue(error);
+    const { wrapper } = mountPage();
+    const result = callbacks();
+
+    await (wrapper.vm as any).onCreate(payload, result);
+
+    expect(ElMessage.error).toHaveBeenCalledWith('Audio is invalid');
+    expect(result.reject).toHaveBeenCalledWith(error);
+    expect(result.resolve).not.toHaveBeenCalled();
+  });
+
+  it('keeps the dedicated balance error when credits are exhausted', async () => {
+    const error = { response: { data: { error: { code: 'used_up' } } } };
+    mocks.createModel.mockRejectedValue(error);
+    const { wrapper } = mountPage();
+    const result = callbacks();
+
+    await (wrapper.vm as any).onCreate(payload, result);
+
+    expect(ElMessage.error).toHaveBeenCalledWith('fish.message.usedUp');
+    expect(result.reject).toHaveBeenCalledWith(error);
+  });
+});

--- a/src/pages/fish/Model.vue
+++ b/src/pages/fish/Model.vue
@@ -68,22 +68,28 @@ export default defineComponent({
     async onGetVoices() {
       await this.$store.dispatch('fish/getVoices');
     },
-    async onCreate(payload: {
-      title: string;
-      voices: string;
-      description?: string;
-      visibility?: 'public' | 'unlist' | 'private';
-      train_mode?: 'fast' | 'precise';
-      texts?: string[];
-      enhance_audio_quality?: boolean;
-      generate_sample?: boolean;
-    }) {
+    async onCreate(
+      payload: {
+        title: string;
+        voices: string;
+        description?: string;
+        visibility?: 'public' | 'unlist' | 'private';
+        train_mode?: 'fast';
+        texts?: string[];
+        enhance_audio_quality?: boolean;
+        generate_sample?: boolean;
+      },
+      callbacks: { resolve: () => void; reject: (error?: unknown) => void }
+    ) {
       if (!ensureLoggedIn()) {
+        callbacks.reject();
         return;
       }
       const token = this.credential?.token;
       if (!token) {
         console.error('no token specified');
+        ElMessage.error(this.$t('fish.message.createModelFailed'));
+        callbacks.reject();
         return;
       }
       this.loading = true;
@@ -91,8 +97,8 @@ export default defineComponent({
       try {
         await fishOperator.createModel(payload, { token });
         ElMessage.success(this.$t('fish.message.createModelSuccess'));
-        // Refresh the voice list so the new entry appears immediately.
         await this.onGetVoices();
+        callbacks.resolve();
       } catch (error: any) {
         const response = error?.response?.data;
         if (response?.error?.code === ERROR_CODE_USED_UP) {
@@ -100,6 +106,7 @@ export default defineComponent({
         } else {
           ElMessage.error(response?.error?.message || this.$t('fish.message.createModelFailed'));
         }
+        callbacks.reject(error);
       } finally {
         this.loading = false;
       }


### PR DESCRIPTION
## Summary
- keep the Fish voice clone form pending until the create request actually finishes
- preserve form input on failures and settle login/credential error paths
- remove the unsupported precise training option and align the response type
- add regression coverage for pending, success, failure, login, credential, and balance paths

## Verification
- `npm run test:run -- src/components/fish/ModelConfigPanel.test.ts src/pages/fish/Model.test.ts src/components/fish/ConfigPanel.test.ts src/components/fish/task/Preview.test.ts src/utils/fish.test.ts` (20 passed)
- `npm run lint:check` (0 errors; 2 existing warnings in `dropUploadMixin.test.ts`)
- `npm run build:web`
- `npm run verify`

🤖 Generated with [Claude Code](https://claude.com/claude-code)