### PR TITLE
fix: preserve Studio login on Auth account pages

### DIFF
--- a/change/auth-profile-sso-4f3a8c1d.json
+++ b/change/auth-profile-sso-4f3a8c1d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Keep users signed in when opening profile and verification pages after embedded login.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/common/TopHeader.vue
+++ b/src/components/common/TopHeader.vue
@@ -71,7 +71,7 @@
 <script lang="ts">
 import { defineComponent } from 'vue';
 import defaultAvatar from '@/assets/images/avatar.png';
-import { getBaseUrlAuth, withCurrentUserIdAndSite, isMainOfficial } from '@/utils';
+import { isMainOfficial, openAuthAccountPage } from '@/utils';
 import { ROUTE_CHATGPT_CONVERSATION_NEW, ROUTE_CONSOLE_ROOT, ROUTE_DOWNLOAD, ROUTE_INDEX } from '@/router';
 import {
   ElCol,
@@ -178,12 +178,10 @@ export default defineComponent({
       });
     },
     onProfile() {
-      const baseUrlAuth = getBaseUrlAuth();
-      this.openTab(withCurrentUserIdAndSite(`${baseUrlAuth}/user/profile`));
+      void openAuthAccountPage('/user/profile');
     },
     onVerify() {
-      const baseUrlAuth = getBaseUrlAuth();
-      this.openTab(withCurrentUserIdAndSite(`${baseUrlAuth}/user/verify`));
+      void openAuthAccountPage('/user/verify');
     },
     onConsole() {
       this.$router.push({

--- a/src/models/auth.ts
+++ b/src/models/auth.ts
@@ -15,3 +15,8 @@ export interface IOAuthTokenResponse {
   expires_in: number;
   refresh_token: string;
 }
+
+export interface IAuthCodeResponse extends IOAuthTokenResponse {
+  code: string;
+  user_id: string;
+}

--- a/src/operators/auth.ts
+++ b/src/operators/auth.ts
@@ -1,11 +1,15 @@
 import { AxiosResponse } from 'axios';
 import { httpClient } from './common';
-import { ITokenResponse, IToken, IOAuthTokenRequest, IOAuthTokenResponse } from '@/models';
+import { IAuthCodeResponse, ITokenResponse, IToken, IOAuthTokenRequest, IOAuthTokenResponse } from '@/models';
 import { getBaseUrlAuth } from '@/utils';
 
 class AuthOperator {
   async refreshToken(payload: IToken): Promise<AxiosResponse<ITokenResponse>> {
     return httpClient.post('/auth/refresh/', payload);
+  }
+
+  async getCode(): Promise<AxiosResponse<IAuthCodeResponse>> {
+    return httpClient.post('/auth/code/', {});
   }
 }
 

--- a/src/utils/authAccount.test.ts
+++ b/src/utils/authAccount.test.ts
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { browserOpen, getCode, native } = vi.hoisted(() => ({
+  getCode: vi.fn(),
+  browserOpen: vi.fn(),
+  native: { value: false }
+}));
+
+vi.mock('@/operators/auth', () => ({
+  authOperator: { getCode }
+}));
+vi.mock('@capacitor/browser', () => ({
+  Browser: { open: browserOpen }
+}));
+vi.mock('./baseUrl', () => ({
+  getBaseUrlAuth: () => 'https://auth.acedata.cloud'
+}));
+vi.mock('./crossSiteUser', () => ({
+  withCurrentSite: (url: string) => {
+    const target = new URL(url);
+    target.searchParams.set('site', 'https://studio.worldai.chat');
+    return target.toString();
+  }
+}));
+vi.mock('./surface', () => ({
+  isNative: () => native.value
+}));
+
+import { openAuthAccountPage } from './authAccount';
+
+describe('Auth account SSO navigation', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    getCode.mockReset();
+    browserOpen.mockReset();
+    native.value = false;
+  });
+
+  it('opens a web tab synchronously and replaces it with an SSO login URL', async () => {
+    const replace = vi.fn();
+    const open = vi.spyOn(window, 'open').mockReturnValue({ location: { replace } } as unknown as Window);
+    getCode.mockResolvedValue({ data: { code: 'single-use-code' } });
+
+    const promise = openAuthAccountPage('/user/profile');
+
+    expect(open).toHaveBeenCalledWith('about:blank', '_blank');
+    await promise;
+    const url = new URL(replace.mock.calls[0][0]);
+    expect(url.pathname).toBe('/auth/login/');
+    expect(url.searchParams.get('code')).toBe('single-use-code');
+    expect(url.searchParams.get('site')).toBe('https://studio.worldai.chat');
+    expect(url.searchParams.get('redirect')).toContain('/user/profile');
+  });
+
+  it('sends a failed web handoff to the normal login fallback', async () => {
+    const replace = vi.fn();
+    vi.spyOn(window, 'open').mockReturnValue({ location: { replace } } as unknown as Window);
+    getCode.mockRejectedValue(new Error('expired session'));
+
+    await openAuthAccountPage('/user/verify');
+
+    const url = new URL(replace.mock.calls[0][0]);
+    expect(url.searchParams.has('code')).toBe(false);
+    expect(url.searchParams.get('redirect')).toContain('/user/verify');
+  });
+
+  it('uses the Capacitor browser without opening a web tab', async () => {
+    native.value = true;
+    const open = vi.spyOn(window, 'open');
+    getCode.mockResolvedValue({ data: { code: 'native-code' } });
+
+    await openAuthAccountPage('/user/profile');
+
+    expect(open).not.toHaveBeenCalled();
+    expect(browserOpen).toHaveBeenCalledOnce();
+    expect(browserOpen.mock.calls[0][0].url).toContain('code=native-code');
+  });
+});

