### PR TITLE
fix: inject Studio tenant SEO into raw HTML

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,5 +66,8 @@ jobs:
       - name: Run tests
         run: npm run test:run
 
+      - name: Verify Studio raw HTML tenant metadata
+        run: npm run test:studio-seo
+
       - name: Build
         run: npm run build

--- a/change/@acedatacloud-nexior-studio-first-response-seo.json
+++ b/change/@acedatacloud-nexior-studio-first-response-seo.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Inject each Studio tenant's branding into crawler-visible first-response HTML",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/deploy/production/studio-html-injector.mjs
+++ b/deploy/production/studio-html-injector.mjs
@@ -1,0 +1,187 @@
+import http from 'node:http';
+import { Readable } from 'node:stream';
+import { pathToFileURL } from 'node:url';
+
+const listenPort = Number(process.env.PORT || 3000);
+const upstream = process.env.STUDIO_UPSTREAM || 'http://studio-frontend.acedatacloud.svc.cluster.local:8085';
+const siteApi = process.env.SITE_API || 'https://platform.acedata.cloud/api/v1/sites/';
+const cacheTtlMs = Number(process.env.SITE_CACHE_TTL_MS || 60_000);
+const staleTtlMs = Number(process.env.SITE_STALE_TTL_MS || 300_000);
+const siteCache = new Map();
+
+function escapeAttribute(value) {
+  return String(value)
+    .replaceAll('&', '&amp;')
+    .replaceAll('"', '&quot;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;');
+}
+
+function escapeText(value) {
+  return String(value).replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
+}
+
+function validHost(rawHost) {
+  const host = String(rawHost || '')
+    .trim()
+    .toLowerCase()
+    .replace(/:\d+$/, '');
+  return /^(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/.test(host)
+    ? host
+    : '';
+}
+
+function replaceTitle(html, title) {
+  const tag = `<title>${escapeText(title)}</title>`;
+  const stripped = html.replace(/<title\b[^>]*>[\s\S]*?<\/title\s*>/gi, '');
+  return stripped.replace(/<head\b[^>]*>/i, (head) => `${head}\n    ${tag}`);
+}
+
+function replaceMeta(html, attribute, key, content) {
+  const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const matcher = new RegExp(`<meta\\b(?=[^>]*\\b${attribute}\\s*=\\s*(["'])${escapedKey}\\1)[^>]*>\\s*`, 'gi');
+  const tag = `<meta ${attribute}="${escapeAttribute(key)}" content="${escapeAttribute(content)}" />`;
+  return html.replace(matcher, '').replace(/<\/head\s*>/i, `    ${tag}\n  </head>`);
+}
+
+function replaceLink(html, relation, href) {
+  const escapedRelation = relation.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const matcher = new RegExp(`<link\\b(?=[^>]*\\brel\\s*=\\s*(["'])${escapedRelation}\\1)[^>]*>\\s*`, 'gi');
+  const tag = `<link rel="${escapeAttribute(relation)}" href="${escapeAttribute(href)}" />`;
+  return html.replace(matcher, '').replace(/<\/head\s*>/i, `    ${tag}\n  </head>`);
+}
+
+export function injectTenantHead(html, site, requestUrl) {
+  const url = new URL(requestUrl);
+  const host = validHost(url.hostname);
+  if (!host) return html;
+
+  const title = String(site?.title || host).trim() || host;
+  const description = String(site?.description || '').trim();
+  const keywords = Array.isArray(site?.keywords) ? site.keywords.filter(Boolean).join(', ') : '';
+  const favicon = String(site?.favicon || '').trim();
+  const canonical = `${url.origin}${url.pathname}`;
+  const shareImage = `https://platform.acedata.cloud/api/v1/og/${encodeURIComponent(host)}.png`;
+
+  let result = replaceTitle(html, title);
+  result = result.replace(/<meta\b(?=[^>]*\bname\s*=\s*(["'])slack-app-id\1)[^>]*>\s*/gi, '');
+  result = replaceMeta(result, 'name', 'description', description);
+  result = replaceMeta(result, 'name', 'keywords', keywords);
+  result = replaceMeta(result, 'property', 'og:type', 'website');
+  result = replaceMeta(result, 'property', 'og:site_name', title);
+  result = replaceMeta(result, 'property', 'og:title', title);
+  result = replaceMeta(result, 'property', 'og:description', description);
+  result = replaceMeta(result, 'property', 'og:url', canonical);
+  result = replaceMeta(result, 'property', 'og:image', shareImage);
+  result = replaceMeta(result, 'name', 'twitter:card', 'summary_large_image');
+  result = replaceMeta(result, 'name', 'twitter:title', title);
+  result = replaceMeta(result, 'name', 'twitter:description', description);
+  result = replaceMeta(result, 'name', 'twitter:image', shareImage);
+  result = replaceLink(result, 'canonical', canonical);
+
+  // A missing tenant favicon must not fall back to Ace Data Cloud's icon.
+  result = result.replace(/<link\b(?=[^>]*\brel\s*=\s*(["'])(?:shortcut\s+)?icon\1)[^>]*>\s*/gi, '');
+  result = result.replace(/<link\b(?=[^>]*\brel\s*=\s*(["'])apple-touch-icon\1)[^>]*>\s*/gi, '');
+  if (favicon) {
+    result = replaceLink(result, 'icon', favicon);
+    result = replaceLink(result, 'apple-touch-icon', favicon);
+  }
+  return result;
+}
+
+async function fetchSite(host) {
+  const now = Date.now();
+  const cached = siteCache.get(host);
+  if (cached && cached.expiresAt > now) return cached.site;
+
+  try {
+    const response = await fetch(`${siteApi}?origin=${encodeURIComponent(host)}`, {
+      signal: AbortSignal.timeout(3_000),
+      headers: { accept: 'application/json' }
+    });
+    if (!response.ok) throw new Error(`site lookup returned ${response.status}`);
+    const payload = await response.json();
+    const site = Array.isArray(payload?.items) ? payload.items[0] || null : null;
+    siteCache.set(host, { site, expiresAt: now + cacheTtlMs, staleUntil: now + staleTtlMs });
+    return site;
+  } catch (error) {
+    if (cached && cached.staleUntil > now) return cached.site;
+    console.error(JSON.stringify({ event: 'site_lookup_failed', host, message: error.message }));
+    return null;
+  }
+}
+
+function copyResponseHeaders(response, outgoing, transformed) {
+  for (const [name, value] of response.headers) {
+    const lower = name.toLowerCase();
+    if (['connection', 'content-length', 'content-encoding', 'transfer-encoding'].includes(lower)) continue;
+    outgoing.setHeader(name, value);
+  }
+  const cookies = response.headers.getSetCookie?.() || [];
+  if (cookies.length) outgoing.setHeader('set-cookie', cookies);
+  if (transformed) {
+    outgoing.setHeader('cache-control', 'no-cache, no-store, max-age=0, must-revalidate');
+    outgoing.setHeader('vary', 'Host, Accept-Encoding');
+  }
+}
+
+async function proxyRequest(request, response) {
+  const host = validHost(request.headers.host);
+  if (!host) {
+    response.writeHead(400, { 'content-type': 'text/plain; charset=utf-8' });
+    response.end('Invalid Host');
+    return;
+  }
+
+  const headers = new Headers();
+  for (const [name, value] of Object.entries(request.headers)) {
+    if (value !== undefined && !['connection', 'content-length', 'host'].includes(name.toLowerCase())) {
+      headers.set(name, Array.isArray(value) ? value.join(', ') : value);
+    }
+  }
+  headers.set('host', host);
+  headers.set('accept-encoding', 'identity');
+  headers.set('x-forwarded-host', host);
+  headers.set('x-forwarded-proto', 'https');
+
+  const method = request.method || 'GET';
+  const upstreamResponse = await fetch(new URL(request.url || '/', upstream), {
+    method,
+    headers,
+    body: ['GET', 'HEAD'].includes(method) ? undefined : Readable.toWeb(request),
+    duplex: ['GET', 'HEAD'].includes(method) ? undefined : 'half',
+    redirect: 'manual',
+    signal: AbortSignal.timeout(300_000)
+  });
+  const contentType = upstreamResponse.headers.get('content-type') || '';
+  const isHtml = method === 'GET' && upstreamResponse.ok && contentType.toLowerCase().includes('text/html');
+
+  response.statusCode = upstreamResponse.status;
+  copyResponseHeaders(upstreamResponse, response, isHtml);
+  if (isHtml) {
+    const [html, site] = await Promise.all([upstreamResponse.text(), fetchSite(host)]);
+    response.end(injectTenantHead(html, site, `https://${host}${request.url || '/'}`));
+    return;
+  }
+  if (!upstreamResponse.body || method === 'HEAD') {
+    response.end();
+    return;
+  }
+  Readable.fromWeb(upstreamResponse.body).pipe(response);
+}
+
+export function startServer() {
+  return http
+    .createServer((request, response) => {
+      proxyRequest(request, response).catch((error) => {
+        console.error(JSON.stringify({ event: 'proxy_failed', message: error.message }));
+        if (!response.headersSent) response.writeHead(502, { 'content-type': 'text/plain; charset=utf-8' });
+        response.end('Bad Gateway');
+      });
+    })
+    .listen(listenPort, '0.0.0.0');
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  startServer();
+}

--- a/deploy/production/studio-proxy.yaml
+++ b/deploy/production/studio-proxy.yaml
@@ -9,6 +9,8 @@
 #   * 80/443 LoadBalancer (separate public CLB; do NOT share with nginx-router)
 #   * Caddy 2 with `tls { on_demand }` and an `ask` callback that consults
 #     PlatformBackend (/api/v1/site-domains/check) before signing a cert.
+#   * A local HTML injector that resolves the Site by Host and writes tenant
+#     title, description, Open Graph, canonical, and favicon into raw HTML.
 #   * cbs PVC at /data so ACME account, certs, and locks survive pod restarts.
 #
 # Tenant flow:
@@ -59,9 +61,10 @@ data:
         on_demand
       }
 
-      # Reverse-proxy to studio-frontend with the original Host header
-      # preserved so Nexior's per-origin Site lookup keeps working.
-      reverse_proxy studio-frontend.acedatacloud.svc.cluster.local:8085 {
+      # The injector streams non-HTML responses unchanged and rewrites only
+      # successful HTML documents, so crawler-visible metadata is tenant-aware
+      # before Vue runs. The original Host remains the Site lookup key.
+      reverse_proxy localhost:3000 {
         header_up Host {host}
         header_up X-Real-IP {remote_host}
         header_up X-Forwarded-For {remote_host}
@@ -140,26 +143,28 @@ spec:
     metadata:
       labels:
         app: caddy-studio-proxy
+      annotations:
+        acedata.cloud/html-injector-sha: '${INJECTOR_SHA}'
     spec:
       containers:
         - name: caddy
           image: caddy:2.8-alpine
           imagePullPolicy: IfNotPresent
-          args: ["caddy", "run", "--config", "/etc/caddy/Caddyfile", "--adapter", "caddyfile"]
+          args: ['caddy', 'run', '--config', '/etc/caddy/Caddyfile', '--adapter', 'caddyfile']
           ports:
-            - { name: http,  containerPort: 80,   protocol: TCP }
-            - { name: https, containerPort: 443,  protocol: TCP }
+            - { name: http, containerPort: 80, protocol: TCP }
+            - { name: https, containerPort: 443, protocol: TCP }
             - { name: admin, containerPort: 2019, protocol: TCP }
           env:
             # Caddy stores everything (ACME account, certs, locks) under
             # $XDG_DATA_HOME/caddy by default. Pin it to /data so the
             # PVC mount actually catches it.
-            - { name: XDG_DATA_HOME,   value: /data }
+            - { name: XDG_DATA_HOME, value: /data }
             - { name: XDG_CONFIG_HOME, value: /config }
           volumeMounts:
             - { name: caddyfile, mountPath: /etc/caddy }
-            - { name: data,      mountPath: /data }
-            - { name: config,    mountPath: /config }
+            - { name: data, mountPath: /data }
+            - { name: config, mountPath: /config }
           resources:
             requests:
               cpu: 100m
@@ -185,6 +190,35 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 30
             failureThreshold: 3
+        - name: html-injector
+          image: node:22-alpine
+          imagePullPolicy: IfNotPresent
+          command: ['node', '/app/server.mjs']
+          ports:
+            - { name: injector, containerPort: 3000, protocol: TCP }
+          env:
+            - { name: PORT, value: '3000' }
+            - { name: STUDIO_UPSTREAM, value: 'http://studio-frontend.acedatacloud.svc.cluster.local:8085' }
+            - { name: SITE_API, value: 'https://platform.acedata.cloud/api/v1/sites/' }
+          volumeMounts:
+            - { name: html-injector, mountPath: /app, readOnly: true }
+          resources:
+            requests:
+              cpu: 25m
+              memory: 48Mi
+            limits:
+              cpu: 250m
+              memory: 128Mi
+          readinessProbe:
+            tcpSocket:
+              port: 3000
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          livenessProbe:
+            tcpSocket:
+              port: 3000
+            initialDelaySeconds: 10
+            periodSeconds: 20
       volumes:
         - name: caddyfile
           configMap:
@@ -197,6 +231,9 @@ spec:
             claimName: caddy-studio
         - name: config
           emptyDir: {}
+        - name: html-injector
+          configMap:
+            name: studio-html-injector
 ---
 apiVersion: v1
 kind: Service
@@ -210,12 +247,12 @@ metadata:
     # the nginx-router LB; that one already terminates 80/443 and would
     # collide). Postpaid traffic + standard accounting.
     service.kubernetes.io/qcloud-loadbalancer-internet-charge-type: TRAFFIC_POSTPAID_BY_HOUR
-    service.kubernetes.io/qcloud-loadbalancer-internet-max-bandwidth-out: "200"
+    service.kubernetes.io/qcloud-loadbalancer-internet-max-bandwidth-out: '200'
 spec:
   type: LoadBalancer
   externalTrafficPolicy: Local
   ports:
-    - { name: http,  port: 80,  targetPort: 80,  protocol: TCP }
+    - { name: http, port: 80, targetPort: 80, protocol: TCP }
     - { name: https, port: 443, targetPort: 443, protocol: TCP }
   selector:
     app: caddy-studio-proxy

--- a/deploy/run.sh
+++ b/deploy/run.sh
@@ -9,4 +9,9 @@ kubectl apply -f deploy/production/studio-ingress.yaml
 # with on-demand Let's Encrypt TLS). Idempotent; safe to re-apply on every
 # deploy. The Service provisions a separate public CLB the first time it
 # runs; subsequent applies are no-ops on the LB.
-kubectl apply -f deploy/production/studio-proxy.yaml
+kubectl create configmap studio-html-injector \
+  --namespace acedatacloud \
+  --from-file=server.mjs=deploy/production/studio-html-injector.mjs \
+  --dry-run=client -o yaml | kubectl apply -f -
+injector_sha=$(sha256sum deploy/production/studio-html-injector.mjs | cut -d' ' -f1)
+sed 's/${INJECTOR_SHA}/'"$injector_sha"'/g' deploy/production/studio-proxy.yaml | kubectl apply -f -

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "lint:staged": "lint-staged",
     "test": "vitest",
     "test:run": "vitest run",
+    "test:studio-seo": "node --test scripts/check-studio-html-injector.mjs",
     "test:e2e:desktop": "playwright test",
     "prettier": "prettier --write .",
     "change": "beachball change --no-commit",

--- a/scripts/check-studio-html-injector.mjs
+++ b/scripts/check-studio-html-injector.mjs
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { injectTenantHead } from '../deploy/production/studio-html-injector.mjs';
+
+const shell = `<!doctype html><html><head>
+<title>Ace Data Cloud - AI Hub</title>
+<meta name="description" content="Ace default">
+<meta property="og:title" content="Ace Data Cloud - AI Hub">
+<meta property="og:description" content="Ace default">
+<meta property="og:image" content="https://platform.acedata.cloud/api/v1/og/__OG_HOST__.png">
+<link rel="icon" href="/favicon.ico"><link rel="apple-touch-icon" href="/apple-touch-icon.png">
+</head><body></body></html>`;
+
+test('injects tenant title, description, Open Graph, canonical and favicon into raw HTML', () => {
+  const output = injectTenantHead(
+    shell,
+    {
+      title: '知数云 & Knowledge Cloud',
+      description: '一站式 AI <能力>平台',
+      keywords: ['知数云', 'AI API'],
+      favicon: 'https://cdn.example.com/favicon?a=1&b=2'
+    },
+    'https://studio.zhishuyun.com/pricing?campaign=test'
+  );
+
+  assert.match(output, /<title>知数云 &amp; Knowledge Cloud<\/title>/);
+  assert.match(output, /name="description" content="一站式 AI &lt;能力&gt;平台"/);
+  assert.match(output, /property="og:title" content="知数云 &amp; Knowledge Cloud"/);
+  assert.match(output, /property="og:url" content="https:\/\/studio\.zhishuyun\.com\/pricing"/);
+  assert.match(
+    output,
+    /property="og:image" content="https:\/\/platform\.acedata\.cloud\/api\/v1\/og\/studio\.zhishuyun\.com\.png"/
+  );
+  assert.match(output, /rel="canonical" href="https:\/\/studio\.zhishuyun\.com\/pricing"/);
+  assert.match(output, /rel="icon" href="https:\/\/cdn\.example\.com\/favicon\?a=1&amp;b=2"/);
+  assert.doesNotMatch(output, /Ace Data Cloud/);
+  assert.doesNotMatch(output, /\/favicon\.ico/);
+});
+
+test('fails closed to the tenant hostname when site lookup is unavailable', () => {
+  const output = injectTenantHead(shell, null, 'https://tenant.example.com/');
+  assert.match(output, /<title>tenant\.example\.com<\/title>/);
+  assert.match(output, /property="og:title" content="tenant\.example\.com"/);
+  assert.doesNotMatch(output, /Ace Data Cloud/);
+  assert.doesNotMatch(output, /rel="icon"/);
+});
+
+test('rejects an invalid host without modifying the document', () => {
+  assert.equal(injectTenantHead(shell, { title: 'Tenant' }, 'https://localhost/'), shell);
+});


### PR DESCRIPTION
## What changed

- route Studio custom domains through a lightweight HTML injector sidecar
- load the tenant's public Site configuration by request host
- inject tenant title, description, keywords, canonical, Open Graph, Twitter Card, favicon, and Apple touch icon into the first HTML response
- stream non-HTML assets without rewriting them
- add short-lived caching, stale fallback, deployment rollout hashing, and a focused CI test

## Why

Nexior is a static SPA. Search crawlers and social preview fetchers may not execute client-side JavaScript, so the first HTML response on a white-label Studio domain could still expose the default Ace Data Cloud metadata even though the rendered app later applied tenant branding.

## Behavior

- With a valid Site configuration, the first HTML response uses the tenant's branding and SEO fields.
- If the Site API is temporarily unavailable, a stale cached configuration is used when available.
- Without any configuration, the response falls back to the requested tenant domain and does not expose the default Ace Data Cloud brand.

## Validation

- focused Studio SEO tests: 3/3 passed
- ESLint: 0 errors; 2 pre-existing warnings
- Prettier, YAML parsing, shell syntax, and `git diff --check`: passed
- production build: passed
- built `dist/index.html` verified with the real Knowledge Cloud Site configuration
- rendered Kubernetes manifest structure verified
- full Vitest: 182 files passed, 1 failed; 1354 tests passed, 5 failed. The only failures are pre-existing local persistent-shell timeouts in `electron/local/shellSession.test.ts`; CI runs Node 22 and is the release gate.

## Root cause

Tenant metadata was only applied after the SPA booted. The raw HTML delivered to crawlers still contained build-time defaults.
