### PR TITLE
ci: use Claude Sonnet 5 for reviews

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -33,4 +33,4 @@ jobs:
           github_token: ${{ secrets.BOT_GITHUB_TOKEN }}
         env:
           ANTHROPIC_BASE_URL: https://api.acedata.cloud
-          ANTHROPIC_DEFAULT_SONNET_MODEL: claude-sonnet-4-20250514
+          ANTHROPIC_DEFAULT_SONNET_MODEL: claude-sonnet-5

--- a/change/@acedatacloud-nexior-claude-sonnet-5.json
+++ b/change/@acedatacloud-nexior-claude-sonnet-5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update the Claude review workflow to use active Claude Sonnet 5",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
Updates the Claude review workflow from retired Sonnet 4 to active Claude Sonnet 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)