### PR TITLE
fix(settings): translate analytics and contain sidebar

### DIFF
--- a/change/@acedatacloud-nexior-settings-sidebar-i18n.json
+++ b/change/@acedatacloud-nexior-settings-sidebar-i18n.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix website analytics labels in settings and keep the desktop settings navigation inside its scroll area.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/user/Setting.test.ts
+++ b/src/components/user/Setting.test.ts
@@ -76,6 +76,15 @@ const mountSetting = () =>
 const tabKeys = (wrapper: ReturnType<typeof mountSetting>): string[] =>
   (wrapper.vm as unknown as { visibleNavItems: { key: string }[] }).visibleNavItems.map((i) => i.key);
 
+describe('user/Setting layout', () => {
+  it('keeps the desktop navigation inside its scroll container', () => {
+    vi.stubEnv('VITE_SURFACE', 'web');
+    const wrapper = mountSetting();
+    const aside = wrapper.find('aside');
+    expect(aside.classes()).toEqual(expect.arrayContaining(['h-full', 'min-h-0', 'overflow-y-auto']));
+  });
+});
+
 describe('user/Setting surface gating', () => {
   beforeEach(() => {
     hostState.official = false;

--- a/src/components/user/Setting.vue
+++ b/src/components/user/Setting.vue
@@ -6,7 +6,7 @@
     @close="onClose"
   >
     <div :class="['settings', mobile ? 'flex flex-col' : 'flex h-[450px]']">
-      <aside :class="mobile ? 'border-b w-full' : 'h-full border-r'">
+      <aside :class="mobile ? 'border-b w-full' : 'h-full min-h-0 overflow-y-auto border-r'">
         <el-menu
           :class="['border-r-0 settings-menu', mobile ? 'is-mobile flex flex-row overflow-x-auto' : '']"
           :mode="mobile ? 'horizontal' : 'vertical'"

--- a/src/i18n/ar/site.json
+++ b/src/i18n/ar/site.json
@@ -1090,31 +1090,55 @@
     "message": "فشل تحميل تخصيص التطبيق",
     "description": "خطأ عند عدم القدرة على قراءة سجلات إدارة تغطية تطبيق القدرة"
   },
-  "analytics": {
-    "title": "تحليلات الموقع",
-    "securityNotice": "يتم دعم مزودي التحليلات المعتمدين فقط. لا يمكن إدراج JavaScript و HTML الخام.",
-    "enabled": "مفعل",
-    "required": "أدخل معرف المزود قبل الحفظ.",
-    "invalidId": "أدخل معرف مزود صالح.",
-    "saveFailed": "فشل في حفظ إعدادات تحليلات الموقع.",
-    "ga4": {
-      "description": "قياس الزيارات والتحويلات باستخدام معرف قياس GA4.",
-      "measurementId": "معرف القياس"
-    },
-    "baidu": {
-      "title": "تحليلات موقع Baidu",
-      "description": "قياس حركة المرور على الموقع باستخدام تحليلات Baidu.",
-      "siteId": "معرف الموقع"
-    },
-    "clarity": {
-      "description": "فهم الجلسات والسلوك باستخدام Microsoft Clarity.",
-      "projectId": "معرف المشروع"
-    },
-    "umami": {
-      "description": "استخدام تحليلات الموقع التي تركز على الخصوصية من خلال Umami.",
-      "websiteId": "معرف الموقع",
-      "serverUrl": "عنوان خادم",
-      "serverUrlHelp": "Umami Cloud متاحة بشكل افتراضي. يجب أن تتم الموافقة على المصادر المستضافة ذاتيًا من قبل مسؤول المنصة أولاً."
-    }
+  "analytics.title": {
+    "message": "تحليلات الموقع"
+  },
+  "analytics.securityNotice": {
+    "message": "يتم دعم مزودي التحليلات المعتمدين فقط. لا يمكن إدراج JavaScript و HTML الخام."
+  },
+  "analytics.enabled": {
+    "message": "مفعل"
+  },
+  "analytics.required": {
+    "message": "أدخل معرف المزود قبل الحفظ."
+  },
+  "analytics.invalidId": {
+    "message": "أدخل معرف مزود صالح."
+  },
+  "analytics.saveFailed": {
+    "message": "فشل في حفظ إعدادات تحليلات الموقع."
+  },
+  "analytics.ga4.description": {
+    "message": "قياس الزيارات والتحويلات باستخدام معرف قياس GA4."
+  },
+  "analytics.ga4.measurementId": {
+    "message": "معرف القياس"
+  },
+  "analytics.baidu.title": {
+    "message": "تحليلات موقع Baidu"
+  },
+  "analytics.baidu.description": {
+    "message": "قياس حركة المرور على الموقع باستخدام تحليلات Baidu."
+  },
+  "analytics.baidu.siteId": {
+    "message": "معرف الموقع"
+  },
+  "analytics.clarity.description": {
+    "message": "فهم الجلسات والسلوك باستخدام Microsoft Clarity."
+  },
+  "analytics.clarity.projectId": {
+    "message": "معرف المشروع"
+  },
+  "analytics.umami.description": {
+    "message": "استخدام تحليلات الموقع التي تركز على الخصوصية من خلال Umami."
+  },
+  "analytics.umami.websiteId": {
+    "message": "معرف الموقع"
+  },
+  "analytics.umami.serverUrl": {
+    "message": "عنوان خادم"
+  },
+  "analytics.umami.serverUrlHelp": {
+    "message": "Umami Cloud متاحة بشكل افتراضي. يجب أن تتم الموافقة على المصادر المستضافة ذاتيًا من قبل مسؤول المنصة أولاً."
   }
 }

--- a/src/i18n/de/site.json
+++ b/src/i18n/de/site.json
@@ -1090,31 +1090,55 @@
     "message": "Laden der benutzerdefinierten Anwendung fehlgeschlagen",
     "description": "Fehler beim Lesen der Verwaltungsaufzeichnungen der Anwendungsüberschreibung"
   },
-  "analytics": {
-    "title": "Website-Analyse",
-    "securityNotice": "Nur genehmigte Analyseanbieter werden unterstützt. Rohes JavaScript und HTML können nicht eingefügt werden.",
-    "enabled": "Aktiviert",
-    "required": "Geben Sie die Anbieter-ID vor dem Speichern ein.",
-    "invalidId": "Geben Sie eine gültige Anbieter-ID ein.",
-    "saveFailed": "Speichern der Website-Analyse-Einstellungen fehlgeschlagen.",
-    "ga4": {
-      "description": "Besuche und Conversions mit einer GA4 Measurement ID messen.",
-      "measurementId": "Measurement ID"
-    },
-    "baidu": {
-      "title": "Baidu-Website-Analyse",
-      "description": "Website-Traffic mit Baidu-Analyse messen.",
-      "siteId": "Site ID"
-    },
-    "clarity": {
-      "description": "Sitzungen und Verhalten mit Microsoft Clarity verstehen.",
-      "projectId": "Projekt-ID"
-    },
-    "umami": {
-      "description": "Verwenden Sie datenschutzorientierte Website-Analyse über Umami.",
-      "websiteId": "Website-ID",
-      "serverUrl": "Server-URL",
-      "serverUrlHelp": "Umami Cloud ist standardmäßig verfügbar. Selbstgehostete Ursprünge müssen zuerst vom Plattformadministrator genehmigt werden."
-    }
+  "analytics.title": {
+    "message": "Website-Analyse"
+  },
+  "analytics.securityNotice": {
+    "message": "Nur genehmigte Analyseanbieter werden unterstützt. Rohes JavaScript und HTML können nicht eingefügt werden."
+  },
+  "analytics.enabled": {
+    "message": "Aktiviert"
+  },
+  "analytics.required": {
+    "message": "Geben Sie die Anbieter-ID vor dem Speichern ein."
+  },
+  "analytics.invalidId": {
+    "message": "Geben Sie eine gültige Anbieter-ID ein."
+  },
+  "analytics.saveFailed": {
+    "message": "Speichern der Website-Analyse-Einstellungen fehlgeschlagen."
+  },
+  "analytics.ga4.description": {
+    "message": "Besuche und Conversions mit einer GA4 Measurement ID messen."
+  },
+  "analytics.ga4.measurementId": {
+    "message": "Measurement ID"
+  },
+  "analytics.baidu.title": {
+    "message": "Baidu-Website-Analyse"
+  },
+  "analytics.baidu.description": {
+    "message": "Website-Traffic mit Baidu-Analyse messen."
+  },
+  "analytics.baidu.siteId": {
+    "message": "Website-ID"
+  },
+  "analytics.clarity.description": {
+    "message": "Sitzungen und Verhalten mit Microsoft Clarity verstehen."
+  },
+  "analytics.clarity.projectId": {
+    "message": "Projekt-ID"
+  },
+  "analytics.umami.description": {
+    "message": "Verwenden Sie datenschutzorientierte Website-Analyse über Umami."
+  },
+  "analytics.umami.websiteId": {
+    "message": "Website-ID"
+  },
+  "analytics.umami.serverUrl": {
+    "message": "Server-URL"
+  },
+  "analytics.umami.serverUrlHelp": {
+    "message": "Umami Cloud ist standardmäßig verfügbar. Selbstgehostete Ursprünge müssen zuerst vom Plattformadministrator genehmigt werden."
   }
 }

--- a/src/i18n/el/site.json
+++ b/src/i18n/el/site.json
@@ -1090,31 +1090,55 @@
     "message": "Αποτυχία φόρτωσης προσαρμοσμένων εφαρμογών",
     "description": "Σφάλμα κατά την ανάγνωση των αρχείων διαχείρισης κάλυψης εφαρμογής"
   },
-  "analytics": {
-    "title": "Αναλύσεις Ιστοσελίδας",
-    "securityNotice": "Υποστηρίζονται μόνο οι εγκεκριμένοι πάροχοι αναλύσεων. Δεν μπορεί να εισαχθεί ακατέργωτος JavaScript και HTML.",
-    "enabled": "Ενεργοποιημένο",
-    "required": "Εισάγετε το ID παρόχου πριν αποθηκεύσετε.",
-    "invalidId": "Εισάγετε ένα έγκυρο ID παρόχου.",
-    "saveFailed": "Αποτυχία αποθήκευσης ρυθμίσεων αναλύσεων ιστοσελίδας.",
-    "ga4": {
-      "description": "Μετρήστε επισκέψεις και μετατροπές με ένα GA4 Measurement ID.",
-      "measurementId": "Measurement ID"
-    },
-    "baidu": {
-      "title": "Αναλύσεις ιστοσελίδας Baidu",
-      "description": "Μετρήστε την κίνηση της ιστοσελίδας με τις αναλύσεις Baidu.",
-      "siteId": "Site ID"
-    },
-    "clarity": {
-      "description": "Κατανοήστε τις συνεδρίες και τη συμπεριφορά με το Microsoft Clarity.",
-      "projectId": "Project ID"
-    },
-    "umami": {
-      "description": "Χρησιμοποιήστε αναλύσεις ιστοσελίδας με επίκεντρο την ιδιωτικότητα μέσω του Umami.",
-      "websiteId": "Website ID",
-      "serverUrl": "Διεύθυνση URL διακομιστή",
-      "serverUrlHelp": "Το Umami Cloud είναι διαθέσιμο από προεπιλογή. Οι αυτοφιλοξενούμενοι προορισμοί πρέπει πρώτα να εγκριθούν από τον διαχειριστή της πλατφόρμας."
-    }
+  "analytics.title": {
+    "message": "Αναλύσεις Ιστοσελίδας"
+  },
+  "analytics.securityNotice": {
+    "message": "Υποστηρίζονται μόνο οι εγκεκριμένοι πάροχοι αναλύσεων. Δεν μπορεί να εισαχθεί ακατέργωτος JavaScript και HTML."
+  },
+  "analytics.enabled": {
+    "message": "Ενεργοποιημένο"
+  },
+  "analytics.required": {
+    "message": "Εισάγετε το ID παρόχου πριν αποθηκεύσετε."
+  },
+  "analytics.invalidId": {
+    "message": "Εισάγετε ένα έγκυρο ID παρόχου."
+  },
+  "analytics.saveFailed": {
+    "message": "Αποτυχία αποθήκευσης ρυθμίσεων αναλύσεων ιστοσελίδας."
+  },
+  "analytics.ga4.description": {
+    "message": "Μετρήστε επισκέψεις και μετατροπές με ένα GA4 Measurement ID."
+  },
+  "analytics.ga4.measurementId": {
+    "message": "Measurement ID"
+  },
+  "analytics.baidu.title": {
+    "message": "Αναλύσεις ιστοσελίδας Baidu"
+  },
+  "analytics.baidu.description": {
+    "message": "Μετρήστε την κίνηση της ιστοσελίδας με τις αναλύσεις Baidu."
+  },
+  "analytics.baidu.siteId": {
+    "message": "Ταυτότητα ιστότοπου"
+  },
+  "analytics.clarity.description": {
+    "message": "Κατανοήστε τις συνεδρίες και τη συμπεριφορά με το Microsoft Clarity."
+  },
+  "analytics.clarity.projectId": {
+    "message": "Ταυτότητα έργου"
+  },
+  "analytics.umami.description": {
+    "message": "Χρησιμοποιήστε αναλύσεις ιστοσελίδας με επίκεντρο την ιδιωτικότητα μέσω του Umami."
+  },
+  "analytics.umami.websiteId": {
+    "message": "Website ID"
+  },
+  "analytics.umami.serverUrl": {
+    "message": "Διεύθυνση URL διακομιστή"
+  },
+  "analytics.umami.serverUrlHelp": {
+    "message": "Το Umami Cloud είναι διαθέσιμο από προεπιλογή. Οι αυτοφιλοξενούμενοι προορισμοί πρέπει πρώτα να εγκριθούν από τον διαχειριστή της πλατφόρμας."
   }
 }

--- a/src/i18n/en/site.json
+++ b/src/i18n/en/site.json
@@ -1040,31 +1040,55 @@
     "message": "Failed to load app customizations",
     "description": "Error shown when capability override management rows cannot be loaded"
   },