--- a/src/utils/authAccount.ts
+++ b/src/utils/authAccount.ts
@@ -1,0 +1,39 @@
+import { Browser } from '@capacitor/browser';
+import { authOperator } from '@/operators/auth';
+import { getBaseUrlAuth } from './baseUrl';
+import { withCurrentSite } from './crossSiteUser';
+import { isNative } from './surface';
+
+const buildAuthLoginUrl = (path: string): string => {
+  const accountUrl = new URL(withCurrentSite(new URL(path, getBaseUrlAuth()).toString()));
+  const redirect = `${accountUrl.pathname}${accountUrl.search}${accountUrl.hash}`;
+  const url = new URL('/auth/login/', getBaseUrlAuth());
+  url.searchParams.set('redirect', redirect);
+  return withCurrentSite(url.toString());
+};
+
+export const openAuthAccountPage = async (path: string): Promise<void> => {
+  const fallbackUrl = buildAuthLoginUrl(path);
+  const targetWindow = isNative() ? null : window.open('about:blank', '_blank');
+  try {
+    const { data } = await authOperator.getCode();
+    const url = new URL(fallbackUrl);
+    url.searchParams.set('code', data.code);
+    if (isNative()) {
+      await Browser.open({ url: url.toString() });
+    } else if (targetWindow) {
+      targetWindow.location.replace(url.toString());
+    } else {
+      window.location.href = url.toString();
+    }
+  } catch (error) {
+    console.warn('failed to open Auth account page with SSO', error);
+    if (isNative()) {
+      await Browser.open({ url: fallbackUrl });
+    } else if (targetWindow) {
+      targetWindow.location.replace(fallbackUrl);
+    } else {
+      window.location.href = fallbackUrl;
+    }
+  }
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -23,5 +23,5 @@ export * from './connections';
 export * from './featureFlag';
 export * from './loginMethod';
 export * from './iap';
-
 export * from './servicePricing';
+export * from './authAccount';


### PR DESCRIPTION
## Summary
- mint the existing one-time SSO code before opening profile and verification pages
- preserve tenant `site` context while restoring the top-level Auth session
- keep Web/Electron popup timing and Capacitor Browser behavior separate
- fall back to the normal Auth login page when code minting fails

## Why
Embedded Auth login can leave Studio authenticated while top-level Auth storage is partitioned by the browser. Direct account links then incorrectly ask the user to sign in again.

## Dependency
Requires the receiver in https://github.com/AceDataCloud/AuthFrontend/pull/266 to deploy first.

## Verification
- `npm run test:run -- src/utils/authAccount.test.ts` (3 passed)
- `npm run lint:check` (0 errors; 2 existing warnings)
- `npm run build:web`
- `npm run verify`
- Prettier + `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)