### PR TITLE
fix(application): route purchases by application type

### DIFF
--- a/change/suno-period-checkout-2026-08-14.json
+++ b/change/suno-period-checkout-2026-08-14.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Route credit and subscription purchases to the matching application checkout.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/application/Info.vue
+++ b/src/components/application/Info.vue
@@ -58,7 +58,7 @@
 </template>
 
 <script lang="ts">
-import { IApplication, IServiceType } from '@/models';
+import { IApplication, IApplicationType, IServiceType, IPackageType } from '@/models';
 import { defineComponent } from 'vue';
 import { ElButton, ElIcon, ElTag } from 'element-plus';
 import { AnalyticsIcon, ConfirmIcon, CreditsIcon, WalletIcon } from '@acedatacloud/core/icons/components';
@@ -110,7 +110,12 @@ export default defineComponent({
       if (this.application?.scope === 'Global') {
         return true;
       }
-      return (this.application?.packages || []).some((p) => p?.metadata?.apple_product_id);
+      if (this.application.type === IApplicationType.PERIOD) {
+        return false;
+      }
+      return (this.application?.packages || []).some(
+        (p) => p.type === IPackageType.USAGE && p?.metadata?.apple_product_id
+      );
     },
     remainingAmountText(): string {
       const amount = Number(this.application?.remaining_amount ?? 0);

--- a/src/components/application/Status.vue
+++ b/src/components/application/Status.vue
@@ -87,11 +87,11 @@ import { WalletIcon } from '@acedatacloud/core/icons/components';
 import { defineComponent, nextTick } from 'vue';
 import { ElButton, ElDialog, ElMessage, ElRadioButton, ElRadioGroup, ElTabPane, ElTabs, ElTag } from 'element-plus';
 import { IApplicationType, IApplication, IService } from '@/models';
-import { ROUTE_CONSOLE_APPLICATION_EXTRA, ROUTE_CONSOLE_USAGE_LIST } from '@/router';
+import { ROUTE_CONSOLE_USAGE_LIST } from '@/router';
 import ApplicationInfo from './Info.vue';
 import ContinuousPaymentCard from './ContinuousPaymentCard.vue';
 import SolanaWalletPickerDialog from '@/components/common/SolanaWalletPickerDialog.vue';
-import { isNative } from '@/utils';
+import { getApplicationPurchaseRoute, isNative } from '@/utils';
 import {
   isScenarioX402Enabled,
   scenarioPaymentState,
@@ -302,7 +302,8 @@ export default defineComponent({
       window.open(this.$router.resolve(target).href, '_blank');
     },
     onBuyMore(application: IApplication) {
-      const target = { name: ROUTE_CONSOLE_APPLICATION_EXTRA, params: { id: application.id } };
+      const target = getApplicationPurchaseRoute(application);
+      if (!target) return;
       // window.open('_blank') is a no-op inside the iOS/Android webview; navigate in-app.
       if (isNative()) {
         this.visible = false;

--- a/src/pages/console/application/Extra.vue
+++ b/src/pages/console/application/Extra.vue
@@ -114,7 +114,13 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { IApplication, IApplicationDetailResponse, IOrderDetailResponse, IPackageType } from '@/models';
+import {
+  IApplication,
+  IApplicationDetailResponse,
+  IApplicationType,
+  IOrderDetailResponse,
+  IPackageType
+} from '@/models';
 import {
   ElRow,
   ElCol,
@@ -310,6 +316,13 @@ export default defineComponent({
         .then(({ data: data }: { data: IApplicationDetailResponse }) => {
           if (data.role === 'grantee') {
             this.$router.replace({ name: ROUTE_CONSOLE_APPLICATION_LIST });
+            return;
+          }
+          if (data.type === IApplicationType.PERIOD) {
+            this.$router.replace({
+              name: ROUTE_CONSOLE_APPLICATION_SUBSCRIBE,
+              params: { id: data.id }
+            });
             return;
           }
           this.application = data;

--- a/src/pages/console/application/List.vue
+++ b/src/pages/console/application/List.vue
@@ -315,8 +315,8 @@ import {
   ElEmpty,
   ElMessage
 } from 'element-plus';
-import { ROUTE_CONSOLE_APPLICATION_EXTRA, ROUTE_CONSOLE_USAGE_LIST } from '@/router/constants';
-import { isIOS, isRechargeDisabled } from '@/utils';
+import { ROUTE_CONSOLE_USAGE_LIST } from '@/router/constants';
+import { getApplicationPurchaseRoute, isIOS, isRechargeDisabled } from '@/utils';
 import {
   IApplication,
   IApplicationListResponse,
@@ -448,13 +448,8 @@ export default defineComponent({
       });
     },
     onBuyMore(application: IApplication | undefined) {
-      if (!application?.id) return;
-      this.$router.push({
-        name: ROUTE_CONSOLE_APPLICATION_EXTRA,
-        params: {
-          id: application.id
-        }
-      });
+      const target = getApplicationPurchaseRoute(application);
+      if (target) this.$router.push(target);
     },
     onPageChange(page: number) {
       this.$router.push({

--- a/src/pages/console/application/List.vue
+++ b/src/pages/console/application/List.vue
@@ -144,7 +144,7 @@
               >
                 <template #default="scope">
                   <el-switch
-                    v-if="scope.row.service?.type === serviceType.API"
+                    v-if="scope.row.service?.type === serviceType.API && scope.row.type === applicationType.USAGE"
                     v-model="scope.row.allow_consume_global"
                     :active-value="true"
                     :inactive-value="false"
@@ -237,7 +237,10 @@
                   <span class="label">{{ $t('application.field.expiredAt') }}</span>
                   <span class="value">{{ $dayjs.format(app.expired_at) }}</span>
                 </div>
-                <div v-if="app.service?.type === serviceType.API" class="application-card__row">
+                <div
+                  v-if="app.service?.type === serviceType.API && app.type === applicationType.USAGE"
+                  class="application-card__row"
+                >
                   <span class="label">{{ $t('application.field.allowConsumeGlobal') }}</span>
                   <el-switch
                     v-model="app.allow_consume_global"
@@ -323,6 +326,7 @@ import {
   IApplicationScope,
   IApplicationType,
   ICredentialType,
+  IPackageType,
   IService,
   IServiceType
 } from '@/models';
@@ -335,6 +339,7 @@ interface IData {
   globalApplicationsTotal: number | undefined;
   limit: number;
   buying: boolean;
+  applicationType: typeof IApplicationType;
   form: {
     amount: number | undefined;
   };
@@ -370,6 +375,7 @@ export default defineComponent({
     return {
       credentialType: ICredentialType,
       serviceType: IServiceType,
+      applicationType: IApplicationType,
       individualApplications: [],
       globalApplications: [],
       individualApplicationsTotal: undefined,
@@ -424,7 +430,12 @@ export default defineComponent({
       if (!isIOS()) {
         return true;
       }
-      return ((application as any)?.packages || []).some((p: any) => p?.metadata?.apple_product_id);
+      if (application.type === IApplicationType.PERIOD) {
+        return false;
+      }
+      return ((application as any)?.packages || []).some(
+        (p: any) => p.type === IPackageType.USAGE && p?.metadata?.apple_product_id
+      );
     },
     updateAllowConsumeGlobal(application: IApplication, value: any) {
       if (!application || !application.id) {

--- a/src/pages/console/application/List.vue
+++ b/src/pages/console/application/List.vue
@@ -472,7 +472,10 @@ export default defineComponent({
               : {}),
             user_id: this.$store.getters.user.id,
             ordering: '-created_at',
-            type: IApplicationType.USAGE,
+            type:
+              scope === IApplicationScope.INDIVIDUAL
+                ? [IApplicationType.USAGE, IApplicationType.PERIOD]
+                : IApplicationType.USAGE,
             scope: scope
           })
           .then(({ data }: { data: IApplicationListResponse }) => {

--- a/src/pages/console/application/Subscribe.vue
+++ b/src/pages/console/application/Subscribe.vue
@@ -86,7 +86,14 @@
                 </el-row>
                 <div v-if="!loading && !loadFailed && showPayment" class="extra">
                   <span>{{ $t('console.message.doNotWantSubscribe') }}</span>
-                  <el-button type="primary" class="btn btn-extra" round size="small" @click="onBuyExtra">
+                  <el-button
+                    type="primary"
+                    class="btn btn-extra"
+                    round
+                    size="small"
+                    :loading="creatingUsageApplication"
+                    @click="onBuyExtra"
+                  >
                     {{ $t('console.message.buyExtra') }}
                   </el-button>
                 </div>
@@ -130,6 +137,7 @@ interface IData {
   loading: boolean;
   loadFailed: boolean;
   creating: boolean;
+  creatingUsageApplication: boolean;
   subscription: ISubscription | undefined;
 }
 
@@ -157,6 +165,7 @@ export default defineComponent({
       loading: false,
       loadFailed: false,
       creating: false,
+      creatingUsageApplication: false,
       subscription: undefined
     };
   },
@@ -254,7 +263,8 @@ export default defineComponent({
           return;
         }
         // Fetch or create the Period Application used by order creation.
-        await Promise.all([this.onFetchApplication2(), this.onFetchUsageApplication()]);
+        await this.onFetchApplication2();
+        void this.onFetchUsageApplication();
         await this.onCreateApplications();
         this.subscription = this.subscriptions.find((item) => item.available);
       } catch {
@@ -265,20 +275,33 @@ export default defineComponent({
     },
     getPriceString,
     async onBuyExtra() {
-      if (!this.usageApplication?.id && this.service?.id) {
-        const { data } = await applicationOperator.create({
-          service_id: this.service.id,
-          type: IApplicationType.USAGE
-        });
-        this.usageApplication = data;
-      }
-      if (!this.usageApplication?.id) return;
-      this.$router.push({
-        name: ROUTE_CONSOLE_APPLICATION_EXTRA,
-        params: {
-          id: this.usageApplication.id
+      if (this.creatingUsageApplication) return;
+      this.creatingUsageApplication = true;
+      try {
+        if (!this.usageApplication?.id && this.service?.id) {
+          try {
+            const { data } = await applicationOperator.create({
+              service_id: this.service.id,
+              type: IApplicationType.USAGE
+            });
+            this.usageApplication = data;
+          } catch {
+            await this.onFetchUsageApplication();
+          }
         }
-      });
+        if (!this.usageApplication?.id) {
+          ElMessage.error(this.$t('console.message.applicationNotFound'));
+          return;
+        }
+        this.$router.push({
+          name: ROUTE_CONSOLE_APPLICATION_EXTRA,
+          params: {
+            id: this.usageApplication.id
+          }
+        });
+      } finally {
+        this.creatingUsageApplication = false;
+      }
     },
     getPackages(duration: number): IPackage[] {
       let result = [];

--- a/src/pages/console/application/Subscribe.vue
+++ b/src/pages/console/application/Subscribe.vue
@@ -115,6 +115,7 @@ import { applicationOperator, orderOperator, serviceOperator } from '@/operators
 import { getPriceString, applyMarkup, getApplicationMarkupRatio } from '@/utils';
 import { isIOS, isRechargeDisabled } from '@/utils';
 import { track } from '@/plugins/telemetry';
+import { ERROR_CODE_DUPLICATION } from '@/constants';
 import { ROUTE_CONSOLE_APPLICATION_EXTRA, ROUTE_CONSOLE_ORDER_DETAIL, ROUTE_CONSOLE_APPLICATION_LIST } from '@/router';
 
 interface ISubscription {
@@ -285,8 +286,17 @@ export default defineComponent({
               type: IApplicationType.USAGE
             });
             this.usageApplication = data;
-          } catch {
-            await this.onFetchUsageApplication();
+          } catch (error: any) {
+            if (error?.response?.data?.code !== ERROR_CODE_DUPLICATION) {
+              ElMessage.error(this.$t('application.message.createFailed'));
+              return;
+            }
+            try {
+              await this.onFetchUsageApplication();
+            } catch {
+              ElMessage.error(this.$t('application.message.fetchFailed'));
+              return;
+            }
           }
         }
         if (!this.usageApplication?.id) {

--- a/src/pages/console/application/Subscribe.vue
+++ b/src/pages/console/application/Subscribe.vue
@@ -124,6 +124,7 @@ interface ISubscription {
 interface IData {
   application: IApplication | undefined;
   application2: IApplication | undefined;
+  usageApplication: IApplication | undefined;
   services: IService[];
   type: string;
   loading: boolean;
@@ -150,6 +151,7 @@ export default defineComponent({
       application: undefined,
       // the application which used for subscription
       application2: undefined,
+      usageApplication: undefined,
       type: IApplicationType.PERIOD,
       services: [],
       loading: false,
@@ -252,7 +254,7 @@ export default defineComponent({
           return;
         }
         // Fetch or create the Period Application used by order creation.
-        await this.onFetchApplication2();
+        await Promise.all([this.onFetchApplication2(), this.onFetchUsageApplication()]);
         await this.onCreateApplications();
         this.subscription = this.subscriptions.find((item) => item.available);
       } catch {
@@ -262,11 +264,19 @@ export default defineComponent({
       }
     },
     getPriceString,
-    onBuyExtra() {
+    async onBuyExtra() {
+      if (!this.usageApplication?.id && this.service?.id) {
+        const { data } = await applicationOperator.create({
+          service_id: this.service.id,
+          type: IApplicationType.USAGE
+        });
+        this.usageApplication = data;
+      }
+      if (!this.usageApplication?.id) return;
       this.$router.push({
         name: ROUTE_CONSOLE_APPLICATION_EXTRA,
         params: {
-          id: this.applicationId
+          id: this.usageApplication.id
         }
       });
     },
@@ -332,6 +342,17 @@ export default defineComponent({
       });
       this.application2 = data.items?.[0];
       console.debug('application2', this.application2);
+    },
+    async onFetchUsageApplication() {
+      const { data } = await applicationOperator.getAll({
+        limit: 1,
+        offset: 0,
+        user_id: this.$store.getters.user.id,
+        ordering: '-created_at',
+        service_id: this.serviceIds,
+        type: IApplicationType.USAGE
+      });
+      this.usageApplication = data.items?.[0];
     },
     onCreateOrder(subscription: ISubscription) {
       const packages = this.getPackages(subscription.duration);

--- a/src/pages/console/application/purchaseRoutingContract.test.ts
+++ b/src/pages/console/application/purchaseRoutingContract.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from 'vitest';
 const readSource = (relativePath: string): string =>
   readFileSync(fileURLToPath(new URL(relativePath, import.meta.url)), 'utf8');
 
+const infoSource = readSource('../../../components/application/Info.vue');
 const statusSource = readSource('../../../components/application/Status.vue');
 const listSource = readSource('./List.vue');
 const extraSource = readSource('./Extra.vue');
@@ -41,6 +42,9 @@ describe('application purchase routing contract', () => {
     expect(subscribeSource).toContain('void this.onFetchUsageApplication()');
     expect(subscribeSource).toContain('if (this.creatingUsageApplication) return;');
     expect(subscribeSource).toContain('await this.onFetchUsageApplication();');
+    expect(subscribeSource).toContain('error?.response?.data?.code !== ERROR_CODE_DUPLICATION');
+    expect(subscribeSource).toContain("$t('application.message.createFailed')");
+    expect(subscribeSource).toContain("$t('application.message.fetchFailed')");
     expect(subscribeSource).toContain('type: IApplicationType.USAGE');
     expect(subscribeSource).toContain('id: this.usageApplication.id');
     expect(subscribeSource).not.toContain('id: this.applicationId');
@@ -55,6 +59,7 @@ describe('application purchase routing contract', () => {
     expect(listSource).toContain('scope.row.type === applicationType.USAGE');
     expect(listSource).toContain('app.type === applicationType.USAGE');
     expect(listSource).toContain('if (application.type === IApplicationType.PERIOD)');
+    expect(infoSource).toContain('if (this.application.type === IApplicationType.PERIOD)');
   });
 
   it('keeps Suno application discovery untyped so Period subscriptions remain usable', () => {

--- a/src/pages/console/application/purchaseRoutingContract.test.ts
+++ b/src/pages/console/application/purchaseRoutingContract.test.ts
@@ -38,9 +38,9 @@ describe('application purchase routing contract', () => {
   });
 
   it('uses the matching Usage application when leaving subscription checkout', () => {
-    expect(subscribeSource).toContain(
-      'await Promise.all([this.onFetchApplication2(), this.onFetchUsageApplication()])'
-    );
+    expect(subscribeSource).toContain('void this.onFetchUsageApplication()');
+    expect(subscribeSource).toContain('if (this.creatingUsageApplication) return;');
+    expect(subscribeSource).toContain('await this.onFetchUsageApplication();');
     expect(subscribeSource).toContain('type: IApplicationType.USAGE');
     expect(subscribeSource).toContain('id: this.usageApplication.id');
     expect(subscribeSource).not.toContain('id: this.applicationId');
@@ -49,6 +49,12 @@ describe('application purchase routing contract', () => {
   it('lists both application types for individual apps but keeps global apps Usage-only', () => {
     expect(listSource).toContain('? [IApplicationType.USAGE, IApplicationType.PERIOD]');
     expect(listSource).toContain(': IApplicationType.USAGE');
+  });
+
+  it('keeps Period-only controls off the Usage balance contract', () => {
+    expect(listSource).toContain('scope.row.type === applicationType.USAGE');
+    expect(listSource).toContain('app.type === applicationType.USAGE');
+    expect(listSource).toContain('if (application.type === IApplicationType.PERIOD)');
   });
 
   it('keeps Suno application discovery untyped so Period subscriptions remain usable', () => {

--- a/src/pages/console/application/purchaseRoutingContract.test.ts
+++ b/src/pages/console/application/purchaseRoutingContract.test.ts
@@ -8,6 +8,7 @@ const readSource = (relativePath: string): string =>
 const statusSource = readSource('../../../components/application/Status.vue');
 const listSource = readSource('./List.vue');
 const extraSource = readSource('./Extra.vue');
+const subscribeSource = readSource('./Subscribe.vue');
 const sunoActionsSource = readSource('../../../store/suno/actions.ts');
 
 describe('application purchase routing contract', () => {
@@ -34,6 +35,20 @@ describe('application purchase routing contract', () => {
     expect(extraSource).toContain('params: { id: data.id }');
     expect(extraSource).toContain('this.$router.replace({');
     expect(guard).toBeLessThan(assignment);
+  });
+
+  it('uses the matching Usage application when leaving subscription checkout', () => {
+    expect(subscribeSource).toContain(
+      'await Promise.all([this.onFetchApplication2(), this.onFetchUsageApplication()])'
+    );
+    expect(subscribeSource).toContain('type: IApplicationType.USAGE');
+    expect(subscribeSource).toContain('id: this.usageApplication.id');
+    expect(subscribeSource).not.toContain('id: this.applicationId');
+  });
+
+  it('lists both application types for individual apps but keeps global apps Usage-only', () => {
+    expect(listSource).toContain('? [IApplicationType.USAGE, IApplicationType.PERIOD]');
+    expect(listSource).toContain(': IApplicationType.USAGE');
   });
 
   it('keeps Suno application discovery untyped so Period subscriptions remain usable', () => {

--- a/src/pages/console/application/purchaseRoutingContract.test.ts
+++ b/src/pages/console/application/purchaseRoutingContract.test.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const readSource = (relativePath: string): string =>
+  readFileSync(fileURLToPath(new URL(relativePath, import.meta.url)), 'utf8');
+
+const statusSource = readSource('../../../components/application/Status.vue');
+const listSource = readSource('./List.vue');
+const extraSource = readSource('./Extra.vue');
+const sunoActionsSource = readSource('../../../store/suno/actions.ts');
+
+describe('application purchase routing contract', () => {
+  it.each([
+    ['Status.vue', statusSource],
+    ['List.vue', listSource]
+  ])('%s routes Buy More through the shared type-aware helper', (_name, source) => {
+    expect(source).toContain('getApplicationPurchaseRoute(application)');
+    expect(source).not.toContain('name: ROUTE_CONSOLE_APPLICATION_EXTRA, params: { id: application.id }');
+  });
+
+  it('preserves native in-app and web new-tab navigation', () => {
+    expect(statusSource).toContain('if (isNative())');
+    expect(statusSource).toContain('this.$router.push(target)');
+    expect(statusSource).toContain("window.open(this.$router.resolve(target).href, '_blank')");
+  });
+
+  it('redirects direct Period top-up URLs to subscription checkout', () => {
+    const guard = extraSource.indexOf('if (data.type === IApplicationType.PERIOD)');
+    const assignment = extraSource.indexOf('this.application = data;');
+
+    expect(guard).toBeGreaterThan(-1);
+    expect(extraSource).toContain('name: ROUTE_CONSOLE_APPLICATION_SUBSCRIBE');
+    expect(extraSource).toContain('params: { id: data.id }');
+    expect(extraSource).toContain('this.$router.replace({');
+    expect(guard).toBeLessThan(assignment);
+  });
+
+  it('keeps Suno application discovery untyped so Period subscriptions remain usable', () => {
+    expect(sunoActionsSource).toContain('service_id: SUNO_SERVICE_ID');
+    expect(sunoActionsSource).not.toContain('service_id: SUNO_SERVICE_ID,\n        type: IApplicationType.USAGE');
+  });
+});

--- a/src/utils/applicationPurchase.test.ts
+++ b/src/utils/applicationPurchase.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { IApplicationType } from '@/models';
+import { ROUTE_CONSOLE_APPLICATION_EXTRA, ROUTE_CONSOLE_APPLICATION_SUBSCRIBE } from '@/router/constants';
+import { getApplicationPurchaseRoute } from './applicationPurchase';
+
+describe('application purchase routing', () => {
+  it('routes Usage applications to credit top-up', () => {
+    expect(getApplicationPurchaseRoute({ id: 'usage-app', type: IApplicationType.USAGE })).toEqual({
+      name: ROUTE_CONSOLE_APPLICATION_EXTRA,
+      params: { id: 'usage-app' }
+    });
+  });
+
+  it('routes Period applications to subscription checkout', () => {
+    expect(getApplicationPurchaseRoute({ id: 'period-app', type: IApplicationType.PERIOD })).toEqual({
+      name: ROUTE_CONSOLE_APPLICATION_SUBSCRIBE,
+      params: { id: 'period-app' }
+    });
+  });
+
+  it('fails closed without a supported type and id', () => {
+    expect(getApplicationPurchaseRoute(undefined)).toBeUndefined();
+    expect(getApplicationPurchaseRoute({ type: IApplicationType.USAGE })).toBeUndefined();
+    expect(getApplicationPurchaseRoute({ id: 'unknown', type: 'Unknown' as IApplicationType })).toBeUndefined();
+  });
+});

--- a/src/utils/applicationPurchase.ts
+++ b/src/utils/applicationPurchase.ts
@@ -1,0 +1,21 @@
+import { IApplication, IApplicationType } from '@/models';
+import { ROUTE_CONSOLE_APPLICATION_EXTRA, ROUTE_CONSOLE_APPLICATION_SUBSCRIBE } from '@/router/constants';
+
+export interface ApplicationPurchaseRoute {
+  name: string;
+  params: { id: string };
+}
+
+export function getApplicationPurchaseRoute(
+  application: IApplication | undefined
+): ApplicationPurchaseRoute | undefined {
+  if (!application?.id) return undefined;
+
+  if (application.type === IApplicationType.USAGE) {
+    return { name: ROUTE_CONSOLE_APPLICATION_EXTRA, params: { id: application.id } };
+  }
+  if (application.type === IApplicationType.PERIOD) {
+    return { name: ROUTE_CONSOLE_APPLICATION_SUBSCRIBE, params: { id: application.id } };
+  }
+  return undefined;
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -10,6 +10,7 @@ export * from './login';
 export * from './site';
 export * from './price';
 export * from './application';
+export * from './applicationPurchase';
 export * from './theme';
 export * from './pasteUpload';
 export * from './pasteUploadMixin';


### PR DESCRIPTION
## Summary
- route Usage applications to credit top-up and Period applications to subscription checkout
- share one fail-closed route helper across wallet and application-list entry points
- redirect direct Period top-up URLs to subscription checkout before order initialization
- preserve Suno's ability to select and use valid Period subscriptions

## Dependency
Deploy https://github.com/AceDataCloud/PlatformBackend/pull/1480 first so each application receives only same-type packages and Suno has the restored Period catalog.

## Verification
- focused Vitest suites: 20 passed
- related application tests: 17 passed
- `npx vue-tsc -b`
- `npm run lint:check` (0 errors; 2 pre-existing warnings in `dropUploadMixin.test.ts`)
- patch Beachball change included

This PR is intentionally left open and unmerged for adversarial review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 🤖 对抗评审 (reviewer: claude-subagent, 3 rounds)
- RISK: Period Application 的 Buy More 错进 Usage 充值页 → 已修：Usage→Extra、Period→Subscribe，并增加直接 URL 防护。
- RISK: Subscribe 的“购买额度”传 Period ID 造成循环重定向 → 已修：解析或创建同服务 Usage Application 后跳转。
- RISK: Individual Application 列表只查 Usage，Period 路由分支不可达 → 已修：Individual 查询 Usage+Period，Global 仍限定 Usage。
- RISK: Deployment 兼容、可选 Usage 查询阻断订阅、并发创建、Period 全局开关、iOS 空购买入口等边界 → 已逐项修复并补契约测试。
- Round 3 仍发现 2 项：钱包 iOS Period 入口与创建错误分类 → 已修；按三轮上限未启动第四轮，本地 Vitest/ESLint/vue-tsc 全通过。
