### PR TITLE
fix: hide recharge for shared applications

### DIFF
--- a/change/@acedatacloud-nexior-hide-shared-recharge.json
+++ b/change/@acedatacloud-nexior-hide-shared-recharge.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Hide recharge actions for applications shared by another user",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/application/Info.vue
+++ b/src/components/application/Info.vue
@@ -101,7 +101,7 @@ export default defineComponent({
     // products). Keyed on scope (always present) rather than packages, which
     // isn't serialized in every view.
     showPayment(): boolean {
-      if (isRechargeDisabled(this.$store.getters.site)) {
+      if (this.application.role === 'grantee' || isRechargeDisabled(this.$store.getters.site)) {
         return false;
       }
       if (!isIOS()) {

--- a/src/components/application/sharedApplicationPaymentContract.test.ts
+++ b/src/components/application/sharedApplicationPaymentContract.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const readSource = (path: string): string => readFileSync(fileURLToPath(new URL(path, import.meta.url)), 'utf8');
+
+describe('shared application payment contract', () => {
+  const infoSource = readSource('./Info.vue');
+  const listSource = readSource('../../pages/console/application/List.vue');
+  const messageSource = readSource('../chat/Message.vue');
+  const extraSource = readSource('../../pages/console/application/Extra.vue');
+  const subscribeSource = readSource('../../pages/console/application/Subscribe.vue');
+
+  it('hides payment actions for grantees in application selectors and lists', () => {
+    expect(infoSource).toContain("this.application.role === 'grantee' || isRechargeDisabled");
+    expect(listSource).toContain("application.role === 'grantee' || isRechargeDisabled");
+  });
+
+  it('hides the used-up payment action for a shared application', () => {
+    expect(messageSource).toContain("this.application?.role === 'grantee' || isRechargeDisabled");
+  });
+
+  it('redirects grantees away from direct purchase pages', () => {
+    expect(extraSource).toContain("if (data.role === 'grantee')");
+    expect(extraSource).toContain('this.$router.replace({ name: ROUTE_CONSOLE_APPLICATION_LIST });');
+    expect(subscribeSource).toContain("if (this.application?.role === 'grantee')");
+    expect(subscribeSource).toContain('this.$router.replace({ name: ROUTE_CONSOLE_APPLICATION_LIST });');
+  });
+});

--- a/src/components/chat/Message.vue
+++ b/src/components/chat/Message.vue
@@ -414,7 +414,7 @@ export default defineComponent({
       // in-chat "Top Up" entry on iOS so it never routes to a payment page
       // that renders empty there (matches showPayment in the console pages).
       // Also hidden when the site admin disabled recharge entirely.
-      if (isRechargeDisabled(this.$store.getters.site)) {
+      if (this.application?.role === 'grantee' || isRechargeDisabled(this.$store.getters.site)) {
         return false;
       }
       return !isIOS() && this.message.role === ROLE_ASSISTANT && this.message.error?.code === ERROR_CODE_USED_UP;

--- a/src/pages/console/application/Extra.vue
+++ b/src/pages/console/application/Extra.vue
@@ -308,6 +308,10 @@ export default defineComponent({
       applicationOperator
         .get(this.id)
         .then(({ data: data }: { data: IApplicationDetailResponse }) => {
+          if (data.role === 'grantee') {
+            this.$router.replace({ name: ROUTE_CONSOLE_APPLICATION_LIST });
+            return;
+          }
           this.application = data;
           this.loading = false;
           // by default select first packageId

--- a/src/pages/console/application/List.vue
+++ b/src/pages/console/application/List.vue
@@ -418,7 +418,7 @@ export default defineComponent({
     // A per-service app row shows "Buy More" on every surface, but on iOS
     // only when it has an Apple-buyable package (apple_product_id mapped).
     rowCanPay(application: IApplication): boolean {
-      if (isRechargeDisabled(this.$store.getters.site)) {
+      if (application.role === 'grantee' || isRechargeDisabled(this.$store.getters.site)) {
         return false;
       }
       if (!isIOS()) {

--- a/src/pages/console/application/Subscribe.vue
+++ b/src/pages/console/application/Subscribe.vue
@@ -247,6 +247,10 @@ export default defineComponent({
       this.loadFailed = false;
       try {
         await this.onFetchApplication();
+        if (this.application?.role === 'grantee') {
+          this.$router.replace({ name: ROUTE_CONSOLE_APPLICATION_LIST });
+          return;
+        }
         // Fetch or create the Period Application used by order creation.
         await this.onFetchApplication2();
         await this.onCreateApplications();


### PR DESCRIPTION
## Summary
- hide recharge actions for applications where the current user is a grantee
- block direct access to usage and subscription purchase pages for shared applications
- cover wallet selector, application list, and used-up chat entry with a contract test

## Verification
- `npm run test:run -- src/components/application/sharedApplicationPaymentContract.test.ts src/pages/console/usage/usageContract.test.ts` (7 passed)
- ESLint on all modified Vue/TS files
- Prettier check on all modified files
- `npm run verify`
- Full `vue-tsc` / Vitest are currently blocked by the reused primary-checkout `node_modules` missing latest `@acedatacloud/core` exports; targeted changed-file checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)