### PR TITLE
fix(x402): restore Base wallet choices

### DIFF
--- a/change/@acedatacloud-nexior-fix-base-wallet-picker.json
+++ b/change/@acedatacloud-nexior-fix-base-wallet-picker.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix per-call Base wallet discovery with WalletConnect and install fallbacks.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "@solana/wallet-adapter-walletconnect": "^0.1.21",
         "@solana/web3.js": "^1.98.2",
         "@vueuse/motion": "^3.0.3",
+        "@walletconnect/universal-provider": "2.19.0",
         "aegis-web-sdk": "^1.41.13",
         "axios": "^1.17.0",
         "buffer": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "@solana/wallet-adapter-walletconnect": "^0.1.21",
     "@solana/web3.js": "^1.98.2",
     "@vueuse/motion": "^3.0.3",
+    "@walletconnect/universal-provider": "2.19.0",
     "aegis-web-sdk": "^1.41.13",
     "axios": "^1.17.0",
     "buffer": "^6.0.3",

--- a/src/components/application/Status.vue
+++ b/src/components/application/Status.vue
@@ -61,11 +61,46 @@
       </div>
     </el-dialog>
     <el-dialog v-model="evmWalletPickerVisible" title="Base" width="420px">
-      <div class="flex flex-col gap-2">
-        <el-button v-for="wallet in evmWallets" :key="wallet.id" @click="connectEvmWallet(wallet)">
-          {{ wallet.name }}
+      <div class="wallet-list">
+        <button
+          v-for="wallet in evmWallets"
+          :key="wallet.id"
+          class="wallet-list-item"
+          :disabled="walletConnecting"
+          @click="connectEvmWallet(wallet)"
+        >
+          <img v-if="wallet.icon" class="wallet-list-icon" :src="wallet.icon" :alt="wallet.name" />
+          <span class="wallet-list-name">{{ wallet.name }}</span>
+          <span class="wallet-list-status">
+            {{
+              $t(
+                wallet.kind === 'walletconnect'
+                  ? 'order.message.x402WalletStatusQr'
+                  : wallet.readyState === 'Detected'
+                    ? 'order.message.x402WalletStatusDetected'
+                    : 'order.message.x402WalletStatusInstall'
+              )
+            }}
+          </span>
+        </button>
+        <p v-if="!evmWallets.length" class="wallet-hint">{{ $t('order.message.x402NoWalletDesc') }}</p>
+      </div>
+    </el-dialog>
+    <el-dialog v-model="walletConnectVisible" :title="$t('order.message.x402WalletConnectTitle')" width="420px">
+      <div class="wallet-connect-panel">
+        <div v-if="walletConnectUri" class="wallet-connect-qr">
+          <qr-code
+            :value="walletConnectUri"
+            :size="260"
+            :type="'image/png'"
+            :color="{ dark: '#000000', light: '#ffffff' }"
+          />
+        </div>
+        <p v-else class="wallet-hint">{{ $t('order.message.x402WalletConnectPreparing') }}</p>
+        <el-button v-if="walletConnectUri && mobileDevice" type="primary" @click="openWalletConnectUri">
+          {{ $t('order.message.x402WalletConnectOpenWallet') }}
         </el-button>
-        <p v-if="!evmWallets.length" class="wallet-hint">{{ $t('order.message.x402ConnectWallet') }}</p>
+        <p class="wallet-hint">{{ $t('order.message.x402WalletConnectScanHint') }}</p>
       </div>
     </el-dialog>
     <solana-wallet-picker-dialog
@@ -85,6 +120,7 @@
 <script lang="ts">
 import { WalletIcon } from '@acedatacloud/core/icons/components';
 import { defineComponent, nextTick } from 'vue';
+import QrCode from 'vue-qrcode';
 import { ElButton, ElDialog, ElMessage, ElRadioButton, ElRadioGroup, ElTabPane, ElTabs, ElTag } from 'element-plus';
 import { IApplicationType, IApplication, IService } from '@/models';
 import { ROUTE_CONSOLE_USAGE_LIST } from '@/router';
@@ -103,8 +139,9 @@ import {
   activeEvmWallet,
   activeWalletRail,
   connectBaseWallet,
+  connectBaseWalletConnect,
+  disconnectBaseWallet,
   discoverEvmWallets,
-  setActiveEvmWallet,
   setActiveWalletRail,
   type EvmWalletInfo
 } from '@/utils/x402/evmWallet';