-  "analytics": {
-    "title": "Website Analytics",
-    "securityNotice": "Only approved analytics providers are supported. Raw JavaScript and HTML cannot be inserted.",
-    "enabled": "Enabled",
-    "required": "Enter the provider ID before saving.",
-    "invalidId": "Enter a valid provider ID.",
-    "saveFailed": "Failed to save website analytics settings.",
-    "ga4": {
-      "description": "Measure visits and conversions with a GA4 Measurement ID.",
-      "measurementId": "Measurement ID"
-    },
-    "baidu": {
-      "title": "Baidu website analytics",
-      "description": "Measure website traffic with Baidu analytics.",
-      "siteId": "Site ID"
-    },
-    "clarity": {
-      "description": "Understand sessions and behavior with Microsoft Clarity.",
-      "projectId": "Project ID"
-    },
-    "umami": {
-      "description": "Use privacy-focused website analytics through Umami.",
-      "websiteId": "Website ID",
-      "serverUrl": "Server URL",
-      "serverUrlHelp": "Umami Cloud is available by default. Self-hosted origins must first be approved by the platform administrator."
-    }
+  "analytics.title": {
+    "message": "Website Analytics"
+  },
+  "analytics.securityNotice": {
+    "message": "Only approved analytics providers are supported. Raw JavaScript and HTML cannot be inserted."
+  },
+  "analytics.enabled": {
+    "message": "Enabled"
+  },
+  "analytics.required": {
+    "message": "Enter the provider ID before saving."
+  },
+  "analytics.invalidId": {
+    "message": "Enter a valid provider ID."
+  },
+  "analytics.saveFailed": {
+    "message": "Failed to save website analytics settings."
+  },
+  "analytics.ga4.description": {
+    "message": "Measure visits and conversions with a GA4 Measurement ID."
+  },
+  "analytics.ga4.measurementId": {
+    "message": "Measurement ID"
+  },
+  "analytics.baidu.title": {
+    "message": "Baidu website analytics"
+  },
+  "analytics.baidu.description": {
+    "message": "Measure website traffic with Baidu analytics."
+  },
+  "analytics.baidu.siteId": {
+    "message": "Site ID"
+  },
+  "analytics.clarity.description": {
+    "message": "Understand sessions and behavior with Microsoft Clarity."
+  },
+  "analytics.clarity.projectId": {
+    "message": "Project ID"
+  },
+  "analytics.umami.description": {
+    "message": "Use privacy-focused website analytics through Umami."
+  },
+  "analytics.umami.websiteId": {
+    "message": "Website ID"
+  },
+  "analytics.umami.serverUrl": {
+    "message": "Server URL"
+  },
+  "analytics.umami.serverUrlHelp": {
+    "message": "Umami Cloud is available by default. Self-hosted origins must first be approved by the platform administrator."
   }
 }

--- a/src/i18n/es/site.json
+++ b/src/i18n/es/site.json
@@ -1091,31 +1091,55 @@
     "message": "Error al cargar la personalización de la aplicación",
     "description": "Error al intentar leer los registros de gestión de sobrecarga de la aplicación de capacidades"
   },
