### PR TITLE
feat(site): separate public branding from management

### DIFF
--- a/change/@acedatacloud-nexior-secure-site-management.json
+++ b/change/@acedatacloud-nexior-secure-site-management.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Load public site branding separately from authenticated tenant management permissions",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/setting/Subsite.test.ts
+++ b/src/components/setting/Subsite.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const siteOperatorMock = vi.hoisted(() => ({
   getAll: vi.fn(),
+  getManaged: vi.fn(),
   create: vi.fn(),
   delete: vi.fn()
 }));
@@ -50,7 +51,7 @@ const mountComponent = () =>
 describe('setting/Subsite', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    siteOperatorMock.getAll.mockResolvedValue({ data: { items: [] } });
+    siteOperatorMock.getManaged.mockResolvedValue({ data: { items: [] } });
     siteDomainOperatorMock.getAll.mockResolvedValue({ data: { items: [] } });
   });
 
@@ -69,7 +70,7 @@ describe('setting/Subsite', () => {
 
     (wrapper.vm as unknown as { onManageSite: (row: ISite) => void }).onManageSite(site);
 
-    expect(open).toHaveBeenCalledWith('https://studio.example.com/?dialog=settings', '_blank', 'noopener');
+    expect(open).toHaveBeenCalledWith('https://studio.example.com/?dialog=settings&tab=site', '_blank', 'noopener');
   });
 
   it('falls back to the default subdomain when no custom domain is active', async () => {
@@ -84,6 +85,10 @@ describe('setting/Subsite', () => {
 
     (wrapper.vm as unknown as { onManageSite: (row: ISite) => void }).onManageSite(site);
 
-    expect(open).toHaveBeenCalledWith('https://brand.studio.acedata.cloud/?dialog=settings', '_blank', 'noopener');
+    expect(open).toHaveBeenCalledWith(
+      'https://brand.studio.acedata.cloud/?dialog=settings&tab=site',
+      '_blank',
+      'noopener'
+    );
   });
 });

--- a/src/components/setting/Subsite.vue
+++ b/src/components/setting/Subsite.vue
@@ -66,6 +66,7 @@
                 {{ $t('subsite.button.manage') }}
               </el-button>
               <el-button
+                v-if="row.permissions?.owner !== false"
                 size="small"
                 round
                 type="danger"
