### PR TITLE
fix: streamline home Gallery and replay showcases

### DIFF
--- a/change/gallery-wide-layout-7d2f6a91.json
+++ b/change/gallery-wide-layout-7d2f6a91.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Fix create-similar hydration for production image showcases and balance service Gallery cards across wide screens.",
+  "comment": "Fix create-similar hydration for production image showcases, remove the redundant home inspiration navigation, and balance service Gallery cards across wide screens.",
   "packageName": "@acedatacloud/nexior",
   "email": "dev@acedata.cloud",
   "dependentChangeType": "patch"

--- a/change/gallery-wide-layout-7d2f6a91.json
+++ b/change/gallery-wide-layout-7d2f6a91.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix create-similar hydration for production image showcases and balance service Gallery cards across wide screens.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/common/ShowcaseGrid.vue
+++ b/src/components/common/ShowcaseGrid.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class="dashboard-section showcase-section" :class="{ compact }" :aria-label="ariaLabel">
+  <section class="dashboard-section showcase-section" :class="{ compact, masonry }" :aria-label="ariaLabel">
     <slot name="heading">
       <div v-if="title" class="section-heading">
         <div>
@@ -83,8 +83,9 @@ withDefaults(
     ariaLabel?: string;
     showCapability?: boolean;
     compact?: boolean;
+    masonry?: boolean;
   }>(),
-  { title: '', eyebrow: '', subtitle: '', ariaLabel: '', showCapability: true, compact: false }
+  { title: '', eyebrow: '', subtitle: '', ariaLabel: '', showCapability: true, compact: false, masonry: false }
 );
 defineEmits<{ 'icon-error': [item: ResolvedShowcase] }>();
 