-  "analytics": {
-    "title": "Análisis de Sitios Web",
-    "securityNotice": "Solo se admiten proveedores de análisis aprobados. No se pueden insertar JavaScript y HTML en bruto.",
-    "enabled": "Habilitado",
-    "required": "Ingrese el ID del proveedor antes de guardar.",
-    "invalidId": "Ingrese un ID de proveedor válido.",
-    "saveFailed": "Error al guardar la configuración de análisis del sitio web.",
-    "ga4": {
-      "description": "Mida visitas y conversiones con un ID de Medición de GA4.",
-      "measurementId": "Measurement ID"
-    },
-    "baidu": {
-      "title": "Análisis de sitios web de Baidu",
-      "description": "Mida el tráfico del sitio web con el análisis de Baidu.",
-      "siteId": "Site ID"
-    },
-    "clarity": {
-      "description": "Comprenda las sesiones y el comportamiento con Microsoft Clarity.",
-      "projectId": "Project ID"
-    },
-    "umami": {
-      "description": "Utilice análisis de sitios web enfocados en la privacidad a través de Umami.",
-      "websiteId": "Website ID",
-      "serverUrl": "URL del servidor",
-      "serverUrlHelp": "Umami Cloud está disponible por defecto. Los orígenes autoalojados deben ser aprobados primero por el administrador de la plataforma."
-    }
+  "analytics.title": {
+    "message": "Análisis de Sitios Web"
+  },
+  "analytics.securityNotice": {
+    "message": "Solo se admiten proveedores de análisis aprobados. No se pueden insertar JavaScript y HTML en bruto."
+  },
+  "analytics.enabled": {
+    "message": "Habilitado"
+  },
+  "analytics.required": {
+    "message": "Ingrese el ID del proveedor antes de guardar."
+  },
+  "analytics.invalidId": {
+    "message": "Ingrese un ID de proveedor válido."
+  },
+  "analytics.saveFailed": {
+    "message": "Error al guardar la configuración de análisis del sitio web."
+  },
+  "analytics.ga4.description": {
+    "message": "Mida visitas y conversiones con un ID de Medición de GA4."
+  },
+  "analytics.ga4.measurementId": {
+    "message": "Measurement ID"
+  },
+  "analytics.baidu.title": {
+    "message": "Análisis de sitios web de Baidu"
+  },
+  "analytics.baidu.description": {
+    "message": "Mida el tráfico del sitio web con el análisis de Baidu."
+  },
+  "analytics.baidu.siteId": {
+    "message": "ID del sitio"
+  },
+  "analytics.clarity.description": {
+    "message": "Comprenda las sesiones y el comportamiento con Microsoft Clarity."
+  },
+  "analytics.clarity.projectId": {
+    "message": "ID del proyecto"
+  },
+  "analytics.umami.description": {
+    "message": "Utilice análisis de sitios web enfocados en la privacidad a través de Umami."
+  },
+  "analytics.umami.websiteId": {
+    "message": "Website ID"
+  },
+  "analytics.umami.serverUrl": {
+    "message": "URL del servidor"
+  },
+  "analytics.umami.serverUrlHelp": {
+    "message": "Umami Cloud está disponible por defecto. Los orígenes autoalojados deben ser aprobados primero por el administrador de la plataforma."
   }
 }

--- a/src/i18n/fi/site.json
+++ b/src/i18n/fi/site.json
@@ -1090,31 +1090,55 @@
     "message": "Sovelluksen mukautusten lataaminen epäonnistui",
     "description": "Virhe, joka näytetään, kun kyvykkyyden korvauksen hallintarivejä ei voida ladata"
   },
-  "analytics": {
-    "title": "Verkkosivuston analytiikka",
-    "securityNotice": "Vain hyväksytyt analytiikkapalvelut ovat tuettuja. Raakajavascriptia ja HTML:ää ei voi lisätä.",
-    "enabled": "Oma käytössä",
-    "required": "Syötä palveluntarjoajan ID ennen tallentamista.",
-    "invalidId": "Syötä voimassa oleva palveluntarjoajan ID.",
-    "saveFailed": "Verkkosivuston analytiikka-asetusten tallentaminen epäonnistui.",
-    "ga4": {
-      "description": "Mittaa vierailuja ja konversioita GA4 Measurement ID:llä.",
-      "measurementId": "Measurement ID"
-    },
-    "baidu": {
-      "title": "Baidu verkkosivuston analytiikka",
-      "description": "Mittaa verkkosivuston liikennettä Baidu-analytiikan avulla.",
-      "siteId": "Verkkosivuston ID"
-    },
-    "clarity": {
-      "description": "Ymmärrä istunnot ja käyttäytyminen Microsoft Clarityn avulla.",
-      "projectId": "Projektin ID"
-    },
-    "umami": {
-      "description": "Käytä yksityisyyttä kunnioittavaa verkkosivuston analytiikkaa Umamin kautta.",
-      "websiteId": "Verkkosivuston ID",
-      "serverUrl": "Palvelimen URL",
-      "serverUrlHelp": "Umami Cloud on oletusarvoisesti käytettävissä. Itse isännöidyt lähteet on ensin hyväksyttävä alustan ylläpitäjän toimesta."
-    }
+  "analytics.title": {
+    "message": "Verkkosivuston analytiikka"
+  },
+  "analytics.securityNotice": {
+    "message": "Vain hyväksytyt analytiikkapalvelut ovat tuettuja. Raakajavascriptia ja HTML:ää ei voi lisätä."
+  },
+  "analytics.enabled": {
+    "message": "Oma käytössä"
+  },
+  "analytics.required": {
+    "message": "Syötä palveluntarjoajan ID ennen tallentamista."
+  },
+  "analytics.invalidId": {
+    "message": "Syötä voimassa oleva palveluntarjoajan ID."
+  },
+  "analytics.saveFailed": {
+    "message": "Verkkosivuston analytiikka-asetusten tallentaminen epäonnistui."
+  },
+  "analytics.ga4.description": {
+    "message": "Mittaa vierailuja ja konversioita GA4 Measurement ID:llä."
+  },
+  "analytics.ga4.measurementId": {
+    "message": "Measurement ID"
+  },
+  "analytics.baidu.title": {
+    "message": "Baidu verkkosivuston analytiikka"
+  },
+  "analytics.baidu.description": {
+    "message": "Mittaa verkkosivuston liikennettä Baidu-analytiikan avulla."
+  },
+  "analytics.baidu.siteId": {
+    "message": "Verkkosivuston ID"
+  },
+  "analytics.clarity.description": {
+    "message": "Ymmärrä istunnot ja käyttäytyminen Microsoft Clarityn avulla."
+  },
+  "analytics.clarity.projectId": {
+    "message": "Projektin ID"
+  },
+  "analytics.umami.description": {
+    "message": "Käytä yksityisyyttä kunnioittavaa verkkosivuston analytiikkaa Umamin kautta."
+  },
+  "analytics.umami.websiteId": {
+    "message": "Verkkosivuston ID"
+  },
+  "analytics.umami.serverUrl": {
+    "message": "Palvelimen URL"
+  },
+  "analytics.umami.serverUrlHelp": {
+    "message": "Umami Cloud on oletusarvoisesti käytettävissä. Itse isännöidyt lähteet on ensin hyväksyttävä alustan ylläpitäjän toimesta."
   }
 }

--- a/src/i18n/fr/site.json
+++ b/src/i18n/fr/site.json
@@ -1093,31 +1093,55 @@
     "message": "Échec du chargement de la personnalisation de l'application",
     "description": "Erreur lors de la lecture des enregistrements de gestion de la couverture de l'application de capacité"
   },
-  "analytics": {
-    "title": "Analyse de site Web",
-    "securityNotice": "Seuls les fournisseurs d'analytique approuvés sont pris en charge. JavaScript et HTML bruts ne peuvent pas être insérés.",
-    "enabled": "Activé",
-    "required": "Entrez l'ID du fournisseur avant de sauvegarder.",
-    "invalidId": "Entrez un ID de fournisseur valide.",
-    "saveFailed": "Échec de la sauvegarde des paramètres d'analyse du site Web.",
-    "ga4": {
-      "description": "Mesurez les visites et les conversions avec un ID de mesure GA4.",
-      "measurementId": "Measurement ID"
-    },
-    "baidu": {
-      "title": "Analyse de site Web Baidu",
-      "description": "Mesurez le trafic du site Web avec l'analyse Baidu.",
-      "siteId": "Site ID"
-    },
-    "clarity": {
-      "description": "Comprenez les sessions et le comportement avec Microsoft Clarity.",
-      "projectId": "Project ID"
-    },
-    "umami": {
-      "description": "Utilisez une analyse de site Web axée sur la confidentialité via Umami.",
-      "websiteId": "Website ID",
-      "serverUrl": "URL du serveur",
-      "serverUrlHelp": "Umami Cloud est disponible par défaut. Les origines auto-hébergées doivent d'abord être approuvées par l'administrateur de la plateforme."
-    }
+  "analytics.title": {
+    "message": "Analyse de site Web"
+  },
+  "analytics.securityNotice": {
+    "message": "Seuls les fournisseurs d'analytique approuvés sont pris en charge. JavaScript et HTML bruts ne peuvent pas être insérés."
+  },
+  "analytics.enabled": {
+    "message": "Activé"
+  },
+  "analytics.required": {
+    "message": "Entrez l'ID du fournisseur avant de sauvegarder."
+  },
+  "analytics.invalidId": {
+    "message": "Entrez un ID de fournisseur valide."
+  },
+  "analytics.saveFailed": {
+    "message": "Échec de la sauvegarde des paramètres d'analyse du site Web."
+  },
+  "analytics.ga4.description": {
+    "message": "Mesurez les visites et les conversions avec un ID de mesure GA4."
+  },
+  "analytics.ga4.measurementId": {
+    "message": "Measurement ID"
+  },
+  "analytics.baidu.title": {
+    "message": "Analyse de site Web Baidu"
+  },
+  "analytics.baidu.description": {
+    "message": "Mesurez le trafic du site Web avec l'analyse Baidu."
+  },
+  "analytics.baidu.siteId": {
+    "message": "ID de site"
+  },
+  "analytics.clarity.description": {
+    "message": "Comprenez les sessions et le comportement avec Microsoft Clarity."
+  },
+  "analytics.clarity.projectId": {
+    "message": "ID de projet"
+  },
+  "analytics.umami.description": {
+    "message": "Utilisez une analyse de site Web axée sur la confidentialité via Umami."
+  },
+  "analytics.umami.websiteId": {
+    "message": "Website ID"
+  },
+  "analytics.umami.serverUrl": {
+    "message": "URL du serveur"
+  },
+  "analytics.umami.serverUrlHelp": {
+    "message": "Umami Cloud est disponible par défaut. Les origines auto-hébergées doivent d'abord être approuvées par l'administrateur de la plateforme."
   }
 }