@@ -289,7 +290,7 @@ export default defineComponent({
         // (`<slug>.studio.acedata.cloud`). No `parent_site_id` needed —
         // the superuser fast path doesn't stamp `metadata.parent_site_id`
         // anyway, which is why the previous metadata filter hid rows.
-        const { data } = await siteOperator.getAll({
+        const { data } = await siteOperator.getManaged({
           user_id: userId,
           origin__endswith: `.${zone}`,
           ordering: '-created_at'
@@ -449,7 +450,7 @@ export default defineComponent({
       // pops the settings dialog. This avoids the blank `/settings`
       // page race where SettingsIndex dispatches `open-user-settings`
       // before UserCenter's listener is registered.
-      window.open(`https://${hostname}/?dialog=settings`, '_blank', 'noopener');
+      window.open(`https://${hostname}/?dialog=settings&tab=site`, '_blank', 'noopener');
     },
     async onDeleteSite(row: ISite) {
       if (!row.id || !row.origin) return;

--- a/src/components/user/Setting.vue
+++ b/src/components/user/Setting.vue
@@ -299,7 +299,8 @@ export default defineComponent({
       return this.visibleNavItems.some((item) => item.key === this.activeTab) ? this.activeTab : SETTING_TAB_GENERAL;
     },
     isSiteAdmin(): boolean {
-      return this.$store?.state?.site?.permissions?.manage === true;
+      const site = this.$store?.state?.site;
+      return site?.permissions?.manage === true || !!site?.admins?.includes(this.$store.getters.user?.id);
     },
     isMainOfficialHost(): boolean {
       return isMainOfficial();
@@ -345,11 +346,21 @@ export default defineComponent({
   watch: {
     // When the parent opens the dialog with an explicit `initialTab`,
     // respect that on each open. Default is back to the General tab.
-    async visible(open: boolean) {
+    visible(open: boolean) {
       if (open) {
-        await this.$store.dispatch('getManagedSite');
         this.activeTab = (this.initialTab as SettingTabKey) || SETTING_TAB_GENERAL;
         this.autoOpenCreateSubsite = false;
+        const requestedTab = this.activeTab;
+        const operatorTabs: SettingTabKey[] = [
+          SETTING_TAB_SITE,
+          SETTING_TAB_SITE_SERVICES,
+          SETTING_TAB_SEO,
+          SETTING_TAB_DISTRIBUTION,
+          SETTING_TAB_FUNCTION,
+          SETTING_TAB_AUTH,
+          SETTING_TAB_CUSTOM_DOMAIN
+        ];
+        if (operatorTabs.includes(requestedTab)) this.$store.dispatch('getManagedSite');
       }
     }
   },

--- a/src/components/user/Setting.vue
+++ b/src/components/user/Setting.vue
@@ -299,7 +299,7 @@ export default defineComponent({
       return this.visibleNavItems.some((item) => item.key === this.activeTab) ? this.activeTab : SETTING_TAB_GENERAL;
     },
     isSiteAdmin(): boolean {
-      return !!this.$store?.state?.site?.admins?.includes(this.$store.getters.user?.id);
+      return this.$store?.state?.site?.permissions?.manage === true;
     },
     isMainOfficialHost(): boolean {
       return isMainOfficial();
@@ -345,8 +345,9 @@ export default defineComponent({
   watch: {
     // When the parent opens the dialog with an explicit `initialTab`,
     // respect that on each open. Default is back to the General tab.
-    visible(open: boolean) {
+    async visible(open: boolean) {
       if (open) {
+        await this.$store.dispatch('getManagedSite');
         this.activeTab = (this.initialTab as SettingTabKey) || SETTING_TAB_GENERAL;
         this.autoOpenCreateSubsite = false;
       }

--- a/src/models/site.ts
+++ b/src/models/site.ts
@@ -170,6 +170,13 @@ export interface ISiteBranding {
   contacts?: ISiteContact[];
 }
 
+export type SiteRole = 'owner' | 'manager' | 'platform_admin';
+
+export interface ISitePermissions {
+  manage: boolean;
+  owner: boolean;
+}
+
 export interface ISite {
   id?: string;
   origin?: string;
@@ -209,6 +216,8 @@ export interface ISite {
   description_source?: string;
   auto_translated_fields?: string[];
   capability_overrides?: Partial<Record<CapabilityKey, ISiteCapabilityPresentation>>;
+  role?: SiteRole | null;
+  permissions?: ISitePermissions;
 }
 
 export interface ISiteListResponse {

--- a/src/operators/site.management.test.ts
+++ b/src/operators/site.management.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const http = vi.hoisted(() => ({ get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn() }));
+vi.mock('./common', () => ({ httpClient: http }));
+
+import { siteOperator } from './site';
+
+describe('siteOperator management contract', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('uses the public and authenticated site endpoints', async () => {
+    http.get.mockResolvedValue({ data: { origin: 'tenant.example.com' } });
+    await siteOperator.resolvePublic('tenant.example.com');
+    await siteOperator.getManaged({ origin__endswith: '.studio.acedata.cloud' });
+    await siteOperator.getManagedCurrent('tenant.example.com');
+
+    expect(http.get).toHaveBeenNthCalledWith(1, '/sites/resolve', { params: { origin: 'tenant.example.com' } });
+    expect(http.get).toHaveBeenNthCalledWith(2, '/sites/managed', {
+      params: { origin__endswith: '.studio.acedata.cloud' }
+    });
+    expect(http.get).toHaveBeenNthCalledWith(3, '/sites/managed/current', {
+      params: { origin: 'tenant.example.com' }
+    });
+  });
+
+  it('does not downgrade a forbidden management response', async () => {
+    http.get.mockRejectedValue({ response: { status: 403 } });
+    await expect(siteOperator.getManagedCurrent('tenant.example.com')).rejects.toMatchObject({
+      response: { status: 403 }
+    });
+    expect(http.get).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back only when the new endpoint is unavailable', async () => {
+    http.get.mockRejectedValueOnce({ response: { status: 404 } }).mockResolvedValueOnce({
+      data: { count: 1, items: [{ origin: 'tenant.example.com' }] }
+    });
+    const response = await siteOperator.resolvePublic('tenant.example.com');
+    expect(response.data).toEqual({ origin: 'tenant.example.com' });
+    expect(http.get).toHaveBeenLastCalledWith('/sites/', { params: { origin: 'tenant.example.com' } });
+  });
+});

--- a/src/operators/site.ts
+++ b/src/operators/site.ts
@@ -11,8 +11,42 @@ export interface ISiteQuery {
   limit?: number;
 }
 
+const canUseLegacySiteApi = (error: unknown): boolean => {
+  const status = (error as { response?: { status?: number } })?.response?.status;
+  return status === 404 || status === 405;
+};
+
 class SiteService {
   key = 'sites';
+
+  async resolvePublic(origin: string): Promise<AxiosResponse<ISiteDetailResponse>> {
+    try {
+      return await httpClient.get(`/${this.key}/resolve`, { params: { origin } });
+    } catch (error) {
+      if (!canUseLegacySiteApi(error)) throw error;
+      const response = await this.getAll({ origin });
+      return { ...response, data: response.data.items?.[0] } as AxiosResponse<ISiteDetailResponse>;
+    }
+  }
+
+  async getManaged(query?: ISiteQuery): Promise<AxiosResponse<ISiteListResponse>> {
+    try {
+      return await httpClient.get(`/${this.key}/managed`, { params: query });
+    } catch (error) {
+      if (!canUseLegacySiteApi(error)) throw error;
+      return await this.getAll(query || {});
+    }
+  }
+
+  async getManagedCurrent(origin: string): Promise<AxiosResponse<ISiteDetailResponse>> {
+    try {
+      return await httpClient.get(`/${this.key}/managed/current`, { params: { origin } });
+    } catch (error) {
+      if (!canUseLegacySiteApi(error)) throw error;
+      const response = await this.getAll({ origin });
+      return { ...response, data: response.data.items?.[0] } as AxiosResponse<ISiteDetailResponse>;
+    }
+  }
 
   async initialize(data: ISite): Promise<AxiosResponse<ISiteDetailResponse>> {
     return await httpClient.post(`/${this.key}/initialize/`, data);

--- a/src/store/common/actions.test.ts
+++ b/src/store/common/actions.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const siteOperatorMock = vi.hoisted(() => ({
-  getAll: vi.fn()
+  getAll: vi.fn(),
+  getManagedCurrent: vi.fn()
 }));
 
 vi.mock('@/operators', () => ({

--- a/src/store/common/actions.ts
+++ b/src/store/common/actions.ts
@@ -142,7 +142,11 @@ export const getSite = async ({ state, commit }: ActionContext<IRootState, IRoot
   console.debug('start to get site');
   try {
     const origin = getSiteOrigin(state?.site);
-    const site = (await siteOperator.resolvePublic(origin)).data;
+    const site = (
+      await siteOperator.getAll({
+        origin
+      })
+    )?.data?.items?.[0];
     commit('setSite', site);
     console.debug('get site success', site);
     return site;

--- a/src/store/common/actions.ts
+++ b/src/store/common/actions.ts
@@ -142,16 +142,27 @@ export const getSite = async ({ state, commit }: ActionContext<IRootState, IRoot
   console.debug('start to get site');
   try {
     const origin = getSiteOrigin(state?.site);
-    const site = (
-      await siteOperator.getAll({
-        origin
-      })
-    )?.data?.items?.[0];
+    const site = (await siteOperator.resolvePublic(origin)).data;
     commit('setSite', site);
     console.debug('get site success', site);
     return site;
   } catch (error) {
     console.error('get site failed', error);
+    return undefined;
+  }
+};
+
+export const getManagedSite = async ({
+  state,
+  commit
+}: ActionContext<IRootState, IRootState>): Promise<ISite | undefined> => {
+  try {
+    const origin = getSiteOrigin(state?.site);
+    const { data } = await siteOperator.getManagedCurrent(origin);
+    commit('setSite', data);
+    return data;
+  } catch (error) {
+    console.error('get managed site failed', error);
     return undefined;
   }
 };


### PR DESCRIPTION
## Summary
- load anonymous branding from the public Site resolve endpoint
- fetch management details only when an authenticated user opens settings
- use server-derived owner/manager permissions instead of public admin IDs
- show invited tenants in the subsite list and reserve delete for owners
- retain 404/405-only fallback for a client-first rollout

## Verification
- `npm run test:run -- src/operators/site.management.test.ts` (3 passed)
- `npx vue-tsc -b`
- `npm run lint:check` (0 errors; 2 existing warnings)
- `python3 scripts/check_i18n_coverage.py`

## Review / merge order
**Keep this PR OPEN; do not merge until owner review.** Recommended future merge order: PlatformBackend compatibility PR first, PlatformFrontend second, then this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)