### PR TITLE
fix: read nested x402 order metadata

### DIFF
--- a/change/@acedatacloud-nexior-compat-x402-metadata.json
+++ b/change/@acedatacloud-nexior-compat-x402-metadata.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Read x402 order payment requirements from their namespaced metadata.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/order/X402Pay.vue
+++ b/src/components/order/X402Pay.vue
@@ -290,9 +290,9 @@ export default defineComponent({
     paymentRequirements(): Record<string, any> | undefined {
       const s = this.session?.payment_requirements || this.session?.paymentRequirements;
       if (s && typeof s === 'object') return s as Record<string, any>;
-      const m = this.orderMetadata?.payment_requirements || this.orderMetadata?.paymentRequirements;
-      if (m && typeof m === 'object') return m as Record<string, any>;
-      return undefined;
+      const x402 = this.orderMetadata?.x402;
+      const requirements = x402 && typeof x402 === 'object' ? x402.payment_requirements : undefined;
+      return requirements && typeof requirements === 'object' ? (requirements as Record<string, any>) : undefined;
     },
     expectedNetwork(): string | undefined {
       return this.selectedNetworkResolved;

--- a/src/components/x402ScenarioContract.test.ts
+++ b/src/components/x402ScenarioContract.test.ts
@@ -55,6 +55,12 @@ describe('x402 image scenario contract', () => {
     expect(operator).not.toContain('localStorage');
   });
 
+  it('reads order requirements only from x402 metadata', () => {
+    const payment = source('components/order/X402Pay.vue');
+    expect(payment).toContain('x402.payment_requirements');
+    expect(payment).not.toContain('this.orderMetadata?.payment_requirements');
+  });
+
   it('uses one shared wallet resolver and prefers Base EIP-3009', () => {
     const operator = source('operators/x402.ts');
     expect(operator).toContain('signEVMPayment');


### PR DESCRIPTION
## Summary
- read order payment requirements from `metadata.x402.payment_requirements`
- keep active session requirements as the immediate request source
- add a focused contract assertion and Beachball patch record

## Validation
- `npm run test:run -- src/components/x402ScenarioContract.test.ts` (8 passed)
- `npm run lint:check -- src/components/order/X402Pay.vue src/components/x402ScenarioContract.test.ts` (0 errors; 2 existing warnings elsewhere)
- `npm run build:web`
- `npm run verify`
- `git diff --check`

## 🤖 对抗评审 (reviewer: codex, 3 rounds)
- Final verdict: CLEAN

🤖 Generated with [Claude Code](https://claude.com/claude-code)