--- a/src/i18n/it/site.json
+++ b/src/i18n/it/site.json
@@ -1090,31 +1090,55 @@
     "message": "Caricamento personalizzazione app fallito",
     "description": "Errore quando non è possibile leggere i record di gestione delle sovrascritture delle app di capacità"
   },
-  "analytics": {
-    "title": "Analisi del Sito Web",
-    "securityNotice": "Sono supportati solo i fornitori di analisi approvati. JavaScript e HTML grezzi non possono essere inseriti.",
-    "enabled": "Abilitato",
-    "required": "Inserisci l'ID del fornitore prima di salvare.",
-    "invalidId": "Inserisci un ID del fornitore valido.",
-    "saveFailed": "Salvataggio delle impostazioni di analisi del sito web non riuscito.",
-    "ga4": {
-      "description": "Misura le visite e le conversioni con un ID di Misurazione GA4.",
-      "measurementId": "Measurement ID"
-    },
-    "baidu": {
-      "title": "Analisi del sito web Baidu",
-      "description": "Misura il traffico del sito web con le analisi di Baidu.",
-      "siteId": "Site ID"
-    },
-    "clarity": {
-      "description": "Comprendi le sessioni e il comportamento con Microsoft Clarity.",
-      "projectId": "Project ID"
-    },
-    "umami": {
-      "description": "Utilizza analisi del sito web incentrate sulla privacy tramite Umami.",
-      "websiteId": "Website ID",
-      "serverUrl": "URL del server",
-      "serverUrlHelp": "Umami Cloud è disponibile per impostazione predefinita. Le origini auto-ospitate devono prima essere approvate dall'amministratore della piattaforma."
-    }
+  "analytics.title": {
+    "message": "Analisi del Sito Web"
+  },
+  "analytics.securityNotice": {
+    "message": "Sono supportati solo i fornitori di analisi approvati. JavaScript e HTML grezzi non possono essere inseriti."
+  },
+  "analytics.enabled": {
+    "message": "Abilitato"
+  },
+  "analytics.required": {
+    "message": "Inserisci l'ID del fornitore prima di salvare."
+  },
+  "analytics.invalidId": {
+    "message": "Inserisci un ID del fornitore valido."
+  },
+  "analytics.saveFailed": {
+    "message": "Salvataggio delle impostazioni di analisi del sito web non riuscito."
+  },
+  "analytics.ga4.description": {
+    "message": "Misura le visite e le conversioni con un ID di Misurazione GA4."
+  },
+  "analytics.ga4.measurementId": {
+    "message": "Measurement ID"
+  },
+  "analytics.baidu.title": {
+    "message": "Analisi del sito web Baidu"
+  },
+  "analytics.baidu.description": {
+    "message": "Misura il traffico del sito web con le analisi di Baidu."
+  },
+  "analytics.baidu.siteId": {
+    "message": "ID del sito"
+  },
+  "analytics.clarity.description": {
+    "message": "Comprendi le sessioni e il comportamento con Microsoft Clarity."
+  },
+  "analytics.clarity.projectId": {
+    "message": "ID del progetto"
+  },
+  "analytics.umami.description": {
+    "message": "Utilizza analisi del sito web incentrate sulla privacy tramite Umami."
+  },
+  "analytics.umami.websiteId": {
+    "message": "Website ID"
+  },
+  "analytics.umami.serverUrl": {
+    "message": "URL del server"
+  },
+  "analytics.umami.serverUrlHelp": {
+    "message": "Umami Cloud è disponibile per impostazione predefinita. Le origini auto-ospitate devono prima essere approvate dall'amministratore della piattaforma."
   }
 }

--- a/src/i18n/ja/site.json
+++ b/src/i18n/ja/site.json
@@ -1090,31 +1090,55 @@
     "message": "アプリのカスタマイズの読み込みに失敗しました",
     "description": "機能オーバーライド管理行の読み込みに失敗した場合のエラー"
   },
-  "analytics": {
-    "title": "ウェブサイト分析",
-    "securityNotice": "承認された分析プロバイダーのみがサポートされています。生のJavaScriptおよびHTMLは挿入できません。",
-    "enabled": "有効",
-    "required": "保存する前にプロバイダーIDを入力してください。",
-    "invalidId": "有効なプロバイダーIDを入力してください。",
-    "saveFailed": "ウェブサイト分析設定の保存に失敗しました。",
-    "ga4": {
-      "description": "GA4 Measurement IDを使用して訪問とコンバージョンを測定します。",
-      "measurementId": "Measurement ID"
-    },
-    "baidu": {
-      "title": "Baiduウェブサイト分析",
-      "description": "Baidu分析を使用してウェブサイトのトラフィックを測定します。",
-      "siteId": "Site ID"
-    },
-    "clarity": {
-      "description": "Microsoft Clarityを使用してセッションと行動を理解します。",
-      "projectId": "Project ID"
-    },
-    "umami": {
-      "description": "Umamiを通じてプライバシー重視のウェブサイト分析を使用します。",
-      "websiteId": "Website ID",
-      "serverUrl": "サーバーURL",
-      "serverUrlHelp": "Umami Cloudはデフォルトで利用可能です。自己ホストされたオリジンは、まずプラットフォーム管理者によって承認される必要があります。"
-    }
+  "analytics.title": {
+    "message": "ウェブサイト分析"
+  },
+  "analytics.securityNotice": {
+    "message": "承認された分析プロバイダーのみがサポートされています。生のJavaScriptおよびHTMLは挿入できません。"
+  },
+  "analytics.enabled": {
+    "message": "有効"
+  },
+  "analytics.required": {
+    "message": "保存する前にプロバイダーIDを入力してください。"
+  },
+  "analytics.invalidId": {
+    "message": "有効なプロバイダーIDを入力してください。"
+  },
+  "analytics.saveFailed": {
+    "message": "ウェブサイト分析設定の保存に失敗しました。"
+  },
+  "analytics.ga4.description": {
+    "message": "GA4 Measurement IDを使用して訪問とコンバージョンを測定します。"
+  },
+  "analytics.ga4.measurementId": {
+    "message": "Measurement ID"
+  },
+  "analytics.baidu.title": {
+    "message": "Baiduウェブサイト分析"
+  },
+  "analytics.baidu.description": {
+    "message": "Baidu分析を使用してウェブサイトのトラフィックを測定します。"
+  },
+  "analytics.baidu.siteId": {
+    "message": "サイト ID"
+  },
+  "analytics.clarity.description": {
+    "message": "Microsoft Clarityを使用してセッションと行動を理解します。"
+  },
+  "analytics.clarity.projectId": {
+    "message": "プロジェクト ID"
+  },
+  "analytics.umami.description": {
+    "message": "Umamiを通じてプライバシー重視のウェブサイト分析を使用します。"
+  },
+  "analytics.umami.websiteId": {
+    "message": "Website ID"
+  },
+  "analytics.umami.serverUrl": {
+    "message": "サーバーURL"
+  },
+  "analytics.umami.serverUrlHelp": {
+    "message": "Umami Cloudはデフォルトで利用可能です。自己ホストされたオリジンは、まずプラットフォーム管理者によって承認される必要があります。"
   }
 }

