### PR TITLE
feat(maestro): add Lite, Standard, and Pro selector

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,1 +1,4 @@
+root=$(git rev-parse --show-toplevel) || exit $?
+unset GIT_DIR GIT_WORK_TREE
+cd "$root" || exit $?
 npm run verify || exit $?

--- a/change/@acedatacloud-nexior-maestro-skus.json
+++ b/change/@acedatacloud-nexior-maestro-skus.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add Lite, Standard, and Pro Maestro SKU selection with tier-aware limits and pricing estimates",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/maestro/ConfigPanel.vue
+++ b/src/components/maestro/ConfigPanel.vue
@@ -54,6 +54,7 @@
               multiple
               collapse-tags
               collapse-tags-tooltip
+              :multiple-limit="additionalLanguageLimit"
               :placeholder="$t('maestro.placeholder.additionalLanguages')"
               class="w-full"
             >
@@ -105,26 +106,41 @@
           v-model="duration"
           class="field-control"
           :min="MAESTRO_MIN_DURATION"
-          :max="MAESTRO_MAX_DURATION"
+          :max="activeSkuPolicy.maxDuration"
           :step="5"
           controls-position="right"
         />
       </div>
 
-      <!-- Quality (production tier) -->
-      <div class="field-row">
+      <!-- SKU -->
+      <div class="field-block sku-field">
         <div class="field-head">
           <h2 class="field-title font-bold">{{ $t('maestro.name.quality') }}</h2>
           <info-icon :content="$t('maestro.description.quality')" class="ml-1" />
         </div>
-        <el-select v-model="quality" class="field-control">
-          <el-option
-            v-for="q in MAESTRO_ALLOWED_QUALITIES"
-            :key="q"
-            :label="$t(`maestro.option.quality.${q}`)"
-            :value="q"
-          />
-        </el-select>
+        <div class="sku-cards" role="radiogroup" :aria-label="$t('maestro.name.quality')">
+          <button
+            v-for="sku in MAESTRO_ALLOWED_QUALITIES"
+            :key="sku"
+            type="button"
+            class="sku-card"
+            :class="{ active: quality === sku }"
+            role="radio"
+            :aria-checked="quality === sku"
+            @click="quality = sku"
+          >
+            <span class="sku-card-name">{{ $t(`maestro.option.quality.${sku}`) }}</span>
+            <strong class="sku-card-price">{{ MAESTRO_SKU_POLICIES[sku].rate }} Cr/s</strong>
+            <span class="sku-card-meta">
+              {{ MAESTRO_SKU_POLICIES[sku].resolution }} · {{ MAESTRO_SKU_POLICIES[sku].fps }} fps ·
+              {{ $t('maestro.name.upToSeconds', { seconds: MAESTRO_SKU_POLICIES[sku].maxDuration }) }}
+            </span>
+          </button>
+        </div>
+        <div class="sku-summary">
+          <span>{{ $t(`maestro.description.quality.${quality}`) }}</span>
+          <strong>{{ $t('maestro.name.estimatedCredits', { credits: estimatedCredits }) }}</strong>
+        </div>
       </div>
 
       <!-- Scenario (video type) -->
@@ -149,26 +165,29 @@
             class="scenario-card"
             :class="{
               active: scenarioCustomizationEnabled && scenario === s,
-              disabled: !scenarioCustomizationEnabled
+              disabled: !scenarioCustomizationEnabled || !isScenarioAvailable(s)
             }"
             role="radio"
             :aria-checked="scenarioCustomizationEnabled && scenario === s"
-            :aria-disabled="!scenarioCustomizationEnabled"
+            :aria-disabled="!scenarioCustomizationEnabled || !isScenarioAvailable(s)"
             :aria-label="$t(`maestro.option.scenario.${s}`)"
-            :tabindex="scenarioCustomizationEnabled ? 0 : -1"
-            @click="scenarioCustomizationEnabled && (scenario = s)"
-            @keydown.enter.prevent="scenarioCustomizationEnabled && (scenario = s)"
-            @keydown.space.prevent="scenarioCustomizationEnabled && (scenario = s)"
+            :tabindex="scenarioCustomizationEnabled && isScenarioAvailable(s) ? 0 : -1"
+            @click="scenarioCustomizationEnabled && isScenarioAvailable(s) && (scenario = s)"
+            @keydown.enter.prevent="scenarioCustomizationEnabled && isScenarioAvailable(s) && (scenario = s)"
+            @keydown.space.prevent="scenarioCustomizationEnabled && isScenarioAvailable(s) && (scenario = s)"
           >
             <div class="scenario-thumb">
               <img :src="MAESTRO_SCENARIO_THUMBNAILS[s]" :alt="$t(`maestro.option.scenario.${s}`)" loading="lazy" />
             </div>
             <p class="scenario-name">{{ $t(`maestro.option.scenario.${s}`) }}</p>
+            <span v-if="!isScenarioAvailable(s)" class="scenario-lock">
+              {{ $t('maestro.name.requiresSku', { sku: requiredSkuForScenario(s) }) }}
+            </span>
           </div>
         </div>
         <el-alert
-          v-if="needsVideoUpload"
-          :title="$t('maestro.message.captionsNeedVideo')"
+          v-if="needsRequiredUpload"
+          :title="$t(scenario === 'avatar' ? 'maestro.message.avatarNeedsImage' : 'maestro.message.captionsNeedVideo')"
           type="warning"
           :closable="false"
           show-icon