@@ -202,10 +203,31 @@ defineExpose({ playingId, startPreview, stopPreview, togglePreview, reducedMotio
   &.compact {
     padding-top: 0;
     padding-bottom: 18px;
+  }
 
+  &.masonry {
     .showcase-grid {
-      grid-template-columns: repeat(3, minmax(0, 1fr));
-      grid-auto-rows: 170px;
+      display: block;
+      columns: 300px;
+      column-gap: 13px;
+    }
+
+    .showcase-card {
+      width: 100%;
+      margin-bottom: 13px;
+      break-inside: avoid;
+
+      &.landscape {
+        aspect-ratio: 16 / 9;
+      }
+
+      &.square {
+        aspect-ratio: 1;
+      }
+
+      &.portrait {
+        aspect-ratio: 3 / 4;
+      }
     }
   }
 }

--- a/src/components/common/ShowcaseGrid.vue
+++ b/src/components/common/ShowcaseGrid.vue
@@ -274,7 +274,6 @@ defineExpose({ playingId, startPreview, stopPreview, togglePreview, reducedMotio
   position: relative;
   min-width: 0;
   overflow: hidden;
-  border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: 15px;
   color: #fff;
   background: #0d131d;

--- a/src/components/common/ShowcaseResultTabs.test.ts
+++ b/src/components/common/ShowcaseResultTabs.test.ts
@@ -13,7 +13,11 @@ vi.mock('vue-i18n', async (importOriginal) => ({
   useI18n: () => ({ locale: { value: 'en' } })
 }));
 vi.mock('./ShowcaseGrid.vue', () => ({
-  default: { name: 'ShowcaseGrid', props: ['items'], template: '<div class="showcase-grid-stub" />' }
+  default: {
+    name: 'ShowcaseGrid',
+    props: { items: Array, compact: Boolean, masonry: Boolean },
+    template: '<div class="showcase-grid-stub" :data-compact="compact" :data-masonry="masonry" />'
+  }
 }));
 
 const ElTabsStub = {
@@ -65,6 +69,10 @@ describe('ShowcaseResultTabs', () => {
     (wrapper.vm as any).activeTab = 'gallery';
     await vi.waitFor(() => expect(showcaseOperator.list).toHaveBeenCalledWith('nano-banana'));
     await vi.waitFor(() => expect((wrapper.vm as any).resolvedItems).toHaveLength(1));
+    expect(wrapper.getComponent({ name: 'ShowcaseGrid' }).props()).toMatchObject({
+      compact: true,
+      masonry: true
+    });
     expect(wrapper.find('.task-sentinel').exists()).toBe(true);
     (wrapper.vm as any).activeTab = 'tasks';
     (wrapper.vm as any).activeTab = 'gallery';

--- a/src/components/common/ShowcaseResultTabs.vue
+++ b/src/components/common/ShowcaseResultTabs.vue
@@ -14,6 +14,7 @@
         :items="resolvedItems"
         :show-capability="false"
         compact
+        masonry
         @icon-error="$emit('icon-error', $event)"
       />
       <div v-else class="gallery-state">{{ $t('intro.serviceGallery.empty') }}</div>

--- a/src/pages/home/Index.test.ts
+++ b/src/pages/home/Index.test.ts
@@ -49,6 +49,11 @@ describe('Studio workbench home', () => {
     expect(showcaseOperator.list).not.toHaveBeenCalled();
   });
 
+  it('does not repeat the inspiration navigation above the home content', () => {
+    const wrapper = mountHome({ id: 'studio', features: studioFeatures });
+    expect(wrapper.findComponent({ name: 'PublicSectionNav' }).exists()).toBe(false);
+  });
+
   it('covers all Studio capabilities through named-route destinations', () => {
     const destinations = [...HOME_BANNERS, ...HOME_CATEGORIES.flatMap((item) => item.candidates)];
     expect(HOME_BANNERS).toHaveLength(3);

--- a/src/pages/home/Index.vue
+++ b/src/pages/home/Index.vue
@@ -1,7 +1,6 @@
 <template>
   <main v-if="siteLoaded" class="studio-home">
     <div class="dashboard">
-      <public-section-nav />
       <home-carousel v-if="banners.length" :slides="banners" @image-error="onImageError" />
       <category-tiles
         v-if="categories.length"
@@ -33,7 +32,6 @@ import { showcaseOperator } from '@/operators';
 import { resolveCapabilityPresentation } from '@/utils/capabilityPresentation';
 import { resolveShowcase } from '@/utils/showcase';
 import ShowcaseGrid from '@/components/common/ShowcaseGrid.vue';
-import PublicSectionNav from '@/components/common/PublicSectionNav.vue';
 import CategoryTiles from './components/CategoryTiles.vue';
 import HomeCarousel from './components/HomeCarousel.vue';
 import {
@@ -49,7 +47,6 @@ export default defineComponent({
   name: 'StudioHome',
   components: {
     CategoryTiles,
-    PublicSectionNav,
     ShowcaseGrid,
     HomeCarousel
   },

--- a/src/utils/showcaseRecreate.test.ts
+++ b/src/utils/showcaseRecreate.test.ts
@@ -64,11 +64,18 @@ describe('showcase recreate consumer', () => {
   it.each([
     [
       'nanobanana',
-      { prompt: 'Portrait', images: ['https://cdn.acedata.cloud/ref'], aspect_ratio: '1:1' },
+      {
+        prompt: 'Portrait',
+        model: 'nano-banana-pro',
+        action: 'generate',
+        images: ['https://cdn.acedata.cloud/ref'],
+        aspect_ratio: '1:1',
+        resolution: '4K'
+      },
       'image_urls'
     ],
     ['openaiimage', { prompt: 'Editorial', size: '1536x1024' }, 'size'],
-    ['seedream', { prompt: 'Mist', max_images: 2, output_format: 'jpeg' }, 'output_format'],
+    ['seedream', { prompt: 'Mist', max_images: 2, output_format: 'jpeg', watermark: false }, 'output_format'],
     ['seedance', { prompt: 'Motion', duration: 4, ratio: '16:9' }, 'ratio'],
     ['kling', { prompt: 'Rain', mode: 'std' }, 'mode'],
     ['veo', { prompt: 'Flower', translation: false }, 'translation'],
@@ -88,6 +95,64 @@ describe('showcase recreate consumer', () => {
       expect(replace).toHaveBeenCalledWith({ path: `/${capability}`, query: { locale: 'en' }, hash: '#form' });
     }
   );
+
+  it('accepts the generate action used by production image snapshots', async () => {
+    const request = {
+      prompt: 'Original fragrance bottle',
+      model: 'nano-banana-pro',
+      action: 'generate',
+      resolution: '4K',
+      aspect_ratio: '4:3'
+    };
+    vi.mocked(showcaseOperator.list).mockResolvedValue({ data: [item('nanobanana', request)] } as any);
+    const { options, commit } = context('nanobanana');
+    expect(await consumeShowcase(options)).toBe('applied');
+    expect(commit).toHaveBeenCalledWith(
+      'nanobanana/setConfig',
+      expect.objectContaining({
+        prompt: 'Original fragrance bottle',
+        model: 'nano-banana-pro',
+        resolution: '4K',
+        aspect_ratio: '4:3'
+      })
+    );
+  });
+
+  it('rejects non-generate image actions', async () => {
+    vi.mocked(showcaseOperator.list).mockResolvedValue({
+      data: [item('nanobanana', { prompt: 'Restyle this', action: 'edit' })]
+    } as any);
+    const { options, commit } = context('nanobanana');
+    expect(await consumeShowcase(options)).toBe('failed');
+    expect(commit).not.toHaveBeenCalled();
+    expect(ElMessage.warning).toHaveBeenCalled();
+  });
+
+  it('accepts a disabled watermark from production Seedream snapshots', async () => {
+    const request = {
+      prompt: 'Mountain dawn',
+      model: 'doubao-seedream-5-0-pro-260628',
+      size: '2K',
+      output_format: 'jpeg',
+      watermark: false
+    };
+    vi.mocked(showcaseOperator.list).mockResolvedValue({ data: [item('seedream', request)] } as any);
+    const { options, commit } = context('seedream');
+    expect(await consumeShowcase(options)).toBe('applied');
+    expect(commit).toHaveBeenCalledWith(
+      'seedream/setConfig',
+      expect.objectContaining({ prompt: 'Mountain dawn', output_format: 'jpeg' })
+    );
+  });
+
+  it('rejects an enabled watermark in Seedream snapshots', async () => {
+    vi.mocked(showcaseOperator.list).mockResolvedValue({
+      data: [item('seedream', { prompt: 'Mountain dawn', watermark: true })]
+    } as any);
+    const { options, commit } = context('seedream');
+    expect(await consumeShowcase(options)).toBe('failed');
+    expect(commit).not.toHaveBeenCalled();
+  });
 
   it('maps curated image references into the Nano Banana form contract', async () => {
     const request = { prompt: 'Restyle this', images: ['https://cdn.acedata.cloud/reference.png'] };

--- a/src/utils/showcaseRecreate.ts
+++ b/src/utils/showcaseRecreate.ts
@@ -93,6 +93,8 @@ const imageAllowed = new Set([
   'guidance_scale',
   'output_format'
 ]);
+const nanoBananaAllowed = new Set([...imageAllowed, 'action']);
+const seedreamAllowed = new Set([...imageAllowed, 'watermark']);
 const videoAllowed = new Set([
   'prompt',
   'negative_prompt',
@@ -116,7 +118,7 @@ const musicAllowed = new Set(['prompt', 'lyric', 'style', 'title', 'instrumental
 
 const adapters: Partial<Record<CapabilityKey, Adapter>> = {
   nanobanana: {
-    allowed: imageAllowed,
+    allowed: nanoBananaAllowed,
     activeKeys: ['prompt', 'image_urls'],
     build: (c) =>
       compact({
@@ -151,7 +153,7 @@ const adapters: Partial<Record<CapabilityKey, Adapter>> = {
       })
   },
   seedream: {
-    allowed: imageAllowed,
+    allowed: seedreamAllowed,
     activeKeys: ['prompt', 'image'],
     build: (c) =>
       compact({
@@ -308,6 +310,10 @@ function validateItem(
   if (!request || typeof request !== 'object' || Array.isArray(request)) throw new Error('invalid config');
   const unknown = Object.keys(request).filter((key) => !adapter.allowed.has(key));
   if (unknown.length) throw new Error('unsupported fields');
+  if (adapter.allowed === nanoBananaAllowed && 'action' in request && request.action !== 'generate')
+    throw new Error('unsupported action');
+  if (capability === 'seedream' && 'watermark' in request && request.watermark !== false)
+    throw new Error('unsupported watermark');
   return { adapter, patch: adapter.build(request) };
 }
 


### PR DESCRIPTION
## Summary
- remove the redundant Home / Inspiration tab row from the home page, which already surfaces curated inspiration below the creation categories
- render service-local Gallery cards as proportional masonry columns so ultrawide landscape cards no longer span most of the result pane
- accept and strictly validate the production Nano Banana `action: generate` and Seedream `watermark: false` snapshot fields during create-similar hydration
- keep GPT Image and unrelated adapters closed to those service-specific fields

## Production bugs reproduced
- Nano Banana create-similar rejected valid published snapshots because `action` was absent from the frontend allowlist
- Seedream create-similar rejected valid published snapshots because `watermark` was absent from the frontend allowlist
- at 2560px, compact landscape cards spanned two of three columns and reached roughly 1100px wide
- the home page repeated Inspiration as a top-level tab despite presenting the curated showcase directly below the creation categories

## Validation
- focused Home and Showcase tests: 35 passed
- changed-file ESLint: passed
- `vue-tsc -b`: passed
- `npm run verify`: passed during push
- GitHub `build-and-test (22.x)`: passed
- Linux E2E smoke: passed
- Cloudflare Workers preview build: passed
- browser against PR assets on the real `studio.acedata.cloud` origin and live production Showcase API:
  - Home renders carousel, category tiles, and showcase with 0 `.public-section-nav` instances and no horizontal overflow
  - Nano Banana service replay returned 200, hydrated the exact 1,536-character production prompt, cleared `showcase`, and showed no unavailable warning
  - Seedream service replay returned 200, hydrated the exact 1,285-character production prompt, cleared `showcase`, and showed no unavailable warning
  - production API currently exposes 30 Nano Banana snapshots with `action` and 30 Seedream snapshots with `watermark`
  - 2560px: 6 columns, 339px cards, no horizontal overflow
  - 1440px: 3 columns, 317px cards, no horizontal overflow
  - 390px: 1 column, 306px cards, no horizontal overflow

## Rollback
Revert the two commits in this PR. No API, database, route, or persisted-state migration is involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)