### PR TITLE
fix(ci): use explicit reusable release modes

### DIFF
--- a/.github/workflows/release-android.yaml
+++ b/.github/workflows/release-android.yaml
@@ -121,7 +121,7 @@ jobs:
 
       - name: Check Play Console for existing AAB/APK
         id: check
-        if: inputs.upload_to_play || github.event_name != 'workflow_call'
+        if: inputs.upload_to_play || startsWith(github.ref, 'refs/tags/android-v')
         env:
           FORCE: ${{ inputs.force }}
           SA_JSON: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
@@ -196,7 +196,7 @@ jobs:
           PY
 
   build:
-    name: Build & Upload to Play Store
+    name: Build Android package
     needs: preflight
     if: needs.preflight.outputs.should-build == 'true'
     runs-on: ubuntu-latest
@@ -245,14 +245,14 @@ jobs:
           mv android/app/src/main/assets/public android/app/src/full/assets/public
 
       - name: Build web assets (play flavor, Computer Use OFF, tree-shaken)
-        if: inputs.upload_to_play || github.event_name != 'workflow_call'
+        if: inputs.upload_to_play || startsWith(github.ref, 'refs/tags/android-v')
         env:
           VITE_STRIPE_PUBLISHABLE_KEY: ${{ secrets.VITE_STRIPE_PUBLISHABLE_KEY }}
           VITE_COMPUTER_USE: 'false'
         run: npm run build:android
 
       - name: Stage play-flavor web assets
-        if: inputs.upload_to_play || github.event_name != 'workflow_call'
+        if: inputs.upload_to_play || startsWith(github.ref, 'refs/tags/android-v')
         # The Play web bundle is compiled with no Local Tools entry and no
         # Computer Use / AccessibilityService adapter code; it lives only in the
         # `play` flavor. cap copy re-processes dist into the main source set the
@@ -278,7 +278,7 @@ jobs:
         shell: bash
 
       - name: Build Play AAB (play flavor, no Computer Use)
-        if: inputs.upload_to_play || github.event_name != 'workflow_call'
+        if: inputs.upload_to_play || startsWith(github.ref, 'refs/tags/android-v')
         working-directory: android
         run: |
           chmod +x gradlew
@@ -304,7 +304,7 @@ jobs:
           path: android/app/build/outputs/apk/full/release/app-full-release.apk
 
       - name: Upload AAB artifact
-        if: inputs.upload_to_play || github.event_name != 'workflow_call'
+        if: inputs.upload_to_play || startsWith(github.ref, 'refs/tags/android-v')
         uses: actions/upload-artifact@v7
         with:
           name: nexior-${{ needs.preflight.outputs.version-name }}.aab
@@ -335,7 +335,7 @@ jobs:
           fail_on_unmatched_files: true
 
       - name: Upload to Play Store
-        if: inputs.upload_to_play || github.event_name != 'workflow_call'
+        if: inputs.upload_to_play || startsWith(github.ref, 'refs/tags/android-v')
         uses: r0adkll/upload-google-play@v1
         with:
           serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
@@ -355,7 +355,7 @@ jobs:
       && needs.preflight.result == 'success'
       && (needs.build.result == 'success' || needs.build.result == 'skipped')
       && needs.preflight.outputs.track != 'production'
-      && (inputs.promote_to_production || github.event_name == 'push')
+      && (inputs.promote_to_production || startsWith(github.ref, 'refs/tags/android-v'))
     runs-on: ubuntu-latest
     steps:
       - name: Set up Python

--- a/.github/workflows/release-desktop.yaml
+++ b/.github/workflows/release-desktop.yaml
@@ -267,7 +267,7 @@ jobs:
           if-no-files-found: error
 
       - name: Verify draft Release exists
-        if: github.event_name == 'workflow_call'
+        if: inputs.release_tag != ''
         env:
           GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN || github.token }}
           REL_TAG: ${{ inputs.release_tag }}
@@ -277,7 +277,7 @@ jobs:
           test "$IS_DRAFT" = "true" || { echo "::error::$REL_TAG is missing or is not a draft"; exit 1; }
 
       - name: Attach installer to draft GitHub Release
-        if: github.event_name == 'workflow_call'
+        if: inputs.release_tag != ''
         uses: softprops/action-gh-release@v3
         env:
           GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN || github.token }}

--- a/change/@acedatacloud-nexior-release-call-context.json
+++ b/change/@acedatacloud-nexior-release-call-context.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Use explicit release inputs inside reusable desktop and Android workflows",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "none"
+}

--- a/scripts/check_release_workflows.py
+++ b/scripts/check_release_workflows.py
@@ -66,8 +66,13 @@ def main() -> None:
     require("workflow_call:" in android, "Android release must be reusable")
     require("workflow_call:" in ios, "iOS release must be reusable")
     require("changesNotSentForReview" not in android, "obsolete Google Play review parameter returned")
+    desktop = read("release-desktop.yaml")
     require("ref: ${{ inputs.release_tag || github.sha }}" in android, "Android assets must checkout their release tag")
-    require("ref: ${{ inputs.release_tag || github.sha }}" in read("release-desktop.yaml"), "desktop assets must checkout their release tag")
+    require("ref: ${{ inputs.release_tag || github.sha }}" in desktop, "desktop assets must checkout their release tag")
+    require("github.event_name != 'workflow_call'" not in android, "Android mode must not depend on the caller event name")
+    require("github.event_name == 'workflow_call'" not in desktop, "desktop attachment must use the explicit release tag")
+    require("if: inputs.release_tag != ''" in desktop, "desktop installers must attach when a release tag is supplied")
+    require("if: inputs.upload_to_play || startsWith(github.ref, 'refs/tags/android-v')" in android, "Play steps must require an explicit store release mode")
 
     for parent in ("release-mobile-testing.yaml", "release-mobile-production.yaml", "release-mobile-manual.yaml"):
         text = read(parent)


### PR DESCRIPTION
## Summary

- use explicit `release_tag` input for desktop Draft Release attachment
- use explicit `upload_to_play` or `android-v*` tag mode for Play-only Android steps
- prevent reusable workflows from inheriting the parent `workflow_dispatch` event as a false standalone mode
- add release contract assertions for these mode boundaries

## Production evidence

The first `Release · Daily` run for 3.361.0 built Web, APK, Windows, and macOS successfully, but final publication failed because Desktop installers were not attached. Android also uploaded its AAB to the beta testing track unexpectedly; Production promotion was skipped.

- Failed run: https://github.com/AceDataCloud/Nexior/actions/runs/31321542224
- Draft Release ID: `367516633`
- Existing Draft assets: Web tarball + SHA256 + APK

## Validation

- `python3 scripts/check_release_workflows.py`
- workflow YAML parse with PyYAML
- `beachball check --branch origin/main`
- `git diff --check`

## Rollout

After merge, rerun `Release · Assets` for `@acedatacloud/nexior_v3.361.0` to attach EXE/DMGs and publish the existing Draft. Do not run mobile production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
