### PR TITLE
refactor(deploy): keep shell apply-only

### DIFF
--- a/.github/workflows/deploy-web.yaml
+++ b/.github/workflows/deploy-web.yaml
@@ -117,6 +117,23 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Deploy
+      - name: Apply manifests
         if: steps.changes.outputs.deploy == 'true'
         run: sh ./deploy/run.sh
+
+      - name: Verify rollouts and images
+        if: steps.changes.outputs.deploy == 'true'
+        run: |
+          kubectl -n acedatacloud rollout status deployment/hub-frontend --timeout=10m
+          kubectl -n acedatacloud rollout status deployment/studio-frontend --timeout=10m
+          expected="ghcr.io/acedatacloud/hub-frontend:$BUILD_NUMBER"
+          test "$(kubectl -n acedatacloud get deployment hub-frontend -o jsonpath='{.spec.template.spec.containers[0].image}')" = "$expected"
+          test "$(kubectl -n acedatacloud get deployment studio-frontend -o jsonpath='{.spec.template.spec.containers[0].image}')" = "$expected"
+
+      - name: Record successful revision
+        if: steps.changes.outputs.deploy == 'true'
+        run: |
+          for deployment in hub-frontend studio-frontend; do
+            kubectl -n acedatacloud annotate deployment "$deployment" \
+              "acedata.cloud/last-successful-revision=$GITHUB_SHA" --overwrite
+          done

--- a/change/@acedatacloud-nexior-deploy-apply-only.json
+++ b/change/@acedatacloud-nexior-deploy-apply-only.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Keep deployment scripts focused on applying manifests and expose rollout verification in CI",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/deploy/run.sh
+++ b/deploy/run.sh
@@ -2,26 +2,10 @@
 set -eu
 
 : "${BUILD_NUMBER:?BUILD_NUMBER is required}"
-: "${GITHUB_SHA:?GITHUB_SHA is required}"
 
 sed 's/\${TAG}/'"$BUILD_NUMBER"'/g' deploy/production/deployment.yaml | kubectl apply -f -
 kubectl apply -f deploy/production/service.yaml
-
 sed 's/\${TAG}/'"$BUILD_NUMBER"'/g' deploy/production/studio-deployment.yaml | kubectl apply -f -
 kubectl apply -f deploy/production/studio-service.yaml
 kubectl apply -f deploy/production/studio-ingress.yaml
 kubectl apply -f deploy/production/studio-proxy.yaml
-
-kubectl rollout status deployment/hub-frontend -n acedatacloud --timeout=10m
-kubectl rollout status deployment/studio-frontend -n acedatacloud --timeout=10m
-
-expected_image="ghcr.io/acedatacloud/hub-frontend:$BUILD_NUMBER"
-hub_image=$(kubectl get deployment hub-frontend -n acedatacloud -o jsonpath='{.spec.template.spec.containers[0].image}')
-studio_image=$(kubectl get deployment studio-frontend -n acedatacloud -o jsonpath='{.spec.template.spec.containers[0].image}')
-test "$hub_image" = "$expected_image"
-test "$studio_image" = "$expected_image"
-
-for deployment in hub-frontend studio-frontend; do
-  kubectl annotate deployment "$deployment" -n acedatacloud \
-    "acedata.cloud/last-successful-revision=$GITHUB_SHA" --overwrite
-done


### PR DESCRIPTION
Move hub/studio rollout, image proof, and SHA annotation into named workflow steps; deploy/run.sh now only applies manifests. Static shell/YAML/diff checks passed.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)