@@ -257,13 +276,13 @@ import FileUrlsInput from './config/FileUrlsInput.vue';
 import {
   MAESTRO_ALLOWED_ASPECTS,
   MAESTRO_MIN_DURATION,
-  MAESTRO_MAX_DURATION,
   MAESTRO_DEFAULT_ACTION,
   MAESTRO_DEFAULT_LANGS,
   MAESTRO_DEFAULT_ASPECT,
   MAESTRO_DEFAULT_DURATION,
   MAESTRO_ALLOWED_QUALITIES,
-  MAESTRO_DEFAULT_QUALITY,
+  MAESTRO_SKU_POLICIES,
+  type IMaestroSku,
   MAESTRO_ALLOWED_SCENARIOS,
   MAESTRO_SCENARIO_THUMBNAILS,
   MAESTRO_UPLOAD_REQUIRED_SCENARIOS,
@@ -273,7 +292,7 @@ import {
   MAESTRO_DEFAULT_VOICE
 } from '@/constants';
 import { IMaestroConfig } from '@/models';
-import { isVideoUrl } from '@/utils/is';
+import { isImageUrl, isVideoUrl } from '@/utils/is';
 import {
   getMaestroLanguageOptions,
   normalizeMaestroLanguages,
@@ -284,6 +303,13 @@ import {
 import ScenarioPaymentMode from '../common/ScenarioPaymentMode.vue';
 import { isScenarioX402Enabled, scenarioPaymentState } from '@/utils/x402/scenarioPayment';
 import { buildMaestroRequest, maestroOperator } from '@/operators/maestro';
+import {
+  clampMaestroDuration,
+  clampMaestroLanguages,
+  estimateMaestroCredits,
+  isMaestroScenarioAvailable,
+  normalizeMaestroSku
+} from '@/utils/maestroSku';
 
 // Preview rectangle dimensions (px) for each aspect-ratio chip.
 const RATIO_PREVIEW: Record<string, { width: number; height: number }> = {
@@ -313,8 +339,8 @@ export default defineComponent({
   data() {
     return {
       MAESTRO_MIN_DURATION,
-      MAESTRO_MAX_DURATION,
       MAESTRO_ALLOWED_QUALITIES,
+      MAESTRO_SKU_POLICIES,
       MAESTRO_ALLOWED_SCENARIOS,
       MAESTRO_SCENARIO_THUMBNAILS,
       MAESTRO_ALLOWED_STYLES,
@@ -345,15 +371,15 @@ export default defineComponent({
     refTaskId(): string | undefined {
       return this.config?.ref_task_id;
     },
-    needsVideoUpload(): boolean {
+    needsRequiredUpload(): boolean {
       if (!this.scenarioCustomizationEnabled) return false;
       const scenario = this.config?.scenario;
       if (!scenario || !MAESTRO_UPLOAD_REQUIRED_SCENARIOS.includes(scenario)) return false;
-      // captions post-processes a talking-head clip, so a video (not an image/audio) must be uploaded.
-      return !(this.config?.file_urls || []).some((u) => isVideoUrl(u));
+      const urls = this.config?.file_urls || [];
+      return scenario === 'captions' ? !urls.some((url) => isVideoUrl(url)) : !urls.some((url) => isImageUrl(url));
     },
     canGenerate(): boolean {
-      return !!this.prompt?.trim() && !this.needsVideoUpload;
+      return !!this.prompt?.trim() && !this.needsRequiredUpload;
     },
     prompt: {
       get(): string | undefined {
@@ -390,8 +416,23 @@ export default defineComponent({
         return this.langs.slice(1);
       },
       set(val: string[]) {
-        this.update({ langs: setMaestroAdditionalLanguages(this.langs, val) });
+        this.update({ langs: clampMaestroLanguages(setMaestroAdditionalLanguages(this.langs, val), this.quality) });
       }
+    },
+    activeSkuPolicy() {
+      return MAESTRO_SKU_POLICIES[this.quality];
+    },
+    additionalLanguageLimit(): number {
+      return Math.max(0, this.activeSkuPolicy.maxLanguages - 1);
+    },
+    estimatedCredits(): number {
+      const scenario = this.scenarioCustomizationEnabled ? this.scenario || 'auto' : 'auto';
+      return estimateMaestroCredits(
+        this.duration || MAESTRO_DEFAULT_DURATION,
+        this.quality,
+        scenario,
+        this.langs.length
+      );
     },
     aspect: {
       get(): string | undefined {
@@ -407,17 +448,31 @@ export default defineComponent({
       },
       set(val: number) {
         // el-input-number can emit null when cleared; clamp into [min, max] with the default as fallback.
-        const n = typeof val === 'number' && !Number.isNaN(val) ? val : MAESTRO_DEFAULT_DURATION;
-        const clamped = Math.min(MAESTRO_MAX_DURATION, Math.max(MAESTRO_MIN_DURATION, Math.round(n)));
-        this.update({ duration: clamped });
+        this.update({ duration: clampMaestroDuration(val, this.quality) });
       }
     },
     quality: {
-      get(): string | undefined {
-        return this.config?.quality;
+      get(): IMaestroSku {
+        return normalizeMaestroSku(this.config?.quality);
       },
-      set(val: string) {
-        this.update({ quality: val });
+      set(val: IMaestroSku) {
+        const patch: Partial<IMaestroConfig> = {
+          quality: val,
+          duration: clampMaestroDuration(this.duration, val),
+          langs: clampMaestroLanguages(this.langs, val)
+        };
+        if (this.scenarioCustomizationEnabled && !isMaestroScenarioAvailable(this.scenario || 'auto', val)) {
+          patch.scenario = 'narrated';
+        }
+        if (val === 'lite' && this.config?.action === 'remix') {
+          patch.action = MAESTRO_DEFAULT_ACTION;
+          patch.ref_task_id = undefined;
+        }
+        if (val !== 'pro' && this.config?.action === 'extend') {
+          patch.action = MAESTRO_DEFAULT_ACTION;
+          patch.ref_task_id = undefined;
+        }
+        this.update(patch);
       }
     },
     scenarioCustomizationEnabled: {
@@ -499,12 +554,16 @@ export default defineComponent({
     }
   },
   mounted() {
+    const quality = normalizeMaestroSku(this.config?.quality);
+    const langs = clampMaestroLanguages(normalizeMaestroLanguages(this.config?.langs), quality);
+    const scenario = this.config?.scenario || 'narrated';
     this.update({
       action: this.config?.action ?? MAESTRO_DEFAULT_ACTION,
-      langs: normalizeMaestroLanguages(this.config?.langs),
+      langs,
       aspect: this.config?.aspect ?? MAESTRO_DEFAULT_ASPECT,
-      duration: this.config?.duration ?? MAESTRO_DEFAULT_DURATION,
-      quality: this.config?.quality ?? MAESTRO_DEFAULT_QUALITY
+      duration: clampMaestroDuration(this.config?.duration, quality),
+      quality,
+      scenario: isMaestroScenarioAvailable(scenario, quality) ? scenario : 'narrated'
     });
   },
   beforeUnmount() {
@@ -513,6 +572,13 @@ export default defineComponent({
     this.quoteRunId += 1;
   },
   methods: {
+    isScenarioAvailable(scenario: string): boolean {
+      return isMaestroScenarioAvailable(scenario, this.quality);
+    },
+    requiredSkuForScenario(scenario: string): string {
+      if (isMaestroScenarioAvailable(scenario, 'standard')) return 'Standard';
+      return 'Pro';
+    },
     scheduleQuote() {
       window.clearTimeout(this.quoteTimer);
       this.quoteTimer = window.setTimeout(this.refreshQuote, 350);
@@ -600,6 +666,78 @@ export default defineComponent({
 }
 .field-control {
   width: 168px;
+}
+.sku-field {
+  margin-top: 20px;
+}
+.sku-cards {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+  margin-top: 8px;
+}
+.sku-card {
+  min-width: 0;
+  padding: 10px 8px;
+  border: 1px solid var(--el-border-color);
+  border-radius: 10px;
+  background: var(--el-fill-color-lighter);
+  color: var(--el-text-color-primary);
+  text-align: left;
+  cursor: pointer;
+  transition:
+    border-color 0.2s ease,
+    box-shadow 0.2s ease;
+
+  &:hover,
+  &:focus-visible {
+    border-color: var(--el-color-primary-light-5);
+  }
+
+  &:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 2px var(--el-color-primary-light-7);
+  }
+
+  &.active {
+    border-color: var(--el-color-primary);
+    background: var(--el-color-primary-light-9);
+    box-shadow: 0 0 0 1px var(--el-color-primary);
+  }
+}
+.sku-card-name,
+.sku-card-price,
+.sku-card-meta {
+  display: block;
+}
+.sku-card-name {
+  font-size: 13px;
+  font-weight: 700;
+}
+.sku-card-price {
+  margin-top: 4px;
+  color: var(--el-color-primary);
+  font-size: 12px;
+}
+.sku-card-meta {
+  margin-top: 4px;
+  color: var(--el-text-color-secondary);
+  font-size: 10px;
+  line-height: 1.4;
+}
+.sku-summary {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 8px;
+  color: var(--el-text-color-secondary);
+  font-size: 11px;
+  line-height: 1.45;
+
+  strong {
+    flex: 0 0 auto;
+    color: var(--el-text-color-primary);
+  }
 }
 .custom-field {
   margin-top: 20px;
@@ -760,6 +898,15 @@ export default defineComponent({
 
   &.disabled {
     cursor: not-allowed;
+    opacity: 0.55;
+  }
+
+  .scenario-lock {
+    display: block;
+    padding: 0 4px 5px;
+    color: var(--el-text-color-secondary);
+    font-size: 10px;
+    text-align: center;
   }
 
   &:focus-visible {

--- a/src/constants/maestro.ts
+++ b/src/constants/maestro.ts
@@ -9,17 +9,50 @@ export const MAESTRO_ACTION_EXTEND = 'extend';
 
 export const MAESTRO_ALLOWED_ASPECTS = ['9:16', '16:9', '1:1'];
 export const MAESTRO_ALLOWED_LANGS = ['zh-cn', 'en', 'ja', 'ko', 'es', 'fr', 'de'];
-// Duration is billed per second (up to 10 min); the user types any value in this range.
-export const MAESTRO_MIN_DURATION = 1;
-export const MAESTRO_MAX_DURATION = 600;
-// Production tier (effort/price): draft = fast preview, standard = balanced, premium = richer.
-export const MAESTRO_ALLOWED_QUALITIES = ['draft', 'standard', 'premium'];
-// Video type: an optional routing hint. Omitting the field lets the director pick.
-// Legacy values (general/explainer/product/website/changelog -> auto; slides/slideshow/motion -> auto)
-// are still accepted by the API but no longer offered here.
+export const MAESTRO_MIN_DURATION = 5;
+export const MAESTRO_MAX_DURATION = 300;
+
+export type IMaestroSku = 'lite' | 'standard' | 'pro';
+
+export interface IMaestroSkuPolicy {
+  rate: number;
+  maxDuration: number;
+  maxLanguages: number;
+  resolution: string;
+  fps: number;
+  scenarios: readonly string[];
+}
+
+export const MAESTRO_SKU_POLICIES: Record<IMaestroSku, IMaestroSkuPolicy> = {
+  lite: {
+    rate: 0.2,
+    maxDuration: 30,
+    maxLanguages: 1,
+    resolution: '720p',
+    fps: 24,
+    scenarios: ['auto', 'narrated', 'captions']
+  },
+  standard: {
+    rate: 0.6,
+    maxDuration: 120,
+    maxLanguages: 2,
+    resolution: '1080p',
+    fps: 30,
+    scenarios: ['auto', 'narrated', 'captions', 'avatar']
+  },
+  pro: {
+    rate: 1.2,
+    maxDuration: 300,
+    maxLanguages: 4,
+    resolution: '1080p',
+    fps: 30,
+    scenarios: ['auto', 'narrated', 'captions', 'avatar', 'drama']
+  }
+};
+export const MAESTRO_ALLOWED_QUALITIES = Object.keys(MAESTRO_SKU_POLICIES) as IMaestroSku[];
 export const MAESTRO_ALLOWED_SCENARIOS = ['narrated', 'drama', 'avatar', 'captions'];
 // `captions` post-processes an EXISTING talking-head video, so it requires an uploaded source clip.
-export const MAESTRO_UPLOAD_REQUIRED_SCENARIOS = ['captions'];
+export const MAESTRO_UPLOAD_REQUIRED_SCENARIOS = ['captions', 'avatar'];
 // Preview thumbnail per scenario — a cohesive set of purpose-made 3:4 portrait
 // thumbnails (subject/head in the upper frame) so each Video Type reads at a
 // glance in the compact vertical cards. Hosted on the CDN like MAESTRO_LOGO.

--- a/src/i18n/.allow-english
+++ b/src/i18n/.allow-english
@@ -8,6 +8,14 @@
 # Cognates / proper nouns (artist names, brands): the English string IS the
 # correct rendering in these locales. Verified: 1264 of 1265 are 1-3 words;
 # the outlier is a US postal address.
+maestro.json:option.quality.lite@de  # 'Lite' product tier
+maestro.json:option.quality.pro@de  # 'Pro' product tier
+maestro.json:option.quality.lite@fi  # 'Lite' product tier
+maestro.json:option.quality.pro@fi  # 'Pro' product tier
+maestro.json:option.quality.lite@pl  # 'Lite' product tier
+maestro.json:option.quality.pro@pl  # 'Pro' product tier
+maestro.json:option.quality.lite@sv  # 'Lite' product tier
+maestro.json:option.quality.pro@sv  # 'Pro' product tier
 api.json:entity.arrayOf@de  # 'Array'
 api.json:entity.arrayOf@it  # 'Array'
 api.json:entity.arrayOf@pt  # 'Array'

--- a/src/i18n/ar/maestro.json
+++ b/src/i18n/ar/maestro.json
@@ -103,17 +103,41 @@
     "message": "الجودة",
     "description": "Production quality tier field"
   },
-  "option.quality.draft": {
-    "message": "مسودة · معاينة سريعة",
-    "description": "Draft quality option"
+  "option.quality.lite": {
+    "message": "Lite خفيف",
+    "description": "خيار SKU Lite"
   },
   "option.quality.standard": {
     "message": "قياسي · متوازن",
     "description": "Standard quality option"
   },
-  "option.quality.premium": {
-    "message": "متميز · تفاصيل أكثر",
-    "description": "Premium quality option"
+  "option.quality.pro": {
+    "message": "Pro محترف",
+    "description": "خيار SKU Pro"
+  },
+  "description.quality.lite": {
+    "message": "إنشاء مقاطع فيديو قصيرة بسيطة بسرعة، مع حركات خفيفة، وإخراج بلغة واحدة.",
+    "description": "ملخص SKU Lite"
+  },
+  "description.quality.standard": {
+    "message": "إنتاج متوازن بدقة 1080p، يدعم التعليق الصوتي الرقمي وما يصل إلى لغتين.",
+    "description": "ملخص SKU Standard"
+  },
+  "description.quality.pro": {
+    "message": "يدعم الفيديوهات الطويلة، والقصص القصيرة، وأكمل قدرات الإبداع.",
+    "description": "ملخص SKU Pro"
+  },
+  "name.upToSeconds": {
+    "message": "أقصى مدة {seconds} ثانية",
+    "description": "أقصى مدة SKU"
+  },
+  "name.estimatedCredits": {
+    "message": "تقدير {credits} نقاط",
+    "description": "نقاط التوليد المقدرة"
+  },
+  "name.requiresSku": {
+    "message": "يتطلب {sku}",
+    "description": "الحد الأدنى من SKU لنوع الفيديو"
   },
   "name.remixing": {
     "message": "إعادة التعديل",
@@ -274,6 +298,10 @@
   "message.captionsNeedVideo": {
     "message": "تعمل التسميات الحركية على فيديو متحدث موجود — ارفع مقطعًا في الأعلى أولًا.",
     "description": "Warning shown when captions video type is selected but no source video is uploaded"
+  },
+  "message.avatarNeedsImage": {
+    "message": "يتطلب التعليق الصوتي الرقمي صورة شخصية، يرجى رفعها أعلاه أولاً.",
+    "description": "تحذير يظهر عند اختيار فيديو الصورة الرمزية ولكن لم يتم رفع صورة"
   },
   "name.style": {
     "message": "الأسلوب البصري",

--- a/src/i18n/de/maestro.json
+++ b/src/i18n/de/maestro.json
@@ -103,17 +103,41 @@
     "message": "Qualität",
     "description": "Feld für die Produktionsqualität"
   },
-  "option.quality.draft": {
-    "message": "Entwurf · schnelle Vorschau",
-    "description": "Option für Entwurfsqualität"
+  "option.quality.lite": {
+    "message": "Lite",
+    "description": "Lite SKU-Option"
   },
   "option.quality.standard": {
     "message": "Standard · ausgewogen",
     "description": "Option für Standardqualität"
   },
-  "option.quality.premium": {
-    "message": "Premium · mehr Details",
-    "description": "Option für Premiumqualität"
+  "option.quality.pro": {
+    "message": "Pro",
+    "description": "Pro SKU-Option"
+  },
+  "description.quality.lite": {
+    "message": "Schnelle Erstellung von einfachen Kurzvideos, leichte Effekte, einsprachige Ausgabe.",
+    "description": "Zusammenfassung des Lite SKU"
+  },
+  "description.quality.standard": {
+    "message": "Ausgewogene 1080p-Produktion, unterstützt digitale Sprachsynthese und bis zu zwei Sprachen.",
+    "description": "Zusammenfassung des Standard SKU"
+  },
+  "description.quality.pro": {
+    "message": "Unterstützt lange Videos, Kurzfilme und die umfassendsten kreativen Produktionsfähigkeiten.",
+    "description": "Zusammenfassung des Pro SKU"
+  },
+  "name.upToSeconds": {
+    "message": "Maximal {seconds} Sekunden",
+    "description": "Maximale SKU-Dauer"
+  },
+  "name.estimatedCredits": {
+    "message": "Geschätzte {credits} Credits",
+    "description": "Geschätzte Generierungsguthaben"
+  },
+  "name.requiresSku": {
+    "message": "Benötigt {sku}",
+    "description": "Minimales SKU für einen Videotyp"
   },
   "name.remixing": {
     "message": "Remix",
@@ -274,6 +298,10 @@
   "message.captionsNeedVideo": {
     "message": "Kinetische Untertitel arbeiten mit einem vorhandenen Talking-Head-Video – lade oben zuerst eines hoch.",
     "description": "Warnung, wenn der Videotyp „Untertitel hinzufügen“ ausgewählt ist, aber kein Quellvideo hochgeladen wurde"
+  },
+  "message.avatarNeedsImage": {
+    "message": "Für die digitale Sprachsynthese wird ein Porträt benötigt, bitte laden Sie es oben hoch.",
+    "description": "Warnung, die angezeigt wird, wenn ein Avatar-Video ausgewählt ist, aber kein Porträt hochgeladen wurde"
   },
   "name.style": {
     "message": "Visueller Stil",

--- a/src/i18n/el/maestro.json
+++ b/src/i18n/el/maestro.json
@@ -36,7 +36,7 @@
     "description": "Επιλογή ενέργειας δημιουργίας"
   },
   "option.action.remix": {
-    "message": "Remix",
+    "message": "Δημιουργία remix",
     "description": "Επιλογή δράσης remix"
   },
   "option.action.edit": {
@@ -103,17 +103,41 @@
     "message": "Ποιότητα",
     "description": "Production quality tier field"
   },
-  "option.quality.draft": {
-    "message": "Πρόχειρο · γρήγορη προεπισκόπηση",
-    "description": "Draft quality option"
+  "option.quality.lite": {
+    "message": "Lite Ελαφρύ",
+    "description": "Επιλογή SKU Lite"
   },
   "option.quality.standard": {
     "message": "Τυπικό · ισορροπημένο",
     "description": "Standard quality option"
   },
-  "option.quality.premium": {
-    "message": "Premium · περισσότερες λεπτομέρειες",
-    "description": "Premium quality option"
+  "option.quality.pro": {
+    "message": "Pro Επαγγελματικό",
+    "description": "Επιλογή SKU Pro"
+  },
+  "description.quality.lite": {
+    "message": "Γρήγορη δημιουργία απλών σύντομων βίντεο, ελαφριές κινήσεις, μονόγλωσση έξοδος.",
+    "description": "Περίληψη SKU Lite"
+  },
+  "description.quality.standard": {
+    "message": "Ισορροπημένη παραγωγή 1080p, υποστηρίζει ψηφιακή αφήγηση και έως δύο γλώσσες.",
+    "description": "Περίληψη SKU Standard"
+  },
+  "description.quality.pro": {
+    "message": "Υποστηρίζει μακροχρόνια βίντεο, σύντομες ταινίες και τις πιο ολοκληρωμένες δυνατότητες δημιουργίας.",
+    "description": "Περίληψη SKU Pro"
+  },
+  "name.upToSeconds": {
+    "message": "Μέχρι {seconds} δευτερόλεπτα",
+    "description": "Μέγιστη διάρκεια SKU"
+  },
+  "name.estimatedCredits": {
+    "message": "Εκτιμώμενα {credits} πιστώσεις",
+    "description": "Εκτιμώμενες πιστώσεις παραγωγής"
+  },
+  "name.requiresSku": {
+    "message": "Απαιτείται {sku}",
+    "description": "Ελάχιστο SKU για έναν τύπο βίντεο"
   },
   "name.remixing": {
     "message": "Επαναδημιουργία",
@@ -274,6 +298,10 @@
   "message.captionsNeedVideo": {
     "message": "Οι κινητικοί υπότιτλοι εφαρμόζονται σε υπάρχον βίντεο ομιλητή — ανεβάστε πρώτα ένα παραπάνω.",
     "description": "Warning shown when captions video type is selected but no source video is uploaded"
+  },
+  "message.avatarNeedsImage": {
+    "message": "Η ψηφιακή αφήγηση χρειάζεται μια εικόνα προσώπου, παρακαλώ ανεβάστε την παραπάνω.",
+    "description": "Προειδοποίηση που εμφανίζεται όταν έχει επιλεγεί βίντεο avatar αλλά δεν έχει ανέβει πορτραίτο"
   },
   "name.style": {
     "message": "Οπτικός στυλ",

--- a/src/i18n/en/maestro.json
+++ b/src/i18n/en/maestro.json
@@ -103,17 +103,41 @@
     "message": "Quality",
     "description": "Production quality tier field"
   },
-  "option.quality.draft": {
-    "message": "Draft · fast preview",
-    "description": "Draft quality option"
+  "option.quality.lite": {
+    "message": "Lite",
+    "description": "Lite SKU option"
   },
   "option.quality.standard": {
-    "message": "Standard · balanced",
-    "description": "Standard quality option"
+    "message": "Standard",
+    "description": "Standard SKU option"
   },
-  "option.quality.premium": {
-    "message": "Premium · more detail",
-    "description": "Premium quality option"
+  "option.quality.pro": {
+    "message": "Pro",
+    "description": "Pro SKU option"
+  },
+  "description.quality.lite": {
+    "message": "Fast, clean short videos with simple motion and one language.",
+    "description": "Lite SKU summary"
+  },
+  "description.quality.standard": {
+    "message": "Balanced 1080p production with avatar video and up to two languages.",
+    "description": "Standard SKU summary"
+  },
+  "description.quality.pro": {
+    "message": "Long-form and short-drama production with the richest creative toolkit.",
+    "description": "Pro SKU summary"
+  },
+  "name.upToSeconds": {
+    "message": "up to {seconds}s",
+    "description": "Maximum SKU duration"
+  },
+  "name.estimatedCredits": {
+    "message": "Estimated {credits} credits",
+    "description": "Estimated generation credits"
+  },
+  "name.requiresSku": {
+    "message": "Requires {sku}",
+    "description": "Minimum SKU for a video type"
   },
   "name.remixing": {
     "message": "Remixing",
@@ -144,11 +168,11 @@
     "description": "Files help"
   },
   "description.duration": {
-    "message": "Target video length in seconds (1–600, up to 10 min). Billed by duration — longer videos take more time and credits to produce.",
+    "message": "Target length in seconds. Lite supports up to 30s, Standard 120s, and Pro 300s.",
     "description": "Duration help"
   },
   "description.quality": {
-    "message": "Higher tiers produce more refined visuals and editing, at higher time and credit cost.",
+    "message": "Choose the speed, output specification, duration limit, and creative capabilities you need.",
     "description": "Quality help"
   },
   "status.pending": {
@@ -274,6 +298,10 @@
   "message.captionsNeedVideo": {
     "message": "Kinetic captions runs on an existing talking-head video — upload one above first.",
     "description": "Warning shown when captions video type is selected but no source video is uploaded"
+  },
+  "message.avatarNeedsImage": {
+    "message": "Avatar video requires a portrait image — upload one above first.",
+    "description": "Warning shown when avatar video is selected but no portrait is uploaded"
   },
   "name.style": {
     "message": "Visual Style",

--- a/src/i18n/es/maestro.json
+++ b/src/i18n/es/maestro.json
@@ -103,17 +103,41 @@
     "message": "Calidad",
     "description": "Production quality tier field"
   },
-  "option.quality.draft": {
-    "message": "Borrador · vista previa rápida",
-    "description": "Draft quality option"
+  "option.quality.lite": {
+    "message": "Lite ligero",
+    "description": "Opción del SKU Lite"
   },
   "option.quality.standard": {
     "message": "Estándar · equilibrado",
     "description": "Standard quality option"
   },
-  "option.quality.premium": {
-    "message": "Premium · más detalle",
-    "description": "Premium quality option"
+  "option.quality.pro": {
+    "message": "Pro profesional",
+    "description": "Opción del SKU Pro"
+  },
+  "description.quality.lite": {
+    "message": "Crea videos cortos y sencillos rápidamente, con animaciones ligeras y salida en un solo idioma.",
+    "description": "Resumen del SKU Lite"
+  },
+  "description.quality.standard": {
+    "message": "Producción equilibrada en 1080p, soporta locución digital y hasta dos idiomas.",
+    "description": "Resumen del SKU Standard"
+  },
+  "description.quality.pro": {
+    "message": "Soporta videos largos, cortometrajes y la capacidad de producción creativa más completa.",
+    "description": "Resumen del SKU Pro"
+  },
+  "name.upToSeconds": {
+    "message": "Máximo {seconds} segundos",
+    "description": "Duración máxima del SKU"
+  },
+  "name.estimatedCredits": {
+    "message": "Estimado {credits} créditos",
+    "description": "Créditos de generación estimados"
+  },
+  "name.requiresSku": {
+    "message": "Se requiere {sku}",
+    "description": "SKU mínimo para un tipo de video"
   },
   "name.remixing": {
     "message": "Rehacer",
@@ -274,6 +298,10 @@
   "message.captionsNeedVideo": {
     "message": "Los subtítulos cinéticos funcionan sobre un vídeo de locutor existente: sube uno arriba primero.",
     "description": "Warning shown when captions video type is selected but no source video is uploaded"
+  },
+  "message.avatarNeedsImage": {
+    "message": "La locución digital necesita un retrato, por favor súbelo arriba primero.",
+    "description": "Advertencia mostrada cuando se selecciona un video de avatar pero no se ha subido un retrato"
   },
   "name.style": {
     "message": "Estilo visual",

--- a/src/i18n/fi/maestro.json
+++ b/src/i18n/fi/maestro.json
@@ -103,17 +103,41 @@
     "message": "Laatu",
     "description": "Tuotantolaadun tasokenttä"
   },
-  "option.quality.draft": {
-    "message": "Luonnos · nopea esikatselu",
-    "description": "Luonnostason vaihtoehto"
+  "option.quality.lite": {
+    "message": "Lite",
+    "description": "Lite SKU vaihtoehto"
   },
   "option.quality.standard": {
     "message": "Vakio · tasapainoinen",
     "description": "Vakiotason vaihtoehto"
   },
-  "option.quality.premium": {
-    "message": "Premium · enemmän yksityiskohtia",
-    "description": "Premiumtason vaihtoehto"
+  "option.quality.pro": {
+    "message": "Pro",
+    "description": "Pro SKU vaihtoehto"
+  },
+  "description.quality.lite": {
+    "message": "Nopea ja yksinkertainen lyhytvideo, kevyet tehosteet, yksi kieli.",
+    "description": "Lite SKU yhteenveto"
+  },
+  "description.quality.standard": {
+    "message": "Tasapainoinen 1080p tuotanto, tukee digitaalista puhetta ja enintään kahta kieltä.",
+    "description": "Standard SKU yhteenveto"
+  },
+  "description.quality.pro": {
+    "message": "Tukee pitkiä videoita, lyhyitä esityksiä ja täydellisiä luovuusmahdollisuuksia.",
+    "description": "Pro SKU yhteenveto"
+  },
+  "name.upToSeconds": {
+    "message": "Enintään {seconds} sekuntia",
+    "description": "Maksimi SKU kesto"
+  },
+  "name.estimatedCredits": {
+    "message": "Arvioidut {credits} krediittiä",
+    "description": "Arvioidut tuotantokrediitit"
+  },
+  "name.requiresSku": {
+    "message": "Vaaditaan {sku}",
+    "description": "Vähimmäis SKU videotyypille"
   },
   "name.remixing": {
     "message": "Remix",
@@ -181,7 +205,7 @@
   },
   "button.remix": {
     "message": "Remix",
-    "description": "Remixaa tämä video"
+    "description": "Remixaa tämä video -painike"
   },
   "button.cancelRemix": {
     "message": "Peru remix",
@@ -274,6 +298,10 @@
   "message.captionsNeedVideo": {
     "message": "Kineettiset tekstitykset toimivat olemassa olevaan puhujavideoon — lataa ensin video yllä.",
     "description": "Varoitus, kun tekstitysvideotyyppi on valittu mutta lähdevideota ei ole ladattu"
+  },
+  "message.avatarNeedsImage": {
+    "message": "Digitaalinen puhe tarvitsee henkilöhahmon kuvan, lataa se ensin ylhäältä.",
+    "description": "Varoitus, joka näytetään, kun avatar-video on valittu mutta kuvaa ei ole ladattu"
   },
   "name.style": {
     "message": "Visuaalinen tyyli",

--- a/src/i18n/fr/maestro.json
+++ b/src/i18n/fr/maestro.json
@@ -103,17 +103,41 @@
     "message": "Qualité",
     "description": "Production quality tier field"
   },
-  "option.quality.draft": {
-    "message": "Brouillon · aperçu rapide",
-    "description": "Draft quality option"
+  "option.quality.lite": {
+    "message": "Lite léger",
+    "description": "Option SKU Lite"
   },
   "option.quality.standard": {
     "message": "Standard · équilibré",
     "description": "Standard quality option"
   },
-  "option.quality.premium": {
-    "message": "Premium · plus de détails",
-    "description": "Premium quality option"
+  "option.quality.pro": {
+    "message": "Pro professionnel",
+    "description": "Option SKU Pro"
+  },
+  "description.quality.lite": {
+    "message": "Création rapide de vidéos courtes et simples, effets légers, sortie en une seule langue.",
+    "description": "Résumé de l'option Lite"
+  },
+  "description.quality.standard": {
+    "message": "Production équilibrée en 1080p, prise en charge de la narration numérique et de deux langues maximum.",
+    "description": "Résumé de l'option Standard"
+  },
+  "description.quality.pro": {
+    "message": "Prise en charge des vidéos longues, des courts métrages et des capacités de création les plus complètes.",
+    "description": "Résumé de l'option Pro"
+  },
+  "name.upToSeconds": {
+    "message": "Durée maximale de {seconds} secondes",
+    "description": "Durée maximale de l'option SKU"
+  },
+  "name.estimatedCredits": {
+    "message": "Crédits estimés {credits}",
+    "description": "Crédits de génération estimés"
+  },
+  "name.requiresSku": {
+    "message": "Nécessite {sku}",
+    "description": "SKU minimum pour un type de vidéo"
   },
   "name.remixing": {
     "message": "Remixage",
@@ -274,6 +298,10 @@
   "message.captionsNeedVideo": {
     "message": "Les sous-titres cinétiques s'appliquent à une vidéo de présentateur existante — importez-en une ci-dessus d'abord.",
     "description": "Warning shown when captions video type is selected but no source video is uploaded"
+  },
+  "message.avatarNeedsImage": {
+    "message": "La narration numérique nécessite un portrait, veuillez d'abord le télécharger ci-dessus.",
+    "description": "Avertissement affiché lorsque la vidéo d'avatar est sélectionnée mais qu'aucun portrait n'est téléchargé"
   },
   "name.style": {
     "message": "Style visuel",

--- a/src/i18n/it/maestro.json
+++ b/src/i18n/it/maestro.json
@@ -103,17 +103,41 @@
     "message": "Qualità",
     "description": "Production quality tier field"
   },
-  "option.quality.draft": {
-    "message": "Bozza · anteprima rapida",
-    "description": "Draft quality option"
+  "option.quality.lite": {
+    "message": "Lite Leggero",
+    "description": "Opzione SKU Lite"
   },
   "option.quality.standard": {
     "message": "Standard · bilanciato",
     "description": "Standard quality option"
   },
-  "option.quality.premium": {
-    "message": "Premium · più dettagli",
-    "description": "Premium quality option"
+  "option.quality.pro": {
+    "message": "Pro Professionale",
+    "description": "Opzione SKU Pro"
+  },
+  "description.quality.lite": {
+    "message": "Crea rapidamente video brevi e semplici, con effetti leggeri e output in un'unica lingua.",
+    "description": "Riepilogo SKU Lite"
+  },
+  "description.quality.standard": {
+    "message": "Produzione equilibrata in 1080p, supporta la narrazione digitale e fino a due lingue.",
+    "description": "Riepilogo SKU Standard"
+  },
+  "description.quality.pro": {
+    "message": "Supporta video lunghi, cortometraggi e la massima capacità creativa.",
+    "description": "Riepilogo SKU Pro"
+  },
+  "name.upToSeconds": {
+    "message": "Massimo {seconds} secondi",
+    "description": "Durata massima dello SKU"
+  },
+  "name.estimatedCredits": {
+    "message": "Stimati {credits} crediti",
+    "description": "Crediti di generazione stimati"
+  },
+  "name.requiresSku": {
+    "message": "Richiede {sku}",
+    "description": "SKU minimo per un tipo di video"
   },
   "name.remixing": {
     "message": "Remix",
@@ -274,6 +298,10 @@
   "message.captionsNeedVideo": {
     "message": "I sottotitoli cinetici lavorano su un video con volto parlante esistente: caricane uno sopra prima.",
     "description": "Warning shown when captions video type is selected but no source video is uploaded"
+  },
+  "message.avatarNeedsImage": {
+    "message": "La narrazione digitale richiede un ritratto, caricalo sopra prima.",
+    "description": "Avviso mostrato quando viene selezionato un video avatar ma non è stato caricato alcun ritratto"
   },
   "name.style": {
     "message": "Stile visivo",

--- a/src/i18n/ja/maestro.json
+++ b/src/i18n/ja/maestro.json
@@ -103,17 +103,41 @@
     "message": "品質",
     "description": "制作品質ティアフィールド"
   },
-  "option.quality.draft": {
-    "message": "ドラフト · 高速プレビュー",
-    "description": "ドラフト品質オプション"
+  "option.quality.lite": {
+    "message": "Lite 軽量",
+    "description": "Lite SKU のオプション"
   },
   "option.quality.standard": {
     "message": "標準 · バランス",
     "description": "標準品質オプション"
   },
-  "option.quality.premium": {
-    "message": "プレミアム · より詳細",
-    "description": "プレミアム品質オプション"
+  "option.quality.pro": {
+    "message": "Pro プロフェッショナル",
+    "description": "Pro SKU のオプション"
+  },
+  "description.quality.lite": {
+    "message": "簡潔な短い動画を迅速に作成し、軽いエフェクトと単一言語出力を提供します。",
+    "description": "Lite SKU の概要"
+  },
+  "description.quality.standard": {
+    "message": "バランスの取れた 1080p 制作で、デジタルナレーションと最大 2 言語をサポートします。",
+    "description": "Standard SKU の概要"
+  },
+  "description.quality.pro": {
+    "message": "長い動画、短編劇、そして最も完全なクリエイティブ制作能力をサポートします。",
+    "description": "Pro SKU の概要"
+  },
+  "name.upToSeconds": {
+    "message": "最大 {seconds} 秒",
+    "description": "SKU の最大持続時間"
+  },
+  "name.estimatedCredits": {
+    "message": "予想 {credits} クレジット",
+    "description": "生成クレジットの予想"
+  },
+  "name.requiresSku": {
+    "message": "{sku} が必要です",
+    "description": "動画タイプに必要な最小 SKU"
   },
   "name.remixing": {
     "message": "リミックス",
@@ -274,6 +298,10 @@
   "message.captionsNeedVideo": {
     "message": "キネティック字幕は既存のトーキングヘッド動画に適用します。まず上で動画をアップロードしてください。",
     "description": "字幕動画タイプが選択されたが動画がアップロードされていない場合の警告"
+  },
+  "message.avatarNeedsImage": {
+    "message": "デジタルナレーションには人物の肖像が必要です。上部でアップロードしてください。",
+    "description": "アバター動画が選択されているが肖像がアップロードされていない場合に表示される警告"
   },
   "name.style": {
     "message": "ビジュアルスタイル",

--- a/src/i18n/ko/maestro.json
+++ b/src/i18n/ko/maestro.json
@@ -83,6 +83,14 @@
     "message": "언어",
     "description": "출력 언어 필드"
   },
+  "name.primaryLanguage": {
+    "message": "주 언어",
+    "description": "주 출력 언어 필드"
+  },
+  "name.additionalLanguages": {
+    "message": "추가 언어 (선택 사항)",
+    "description": "추가 출력 언어 필드"
+  },
   "name.aspect": {
     "message": "화면 비율",
     "description": "화면 비율 필드"
@@ -95,17 +103,41 @@
     "message": "품질",
     "description": "제작 품질 등급 필드"
   },
-  "option.quality.draft": {
-    "message": "초안 · 빠른 미리보기",
-    "description": "초안 품질 옵션"
+  "option.quality.lite": {
+    "message": "Lite 경량",
+    "description": "Lite SKU 옵션"
   },
   "option.quality.standard": {
     "message": "표준 · 균형",
     "description": "표준 품질 옵션"
   },
-  "option.quality.premium": {
-    "message": "프리미엄 · 더 세밀함",
-    "description": "프리미엄 품질 옵션"
+  "option.quality.pro": {
+    "message": "Pro 전문",
+    "description": "Pro SKU 옵션"
+  },
+  "description.quality.lite": {
+    "message": "간편한 짧은 비디오 제작, 간단한 효과, 단일 언어 출력.",
+    "description": "Lite SKU 요약"
+  },
+  "description.quality.standard": {
+    "message": "균형 잡힌 1080p 제작, 디지털 내레이션 및 최대 두 가지 언어 지원.",
+    "description": "Standard SKU 요약"
+  },
+  "description.quality.pro": {
+    "message": "긴 비디오, 단편극 및 가장 완벽한 창작 능력을 지원합니다.",
+    "description": "Pro SKU 요약"
+  },
+  "name.upToSeconds": {
+    "message": "최대 {seconds} 초",
+    "description": "최대 SKU 지속 시간"
+  },
+  "name.estimatedCredits": {
+    "message": "예상 {credits} 크레딧",
+    "description": "예상 생성 크레딧"
+  },
+  "name.requiresSku": {
+    "message": "{sku} 필요",
+    "description": "비디오 유형에 대한 최소 SKU"
   },
   "name.remixing": {
     "message": "리믹스",
@@ -118,6 +150,10 @@
   "placeholder.select": {
     "message": "선택하세요",
     "description": "일반적인 선택 자리 표시자"
+  },
+  "placeholder.additionalLanguages": {
+    "message": "출력 언어 추가",
+    "description": "추가 언어 자리 표시자"
   },
   "description.prompt": {
     "message": "원하는 내용을 간단히 설명하세요. 스크립트, 화면, 더빙, 편집은 Maestro에게 맡기세요.",
@@ -207,6 +243,30 @@
     "message": "아직 비디오가 없습니다 — 왼쪽에서 첫 번째 비디오를 생성하세요.",
     "description": "작업 없음"
   },
+  "name.customize": {
+    "message": "맞춤 설정",
+    "description": "선택적 크리에이티브 제어 토글"
+  },
+  "description.customize.auto": {
+    "message": "자동 · 동영상 유형, 시각적 스타일, 내레이터 음색은 Maestro가 결정합니다.",
+    "description": "사용자 지정 비활성화 상태"
+  },
+  "description.customize.manual": {
+    "message": "동영상 유형, 시각적 스타일, 내레이터 음색을 선택하세요.",
+    "description": "사용자 지정 활성화 상태"
+  },
+  "name.customizeScenario": {
+    "message": "동영상 유형 맞춤 설정",
+    "description": "비디오 유형 사용자 지정 토글"
+  },
+  "name.customizeStyle": {
+    "message": "시각적 스타일 맞춤 설정",
+    "description": "시각적 스타일 사용자 지정 토글"
+  },
+  "name.customizeVoice": {
+    "message": "내레이터 음색 맞춤 설정",
+    "description": "음성 음색 사용자 지정 토글"
+  },
   "name.scenario": {
     "message": "동영상 유형",
     "description": "비디오 유형 필드"
@@ -238,6 +298,10 @@
   "message.captionsNeedVideo": {
     "message": "키네틱 자막은 기존 토킹헤드 영상에 적용됩니다. 먼저 위에서 영상을 업로드하세요.",
     "description": "자막 비디오 유형을 선택했으나 소스 비디오가 업로드되지 않은 경우 표시되는 경고"
+  },
+  "message.avatarNeedsImage": {
+    "message": "디지털 내레이션을 위해 인물 초상이 필요합니다. 위에서 먼저 업로드하세요.",
+    "description": "아바타 비디오가 선택되었지만 초상이 업로드되지 않았을 때 표시되는 경고"
   },
   "name.style": {
     "message": "시각적 스타일",
@@ -450,41 +514,5 @@
   "option.scenario.changelog": {
     "message": "변경 로그 (PR)",
     "description": "변경 이력 시나리오 옵션"
-  },
-  "name.customize": {
-    "message": "맞춤 설정",
-    "description": "선택적 크리에이티브 제어 토글"
-  },
-  "description.customize.auto": {
-    "message": "자동 · 동영상 유형, 시각적 스타일, 내레이터 음색은 Maestro가 결정합니다.",
-    "description": "사용자 지정 비활성화 상태"
-  },
-  "description.customize.manual": {
-    "message": "동영상 유형, 시각적 스타일, 내레이터 음색을 선택하세요.",
-    "description": "사용자 지정 활성화 상태"
-  },
-  "name.primaryLanguage": {
-    "message": "주 언어",
-    "description": "주 출력 언어 필드"
-  },
-  "name.additionalLanguages": {
-    "message": "추가 언어 (선택 사항)",
-    "description": "추가 출력 언어 필드"
-  },
-  "placeholder.additionalLanguages": {
-    "message": "출력 언어 추가",
-    "description": "추가 언어 자리 표시자"
-  },
-  "name.customizeScenario": {
-    "message": "동영상 유형 맞춤 설정",
-    "description": "비디오 유형 사용자 지정 토글"
-  },
-  "name.customizeStyle": {
-    "message": "시각적 스타일 맞춤 설정",
-    "description": "시각적 스타일 사용자 지정 토글"
-  },
-  "name.customizeVoice": {
-    "message": "내레이터 음색 맞춤 설정",
-    "description": "음성 음색 사용자 지정 토글"
   }
 }

--- a/src/i18n/pl/maestro.json
+++ b/src/i18n/pl/maestro.json
@@ -103,17 +103,41 @@
     "message": "Jakość",
     "description": "Pole poziomu jakości produkcji"
   },
-  "option.quality.draft": {
-    "message": "Szkic · szybki podgląd",
-    "description": "Opcja jakości szkicowej"
+  "option.quality.lite": {
+    "message": "Lite",
+    "description": "Opcja SKU Lite"
   },
   "option.quality.standard": {
     "message": "Standard · zrównoważony",
     "description": "Opcja jakości standardowej"
   },
-  "option.quality.premium": {
-    "message": "Premium · więcej szczegółów",
-    "description": "Opcja jakości premium"
+  "option.quality.pro": {
+    "message": "Pro",
+    "description": "Opcja SKU Pro"
+  },
+  "description.quality.lite": {
+    "message": "Szybkie tworzenie prostych, krótkich filmów, z lekkimi efektami, w jednym języku.",
+    "description": "Podsumowanie SKU Lite"
+  },
+  "description.quality.standard": {
+    "message": "Zrównoważona produkcja 1080p, obsługuje cyfrowe lektury i maksymalnie dwa języki.",
+    "description": "Podsumowanie SKU Standard"
+  },
+  "description.quality.pro": {
+    "message": "Obsługuje długie filmy, krótkie dramaty i pełne możliwości twórcze.",
+    "description": "Podsumowanie SKU Pro"
+  },
+  "name.upToSeconds": {
+    "message": "Maksymalnie {seconds} sekund",
+    "description": "Maksymalny czas trwania SKU"
+  },
+  "name.estimatedCredits": {
+    "message": "Szacowane {credits} punkty",
+    "description": "Szacowane kredyty generacji"
+  },
+  "name.requiresSku": {
+    "message": "Wymagana {sku}",
+    "description": "Minimalne SKU dla typu wideo"
   },
   "name.remixing": {
     "message": "Remixowanie",
@@ -274,6 +298,10 @@
   "message.captionsNeedVideo": {
     "message": "Napisy kinetyczne działają na istniejącym filmie z mówiącą osobą — najpierw prześlij go powyżej.",
     "description": "Ostrzeżenie wyświetlane po wybraniu typu z napisami bez przesłanego wideo źródłowego"
+  },
+  "message.avatarNeedsImage": {
+    "message": "Cyfrowa lektura wymaga portretu, proszę najpierw przesłać obrazek powyżej.",
+    "description": "Ostrzeżenie wyświetlane, gdy wybrano wideo awatara, ale nie przesłano portretu"
   },
   "name.style": {
     "message": "Styl wizualny",

--- a/src/i18n/pt/maestro.json
+++ b/src/i18n/pt/maestro.json
@@ -103,17 +103,41 @@
     "message": "Qualidade",
     "description": "Production quality tier field"
   },
-  "option.quality.draft": {
-    "message": "Rascunho · pré-visualização rápida",
-    "description": "Draft quality option"
+  "option.quality.lite": {
+    "message": "Lite Leve",
+    "description": "Opção SKU Lite"
   },
   "option.quality.standard": {
     "message": "Padrão · equilibrado",
     "description": "Standard quality option"
   },
-  "option.quality.premium": {
-    "message": "Premium · mais detalhes",
-    "description": "Premium quality option"
+  "option.quality.pro": {
+    "message": "Pro Profissional",
+    "description": "Opção SKU Pro"
+  },
+  "description.quality.lite": {
+    "message": "Criação rápida de vídeos curtos e simples, com animações leves e saída em um único idioma.",
+    "description": "Resumo do SKU Lite"
+  },
+  "description.quality.standard": {
+    "message": "Produção equilibrada em 1080p, suporta narração digital e até duas línguas.",
+    "description": "Resumo do SKU Standard"
+  },
+  "description.quality.pro": {
+    "message": "Suporta vídeos longos, curtas-metragens e a capacidade criativa mais completa.",
+    "description": "Resumo do SKU Pro"
+  },
+  "name.upToSeconds": {
+    "message": "Máximo de {seconds} segundos",
+    "description": "Duração máxima do SKU"
+  },
+  "name.estimatedCredits": {
+    "message": "Estimativa de {credits} créditos",
+    "description": "Créditos estimados para geração"
+  },
+  "name.requiresSku": {
+    "message": "Necessário {sku}",
+    "description": "SKU mínimo para um tipo de vídeo"
   },
   "name.remixing": {
     "message": "Remixando",
@@ -274,6 +298,10 @@
   "message.captionsNeedVideo": {
     "message": "As legendas cinéticas funcionam sobre um vídeo de locutor existente — envie um acima primeiro.",
     "description": "Warning shown when captions video type is selected but no source video is uploaded"
+  },
+  "message.avatarNeedsImage": {
+    "message": "A narração digital precisa de um retrato, por favor, faça o upload acima primeiro.",
+    "description": "Aviso exibido quando um vídeo de avatar é selecionado, mas nenhum retrato foi enviado"
   },
   "name.style": {
     "message": "Estilo visual",

--- a/src/i18n/ru/maestro.json
+++ b/src/i18n/ru/maestro.json
@@ -103,17 +103,41 @@
     "message": "Качество",
     "description": "Production quality tier field"
   },
-  "option.quality.draft": {
-    "message": "Черновик · быстрый предпросмотр",
-    "description": "Draft quality option"
+  "option.quality.lite": {
+    "message": "Lite легкий",
+    "description": "Опция Lite SKU"
   },
   "option.quality.standard": {
     "message": "Стандарт · сбалансированно",
     "description": "Standard quality option"
   },
-  "option.quality.premium": {
-    "message": "Премиум · больше деталей",
-    "description": "Premium quality option"
+  "option.quality.pro": {
+    "message": "Pro профессиональный",
+    "description": "Опция Pro SKU"
+  },
+  "description.quality.lite": {
+    "message": "Быстрое создание простых коротких видео, легкие эффекты, одноличный вывод.",
+    "description": "Резюме Lite SKU"
+  },
+  "description.quality.standard": {
+    "message": "Сбалансированное производство 1080p, поддержка цифрового озвучивания и до двух языков.",
+    "description": "Резюме Standard SKU"
+  },
+  "description.quality.pro": {
+    "message": "Поддержка длинных видео, коротких сериалов и самых полных возможностей креативного производства.",
+    "description": "Резюме Pro SKU"
+  },
+  "name.upToSeconds": {
+    "message": "Максимум {seconds} секунд",
+    "description": "Максимальная продолжительность SKU"
+  },
+  "name.estimatedCredits": {
+    "message": "Ожидается {credits} кредитов",
+    "description": "Оцененные кредиты на генерацию"
+  },
+  "name.requiresSku": {
+    "message": "Требуется {sku}",
+    "description": "Минимальный SKU для типа видео"
   },
   "name.remixing": {
     "message": "Ремикс",
@@ -274,6 +298,10 @@
   "message.captionsNeedVideo": {
     "message": "Кинетические субтитры работают с уже существующим видео с говорящим — сначала загрузите его выше.",
     "description": "Warning shown when captions video type is selected but no source video is uploaded"
+  },
+  "message.avatarNeedsImage": {
+    "message": "Цифровое озвучивание требует изображения персонажа, пожалуйста, загрузите его выше.",
+    "description": "Предупреждение, отображаемое при выборе видео с аватаром, но без загруженного портрета"
   },
   "name.style": {
     "message": "Визуальный стиль",

--- a/src/i18n/sr/maestro.json
+++ b/src/i18n/sr/maestro.json
@@ -83,6 +83,14 @@
     "message": "Језици",
     "description": "Поље за излазне језике"
   },
+  "name.primaryLanguage": {
+    "message": "Главни језик",
+    "description": "Поље главног излазног језика"
+  },
+  "name.additionalLanguages": {
+    "message": "Додатни језици (опционо)",
+    "description": "Поље додатних излазних језика"
+  },
   "name.aspect": {
     "message": "Odnos stranica",
     "description": "Polje za odnos stranica"
@@ -95,17 +103,41 @@
     "message": "Квалитет",
     "description": "Поље нивоа продукционог квалитета"
   },
-  "option.quality.draft": {
-    "message": "Нацрт · брзи преглед",
-    "description": "Опција квалитета нацрта"
+  "option.quality.lite": {
+    "message": "Lite lagani",
+    "description": "Opcija Lite SKU"
   },
   "option.quality.standard": {
     "message": "Стандард · уравнотежено",
     "description": "Опција стандардног квалитета"
   },
-  "option.quality.premium": {
-    "message": "Премијум · више детаља",
-    "description": "Опција Premium квалитета"
+  "option.quality.pro": {
+    "message": "Pro profesionalni",
+    "description": "Opcija Pro SKU"
+  },
+  "description.quality.lite": {
+    "message": "Brzo pravite jednostavne kratke video zapise, lagani efekti, izlaz na jednom jeziku.",
+    "description": "Sažetak Lite SKU"
+  },
+  "description.quality.standard": {
+    "message": "Izbalansirana 1080p produkcija, podržava digitalnu naraciju i do dva jezika.",
+    "description": "Sažetak Standard SKU"
+  },
+  "description.quality.pro": {
+    "message": "Podržava duge video zapise, kratke drame i najpotpunije mogućnosti kreativne produkcije.",
+    "description": "Sažetak Pro SKU"
+  },
+  "name.upToSeconds": {
+    "message": "Najduže {seconds} sekundi",
+    "description": "Maksimalna trajanje SKU"
+  },
+  "name.estimatedCredits": {
+    "message": "Procena {credits} kredita",
+    "description": "Procena generisanih kredita"
+  },
+  "name.requiresSku": {
+    "message": "Potrebno {sku}",
+    "description": "Minimalni SKU za tip video zapisa"
   },
   "name.remixing": {
     "message": "Ремиксовање",
@@ -118,6 +150,10 @@
   "placeholder.select": {
     "message": "Izaberite",
     "description": "Generički placeholder za izbor"
+  },
+  "placeholder.additionalLanguages": {
+    "message": "Додај језике излаза",
+    "description": "Место за додатне језике"
   },
   "description.prompt": {
     "message": "Јасно изразите шта желите, сценарио, слике, глас, монтажу оставите Maestro-у.",
@@ -207,6 +243,30 @@
     "message": "Još nema videa — kreiraj svoj prvi sa leve strane.",
     "description": "Nema zadataka"
   },
+  "name.customize": {
+    "message": "Прилагоди",
+    "description": "Прекидач за опционе креативне контроле"
+  },
+  "description.customize.auto": {
+    "message": "Аутоматски · Maestro бира тип видеа, визуелни стил и тон гласа.",
+    "description": "Стање када је прилагођавање искључено"
+  },
+  "description.customize.manual": {
+    "message": "Изаберите тип видеа, визуелни стил и тон гласа.",
+    "description": "Стање када је прилагођавање укључено"
+  },
+  "name.customizeScenario": {
+    "message": "Прилагоди тип видеа",
+    "description": "Прекидач за прилагођавање типа видеа"
+  },
+  "name.customizeStyle": {
+    "message": "Прилагоди визуелни стил",
+    "description": "Прекидач за прилагођавање визуелног стила"
+  },
+  "name.customizeVoice": {
+    "message": "Прилагоди тон гласа",
+    "description": "Прекидач за прилагођавање боје гласа"
+  },
   "name.scenario": {
     "message": "Тип видеа",
     "description": "Поље типа видеа"
@@ -238,6 +298,10 @@
   "message.captionsNeedVideo": {
     "message": "Кинетички титлови раде на постојећем видеу говорника — прво отпремите један изнад.",
     "description": "Упозорење када је изабран тип видеа са титловима, а није отпремљен изворни видео"
+  },
+  "message.avatarNeedsImage": {
+    "message": "Digitalna naracija zahteva sliku lica, molimo vas da je prvo otpremite gore.",
+    "description": "Upozorenje se prikazuje kada je izabran avatar video, ali nijedna slika nije otpremljena"
   },
   "name.style": {
     "message": "Визуелни стил",
@@ -450,41 +514,5 @@
   "option.scenario.changelog": {
     "message": "Списак измена (PR)",
     "description": "Changelog scenario option"
-  },
-  "name.customize": {
-    "message": "Прилагоди",
-    "description": "Прекидач за опционе креативне контроле"
-  },
-  "description.customize.auto": {
-    "message": "Аутоматски · Maestro бира тип видеа, визуелни стил и тон гласа.",
-    "description": "Стање када је прилагођавање искључено"
-  },
-  "description.customize.manual": {
-    "message": "Изаберите тип видеа, визуелни стил и тон гласа.",
-    "description": "Стање када је прилагођавање укључено"
-  },
-  "name.primaryLanguage": {
-    "message": "Главни језик",
-    "description": "Поље главног излазног језика"
-  },
-  "name.additionalLanguages": {
-    "message": "Додатни језици (опционо)",
-    "description": "Поље додатних излазних језика"
-  },
-  "placeholder.additionalLanguages": {
-    "message": "Додај језике излаза",
-    "description": "Место за додатне језике"
-  },
-  "name.customizeScenario": {
-    "message": "Прилагоди тип видеа",
-    "description": "Прекидач за прилагођавање типа видеа"
-  },
-  "name.customizeStyle": {
-    "message": "Прилагоди визуелни стил",
-    "description": "Прекидач за прилагођавање визуелног стила"
-  },
-  "name.customizeVoice": {
-    "message": "Прилагоди тон гласа",
-    "description": "Прекидач за прилагођавање боје гласа"
   }
 }

--- a/src/i18n/sv/maestro.json
+++ b/src/i18n/sv/maestro.json
@@ -103,17 +103,41 @@
     "message": "Kvalitet",
     "description": "Production quality tier field"
   },
-  "option.quality.draft": {
-    "message": "Utkast · snabb förhandsvisning",
-    "description": "Draft quality option"
+  "option.quality.lite": {
+    "message": "Lite",
+    "description": "Alternativ för Lite SKU"
   },
   "option.quality.standard": {
     "message": "Standard · balanserad",
     "description": "Standard quality option"
   },
-  "option.quality.premium": {
-    "message": "Premium · mer detaljer",
-    "description": "Premium quality option"
+  "option.quality.pro": {
+    "message": "Pro",
+    "description": "Alternativ för Pro SKU"
+  },
+  "description.quality.lite": {
+    "message": "Snabbt skapa enkla korta videor, lätt animation, en språkversion.",
+    "description": "Sammanfattning av Lite SKU"
+  },
+  "description.quality.standard": {
+    "message": "Balanserad 1080p-produktion, stöd för digital röstuppläsning och upp till två språk.",
+    "description": "Sammanfattning av Standard SKU"
+  },
+  "description.quality.pro": {
+    "message": "Stöd för långa videor, korta serier och den mest kompletta kreativa produktionskapaciteten.",
+    "description": "Sammanfattning av Pro SKU"
+  },
+  "name.upToSeconds": {
+    "message": "Max {seconds} sekunder",
+    "description": "Maximal SKU-längd"
+  },
+  "name.estimatedCredits": {
+    "message": "Beräknade {credits} poäng",
+    "description": "Beräknade genereringspoäng"
+  },
+  "name.requiresSku": {
+    "message": "Kräver {sku}",
+    "description": "Minsta SKU för en videotyp"
   },
   "name.remixing": {
     "message": "Remix",
@@ -274,6 +298,10 @@
   "message.captionsNeedVideo": {
     "message": "Kinetiska undertexter arbetar på en befintlig talande-huvud-video – ladda upp en ovan först.",
     "description": "Warning shown when captions video type is selected but no source video is uploaded"
+  },
+  "message.avatarNeedsImage": {
+    "message": "Digital röstuppläsning kräver ett porträtt, vänligen ladda upp ovan.",
+    "description": "Varning som visas när avatarvideo är vald men inget porträtt har laddats upp"
   },
   "name.style": {
     "message": "Visuell stil",

--- a/src/i18n/uk/maestro.json
+++ b/src/i18n/uk/maestro.json
@@ -103,17 +103,41 @@
     "message": "Якість",
     "description": "Production quality tier field"
   },
-  "option.quality.draft": {
-    "message": "Чернетка · швидкий перегляд",
-    "description": "Draft quality option"
+  "option.quality.lite": {
+    "message": "Lite легкий",
+    "description": "Опція SKU Lite"
   },
   "option.quality.standard": {
     "message": "Стандарт · збалансовано",
     "description": "Standard quality option"
   },
-  "option.quality.premium": {
-    "message": "Преміум · більше деталей",
-    "description": "Premium quality option"
+  "option.quality.pro": {
+    "message": "Pro професійний",
+    "description": "Опція SKU Pro"
+  },
+  "description.quality.lite": {
+    "message": "Швидке створення простих коротких відео, легка анімація, однією мовою.",
+    "description": "Резюме SKU Lite"
+  },
+  "description.quality.standard": {
+    "message": "Збалансоване виробництво 1080p, підтримка цифрового озвучення та до двох мов.",
+    "description": "Резюме SKU Standard"
+  },
+  "description.quality.pro": {
+    "message": "Підтримка довгих відео, коротких п'єс та найповніших можливостей креативного виробництва.",
+    "description": "Резюме SKU Pro"
+  },
+  "name.upToSeconds": {
+    "message": "Максимум {seconds} секунд",
+    "description": "Максимальна тривалість SKU"
+  },
+  "name.estimatedCredits": {
+    "message": "Приблизно {credits} кредитів",
+    "description": "Оцінені кредити на генерацію"
+  },
+  "name.requiresSku": {
+    "message": "Потрібен {sku}",
+    "description": "Мінімальний SKU для типу відео"
   },
   "name.remixing": {
     "message": "Ремікс",
@@ -274,6 +298,10 @@
   "message.captionsNeedVideo": {
     "message": "Кінетичні субтитри працюють із наявним відео з мовцем — спершу завантажте його вище.",
     "description": "Warning shown when captions video type is selected but no source video is uploaded"
+  },
+  "message.avatarNeedsImage": {
+    "message": "Цифрове озвучення потребує зображення персонажа, будь ласка, спочатку завантажте його вище.",
+    "description": "Попередження, яке з'являється, коли вибрано відео аватара, але портрет не завантажено"
   },
   "name.style": {
     "message": "Візуальний стиль",

--- a/src/i18n/zh-CN/maestro.json
+++ b/src/i18n/zh-CN/maestro.json
@@ -103,17 +103,41 @@
     "message": "制作档位",
     "description": "Production quality tier field"
   },
-  "option.quality.draft": {
-    "message": "草稿 · 快速预览",
-    "description": "Draft quality option"
+  "option.quality.lite": {
+    "message": "Lite 轻量",
+    "description": "Lite SKU option"
   },
   "option.quality.standard": {
-    "message": "标准 · 均衡",
-    "description": "Standard quality option"
+    "message": "Standard 标准",
+    "description": "Standard SKU option"
   },
-  "option.quality.premium": {
-    "message": "高级 · 更精细",
-    "description": "Premium quality option"
+  "option.quality.pro": {
+    "message": "Pro 专业",
+    "description": "Pro SKU option"
+  },
+  "description.quality.lite": {
+    "message": "快速制作简洁短视频，轻动效，单语言输出。",
+    "description": "Lite SKU summary"
+  },
+  "description.quality.standard": {
+    "message": "均衡的 1080p 制作，支持数字人口播和最多两种语言。",
+    "description": "Standard SKU summary"
+  },
+  "description.quality.pro": {
+    "message": "支持长视频、短剧和最完整的创意制作能力。",
+    "description": "Pro SKU summary"
+  },
+  "name.upToSeconds": {
+    "message": "最长 {seconds} 秒",
+    "description": "Maximum SKU duration"
+  },
+  "name.estimatedCredits": {
+    "message": "预计 {credits} 积分",
+    "description": "Estimated generation credits"
+  },
+  "name.requiresSku": {
+    "message": "需 {sku}",
+    "description": "Minimum SKU for a video type"
   },
   "name.remixing": {
     "message": "二次创作",
@@ -144,11 +168,11 @@
     "description": "Files help"
   },
   "description.duration": {
-    "message": "目标视频时长（秒，1–600，最长 10 分钟）。按时长计费——越长则制作耗时与消耗的积分越多。",
+    "message": "目标视频时长（秒）。Lite 最长 30 秒，Standard 120 秒，Pro 300 秒。",
     "description": "Duration help"
   },
   "description.quality": {
-    "message": "制作档位越高,画面与剪辑越精细,但耗时与积分也更高。",
+    "message": "按所需速度、输出规格、时长上限和创意能力选择档位。",
     "description": "Quality help"
   },
   "status.pending": {
@@ -274,6 +298,10 @@
   "message.captionsNeedVideo": {
     "message": "字幕花字需要基于已有的口播视频制作，请先在上方上传一段视频。",
     "description": "Warning shown when captions video type is selected but no source video is uploaded"
+  },
+  "message.avatarNeedsImage": {
+    "message": "数字人口播需要一张人物肖像，请先在上方上传。",
+    "description": "Warning shown when avatar video is selected but no portrait is uploaded"
   },
   "name.style": {
     "message": "视觉风格",

--- a/src/i18n/zh-TW/maestro.json
+++ b/src/i18n/zh-TW/maestro.json
@@ -83,6 +83,14 @@
     "message": "語言",
     "description": "輸出語言欄位"
   },
+  "name.primaryLanguage": {
+    "message": "主語言",
+    "description": "Primary output language field"
+  },
+  "name.additionalLanguages": {
+    "message": "其他語言（可選）",
+    "description": "Additional output languages field"
+  },
   "name.aspect": {
     "message": "畫面比例",
     "description": "畫面比例欄位"
@@ -95,17 +103,41 @@
     "message": "製作檔位",
     "description": "Production quality tier field"
   },
-  "option.quality.draft": {
-    "message": "草稿 · 快速預覽",
-    "description": "Draft quality option"
+  "option.quality.lite": {
+    "message": "Lite 輕量",
+    "description": "Lite SKU 選項"
   },
   "option.quality.standard": {
     "message": "標準 · 均衡",
     "description": "Standard quality option"
   },
-  "option.quality.premium": {
-    "message": "高階 · 更精細",
-    "description": "Premium quality option"
+  "option.quality.pro": {
+    "message": "Pro 專業",
+    "description": "Pro SKU 選項"
+  },
+  "description.quality.lite": {
+    "message": "快速製作簡潔短影片，輕動效，單語言輸出。",
+    "description": "Lite SKU 總結"
+  },
+  "description.quality.standard": {
+    "message": "均衡的 1080p 製作，支持數位人口播和最多兩種語言。",
+    "description": "Standard SKU 總結"
+  },
+  "description.quality.pro": {
+    "message": "支持長影片、短劇和最完整的創意製作能力。",
+    "description": "Pro SKU 總結"
+  },
+  "name.upToSeconds": {
+    "message": "最長 {seconds} 秒",
+    "description": "最大 SKU 時長"
+  },
+  "name.estimatedCredits": {
+    "message": "預計 {credits} 積分",
+    "description": "預估的生成積分"
+  },
+  "name.requiresSku": {
+    "message": "需 {sku}",
+    "description": "影片類型的最低 SKU"
   },
   "name.remixing": {
     "message": "二次創作",
@@ -118,6 +150,10 @@
   "placeholder.select": {
     "message": "請選擇",
     "description": "通用選擇佔位符"
+  },
+  "placeholder.additionalLanguages": {
+    "message": "新增其他輸出語言",
+    "description": "Additional languages placeholder"
   },
   "description.prompt": {
     "message": "用大白話說清楚你想要什麼,指令碼、畫面、配音、剪輯都交給 Maestro。",
@@ -207,6 +243,30 @@
     "message": "還沒有影片 — 在左側建立你的第一個吧。",
     "description": "沒有任務"
   },
+  "name.customize": {
+    "message": "自訂",
+    "description": "Optional creative controls toggle"
+  },
+  "description.customize.auto": {
+    "message": "自動 · 由 Maestro 決定影片型別、視覺風格與配音音色。",
+    "description": "Customization disabled state"
+  },
+  "description.customize.manual": {
+    "message": "選擇影片型別、視覺風格與配音音色。",
+    "description": "Customization enabled state"
+  },
+  "name.customizeScenario": {
+    "message": "自訂影片型別",
+    "description": "Video type customization toggle"
+  },
+  "name.customizeStyle": {
+    "message": "自訂視覺風格",
+    "description": "Visual style customization toggle"
+  },
+  "name.customizeVoice": {
+    "message": "自訂配音音色",
+    "description": "Voice timbre customization toggle"
+  },
   "name.scenario": {
     "message": "影片型別",
     "description": "Video type field"
@@ -238,6 +298,10 @@
   "message.captionsNeedVideo": {
     "message": "字幕花字需要以既有的口播影片製作，請先在上方上傳一段影片。",
     "description": "Warning shown when captions video type is selected but no source video is uploaded"
+  },
+  "message.avatarNeedsImage": {
+    "message": "數位人口播需要一張人物肖像，請先在上方上傳。",
+    "description": "當選擇了頭像影片但未上傳肖像時顯示的警告"
   },
   "name.style": {
     "message": "視覺風格",
@@ -450,41 +514,5 @@
   "option.scenario.changelog": {
     "message": "更新日誌 (PR)",
     "description": "Changelog scenario option"
-  },
-  "name.customize": {
-    "message": "自訂",
-    "description": "Optional creative controls toggle"
-  },
-  "description.customize.auto": {
-    "message": "自動 · 由 Maestro 決定影片型別、視覺風格與配音音色。",
-    "description": "Customization disabled state"
-  },
-  "description.customize.manual": {
-    "message": "選擇影片型別、視覺風格與配音音色。",
-    "description": "Customization enabled state"
-  },
-  "name.primaryLanguage": {
-    "message": "主語言",
-    "description": "Primary output language field"
-  },
-  "name.additionalLanguages": {
-    "message": "其他語言（可選）",
-    "description": "Additional output languages field"
-  },
-  "placeholder.additionalLanguages": {
-    "message": "新增其他輸出語言",
-    "description": "Additional languages placeholder"
-  },
-  "name.customizeScenario": {
-    "message": "自訂影片型別",
-    "description": "Video type customization toggle"
-  },
-  "name.customizeStyle": {
-    "message": "自訂視覺風格",
-    "description": "Visual style customization toggle"
-  },
-  "name.customizeVoice": {
-    "message": "自訂配音音色",
-    "description": "Voice timbre customization toggle"
   }
 }

--- a/src/models/maestro.ts
+++ b/src/models/maestro.ts
@@ -1,3 +1,5 @@
+import type { IMaestroSku } from '@/constants/maestro';
+
 export type IMaestroAction = 'generate' | 'remix' | 'edit' | 'extend';
 
 export interface IMaestroConfig {
@@ -13,7 +15,7 @@ export interface IMaestroConfig {
   langs?: string[];
   aspect?: string; // '9:16' | '16:9' | '1:1'
   duration?: number;
-  quality?: string; // 'draft' | 'standard' | 'premium'
+  quality?: IMaestroSku;
   scenario?: string; // 'auto' | 'narrated' | 'drama' | 'avatar' | 'captions'
   style?: string; // freeform visual hint (e.g. 'auto' | 'cinematic' | 'minimal' | 'neon' | 'corporate'); orthogonal to scenario
   voice?: string; // narration timbre: 'auto' (director picks) | a preset key (constants) | a 32-hex Fish reference_id

--- a/src/operators/x402ScenarioRequests.test.ts
+++ b/src/operators/x402ScenarioRequests.test.ts
@@ -150,10 +150,10 @@ describe('scenario-owned x402 requests', () => {
       buildMaestroRequest({
         prompt: 'video',
         duration: 30,
-        quality: 'premium',
+        quality: 'pro',
         scenario_customization_enabled: true,
         scenario: 'drama'
       })
-    ).toMatchObject({ prompt: 'video', duration: 30, quality: 'premium', scenario: 'drama' });
+    ).toMatchObject({ prompt: 'video', duration: 30, quality: 'pro', scenario: 'drama' });
   });
 });

--- a/src/utils/maestroSku.test.ts
+++ b/src/utils/maestroSku.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import {
+  clampMaestroDuration,
+  clampMaestroLanguages,
+  estimateMaestroCredits,
+  isMaestroScenarioAvailable,
+  normalizeMaestroSku
+} from './maestroSku';
+
+describe('Maestro SKU policy', () => {
+  it('migrates legacy persisted qualities', () => {
+    expect(normalizeMaestroSku('draft')).toBe('lite');
+    expect(normalizeMaestroSku('premium')).toBe('pro');
+    expect(normalizeMaestroSku('unknown')).toBe('standard');
+  });
+
+  it('clamps duration to each SKU', () => {
+    expect(clampMaestroDuration(31, 'lite')).toBe(30);
+    expect(clampMaestroDuration(121, 'standard')).toBe(120);
+    expect(clampMaestroDuration(301, 'pro')).toBe(300);
+    expect(clampMaestroDuration(1, 'lite')).toBe(5);
+  });
+
+  it('limits output languages by SKU', () => {
+    const langs = ['zh-cn', 'en', 'ja', 'ko'];
+    expect(clampMaestroLanguages(langs, 'lite')).toEqual(['zh-cn']);
+    expect(clampMaestroLanguages(langs, 'standard')).toEqual(['zh-cn', 'en']);
+    expect(clampMaestroLanguages(langs, 'pro')).toEqual(langs);
+  });
+
+  it('gates expensive scenarios', () => {
+    expect(isMaestroScenarioAvailable('avatar', 'lite')).toBe(false);
+    expect(isMaestroScenarioAvailable('avatar', 'standard')).toBe(true);
+    expect(isMaestroScenarioAvailable('drama', 'standard')).toBe(false);
+    expect(isMaestroScenarioAvailable('drama', 'pro')).toBe(true);
+  });
+
+  it('estimates credits using public billing formula', () => {
+    expect(estimateMaestroCredits(30, 'lite')).toBe(6);
+    expect(estimateMaestroCredits(30, 'standard', 'avatar', 2)).toBe(26.7);
+    expect(estimateMaestroCredits(30, 'pro', 'drama')).toBe(48.6);
+  });
+});

--- a/src/utils/maestroSku.ts
+++ b/src/utils/maestroSku.ts
@@ -1,0 +1,42 @@
+import {
+  MAESTRO_DEFAULT_QUALITY,
+  MAESTRO_MIN_DURATION,
+  MAESTRO_SKU_POLICIES,
+  type IMaestroSku
+} from '@/constants/maestro';
+
+const LEGACY_SKUS: Record<string, IMaestroSku> = {
+  draft: 'lite',
+  premium: 'pro'
+};
+
+export function normalizeMaestroSku(value?: string): IMaestroSku {
+  const normalized = value?.trim().toLowerCase() || MAESTRO_DEFAULT_QUALITY;
+  if (normalized in MAESTRO_SKU_POLICIES) return normalized as IMaestroSku;
+  return LEGACY_SKUS[normalized] || MAESTRO_DEFAULT_QUALITY;
+}
+
+export function clampMaestroDuration(value: unknown, sku: IMaestroSku): number {
+  const fallback = Math.min(30, MAESTRO_SKU_POLICIES[sku].maxDuration);
+  const duration = typeof value === 'number' && Number.isFinite(value) ? Math.round(value) : fallback;
+  return Math.min(MAESTRO_SKU_POLICIES[sku].maxDuration, Math.max(MAESTRO_MIN_DURATION, duration));
+}
+
+export function clampMaestroLanguages(langs: string[] | undefined, sku: IMaestroSku): string[] {
+  return (langs?.length ? langs : ['zh-cn']).slice(0, MAESTRO_SKU_POLICIES[sku].maxLanguages);
+}
+
+export function isMaestroScenarioAvailable(scenario: string, sku: IMaestroSku): boolean {
+  return MAESTRO_SKU_POLICIES[sku].scenarios.includes(scenario);
+}
+
+export function estimateMaestroCredits(
+  duration: number,
+  sku: IMaestroSku,
+  scenario = 'auto',
+  languageCount = 1
+): number {
+  const scenarioMultiplier = scenario === 'drama' ? 1.35 : scenario === 'avatar' ? 1.15 : 1;
+  const languageSurcharge = Math.max(0, languageCount - 1) * 6;
+  return Number((duration * MAESTRO_SKU_POLICIES[sku].rate * scenarioMultiplier + languageSurcharge).toFixed(2));
+}


### PR DESCRIPTION
## Summary
- replace legacy quality dropdown with comparable Lite / Standard / Pro cards
- clamp duration, languages, actions, and scenarios when changing SKU and migrate persisted draft/premium values
- show public per-second pricing and estimated credits
- add translated SKU copy across all 18 locales and make pre-push Beachball validation work in linked worktrees

## Validation
- Vitest — 185 files, 1367 tests passed
- ESLint — 0 errors
- vue-tsc — passed
- i18n coverage — passed
- web production build — passed
- Beachball check — passed

## Rollout
Release after the PlatformBackend and PlatformService SKU contracts are deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)