@@ -113,6 +150,8 @@ export interface IData {
   walletPickerVisible: boolean;
   evmWalletPickerVisible: boolean;
   evmWallets: EvmWalletInfo[];
+  walletConnectVisible: boolean;
+  walletConnectUri?: string;
   walletConnecting: boolean;
   applicationType: typeof IApplicationType;
 }
@@ -121,6 +160,7 @@ export default defineComponent({
   name: 'ApplicationStatus',
   components: {
     WalletIcon,
+    QrCode,
     ElButton,
     ElDialog,
     ElRadioButton,
@@ -157,6 +197,8 @@ export default defineComponent({
       walletPickerVisible: false,
       evmWalletPickerVisible: false,
       evmWallets: [],
+      walletConnectVisible: false,
+      walletConnectUri: undefined,
       walletConnecting: false,
       applicationType: IApplicationType
     };
@@ -210,6 +252,9 @@ export default defineComponent({
       const weight = (state: string) => (state === 'Installed' ? 0 : state === 'Loadable' ? 1 : 2);
       return [...wallets].sort((a, b) => weight(a.readyState) - weight(b.readyState));
     },
+    mobileDevice(): boolean {
+      return /Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
+    },
     authenticated() {
       return !!this.$store.state.token.access;
     },
@@ -255,9 +300,23 @@ export default defineComponent({
     },
     async connectEvmWallet(wallet: EvmWalletInfo) {
       if (this.walletConnecting) return;
+      if (wallet.installUrl && !wallet.provider) {
+        window.open(wallet.installUrl, '_blank', 'noopener,noreferrer');
+        return;
+      }
       this.walletConnecting = true;
       try {
-        await connectBaseWallet(wallet.provider);
+        if (wallet.kind === 'walletconnect') {
+          this.walletConnectUri = undefined;
+          this.walletConnectVisible = true;
+          await connectBaseWalletConnect((uri) => {
+            this.walletConnectUri = uri;
+          });
+          this.walletConnectVisible = false;
+        } else {
+          if (!wallet.provider) return;
+          await connectBaseWallet(wallet.provider);
+        }
         setActiveWalletRail('base');
         this.evmWalletPickerVisible = false;
       } catch (error) {
@@ -267,8 +326,11 @@ export default defineComponent({
         this.walletConnecting = false;
       }
     },
-    disconnectEvmWallet() {
-      setActiveEvmWallet(undefined);
+    openWalletConnectUri() {
+      if (this.walletConnectUri) window.location.href = this.walletConnectUri;
+    },
+    async disconnectEvmWallet() {
+      await disconnectBaseWallet();
     },
     async connectSolanaWallet(wallet: any) {
       const walletApi = (this as any).$wallet;
@@ -349,6 +411,62 @@ export default defineComponent({
   color: var(--el-text-color-secondary);
   font-size: 12px;
   text-align: center;
+}
+
+.wallet-list,
+.wallet-connect-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.wallet-connect-panel {
+  align-items: center;
+}
+
+.wallet-connect-qr {
+  padding: 12px;
+  border-radius: 12px;
+  background: #fff;
+}
+
+.wallet-list-item {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  gap: 12px;
+  padding: 12px 14px;
+  border: 0;
+  border-radius: 12px;
+  background: var(--el-fill-color-light);
+  color: var(--el-text-color-primary);
+  cursor: pointer;
+}
+
+.wallet-list-item:hover:not(:disabled) {
+  background: var(--el-fill-color);
+}
+
+.wallet-list-item:disabled {
+  cursor: wait;
+  opacity: 0.65;
+}
+
+.wallet-list-icon {
+  width: 28px;
+  height: 28px;
+  object-fit: contain;
+}
+
+.wallet-list-name {
+  flex: 1;
+  text-align: left;
+  font-weight: 600;
+}
+
+.wallet-list-status {
+  color: var(--el-text-color-secondary);
+  font-size: 12px;
 }
 
 .entry {

--- a/src/components/application/Status.vue
+++ b/src/components/application/Status.vue
@@ -97,9 +97,15 @@
           />
         </div>
         <p v-else class="wallet-hint">{{ $t('order.message.x402WalletConnectPreparing') }}</p>
-        <el-button v-if="walletConnectUri && mobileDevice" type="primary" @click="openWalletConnectUri">
-          {{ $t('order.message.x402WalletConnectOpenWallet') }}
-        </el-button>
+        <div v-if="walletConnectUri" class="wallet-connect-actions">
+          <el-button v-if="mobileDevice" type="primary" @click="openWalletConnectUri">
+            {{ $t('order.message.x402WalletConnectOpenWallet') }}
+          </el-button>
+          <span class="wallet-connect-uri">
+            {{ shortWalletConnectUri }}
+            <copy-to-clipboard :content="walletConnectUri" />
+          </span>
+        </div>
         <p class="wallet-hint">{{ $t('order.message.x402WalletConnectScanHint') }}</p>
       </div>
     </el-dialog>
@@ -126,6 +132,7 @@ import { IApplicationType, IApplication, IService } from '@/models';
 import { ROUTE_CONSOLE_USAGE_LIST } from '@/router';
 import ApplicationInfo from './Info.vue';
 import ContinuousPaymentCard from './ContinuousPaymentCard.vue';
+import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 import SolanaWalletPickerDialog from '@/components/common/SolanaWalletPickerDialog.vue';
 import { getApplicationPurchaseRoute, isNative } from '@/utils';
 import {
@@ -170,6 +177,7 @@ export default defineComponent({
     ElTag,
     ApplicationInfo,
     ContinuousPaymentCard,
+    CopyToClipboard,
     SolanaWalletPickerDialog
   },
   props: {
@@ -254,6 +262,10 @@ export default defineComponent({
     },
     mobileDevice(): boolean {
       return /Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
+    },
+    shortWalletConnectUri(): string {
+      const uri = this.walletConnectUri || '';
+      return uri.length > 32 ? `${uri.slice(0, 18)}…${uri.slice(-10)}` : uri;
     },
     authenticated() {
       return !!this.$store.state.token.access;
@@ -422,6 +434,26 @@ export default defineComponent({
 
 .wallet-connect-panel {
   align-items: center;
+}
+
+.wallet-connect-actions,
+.wallet-connect-uri {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.wallet-connect-actions {
+  max-width: 100%;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.wallet-connect-uri {
+  min-width: 0;
+  color: var(--el-text-color-secondary);
+  font-family: monospace;
+  font-size: 12px;
 }
 
 .wallet-connect-qr {

--- a/src/components/order/X402Pay.vue
+++ b/src/components/order/X402Pay.vue
@@ -189,13 +189,9 @@ import { IOrder } from '@/models';
 import { httpClient, orderOperator } from '@/operators';
 import { isMobile } from '@/utils';
 import { buildSolanaX402Header, executeSolanaPayment, SolanaPaymentRequirements } from '@/utils/x402/solana';
+import { discoverEvmWallets, type EvmWalletInfo } from '@/utils/x402/evmWallet';
 
-interface IEvmWalletInfo {
-  id: string;
-  name: string;
-  icon?: string;
-  provider: any;
-}
+type IEvmWalletInfo = EvmWalletInfo;
 
 interface IData {
   signing: boolean;
@@ -545,58 +541,17 @@ export default defineComponent({
       void this.refreshEvmWallets();
     },
     async refreshEvmWallets() {
-      if (typeof window === 'undefined') return;
-
-      const collected = new Map<string, IEvmWalletInfo>();
-      const handler = (event: any) => {
-        const detail = event?.detail;
-        const info = detail?.info;
-        const provider = detail?.provider;
-        if (!info || !provider) return;
-        const id = String(info.uuid || info.rdns || info.name || '');
-        if (!id) return;
-        if (!collected.has(id)) {
-          collected.set(id, {
-            id,
-            name: String(info.name || 'Wallet'),
-            icon: typeof info.icon === 'string' ? info.icon : undefined,
-            provider
-          });
-        }
-      };
-
-      try {
-        window.addEventListener('eip6963:announceProvider', handler as any);
-        window.dispatchEvent(new Event('eip6963:requestProvider'));
-        await new Promise((resolve) => window.setTimeout(resolve, 120));
-      } finally {
-        window.removeEventListener('eip6963:announceProvider', handler as any);
-      }
-
-      if (collected.size === 0) {
-        const eth: any = (window as any).ethereum;
-        const providers: any[] = Array.isArray(eth?.providers) ? eth.providers : eth ? [eth] : [];
-        providers.forEach((p: any, index: number) => {
-          if (!p) return;
-          let name = 'Injected';
-          if (p.isMetaMask) name = 'MetaMask';
-          else if (p.isCoinbaseWallet) name = 'Coinbase Wallet';
-          else if (p.isBraveWallet) name = 'Brave Wallet';
-          else if (p.isRabby) name = 'Rabby';
-          else if (p.isPhantom) name = 'Phantom';
-          const id = `injected:${name}:${index}`;
-          collected.set(id, { id, name, icon: undefined, provider: p });
-        });
-      }
-
-      this.evmWallets = Array.from(collected.values());
+      this.evmWallets = (await discoverEvmWallets()).filter(
+        (wallet): wallet is IEvmWalletInfo & { provider: NonNullable<IEvmWalletInfo['provider']> } =>
+          wallet.readyState === 'Detected' && wallet.kind === 'injected' && Boolean(wallet.provider)
+      );
     },
     async onSelectEvmWallet(wallet: IEvmWalletInfo) {
-      if (!wallet?.provider) return;
+      if (!wallet.provider) return;
       this.evmWalletModalVisible = false;
       this.evmWalletConnecting = true;
       try {
-        const accounts: string[] = await wallet.provider.request({ method: 'eth_requestAccounts' });
+        const accounts = (await wallet.provider.request({ method: 'eth_requestAccounts' })) as string[];
         const address = Array.isArray(accounts) ? accounts[0] : undefined;
         if (!address) {
           throw new Error('No account returned from wallet');

--- a/src/components/x402ScenarioContract.test.ts
+++ b/src/components/x402ScenarioContract.test.ts
@@ -18,6 +18,8 @@ describe('x402 image scenario contract', () => {
     expect(status).toContain("wallet.kind === 'walletconnect'");
     expect(status).toContain("wallet.readyState === 'Detected'");
     expect(status).toContain('order.message.x402NoWalletDesc');
+    expect(status).toContain('<copy-to-clipboard :content="walletConnectUri"');
+    expect(status).toContain('shortWalletConnectUri');
     expect(source('components/order/X402Pay.vue')).toContain('solana-wallet-picker-dialog');
     expect(source('components/order/X402Pay.vue')).toContain('discoverEvmWallets');
     expect(selector).not.toContain('solana-wallet-picker-dialog');

--- a/src/components/x402ScenarioContract.test.ts
+++ b/src/components/x402ScenarioContract.test.ts
@@ -14,7 +14,12 @@ describe('x402 image scenario contract', () => {
     expect(status).toContain('value="base"');
     expect(status).toContain('value="solana"');
     expect(status).toContain('discoverEvmWallets');
+    expect(status).toContain('connectBaseWalletConnect');
+    expect(status).toContain("wallet.kind === 'walletconnect'");
+    expect(status).toContain("wallet.readyState === 'Detected'");
+    expect(status).toContain('order.message.x402NoWalletDesc');
     expect(source('components/order/X402Pay.vue')).toContain('solana-wallet-picker-dialog');
+    expect(source('components/order/X402Pay.vue')).toContain('discoverEvmWallets');
     expect(selector).not.toContain('solana-wallet-picker-dialog');
     expect(selector).not.toContain('el-radio');
   });

--- a/src/utils/x402/evmWallet.test.ts
+++ b/src/utils/x402/evmWallet.test.ts
@@ -1,8 +1,38 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { activeEvmWallet, connectBaseWallet, setActiveEvmWallet } from './evmWallet';
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const walletConnect = vi.hoisted(() => {
+  const listeners: Record<string, (...args: any[]) => void> = {};
+  const provider = {
+    on: vi.fn((event: string, listener: (...args: any[]) => void) => {
+      listeners[event] = listener;
+    }),
+    connect: vi.fn(async () => {
+      listeners.display_uri?.('wc:test-uri');
+    }),
+    request: vi.fn(async ({ method }: { method: string }) => (method === 'eth_accounts' ? ['0xwalletconnect'] : [])),
+    disconnect: vi.fn()
+  };
+  return { init: vi.fn(async () => provider), listeners, provider };
+});
+
+vi.mock('@walletconnect/universal-provider', () => ({ default: { init: walletConnect.init } }));
+
+import {
+  activeEvmWallet,
+  connectBaseWallet,
+  connectBaseWalletConnect,
+  discoverEvmWallets,
+  disconnectBaseWallet,
+  setActiveEvmWallet
+} from './evmWallet';
+
+const originalEthereum = (globalThis as any).ethereum;
 
 describe('Base EVM wallet', () => {
-  beforeEach(() => setActiveEvmWallet(undefined));
+  beforeEach(() => {
+    setActiveEvmWallet(undefined);
+    (globalThis as any).ethereum = undefined;
+  });
 
   it('switches to Base and stores the connected account', async () => {
     const request = vi
@@ -44,4 +74,64 @@ describe('Base EVM wallet', () => {
 
     expect(request).toHaveBeenCalledTimes(2);
   });
+
+  it('discovers multiple legacy injected wallets', async () => {
+    const metamask = { request: vi.fn(), isMetaMask: true };
+    const rabby = { request: vi.fn(), isRabby: true };
+    (globalThis as any).ethereum = { providers: [metamask, rabby] };
+
+    const wallets = await discoverEvmWallets();
+
+    expect(wallets).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'MetaMask', provider: metamask, readyState: 'Detected' }),
+        expect.objectContaining({ name: 'Rabby', provider: rabby, readyState: 'Detected' })
+      ])
+    );
+  });
+
+  it('keeps WalletConnect and install choices when no provider is injected', async () => {
+    const wallets = await discoverEvmWallets();
+
+    expect(wallets[0]).toMatchObject({ id: 'walletconnect', name: 'WalletConnect', kind: 'walletconnect' });
+    expect(wallets).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'MetaMask', readyState: 'NotDetected', installUrl: expect.any(String) }),
+        expect.objectContaining({ name: 'Coinbase Wallet', readyState: 'NotDetected', installUrl: expect.any(String) })
+      ])
+    );
+  });
+
+  it('connects WalletConnect to Base and stores its EIP-1193 provider', async () => {
+    const onUri = vi.fn();
+
+    const connected = await connectBaseWalletConnect(onUri);
+
+    expect(onUri).toHaveBeenCalledWith('wc:test-uri');
+    expect(walletConnect.provider.connect).toHaveBeenCalledWith({
+      namespaces: {
+        eip155: expect.objectContaining({ chains: ['eip155:8453'] })
+      }
+    });
+    expect(connected).toMatchObject({ address: '0xwalletconnect', kind: 'walletconnect' });
+    expect(activeEvmWallet()?.provider).toBe(walletConnect.provider);
+  });
+
+  it('disconnects the active WalletConnect provider', async () => {
+    const disconnect = vi.fn();
+    setActiveEvmWallet({
+      address: '0xpayer',
+      provider: { request: vi.fn(), disconnect },
+      kind: 'walletconnect'
+    });
+
+    await disconnectBaseWallet();
+
+    expect(disconnect).toHaveBeenCalledOnce();
+    expect(activeEvmWallet()).toBeUndefined();
+  });
+});
+
+afterAll(() => {
+  (globalThis as any).ethereum = originalEthereum;
 });

--- a/src/utils/x402/evmWallet.test.ts
+++ b/src/utils/x402/evmWallet.test.ts
@@ -110,11 +110,17 @@ describe('Base EVM wallet', () => {
     expect(onUri).toHaveBeenCalledWith('wc:test-uri');
     expect(walletConnect.provider.connect).toHaveBeenCalledWith({
       namespaces: {
-        eip155: expect.objectContaining({ chains: ['eip155:8453'] })
+        eip155: expect.objectContaining({
+          chains: ['eip155:8453'],
+          rpcMap: { 8453: expect.stringContaining('chainId=eip155:8453') }
+        })
       }
     });
     expect(connected).toMatchObject({ address: '0xwalletconnect', kind: 'walletconnect' });
     expect(activeEvmWallet()?.provider).toBe(walletConnect.provider);
+
+    walletConnect.listeners.session_delete();
+    expect(activeEvmWallet()).toBeUndefined();
   });
 
   it('disconnects the active WalletConnect provider', async () => {

--- a/src/utils/x402/evmWallet.ts
+++ b/src/utils/x402/evmWallet.ts
@@ -139,9 +139,11 @@ function watchProvider(provider: Eip1193Provider, kind: EvmWalletConnection['kin
   provider.on('chainChanged', (...args: any[]) => {
     if (String(args[0]).toLowerCase() !== BASE_CHAIN_ID) connection.value = undefined;
   });
-  provider.on('disconnect', () => {
+  const clearConnection = () => {
     if (connection.value?.provider === provider) connection.value = undefined;
-  });
+  };
+  provider.on('disconnect', clearConnection);
+  if (kind === 'walletconnect') provider.on('session_delete', clearConnection);
 }
 
 export async function connectBaseWallet(provider: Eip1193Provider): Promise<EvmWalletConnection> {
@@ -192,7 +194,10 @@ export async function connectBaseWalletConnect(onUri: (uri: string) => void): Pr
       eip155: {
         methods: ['eth_accounts', 'eth_chainId', 'eth_signTypedData_v4'],
         chains: [BASE_CAIP_CHAIN],
-        events: ['accountsChanged', 'chainChanged']
+        events: ['accountsChanged', 'chainChanged'],
+        rpcMap: {
+          8453: `https://rpc.walletconnect.org?chainId=${BASE_CAIP_CHAIN}&projectId=${WALLETCONNECT_PROJECT_ID}`
+        }
       }
     }
   });

--- a/src/utils/x402/evmWallet.ts
+++ b/src/utils/x402/evmWallet.ts
@@ -3,19 +3,37 @@ import { shallowRef } from 'vue';
 export interface Eip1193Provider {
   request(args: { method: string; params?: unknown[] }): Promise<unknown>;
   on?(event: string, listener: (...args: any[]) => void): void;
+  disconnect?(): Promise<void>;
 }
 
 export interface EvmWalletConnection {
   address: string;
   provider: Eip1193Provider;
+  kind?: 'injected' | 'walletconnect';
 }
 
 export interface EvmWalletInfo {
   id: string;
   name: string;
   icon?: string;
-  provider: Eip1193Provider;
+  provider?: Eip1193Provider;
+  kind: 'injected' | 'walletconnect';
+  readyState: 'Detected' | 'NotDetected';
+  installUrl?: string;
 }
+
+const BASE_CHAIN_ID = '0x2105';
+const BASE_CAIP_CHAIN = 'eip155:8453';
+const WALLETCONNECT_PROJECT_ID = import.meta.env.VITE_WALLETCONNECT_PROJECT_ID || '8442ba82a50e5d4a993fc9d82ba15c59';
+const KNOWN_WALLETS = [
+  { name: 'MetaMask', installUrl: 'https://metamask.io/download/' },
+  { name: 'Coinbase Wallet', installUrl: 'https://www.coinbase.com/wallet/downloads' },
+  { name: 'Rabby', installUrl: 'https://rabby.io/' },
+  { name: 'OKX Wallet', installUrl: 'https://www.okx.com/web3' },
+  { name: 'Trust Wallet', installUrl: 'https://trustwallet.com/browser-extension' },
+  { name: 'Phantom', installUrl: 'https://phantom.app/download' },
+  { name: 'Rainbow', installUrl: 'https://rainbow.me/download' }
+];
 
 const connection = shallowRef<EvmWalletConnection>();
 const watchedProviders = new WeakSet<object>();
@@ -37,6 +55,17 @@ export function setActiveEvmWallet(value: EvmWalletConnection | undefined): void
   connection.value = value;
 }
 
+function injectedWalletName(provider: any): string {
+  if (provider?.isMetaMask) return 'MetaMask';
+  if (provider?.isCoinbaseWallet) return 'Coinbase Wallet';
+  if (provider?.isBraveWallet) return 'Brave Wallet';
+  if (provider?.isRabby) return 'Rabby';
+  if (provider?.isOkxWallet || provider?.isOKExWallet) return 'OKX Wallet';
+  if (provider?.isTrust || provider?.isTrustWallet) return 'Trust Wallet';
+  if (provider?.isPhantom) return 'Phantom';
+  return 'Injected Wallet';
+}
+
 export async function discoverEvmWallets(): Promise<EvmWalletInfo[]> {
   const found = new Map<string, EvmWalletInfo>();
   if (typeof window !== 'undefined') {
@@ -44,35 +73,91 @@ export async function discoverEvmWallets(): Promise<EvmWalletInfo[]> {
       const detail = (event as CustomEvent).detail || {};
       const provider = detail.provider as Eip1193Provider | undefined;
       if (!provider) return;
-      const id = String(detail.info?.uuid || detail.info?.rdns || detail.info?.name || found.size);
-      found.set(id, { id, name: String(detail.info?.name || 'Wallet'), icon: detail.info?.icon, provider });
+      const name = String(detail.info?.name || 'Wallet');
+      const id = String(detail.info?.uuid || detail.info?.rdns || name || found.size);
+      found.set(id, {
+        id,
+        name,
+        icon: typeof detail.info?.icon === 'string' ? detail.info.icon : undefined,
+        provider,
+        kind: 'injected',
+        readyState: 'Detected'
+      });
     };
     window.addEventListener('eip6963:announceProvider', handler);
     window.dispatchEvent(new Event('eip6963:requestProvider'));
     await new Promise((resolve) => window.setTimeout(resolve, 120));
     window.removeEventListener('eip6963:announceProvider', handler);
   }
-  const injected = (globalThis as any).ethereum as Eip1193Provider | undefined;
-  if (injected && found.size === 0)
-    found.set('injected', { id: 'injected', name: 'Injected Wallet', provider: injected });
-  return Array.from(found.values());
+
+  if (found.size === 0) {
+    const ethereum = (globalThis as any).ethereum;
+    const providers = Array.isArray(ethereum?.providers) ? ethereum.providers : ethereum ? [ethereum] : [];
+    providers.forEach((provider: Eip1193Provider, index: number) => {
+      const name = injectedWalletName(provider);
+      found.set(`injected:${name}:${index}`, {
+        id: `injected:${name}:${index}`,
+        name,
+        provider,
+        kind: 'injected',
+        readyState: 'Detected'
+      });
+    });
+  }
+
+  const wallets: EvmWalletInfo[] = [
+    {
+      id: 'walletconnect',
+      name: 'WalletConnect',
+      kind: 'walletconnect',
+      readyState: 'Detected'
+    },
+    ...Array.from(found.values())
+  ];
+  const normalized = new Set(wallets.map((wallet) => wallet.name.toLowerCase().replace(/\s+/g, '')));
+  KNOWN_WALLETS.forEach((wallet) => {
+    const key = wallet.name.toLowerCase().replace(/\s+/g, '');
+    if (normalized.has(key)) return;
+    wallets.push({
+      id: `install:${key}`,
+      name: wallet.name,
+      kind: 'injected',
+      readyState: 'NotDetected',
+      installUrl: wallet.installUrl
+    });
+  });
+  return wallets;
+}
+
+function watchProvider(provider: Eip1193Provider, kind: EvmWalletConnection['kind'] = 'injected'): void {
+  if (!provider.on || watchedProviders.has(provider as object)) return;
+  watchedProviders.add(provider as object);
+  provider.on('accountsChanged', (...args: any[]) => {
+    const accounts = args[0] as string[] | undefined;
+    connection.value = accounts?.[0] ? { address: accounts[0], provider, kind } : undefined;
+  });
+  provider.on('chainChanged', (...args: any[]) => {
+    if (String(args[0]).toLowerCase() !== BASE_CHAIN_ID) connection.value = undefined;
+  });
+  provider.on('disconnect', () => {
+    if (connection.value?.provider === provider) connection.value = undefined;
+  });
 }
 
 export async function connectBaseWallet(provider: Eip1193Provider): Promise<EvmWalletConnection> {
   const accounts = (await provider.request({ method: 'eth_requestAccounts' })) as string[];
   const address = accounts?.[0];
   if (!address) throw new Error('No EVM wallet account is available');
-  const baseChainId = '0x2105';
   const chainId = String(await provider.request({ method: 'eth_chainId' })).toLowerCase();
-  if (chainId !== baseChainId) {
+  if (chainId !== BASE_CHAIN_ID) {
     try {
-      await provider.request({ method: 'wallet_switchEthereumChain', params: [{ chainId: baseChainId }] });
+      await provider.request({ method: 'wallet_switchEthereumChain', params: [{ chainId: BASE_CHAIN_ID }] });
     } catch {
       await provider.request({
         method: 'wallet_addEthereumChain',
         params: [
           {
-            chainId: baseChainId,
+            chainId: BASE_CHAIN_ID,
             chainName: 'Base',
             nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
             rpcUrls: ['https://mainnet.base.org'],
@@ -82,16 +167,45 @@ export async function connectBaseWallet(provider: Eip1193Provider): Promise<EvmW
       });
     }
   }
-  connection.value = { address, provider };
-  if (provider.on && !watchedProviders.has(provider as object)) {
-    watchedProviders.add(provider as object);
-    provider.on('accountsChanged', (...args: any[]) => {
-      const accounts = args[0] as string[] | undefined;
-      connection.value = accounts?.[0] ? { address: accounts[0], provider } : undefined;
-    });
-    provider.on('chainChanged', (...args: any[]) => {
-      if (String(args[0]).toLowerCase() !== baseChainId) connection.value = undefined;
-    });
-  }
+  connection.value = { address, provider, kind: 'injected' };
+  watchProvider(provider);
   return connection.value;
+}
+
+export async function connectBaseWalletConnect(onUri: (uri: string) => void): Promise<EvmWalletConnection> {
+  const { default: UniversalProvider } = await import('@walletconnect/universal-provider');
+  const provider = (await UniversalProvider.init({
+    projectId: WALLETCONNECT_PROJECT_ID,
+    metadata: {
+      name: 'Nexior',
+      description: 'Nexior Base USDC payments',
+      url: typeof window === 'undefined' ? 'https://studio.acedata.cloud' : window.location.origin,
+      icons: ['https://studio.acedata.cloud/favicon.ico']
+    }
+  })) as unknown as Eip1193Provider & {
+    connect(options: unknown): Promise<unknown>;
+    on(event: string, listener: (...args: any[]) => void): void;
+  };
+  provider.on('display_uri', onUri);
+  await provider.connect({
+    namespaces: {
+      eip155: {
+        methods: ['eth_accounts', 'eth_chainId', 'eth_signTypedData_v4'],
+        chains: [BASE_CAIP_CHAIN],
+        events: ['accountsChanged', 'chainChanged']
+      }
+    }
+  });
+  const accounts = (await provider.request({ method: 'eth_accounts' })) as string[];
+  const address = accounts?.[0];
+  if (!address) throw new Error('No EVM wallet account is available');
+  connection.value = { address, provider, kind: 'walletconnect' };
+  watchProvider(provider, 'walletconnect');
+  return connection.value;
+}
+
+export async function disconnectBaseWallet(): Promise<void> {
+  const current = connection.value;
+  connection.value = undefined;
+  if (current?.kind === 'walletconnect') await current.provider.disconnect?.();
 }


### PR DESCRIPTION
## Summary

- share EIP-6963 and legacy multi-provider wallet discovery between order and per-call X402 flows
- keep Base payment usable without an injected extension through WalletConnect QR pairing and wallet install choices
- replace the blank Base picker with explicit detected / QR / install states and clean WalletConnect disconnect handling

## Root cause

When a user selected **USDC Wallet → Base** in a per-call scenario without an injected EVM provider, Nexior returned an empty wallet array and rendered a blank picker. The order payment surface had a broader provider fallback, but the new per-call path had implemented a separate, reduced discovery function and no WalletConnect transport.

## Verification

- `npm run test:run -- --run src/**/*x402*.test.ts src/components/x402*.test.ts src/utils/x402/*.test.ts` — 23 files, 100 tests passed
- `npm run lint:check` — 0 errors (2 pre-existing `vue/one-component-per-file` warnings)
- `npm run build:web` — production build passed
- `npm run verify` — beachball change file passed
- local headless Chrome, no injected provider: Nano Banana Base picker displayed WalletConnect, QR Code, MetaMask, Coinbase Wallet, Rabby, OKX Wallet, Trust Wallet, Phantom, Rainbow, and Install states

🤖 Generated with [Claude Code](https://claude.com/claude-code)