--- a/src/i18n/ko/site.json
+++ b/src/i18n/ko/site.json
@@ -1090,31 +1090,55 @@
     "message": "앱 사용자 지정 불러오기 실패",
     "description": "기능 재정의 관리 행을 불러올 수 없을 때 표시되는 오류"
   },
-  "analytics": {
-    "title": "웹사이트 분석",
-    "securityNotice": "승인된 분석 제공자만 지원됩니다. 원시 JavaScript 및 HTML을 삽입할 수 없습니다.",
-    "enabled": "활성화됨",
-    "required": "저장하기 전에 제공자 ID를 입력하세요.",
-    "invalidId": "유효한 제공자 ID를 입력하세요.",
-    "saveFailed": "웹사이트 분석 설정을 저장하지 못했습니다.",
-    "ga4": {
-      "description": "GA4 측정 ID로 방문 및 전환을 측정합니다.",
-      "measurementId": "측정 ID"
-    },
-    "baidu": {
-      "title": "바이두 웹사이트 분석",
-      "description": "바이두 분석으로 웹사이트 트래픽을 측정합니다.",
-      "siteId": "사이트 ID"
-    },
-    "clarity": {
-      "description": "Microsoft Clarity로 세션 및 행동을 이해합니다.",
-      "projectId": "프로젝트 ID"
-    },
-    "umami": {
-      "description": "Umami를 통해 개인 정보 보호 중심의 웹사이트 분석을 사용합니다.",
-      "websiteId": "웹사이트 ID",
-      "serverUrl": "서버 URL",
-      "serverUrlHelp": "Umami Cloud는 기본적으로 제공됩니다. 자체 호스팅된 출처는 먼저 플랫폼 관리자에 의해 승인되어야 합니다."
-    }
+  "analytics.title": {
+    "message": "웹사이트 분석"
+  },
+  "analytics.securityNotice": {
+    "message": "승인된 분석 제공자만 지원됩니다. 원시 JavaScript 및 HTML을 삽입할 수 없습니다."
+  },
+  "analytics.enabled": {
+    "message": "활성화됨"
+  },
+  "analytics.required": {
+    "message": "저장하기 전에 제공자 ID를 입력하세요."
+  },
+  "analytics.invalidId": {
+    "message": "유효한 제공자 ID를 입력하세요."
+  },
+  "analytics.saveFailed": {
+    "message": "웹사이트 분석 설정을 저장하지 못했습니다."
+  },
+  "analytics.ga4.description": {
+    "message": "GA4 측정 ID로 방문 및 전환을 측정합니다."
+  },
+  "analytics.ga4.measurementId": {
+    "message": "측정 ID"
+  },
+  "analytics.baidu.title": {
+    "message": "바이두 웹사이트 분석"
+  },
+  "analytics.baidu.description": {
+    "message": "바이두 분석으로 웹사이트 트래픽을 측정합니다."
+  },
+  "analytics.baidu.siteId": {
+    "message": "사이트 ID"
+  },
+  "analytics.clarity.description": {
+    "message": "Microsoft Clarity로 세션 및 행동을 이해합니다."
+  },
+  "analytics.clarity.projectId": {
+    "message": "프로젝트 ID"
+  },
+  "analytics.umami.description": {
+    "message": "Umami를 통해 개인 정보 보호 중심의 웹사이트 분석을 사용합니다."
+  },
+  "analytics.umami.websiteId": {
+    "message": "웹사이트 ID"
+  },
+  "analytics.umami.serverUrl": {
+    "message": "서버 URL"
+  },
+  "analytics.umami.serverUrlHelp": {
+    "message": "Umami Cloud는 기본적으로 제공됩니다. 자체 호스팅된 출처는 먼저 플랫폼 관리자에 의해 승인되어야 합니다."
   }
 }

--- a/src/i18n/pl/site.json
+++ b/src/i18n/pl/site.json
@@ -1090,31 +1090,55 @@
     "message": "Nie udało się wczytać dostosowań aplikacji",
     "description": "Błąd wyświetlany, gdy nie można wczytać wierszy zarządzania nadpisaniami aplikacji funkcji"
   },
-  "analytics": {
-    "title": "Analiza Strony Internetowej",
-    "securityNotice": "Obsługiwani są tylko zatwierdzeni dostawcy analityki. Surowy JavaScript i HTML nie mogą być wstawiane.",
-    "enabled": "Włączone",
-    "required": "Wprowadź identyfikator dostawcy przed zapisaniem.",
-    "invalidId": "Wprowadź prawidłowy identyfikator dostawcy.",
-    "saveFailed": "Nie udało się zapisać ustawień analityki strony internetowej.",
-    "ga4": {
-      "description": "Mierz wizyty i konwersje za pomocą identyfikatora pomiaru GA4.",
-      "measurementId": "Measurement ID"
-    },
-    "baidu": {
-      "title": "Analityka strony Baidu",
-      "description": "Mierz ruch na stronie internetowej za pomocą analityki Baidu.",
-      "siteId": "Site ID"
-    },
-    "clarity": {
-      "description": "Zrozum sesje i zachowanie za pomocą Microsoft Clarity.",
-      "projectId": "Project ID"
-    },
-    "umami": {
-      "description": "Korzystaj z analityki strony internetowej skoncentrowanej na prywatności za pomocą Umami.",
-      "websiteId": "Website ID",
-      "serverUrl": "Adres URL serwera",
-      "serverUrlHelp": "Umami Cloud jest dostępny domyślnie. Samodzielnie hostowane źródła muszą najpierw zostać zatwierdzone przez administratora platformy."
-    }
+  "analytics.title": {
+    "message": "Analiza Strony Internetowej"
+  },
+  "analytics.securityNotice": {
+    "message": "Obsługiwani są tylko zatwierdzeni dostawcy analityki. Surowy JavaScript i HTML nie mogą być wstawiane."
+  },
+  "analytics.enabled": {
+    "message": "Włączone"
+  },
+  "analytics.required": {
+    "message": "Wprowadź identyfikator dostawcy przed zapisaniem."
+  },
+  "analytics.invalidId": {
+    "message": "Wprowadź prawidłowy identyfikator dostawcy."
+  },
+  "analytics.saveFailed": {
+    "message": "Nie udało się zapisać ustawień analityki strony internetowej."
+  },
+  "analytics.ga4.description": {
+    "message": "Mierz wizyty i konwersje za pomocą identyfikatora pomiaru GA4."
+  },
+  "analytics.ga4.measurementId": {
+    "message": "Measurement ID"
+  },
+  "analytics.baidu.title": {
+    "message": "Analityka strony Baidu"
+  },
+  "analytics.baidu.description": {
+    "message": "Mierz ruch na stronie internetowej za pomocą analityki Baidu."
+  },
+  "analytics.baidu.siteId": {
+    "message": "ID witryny"
+  },
+  "analytics.clarity.description": {
+    "message": "Zrozum sesje i zachowanie za pomocą Microsoft Clarity."
+  },
+  "analytics.clarity.projectId": {
+    "message": "ID projektu"
+  },
+  "analytics.umami.description": {
+    "message": "Korzystaj z analityki strony internetowej skoncentrowanej na prywatności za pomocą Umami."
+  },
+  "analytics.umami.websiteId": {
+    "message": "Website ID"
+  },
+  "analytics.umami.serverUrl": {
+    "message": "Adres URL serwera"
+  },
+  "analytics.umami.serverUrlHelp": {
+    "message": "Umami Cloud jest dostępny domyślnie. Samodzielnie hostowane źródła muszą najpierw zostać zatwierdzone przez administratora platformy."
   }
 }

--- a/src/i18n/pt/site.json
+++ b/src/i18n/pt/site.json
@@ -1090,31 +1090,55 @@
     "message": "Falha ao carregar personalização do aplicativo",
     "description": "Erro ao tentar ler os registros de gerenciamento de sobreposição do aplicativo de capacidade"
   },
