### PR TITLE
fix(ci): move Intel desktop build to supported runner

### DIFF
--- a/.github/workflows/release-desktop.yaml
+++ b/.github/workflows/release-desktop.yaml
@@ -165,7 +165,7 @@ jobs:
         include:
           - os: windows-latest
             arch: x64
-          - os: macos-13
+          - os: macos-15-intel
             arch: x64
           - os: macos-14
             arch: arm64

--- a/change/@acedatacloud-nexior-desktop-intel-runner.json
+++ b/change/@acedatacloud-nexior-desktop-intel-runner.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Move Intel desktop builds to the supported macOS 15 Intel runner",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/scripts/check_release_workflows.py
+++ b/scripts/check_release_workflows.py
@@ -74,6 +74,8 @@ def main() -> None:
     require("if: inputs.release_tag != ''" in desktop, "desktop installers must attach when a release tag is supplied")
     require("release/*-arm64-mac.zip" in desktop, "desktop workflow must verify the electron-builder arm64 ZIP name")
     require("release/*-arm64.zip" not in desktop, "desktop workflow still verifies the obsolete arm64 ZIP name")
+    require("os: macos-15-intel" in desktop, "desktop workflow must use the supported Intel macOS runner")
+    require("os: macos-13" not in desktop, "desktop workflow still uses the retired macOS 13 runner")
     require("if: inputs.upload_to_play || startsWith(github.ref, 'refs/tags/android-v')" in android, "Play steps must require an explicit store release mode")
 
     for parent in ("release-mobile-testing.yaml", "release-mobile-production.yaml", "release-mobile-manual.yaml"):


### PR DESCRIPTION
## Summary
- replace the retired `macos-13` label with GitHub’s supported `macos-15-intel` runner
- lock the supported Intel runner label in the release workflow contract check

## Verification
- `python3 scripts/check_release_workflows.py`
- `beachball check --no-fetch`

## Production evidence
The prior beta run remains permanently queued with `runner_id=0` on `macos-13`: https://github.com/AceDataCloud/Nexior/actions/runs/31568162452. GitHub retired macOS 13 runners in December 2025.

🤖 Generated with [Claude Code](https://claude.com/claude-code)