### PR TITLE
fix(ci): validate generated arm64 desktop zip

### DIFF
--- a/.github/workflows/release-desktop.yaml
+++ b/.github/workflows/release-desktop.yaml
@@ -260,7 +260,7 @@ jobs:
           else
             test -f "release/${ELECTRON_BUILDER_CHANNEL}-mac.yml"
             if [ "${{ matrix.arch }}" = arm64 ]; then
-              compgen -G 'release/*-arm64.zip' >/dev/null
+              compgen -G 'release/*-arm64-mac.zip' >/dev/null
               compgen -G 'release/*-arm64.dmg' >/dev/null
             else
               compgen -G 'release/*-mac.zip' >/dev/null

--- a/change/@acedatacloud-nexior-desktop-arm64-artifact-check.json
+++ b/change/@acedatacloud-nexior-desktop-arm64-artifact-check.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix the desktop release pipeline to validate the generated Apple Silicon update ZIP",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/scripts/check_release_workflows.py
+++ b/scripts/check_release_workflows.py
@@ -72,6 +72,8 @@ def main() -> None:
     require("github.event_name != 'workflow_call'" not in android, "Android mode must not depend on the caller event name")
     require("github.event_name == 'workflow_call'" not in desktop, "desktop attachment must use the explicit release tag")
     require("if: inputs.release_tag != ''" in desktop, "desktop installers must attach when a release tag is supplied")
+    require("release/*-arm64-mac.zip" in desktop, "desktop workflow must verify the electron-builder arm64 ZIP name")
+    require("release/*-arm64.zip" not in desktop, "desktop workflow still verifies the obsolete arm64 ZIP name")
     require("if: inputs.upload_to_play || startsWith(github.ref, 'refs/tags/android-v')" in android, "Play steps must require an explicit store release mode")
 
     for parent in ("release-mobile-testing.yaml", "release-mobile-production.yaml", "release-mobile-manual.yaml"):

--- a/scripts/test_publish_desktop_release.py
+++ b/scripts/test_publish_desktop_release.py
@@ -17,9 +17,9 @@ def complete_set() -> tuple[list[Path], list[Path]]:
             "AceData-1.2.3.dmg",
             "AceData-1.2.3-arm64.dmg",
             "AceData-1.2.3.zip",
-            "AceData-1.2.3-arm64.zip",
+            "AceData-1.2.3-arm64-mac.zip",
             "AceData-1.2.3.zip.blockmap",
-            "AceData-1.2.3-arm64.zip.blockmap",
+            "AceData-1.2.3-arm64-mac.zip.blockmap",
         ),
         paths("latest.yml", "latest-mac.yml"),
     )
@@ -38,7 +38,7 @@ def test_accepts_complete_cross_platform_update_set() -> None:
         ("AceData-1.2.3.exe.blockmap", "installer blockmap"),
         ("AceData-1.2.3-arm64.dmg", "arm64 DMG"),
         ("AceData-1.2.3.zip", "x64 update ZIP"),
-        ("AceData-1.2.3-arm64.zip", "arm64 update ZIP"),
+        ("AceData-1.2.3-arm64-mac.zip", "arm64 update ZIP"),
     ],
 )
 def test_rejects_incomplete_update_set(missing: str, message: str) -> None:


### PR DESCRIPTION
## Summary
- match the Apple Silicon ZIP name emitted by electron-builder
- align desktop publisher fixtures with real macOS artifact names
- lock the workflow glob in the release contract check

## Verification
- `python3 -m pytest scripts/test_publish_desktop_release.py`
- `python3 scripts/check_release_workflows.py`
- `npm run verify`

## Production evidence
Fixes the deterministic artifact validation failure in https://github.com/AceDataCloud/Nexior/actions/runs/31564335254.

🤖 Generated with [Claude Code](https://claude.com/claude-code)