-  "analytics": {
-    "title": "Análise de Website",
-    "securityNotice": "Apenas provedores de análise aprovados são suportados. JavaScript e HTML brutos não podem ser inseridos.",
-    "enabled": "Ativado",
-    "required": "Insira o ID do provedor antes de salvar.",
-    "invalidId": "Insira um ID de provedor válido.",
-    "saveFailed": "Falha ao salvar as configurações de análise do website.",
-    "ga4": {
-      "description": "Meça visitas e conversões com um ID de Medição GA4.",
-      "measurementId": "ID de Medição"
-    },
-    "baidu": {
-      "title": "Análise de website Baidu",
-      "description": "Meça o tráfego do website com a análise do Baidu.",
-      "siteId": "ID do Site"
-    },
-    "clarity": {
-      "description": "Entenda sessões e comportamentos com o Microsoft Clarity.",
-      "projectId": "ID do Projeto"
-    },
-    "umami": {
-      "description": "Use análises de website focadas em privacidade através do Umami.",
-      "websiteId": "ID do Website",
-      "serverUrl": "URL do Servidor",
-      "serverUrlHelp": "O Umami Cloud está disponível por padrão. Origens auto-hospedadas devem ser aprovadas primeiro pelo administrador da plataforma."
-    }
+  "analytics.title": {
+    "message": "Análise de Website"
+  },
+  "analytics.securityNotice": {
+    "message": "Apenas provedores de análise aprovados são suportados. JavaScript e HTML brutos não podem ser inseridos."
+  },
+  "analytics.enabled": {
+    "message": "Ativado"
+  },
+  "analytics.required": {
+    "message": "Insira o ID do provedor antes de salvar."
+  },
+  "analytics.invalidId": {
+    "message": "Insira um ID de provedor válido."
+  },
+  "analytics.saveFailed": {
+    "message": "Falha ao salvar as configurações de análise do website."
+  },
+  "analytics.ga4.description": {
+    "message": "Meça visitas e conversões com um ID de Medição GA4."
+  },
+  "analytics.ga4.measurementId": {
+    "message": "ID de Medição"
+  },
+  "analytics.baidu.title": {
+    "message": "Análise de website Baidu"
+  },
+  "analytics.baidu.description": {
+    "message": "Meça o tráfego do website com a análise do Baidu."
+  },
+  "analytics.baidu.siteId": {
+    "message": "ID do Site"
+  },
+  "analytics.clarity.description": {
+    "message": "Entenda sessões e comportamentos com o Microsoft Clarity."
+  },
+  "analytics.clarity.projectId": {
+    "message": "ID do Projeto"
+  },
+  "analytics.umami.description": {
+    "message": "Use análises de website focadas em privacidade através do Umami."
+  },
+  "analytics.umami.websiteId": {
+    "message": "ID do Website"
+  },
+  "analytics.umami.serverUrl": {
+    "message": "URL do Servidor"
+  },
+  "analytics.umami.serverUrlHelp": {
+    "message": "O Umami Cloud está disponível por padrão. Origens auto-hospedadas devem ser aprovadas primeiro pelo administrador da plataforma."
   }
 }

--- a/src/i18n/ru/site.json
+++ b/src/i18n/ru/site.json
@@ -1090,31 +1090,55 @@
     "message": "Не удалось загрузить настройки приложения",
     "description": "Ошибка при попытке прочитать записи управления переопределением приложения"
   },
-  "analytics": {
-    "title": "Аналитика сайта",
-    "securityNotice": "Поддерживаются только одобренные провайдеры аналитики. Сырой JavaScript и HTML не могут быть вставлены.",
-    "enabled": "Включено",
-    "required": "Введите идентификатор провайдера перед сохранением.",
-    "invalidId": "Введите действительный идентификатор провайдера.",
-    "saveFailed": "Не удалось сохранить настройки аналитики сайта.",
-    "ga4": {
-      "description": "Измеряйте посещения и конверсии с помощью GA4 Measurement ID.",
-      "measurementId": "Measurement ID"
-    },
-    "baidu": {
-      "title": "Аналитика сайта Baidu",
-      "description": "Измеряйте трафик сайта с помощью аналитики Baidu.",
-      "siteId": "Site ID"
-    },
-    "clarity": {
-      "description": "Понимание сессий и поведения с Microsoft Clarity.",
-      "projectId": "Project ID"
-    },
-    "umami": {
-      "description": "Используйте ориентированную на конфиденциальность аналитику сайта через Umami.",
-      "websiteId": "Website ID",
-      "serverUrl": "URL сервера",
-      "serverUrlHelp": "Umami Cloud доступен по умолчанию. Самостоятельно размещенные источники должны быть сначала одобрены администратором платформы."
-    }
+  "analytics.title": {
+    "message": "Аналитика сайта"
+  },
+  "analytics.securityNotice": {
+    "message": "Поддерживаются только одобренные провайдеры аналитики. Сырой JavaScript и HTML не могут быть вставлены."
+  },
+  "analytics.enabled": {
+    "message": "Включено"
+  },
+  "analytics.required": {
+    "message": "Введите идентификатор провайдера перед сохранением."
+  },
+  "analytics.invalidId": {
+    "message": "Введите действительный идентификатор провайдера."
+  },
+  "analytics.saveFailed": {
+    "message": "Не удалось сохранить настройки аналитики сайта."
+  },
+  "analytics.ga4.description": {
+    "message": "Измеряйте посещения и конверсии с помощью GA4 Measurement ID."
+  },
+  "analytics.ga4.measurementId": {
+    "message": "Measurement ID"
+  },
+  "analytics.baidu.title": {
+    "message": "Аналитика сайта Baidu"
+  },
+  "analytics.baidu.description": {
+    "message": "Измеряйте трафик сайта с помощью аналитики Baidu."
+  },
+  "analytics.baidu.siteId": {
+    "message": "ID сайта"
+  },
+  "analytics.clarity.description": {
+    "message": "Понимание сессий и поведения с Microsoft Clarity."
+  },
+  "analytics.clarity.projectId": {
+    "message": "ID проекта"
+  },
+  "analytics.umami.description": {
+    "message": "Используйте ориентированную на конфиденциальность аналитику сайта через Umami."
+  },
+  "analytics.umami.websiteId": {
+    "message": "Website ID"
+  },
+  "analytics.umami.serverUrl": {
+    "message": "URL сервера"
+  },
+  "analytics.umami.serverUrlHelp": {
+    "message": "Umami Cloud доступен по умолчанию. Самостоятельно размещенные источники должны быть сначала одобрены администратором платформы."
   }
 }

--- a/src/i18n/siteAnalyticsLocales.test.ts
+++ b/src/i18n/siteAnalyticsLocales.test.ts
@@ -1,38 +1,52 @@
+import { createI18n } from 'vue-i18n';
 import { describe, expect, it } from 'vitest';
+import { makeFlatLoader } from '@acedatacloud/core/i18n';
 
 const localeModules = import.meta.glob('./*/site.json', { eager: true }) as Record<
   string,
   { default: Record<string, unknown> }
 >;
+const localePaths = Object.keys(localeModules);
 const required = [
-  'title',
-  'securityNotice',
-  'enabled',
-  'required',
-  'invalidId',
-  'saveFailed',
-  'ga4',
-  'baidu',
-  'clarity',
-  'umami'
+  'analytics.title',
+  'analytics.securityNotice',
+  'analytics.enabled',
+  'analytics.required',
+  'analytics.invalidId',
+  'analytics.saveFailed',
+  'analytics.ga4.description',
+  'analytics.baidu.title',
+  'analytics.clarity.description',
+  'analytics.umami.description'
 ];
 
