### PR TITLE
feat(midjourney): add version 8.2 controls

### DIFF
--- a/change/@acedatacloud-nexior-midjourney-8-2.json
+++ b/change/@acedatacloud-nexior-midjourney-8-2.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add Midjourney 8.2 generation controls",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/midjourney/ConfigPanel.vue
+++ b/src/components/midjourney/ConfigPanel.vue
@@ -130,7 +130,7 @@ export default defineComponent({
       return this.$store.state.midjourney.config;
     },
     isV8(): boolean {
-      return this.config?.version === '8' || this.config?.version === '8.1';
+      return ['8', '8.1', '8.2'].includes(this.config?.version || '');
     },
     isNiji(): boolean {
       return !!this.config?.model?.includes('niji');

--- a/src/components/midjourney/config/QualitySelector.vue
+++ b/src/components/midjourney/config/QualitySelector.vue
@@ -27,11 +27,20 @@ export default defineComponent({
     isV8(): boolean {
       return this.version === '8';
     },
+    isV82(): boolean {
+      return this.version === '8.2';
+    },
     options() {
       if (this.isV8) {
         return [
           { label: this.$t('midjourney.button.standard'), value: '1' },
           { label: this.$t('midjourney.button.ultra'), value: '4' }
+        ];
+      }
+      if (this.isV82) {
+        return [
+          { label: this.$t('midjourney.button.standard'), value: '1' },
+          { label: this.$t('midjourney.button.ultra'), value: '2' }
         ];
       }
       return [
@@ -53,6 +62,11 @@ export default defineComponent({
     }
   },
   watch: {
+    version() {
+      if (this.isV82 && !['1', '2'].includes(this.value || '')) {
+        this.value = MIDJOURNEY_DEFAULT_QUALITY;
+      }
+    },
     isV8(newVal) {
       if (newVal && this.value !== '1' && this.value !== '4') {
         this.value = MIDJOURNEY_DEFAULT_QUALITY;

--- a/src/components/midjourney/config/VersionSelector.vue
+++ b/src/components/midjourney/config/VersionSelector.vue
@@ -11,7 +11,7 @@
 import { defineComponent } from 'vue';
 import { ElSelect, ElOption } from 'element-plus';
 
-const DEFAULT_VERSION = '8.1';
+const DEFAULT_VERSION = '8.2';
 
 export default defineComponent({
   name: 'VersionSelector',
@@ -29,6 +29,10 @@ export default defineComponent({
   data() {
     return {
       options: [
+        {
+          value: '8.2',
+          label: '8.2'
+        },
         {
           value: '8.1',
           label: '8.1'

--- a/src/components/midjourney/v81Capabilities.test.ts
+++ b/src/components/midjourney/v81Capabilities.test.ts
@@ -5,18 +5,20 @@ import { describe, expect, it } from 'vitest';
 
 const source = (relativePath: string) => readFileSync(fileURLToPath(new URL(relativePath, import.meta.url)), 'utf8');
 
-describe('Midjourney V8.1 capability controls', () => {
+describe('Midjourney V8.1 and V8.2 capability controls', () => {
   const panel = source('./ConfigPanel.vue');
   const versionSelector = source('./config/VersionSelector.vue');
   const modeSelector = source('./config/ModeSelector2.vue');
   const qualitySelector = source('./config/QualitySelector.vue');
   const operator = source('../../operators/midjourney.ts');
 
-  it('hides the unsupported Quality control', () => {
+  it('keeps Quality hidden only for V8.1', () => {
     expect(panel).toContain('<quality-selector v-if="config?.version !== \'8.1\'"');
   });
 
-  it('normalizes persisted Quality and Turbo values when V8.1 is selected', () => {
+  it('recommends V8.2 and normalizes persisted values only for V8.1', () => {
+    expect(versionSelector).toContain("const DEFAULT_VERSION = '8.2'");
+    expect(versionSelector).toContain("value: '8.2'");
     expect(versionSelector).toContain("val === '8.1' ? { quality: undefined");
     expect(versionSelector).toContain("config.mode === 'turbo' ? 'fast' : config.mode");
     expect(versionSelector).toContain("val === '8.1' && (config.quality || config.mode === 'turbo')");
@@ -29,9 +31,12 @@ describe('Midjourney V8.1 capability controls', () => {
     expect(modeSelector).toContain('this.value = DEFAULT_MODE');
   });
 
-  it('keeps video Turbo available and omits Quality from V8.1 requests', () => {
+  it('keeps V8.2 in the V8 control family while preserving V8.1 request limits', () => {
+    expect(panel).toContain("['8', '8.1', '8.2'].includes");
     expect(modeSelector).toContain("return this.$store.state.midjourney.config.type || 'imagine'");
     expect(qualitySelector).toContain("return this.version === '8'");
+    expect(qualitySelector).toContain("return this.version === '8.2'");
+    expect(qualitySelector).toContain("value: '2'");
     expect(operator).toContain("const isV81 = config.version === '8.1'");
     expect(operator.match(/\.\.\.\(!isV81 \? \{ quality:/g)).toHaveLength(2);
     expect(operator).toContain('mode: isV81 ? MIDJOURNEY_DEFAULT_MODE : config.mode || MIDJOURNEY_DEFAULT_MODE');

--- a/src/operators/x402MidjourneyRequests.test.ts
+++ b/src/operators/x402MidjourneyRequests.test.ts
@@ -16,6 +16,17 @@ vi.mock('./x402', async (importOriginal) => ({
 }));
 
 describe('Midjourney x402 requests', () => {
+  it('builds V8.2 prompts with quality and structured metadata', () => {
+    expect(buildMidjourneyImagineRequest({ prompt: 'cat', version: '8.2', quality: '2', mode: 'turbo' })).toMatchObject(
+      {
+        prompt: expect.stringContaining('cat --version 8.2 --quality 2'),
+        version: '8.2',
+        quality: '2',
+        mode: 'turbo'
+      }
+    );
+  });
+
   it('builds one authoritative imagine prompt with V8 pricing flags', () => {
     expect(
       buildMidjourneyImagineRequest({


### PR DESCRIPTION
## Dependency graph
Consumer UI node; depends on the PlatformBackend 8.2 contract and PlatformService runtime support.

## Contract
- Make 8.2 the default Midjourney version.
- Keep Turbo available for 8.2 while preserving V8.1 restrictions.
- Offer V8.2 Quality 1/2 controls and include the structured version/quality metadata in requests.

## Evidence
- Targeted Vitest: 8 passed.
- Prettier, ESLint (0 errors; 2 pre-existing warnings), and vue-tsc passed.
- Beachball change file included; local remote fetch timed out, so CI will perform the authoritative beachball check.

## Rollout / rollback
Normal Nexior release. Revert to restore 8.1 as the default.

## Out of scope
No new translations are required because labels are numeric/existing keys.

## Adversarial review
Not requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)