### PR TITLE
fix(desktop): persist any-path consent tool-wide

### DIFF
--- a/change/@acedatacloud-nexior-desktop-consent-any-path.json
+++ b/change/@acedatacloud-nexior-desktop-consent-any-path.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix desktop local-tool consent so Always allow (any path) applies to future invocations of the selected tool",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/electron/local/consent.test.ts
+++ b/electron/local/consent.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { ToolInvoke } from './types';
+
+const state = vi.hoisted(() => ({ userData: '', responses: [] as number[] }));
+const showMessageBox = vi.hoisted(() => vi.fn(async () => ({ response: state.responses.shift() ?? 0 })));
+vi.mock('electron', () => ({
+  app: { getPath: () => state.userData },
+  dialog: { showMessageBox },
+  BrowserWindow: class BrowserWindow {}
+}));
+
+import { consentOk, grantKey, resetConsent } from './consent';
+import { load, save } from './config';
+import { dirGrantKey } from './dirGrants';
+import { _resetRootsForTesting } from './fs';
+
+const dirs: string[] = [];
+
+function tmpUserData(): string {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'nx-consent-'));
+  dirs.push(dir);
+  state.userData = dir;
+  return dir;
+}
+
+function invocation(name: string, input: Record<string, unknown>): ToolInvoke {
+  return { name, input, sessionId: 'session-1' };
+}
+
+afterEach(() => {
+  resetConsent();
+  _resetRootsForTesting();
+  state.responses = [];
+  showMessageBox.mockClear();
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('local-tool consent choices', () => {
+  it('persists the path-aware any-path choice as a tool-wide grant', async () => {
+    const root = tmpUserData();
+    const project = path.join(root, 'project');
+    mkdirSync(project);
+    const first = path.join(project, 'requirements.md');
+    writeFileSync(first, 'first');
+    state.responses = [3];
+
+    const initial = invocation('fs.read_file', { path: first, offset: 405, limit: 30 });
+    expect((await consentOk(initial, null)).ok).toBe(true);
+    expect(load().grants).toEqual(['fs.read_file']);
+    expect(load().grants).not.toContain(grantKey(initial));
+    expect(load().roots).toEqual([realpathSync(project)]);
+
+    const next = invocation('fs.read_file', { path: path.join(root, 'elsewhere.md'), offset: 1, limit: 100 });
+    expect((await consentOk(next, null)).ok).toBe(true);
+    expect(showMessageBox).toHaveBeenCalledTimes(1);
+
+    const options = showMessageBox.mock.calls[0][0];
+    expect(options.buttons).toHaveLength(5);
+    expect(options.buttons[0]).toBe('Allow once');
+    expect(options.buttons[1]).toBe('Allow for session');
+    expect(options.buttons[2]).toMatch(/^Always allow in /);
+    expect(options.buttons[2]).toContain(path.basename(project));
+    expect(options.buttons[3]).toBe('Always allow (any path)');
+    expect(options.buttons[4]).toBe('Deny');
+    expect(options.detail).toContain('permits this tool in any folder you have authorized');
+    expect(options.detail).toContain('other folders stay blocked');
+  });
+
+  it('keeps the directory choice scoped to that directory tree', async () => {
+    const root = tmpUserData();
+    const project = path.join(root, 'project');
+    mkdirSync(project);
+    state.responses = [2, 4];
+
+    const initial = invocation('shell.exec', { command: 'npm test', cwd: project });
+    expect((await consentOk(initial, null)).ok).toBe(true);
+    expect(load().grants).toEqual([dirGrantKey('shell.exec', project)]);
+    expect(load().grants).not.toContain('shell.exec');
+
+    const nested = invocation('shell.exec', { command: 'npm run lint', cwd: path.join(project, 'src') });
+    expect((await consentOk(nested, null)).ok).toBe(true);
+    expect(showMessageBox).toHaveBeenCalledTimes(1);
+
+    const outside = invocation('shell.exec', { command: 'npm run build', cwd: path.join(root, 'other') });
+    expect((await consentOk(outside, null)).ok).toBe(false);
+    expect(showMessageBox).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps the four-button always choice exact-input scoped', async () => {
+    tmpUserData();
+    state.responses = [2, 3];
+    const initial = invocation('project.load_context', {});
+
+    expect((await consentOk(initial, null)).ok).toBe(true);
+    expect(load().grants).toEqual([grantKey(initial)]);
+    expect(load().grants).not.toContain('project.load_context');
+
+    const different = invocation('project.load_context', { mode: 'full' });
+    expect((await consentOk(different, null)).ok).toBe(false);
+    expect(showMessageBox).toHaveBeenCalledTimes(2);
+    expect(showMessageBox.mock.calls[0][0].buttons).toEqual([
+      'Allow once',
+      'Allow for session',
+      'Always allow',
+      'Deny'
+    ]);
+  });
+
+  it('does not widen a legacy exact-input grant', async () => {
+    tmpUserData();
+    const original = invocation('fs.grep', { pattern: 'TODO' });
+    save({ roots: [], mcp: [], grants: [grantKey(original)], computerUse: false });
+
+    expect((await consentOk(original, null)).ok).toBe(true);
+    expect(showMessageBox).not.toHaveBeenCalled();
+
+    state.responses = [3];
+    const different = invocation('fs.grep', { pattern: 'FIXME' });
+    expect((await consentOk(different, null)).ok).toBe(false);
+    expect(showMessageBox).toHaveBeenCalledTimes(1);
+    expect(load().grants).toEqual([grantKey(original)]);
+    expect(load().grants).not.toContain('fs.grep');
+  });
+});

--- a/electron/local/consent.ts
+++ b/electron/local/consent.ts
@@ -14,14 +14,13 @@ import { authorizeConsentedPath, revokeOnceRoot } from './fs';
 //                      Honored by EVERY tool, mutating included: the key is
 //                      input-bound (except computer.*), so it only skips the
 //                      prompt for a byte-identical repeat of what was approved.
-//   • Always allow   — persist a session-independent grant to disk so the call
-//                      never prompts again. Revocable from Settings.
-// fs/shell grants are bound to the EXACT input; computer.* grants are name-
-// scoped (their inputs — mouse coords, typed text — vary every call, so an
-// input-scoped grant would never match twice). A computer.* "Always allow" is
-// thus an explicit opt-in to prompt-less screen control; the panic hotkey still
-// hard-disables Computer Use regardless (the registry gate blocks every
-// computer.* call before consent runs).
+//   • Always allow   — persist a session-independent grant to disk. The plain
+//                      four-button form is input-bound; "any path" is tool-wide.
+// computer.* grants are name-scoped (their inputs — mouse coords, typed text —
+// vary every call, so an input-scoped grant would never match twice). A
+// computer.* "Always allow" is thus an explicit opt-in to prompt-less screen
+// control; the panic hotkey still hard-disables Computer Use regardless (the
+// registry gate blocks every computer.* call before consent runs).
 // For fs.* the approval authorizes the containing FOLDER (read + write), which
 // the dialog states outright — one file is rarely the useful unit of work, and
 // a file-scoped grant would re-prompt for every sibling.
@@ -59,9 +58,9 @@ function sessionKey(inv: ToolInvoke): string {
   return `${inv.sessionId}:${inv.name}:${stable(inv.input)}`;
 }
 
-// Session-independent key for persistent "Always allow" grants. fs/shell grants
-// are scoped to the EXACT tool + input, so always-allowing `ls /Desktop` never
-// auto-runs `rm`. computer.* grants are name-scoped (see file header).
+// Session-independent key for exact-input "Always allow" grants. The explicit
+// "any path" tier stores the bare tool name instead. computer.* grants are
+// always name-scoped (see file header).
 export function grantKey(inv: ToolInvoke): string {
   if (inv.name.startsWith('computer.')) return inv.name;
   return `${inv.name}:${stable(inv.input)}`;
@@ -122,18 +121,20 @@ function consentDetail(inv: ToolInvoke, scopeDir: string | null, dirTarget: stri
   if (scopeDir) {
     lines.push('', `Approving grants read + write access to this folder and everything inside it:\n${scopeDir}`);
   }
-  // Spell out the repeat semantics: a session/always grant re-runs this exact
-  // call without asking again, which for a non-idempotent tool (sending,
-  // posting, deleting) means the side effect can happen more than once.
   lines.push(
     '',
-    '"Allow for session" and "Always allow" re-run this exact call without asking again — if it sends, posts or deletes something, that can happen again.'
+    '"Allow for session" re-runs this exact call without asking again — if it sends, posts or deletes something, that can happen again.'
   );
   if (dirTarget) {
     lines.push(
       '',
-      `"Always allow in …" is broader: ANY ${inv.name} call under ${dirTarget} runs without asking, including commands you have not seen yet. It stays limited to that folder.`
+      `"Always allow in …" permits ANY ${inv.name} call under ${dirTarget}.`,
+      inv.name.startsWith('fs.')
+        ? '"Always allow (any path)" permits this tool in any folder you have authorized; other folders stay blocked.'
+        : `"Always allow (any path)" permits ANY ${inv.name} input without asking, in any folder.`
     );
+  } else {
+    lines.push('', '"Always allow" re-runs this exact call without asking again.');
   }
   return lines.join('\n');
 }
@@ -219,7 +220,9 @@ export async function consentOk(inv: ToolInvoke, win: BrowserWindow | null): Pro
   if (response === alwaysBtn) {
     const cfg = load();
     const grants = new Set(cfg.grants ?? []);
-    grants.add(gk);
+    // The path-aware dialog explicitly promises tool-wide consent. The plain
+    // four-button "Always allow" remains bound to this exact input.
+    grants.add(dirTarget ? inv.name : gk);
     save({ ...cfg, grants: [...grants] });
   }
   // Authorize the approved path's FOLDER (fs.* tools), bound to its realpath AT

--- a/electron/local/types.ts
+++ b/electron/local/types.ts
@@ -48,9 +48,8 @@ export interface McpServerStatus {
 export interface LocalConfig {
   roots: string[];
   mcp: McpServerConf[];
-  // Persistent "always allow" consent grants. Each entry is a
-  // session-independent key `<tool.name>:<stable json input>` the user
-  // explicitly chose to always allow; matching invocations skip the prompt.
+  // Persistent consent grants: exact input (`<tool>:<json>`), directory scoped
+  // (`dir:<tool>:<path>`), or tool-wide (bare `<tool>`).
   grants?: string[];
   // Opt-in Computer Use (screen capture + mouse/keyboard control). Default
   // false; while false the `computer.*` tools are not advertised or invokable.


### PR DESCRIPTION
## Summary
- persist the desktop “Always allow (any path)” choice as a real tool-wide grant
- preserve directory-scoped, exact-input, legacy grant, and filesystem root-boundary behavior
- add dialog-level regression coverage for each consent tier

## Verification
- `npx vitest run electron/local/consent.test.ts electron/local/dirGrants.test.ts electron/local/config.test.ts electron/local/fs.test.ts`
- `npx tsc -p electron/tsconfig.json --noEmit`
- `npx vitest run --maxWorkers=1` (190 files, 1398 tests)
- `npm run lint:check` (0 errors; 2 existing warnings)
- `npm run compile:electron`
- `npm run build`
- `npm run verify`

🤖 Generated with [Claude Code](https://claude.com/claude-code)