+const loadMessages = async (locale: string) => {
+  const i18n = createI18n({ legacy: true });
+  const loader = makeFlatLoader({
+    scopes: ['site'],
+    loadResource: async (_scope, requestedLocale) => localeModules[`./${requestedLocale}/site.json`].default
+  });
+  await loader(i18n, locale);
+  return i18n.global.getLocaleMessage(locale) as Record<string, string>;
+};
+
 describe('site analytics locales', () => {
-  it('keeps the complete analytics tree in every locale', () => {
-    expect(Object.keys(localeModules)).toHaveLength(18);
-    for (const [path, module] of Object.entries(localeModules)) {
-      const analytics = module.default.analytics as Record<string, unknown> | undefined;
-      expect(analytics, path).toBeDefined();
-      expect(Object.keys(analytics || {}), path).toEqual(expect.arrayContaining(required));
+  it('resolves every analytics key through the production flat loader', async () => {
+    expect(localePaths).toHaveLength(18);
+    for (const path of localePaths) {
+      const locale = path.split('/')[1];
+      const messages = await loadMessages(locale);
+      for (const key of required) expect(messages[`site.${key}`], `${path}: ${key}`).toBeTruthy();
     }
   });
 
-  it('does not ship English placeholders to generated locales', () => {
-    const english = (localeModules['./en/site.json'].default.analytics as Record<string, unknown>).securityNotice;
-    for (const [path, module] of Object.entries(localeModules)) {
-      if (path.includes('/en/') || path.includes('/zh-CN/')) continue;
-      const analytics = module.default.analytics as Record<string, unknown>;
-      expect(analytics.securityNotice, path).not.toBe(english);
+  it('does not ship English placeholders to generated locales', async () => {
+    const english = (await loadMessages('en'))['site.analytics.securityNotice'];
+    for (const path of localePaths) {
+      const locale = path.split('/')[1];
+      if (locale === 'en' || locale === 'zh-CN') continue;
+      const messages = await loadMessages(locale);
+      expect(messages['site.analytics.securityNotice'], path).not.toBe(english);
     }
   });
 });

--- a/src/i18n/sr/site.json
+++ b/src/i18n/sr/site.json
@@ -1090,31 +1090,55 @@
     "message": "Учитавање прилагођавања апликације није успело",
     "description": "Error shown when capability override management rows cannot be loaded"
   },
-  "analytics": {
-    "title": "Analitika Veb Sajta",
-    "securityNotice": "Samo odobreni provajderi analitike su podržani. Siromašni JavaScript i HTML ne mogu biti umetnuti.",
-    "enabled": "Omogućeno",
-    "required": "Unesite ID provajdera pre nego što sačuvate.",
-    "invalidId": "Unesite važeći ID provajdera.",
-    "saveFailed": "Nije uspelo čuvanje podešavanja analitike veb sajta.",
-    "ga4": {
-      "description": "Merite posete i konverzije sa GA4 Measurement ID.",
-      "measurementId": "Measurement ID"
-    },
-    "baidu": {
-      "title": "Baidu analitika veb sajta",
-      "description": "Merite saobraćaj veb sajta sa Baidu analitikom.",
-      "siteId": "Site ID"
-    },
-    "clarity": {
-      "description": "Razumite sesije i ponašanje sa Microsoft Clarity.",
-      "projectId": "Project ID"
-    },
-    "umami": {
-      "description": "Koristite analitiku veb sajta fokusiranu na privatnost putem Umami.",
-      "websiteId": "Website ID",
-      "serverUrl": "URL servera",
-      "serverUrlHelp": "Umami Cloud je dostupan po defaultu. Samostalno hostovane adrese moraju prvo biti odobrene od strane administratora platforme."
-    }
+  "analytics.title": {
+    "message": "Analitika Veb Sajta"
+  },
+  "analytics.securityNotice": {
+    "message": "Samo odobreni provajderi analitike su podržani. Siromašni JavaScript i HTML ne mogu biti umetnuti."
+  },
+  "analytics.enabled": {
+    "message": "Omogućeno"
+  },
+  "analytics.required": {
+    "message": "Unesite ID provajdera pre nego što sačuvate."
+  },
+  "analytics.invalidId": {
+    "message": "Unesite važeći ID provajdera."
+  },
+  "analytics.saveFailed": {
+    "message": "Nije uspelo čuvanje podešavanja analitike veb sajta."
+  },
+  "analytics.ga4.description": {
+    "message": "Merite posete i konverzije sa GA4 Measurement ID."
+  },
+  "analytics.ga4.measurementId": {
+    "message": "Measurement ID"
+  },
+  "analytics.baidu.title": {
+    "message": "Baidu analitika veb sajta"
+  },
+  "analytics.baidu.description": {
+    "message": "Merite saobraćaj veb sajta sa Baidu analitikom."
+  },
+  "analytics.baidu.siteId": {
+    "message": "ID sajta"
+  },
+  "analytics.clarity.description": {
+    "message": "Razumite sesije i ponašanje sa Microsoft Clarity."
+  },
+  "analytics.clarity.projectId": {
+    "message": "ID projekta"
+  },
+  "analytics.umami.description": {
+    "message": "Koristite analitiku veb sajta fokusiranu na privatnost putem Umami."
+  },
+  "analytics.umami.websiteId": {
+    "message": "Website ID"
+  },
+  "analytics.umami.serverUrl": {
+    "message": "URL servera"
+  },
+  "analytics.umami.serverUrlHelp": {
+    "message": "Umami Cloud je dostupan po defaultu. Samostalno hostovane adrese moraju prvo biti odobrene od strane administratora platforme."
   }
 }

--- a/src/i18n/sv/site.json
+++ b/src/i18n/sv/site.json
@@ -1090,31 +1090,55 @@
     "message": "Misslyckades med att ladda applikationens anpassningar",
     "description": "Fel när man inte kan läsa kapabilitetsapplikationens överskrivningshanteringsposter"
   },
-  "analytics": {
-    "title": "Webbplatsanalys",
-    "securityNotice": "Endast godkända analysleverantörer stöds. Rå JavaScript och HTML kan inte infogas.",
-    "enabled": "Aktiverad",
-    "required": "Ange leverantörens ID innan du sparar.",
-    "invalidId": "Ange ett giltigt leverantörs-ID.",
-    "saveFailed": "Misslyckades med att spara inställningarna för webbplatsanalys.",
-    "ga4": {
-      "description": "Mät besök och konverteringar med en GA4 Measurement ID.",
-      "measurementId": "Measurement ID"
-    },
-    "baidu": {
-      "title": "Baidu webbplatsanalys",
-      "description": "Mät webbplatstrafik med Baidu-analys.",
-      "siteId": "Site ID"
-    },
-    "clarity": {
-      "description": "Förstå sessioner och beteende med Microsoft Clarity.",
-      "projectId": "Projekt-ID"
-    },
-    "umami": {
-      "description": "Använd integritetsfokuserad webbplatsanalys genom Umami.",
-      "websiteId": "Webbplats-ID",
-      "serverUrl": "Server-URL",
-      "serverUrlHelp": "Umami Cloud är tillgänglig som standard. Självhostade ursprung måste först godkännas av plattformens administratör."
-    }
+  "analytics.title": {
+    "message": "Webbplatsanalys"
+  },
+  "analytics.securityNotice": {
+    "message": "Endast godkända analysleverantörer stöds. Rå JavaScript och HTML kan inte infogas."
+  },
+  "analytics.enabled": {
+    "message": "Aktiverad"
+  },
+  "analytics.required": {
+    "message": "Ange leverantörens ID innan du sparar."
+  },
+  "analytics.invalidId": {
+    "message": "Ange ett giltigt leverantörs-ID."
+  },
+  "analytics.saveFailed": {
+    "message": "Misslyckades med att spara inställningarna för webbplatsanalys."
+  },
+  "analytics.ga4.description": {
+    "message": "Mät besök och konverteringar med en GA4 Measurement ID."
+  },
+  "analytics.ga4.measurementId": {
+    "message": "Measurement ID"
+  },
+  "analytics.baidu.title": {
+    "message": "Baidu webbplatsanalys"
+  },
+  "analytics.baidu.description": {
+    "message": "Mät webbplatstrafik med Baidu-analys."
+  },
+  "analytics.baidu.siteId": {
+    "message": "Webbplats-ID"
+  },
+  "analytics.clarity.description": {
+    "message": "Förstå sessioner och beteende med Microsoft Clarity."
+  },
+  "analytics.clarity.projectId": {
+    "message": "Projekt-ID"
+  },
+  "analytics.umami.description": {
+    "message": "Använd integritetsfokuserad webbplatsanalys genom Umami."
+  },
+  "analytics.umami.websiteId": {
+    "message": "Webbplats-ID"
+  },
+  "analytics.umami.serverUrl": {
+    "message": "Server-URL"
+  },
+  "analytics.umami.serverUrlHelp": {
+    "message": "Umami Cloud är tillgänglig som standard. Självhostade ursprung måste först godkännas av plattformens administratör."
   }
 }

--- a/src/i18n/uk/site.json
+++ b/src/i18n/uk/site.json
@@ -1090,31 +1090,55 @@
     "message": "Не вдалося завантажити налаштування програми",
     "description": "Помилка при спробі прочитати записи управління перекриттям програми"
   },
-  "analytics": {
-    "title": "Аналітика веб-сайту",
-    "securityNotice": "Підтримуються лише затверджені постачальники аналітики. Сирий JavaScript та HTML не можуть бути вставлені.",
-    "enabled": "Увімкнено",
-    "required": "Введіть ідентифікатор постачальника перед збереженням.",
-    "invalidId": "Введіть дійсний ідентифікатор постачальника.",
-    "saveFailed": "Не вдалося зберегти налаштування аналітики веб-сайту.",
-    "ga4": {
-      "description": "Вимірюйте відвідування та конверсії за допомогою GA4 Measurement ID.",
-      "measurementId": "Measurement ID"
-    },
-    "baidu": {
-      "title": "Аналітика веб-сайту Baidu",
-      "description": "Вимірюйте трафік веб-сайту за допомогою аналітики Baidu.",
-      "siteId": "Site ID"
-    },
-    "clarity": {
-      "description": "Розумійте сесії та поведінку за допомогою Microsoft Clarity.",
-      "projectId": "Project ID"
-    },
-    "umami": {
-      "description": "Використовуйте аналітику веб-сайту, орієнтовану на конфіденційність, через Umami.",
-      "websiteId": "Website ID",
-      "serverUrl": "URL сервера",
-      "serverUrlHelp": "Umami Cloud доступний за замовчуванням. Самостійно розміщені джерела повинні спочатку бути затверджені адміністратором платформи."
-    }
+  "analytics.title": {
+    "message": "Аналітика веб-сайту"
+  },
+  "analytics.securityNotice": {
+    "message": "Підтримуються лише затверджені постачальники аналітики. Сирий JavaScript та HTML не можуть бути вставлені."
+  },
+  "analytics.enabled": {
+    "message": "Увімкнено"
+  },
+  "analytics.required": {
+    "message": "Введіть ідентифікатор постачальника перед збереженням."
+  },
+  "analytics.invalidId": {
+    "message": "Введіть дійсний ідентифікатор постачальника."
+  },
+  "analytics.saveFailed": {
+    "message": "Не вдалося зберегти налаштування аналітики веб-сайту."
+  },
+  "analytics.ga4.description": {
+    "message": "Вимірюйте відвідування та конверсії за допомогою GA4 Measurement ID."
+  },
+  "analytics.ga4.measurementId": {
+    "message": "Measurement ID"
+  },
+  "analytics.baidu.title": {
+    "message": "Аналітика веб-сайту Baidu"
+  },
+  "analytics.baidu.description": {
+    "message": "Вимірюйте трафік веб-сайту за допомогою аналітики Baidu."
+  },
+  "analytics.baidu.siteId": {
+    "message": "ID сайту"
+  },
+  "analytics.clarity.description": {
+    "message": "Розумійте сесії та поведінку за допомогою Microsoft Clarity."
+  },
+  "analytics.clarity.projectId": {
+    "message": "ID проекту"
+  },
+  "analytics.umami.description": {
+    "message": "Використовуйте аналітику веб-сайту, орієнтовану на конфіденційність, через Umami."
+  },
+  "analytics.umami.websiteId": {
+    "message": "Website ID"
+  },
+  "analytics.umami.serverUrl": {
+    "message": "URL сервера"
+  },
+  "analytics.umami.serverUrlHelp": {
+    "message": "Umami Cloud доступний за замовчуванням. Самостійно розміщені джерела повинні спочатку бути затверджені адміністратором платформи."
   }
 }

--- a/src/i18n/zh-CN/site.json
+++ b/src/i18n/zh-CN/site.json
@@ -1040,31 +1040,55 @@
     "message": "加载应用自定义失败",
     "description": "无法读取能力应用覆盖管理记录时的错误"
   },
-  "analytics": {
-    "title": "网站统计",
-    "securityNotice": "仅支持经过审核的统计平台，不允许插入原始 JavaScript 或 HTML。",
-    "enabled": "启用",
-    "required": "保存前请填写统计平台 ID。",
-    "invalidId": "请输入有效的统计平台 ID。",
-    "saveFailed": "网站统计设置保存失败。",
-    "ga4": {
-      "description": "通过 GA4 Measurement ID 统计访问与转化。",
-      "measurementId": "Measurement ID"
-    },
-    "baidu": {
-      "title": "百度统计",
-      "description": "通过百度统计了解网站流量。",
-      "siteId": "站点 ID"
-    },
-    "clarity": {
-      "description": "通过 Microsoft Clarity 了解会话和用户行为。",
-      "projectId": "项目 ID"
-    },
-    "umami": {
-      "description": "通过 Umami 使用注重隐私的网站统计。",
-      "websiteId": "Website ID",
-      "serverUrl": "服务地址",
-      "serverUrlHelp": "默认支持 Umami Cloud；自托管地址须先由平台管理员加入审核白名单。"
-    }
+  "analytics.title": {
+    "message": "网站统计"
+  },
+  "analytics.securityNotice": {
+    "message": "仅支持经过审核的统计平台，不允许插入原始 JavaScript 或 HTML。"
+  },
+  "analytics.enabled": {
+    "message": "启用"
+  },
+  "analytics.required": {
+    "message": "保存前请填写统计平台 ID。"
+  },
+  "analytics.invalidId": {
+    "message": "请输入有效的统计平台 ID。"
+  },
+  "analytics.saveFailed": {
+    "message": "网站统计设置保存失败。"
+  },
+  "analytics.ga4.description": {
+    "message": "通过 GA4 Measurement ID 统计访问与转化。"
+  },
+  "analytics.ga4.measurementId": {
+    "message": "Measurement ID"
+  },
+  "analytics.baidu.title": {
+    "message": "百度统计"
+  },
+  "analytics.baidu.description": {
+    "message": "通过百度统计了解网站流量。"
+  },
+  "analytics.baidu.siteId": {
+    "message": "站点 ID"
+  },
+  "analytics.clarity.description": {
+    "message": "通过 Microsoft Clarity 了解会话和用户行为。"
+  },
+  "analytics.clarity.projectId": {
+    "message": "项目 ID"
+  },
+  "analytics.umami.description": {
+    "message": "通过 Umami 使用注重隐私的网站统计。"
+  },
+  "analytics.umami.websiteId": {
+    "message": "Website ID"
+  },
+  "analytics.umami.serverUrl": {
+    "message": "服务地址"
+  },
+  "analytics.umami.serverUrlHelp": {
+    "message": "默认支持 Umami Cloud；自托管地址须先由平台管理员加入审核白名单。"
   }
 }

--- a/src/i18n/zh-TW/site.json
+++ b/src/i18n/zh-TW/site.json
@@ -1090,31 +1090,55 @@
     "message": "載入應用自定義失敗",
     "description": "無法讀取能力應用覆蓋管理記錄時的錯誤"
   },
-  "analytics": {
-    "title": "網站分析",
-    "securityNotice": "僅支援經批准的分析提供者。無法插入原始 JavaScript 和 HTML。",
-    "enabled": "已啟用",
-    "required": "在保存之前請輸入提供者 ID。",
-    "invalidId": "請輸入有效的提供者 ID。",
-    "saveFailed": "保存網站分析設置失敗。",
-    "ga4": {
-      "description": "使用 GA4 測量 ID 測量訪問和轉換。",
-      "measurementId": "Measurement ID"
-    },
-    "baidu": {
-      "title": "百度網站分析",
-      "description": "使用百度分析測量網站流量。",
-      "siteId": "Site ID"
-    },
-    "clarity": {
-      "description": "使用 Microsoft Clarity 了解會話和行為。",
-      "projectId": "Project ID"
-    },
-    "umami": {
-      "description": "通過 Umami 使用以隱私為重點的網站分析。",
-      "websiteId": "Website ID",
-      "serverUrl": "伺服器 URL",
-      "serverUrlHelp": "Umami Cloud 默認可用。自託管來源必須先經平台管理員批准。"
-    }
+  "analytics.title": {
+    "message": "網站分析"
+  },
+  "analytics.securityNotice": {
+    "message": "僅支援經批准的分析提供者。無法插入原始 JavaScript 和 HTML。"
+  },
+  "analytics.enabled": {
+    "message": "已啟用"
+  },
+  "analytics.required": {
+    "message": "在保存之前請輸入提供者 ID。"
+  },
+  "analytics.invalidId": {
+    "message": "請輸入有效的提供者 ID。"
+  },
+  "analytics.saveFailed": {
+    "message": "保存網站分析設置失敗。"
+  },
+  "analytics.ga4.description": {
+    "message": "使用 GA4 測量 ID 測量訪問和轉換。"
+  },
+  "analytics.ga4.measurementId": {
+    "message": "Measurement ID"
+  },
+  "analytics.baidu.title": {
+    "message": "百度網站分析"
+  },
+  "analytics.baidu.description": {
+    "message": "使用百度分析測量網站流量。"
+  },
+  "analytics.baidu.siteId": {
+    "message": "站點 ID"
+  },
+  "analytics.clarity.description": {
+    "message": "使用 Microsoft Clarity 了解會話和行為。"
+  },
+  "analytics.clarity.projectId": {
+    "message": "專案 ID"
+  },
+  "analytics.umami.description": {
+    "message": "通過 Umami 使用以隱私為重點的網站分析。"
+  },
+  "analytics.umami.websiteId": {
+    "message": "Website ID"
+  },
+  "analytics.umami.serverUrl": {
+    "message": "伺服器 URL"
+  },
+  "analytics.umami.serverUrlHelp": {
+    "message": "Umami Cloud 默認可用。自託管來源必須先經平台管理員批准。"
   }
 }


### PR DESCRIPTION
## Summary
- flatten the website analytics locale entries to match Nexior's dotted-key i18n loader so labels resolve instead of rendering `site.analytics.title`
- add real generated-language translations for newly exposed ID labels and verify all analytics labels through the production loader
- keep the desktop settings navigation inside its fixed-height pane with independent vertical scrolling

## Validation
- `python3 scripts/check_i18n_coverage.py` — passed (17 locales × 49 namespaces)
- `npm run test:run -- src/i18n/siteAnalyticsLocales.test.ts src/components/user/Setting.test.ts` — 13/13 passed
- `npm run test:run` under Node 22.18.0 — 1495/1495 passed
- `npm run lint:check` — passed with two pre-existing warnings in `src/utils/dropUploadMixin.test.ts`
- `npm run build:web` — passed
- `npx beachball check --branch origin/main` — passed

## Rollout / rollback
- standard Nexior web deployment; rollback by reverting this commit

## Review
- no adversarial review requested

🤖 Generated with [Claude Code](https://claude.com/claude-code)
