### PR TITLE
fix: restore service Gallery detail previews

### DIFF
--- a/change/gallery-dialog-preview-8f31d07a.json
+++ b/change/gallery-dialog-preview-8f31d07a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Restore accessible detail previews for service Gallery cards while keeping create-similar actions independent.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/common/ShowcaseGrid.test.ts
+++ b/src/components/common/ShowcaseGrid.test.ts
@@ -45,17 +45,17 @@ const items: ResolvedShowcase[] = [
   }
 ];
 
-function mountGrid(reduced = false) {
+function mountGrid(reduced = false, detailPreview = false) {
   vi.stubGlobal('matchMedia', () => ({
     matches: reduced,
     addEventListener: vi.fn(),
     removeEventListener: vi.fn()
   }));
   const wrapper = mount(ShowcaseGrid, {
-    props: { items },
+    props: { items, detailPreview },
     global: {
       stubs: { RouterLink: { props: ['to'], template: '<a class="router-link"><slot /></a>' } },
-      mocks: { $t: (key: string) => key }
+      mocks: { $t: (key: string, params?: { title?: string }) => `${key}${params?.title ? ` ${params.title}` : ''}` }
     }
   });
   const video = wrapper.get('video').element as HTMLVideoElement;
@@ -77,6 +77,18 @@ describe('ShowcaseGrid', () => {
     expect((wrapper.get('video').element as HTMLVideoElement).muted).toBe(true);
     expect(wrapper.get('audio').attributes('preload')).toBe('metadata');
     expect(wrapper.findAll('.router-link')[0].text()).toContain('intro.home.showcase.createSimilar');
+    expect(wrapper.find('.detail-trigger').exists()).toBe(false);
+  });
+
+  it('uses a native button to select a card for detail preview', async () => {
+    const { wrapper } = mountGrid(false, true);
+    const triggers = wrapper.findAll('button.detail-trigger');
+    expect(triggers).toHaveLength(2);
+    expect(triggers[0].attributes('type')).toBe('button');
+    expect(triggers[0].attributes('aria-label')).toContain('Origami Fox');
+
+    await triggers[1].trigger('click');
+    expect(wrapper.emitted('select')).toEqual([[items[1]]]);
   });
 
   it('autoplays silent video, keeps audio explicit, and plays only one preview', async () => {
@@ -93,6 +105,7 @@ describe('ShowcaseGrid', () => {
     await Promise.resolve();
     expect(video.pause).toHaveBeenCalled();
     expect(audio.play).toHaveBeenCalled();
+    expect(wrapper.emitted('select')).toBeUndefined();
     await cards[0].trigger('mouseleave');
     expect(video.pause).toHaveBeenCalled();
   });
@@ -103,6 +116,8 @@ describe('ShowcaseGrid', () => {
     expect(wrapper.find('video').exists()).toBe(false);
     expect(wrapper.findAll('.showcase-card')).toHaveLength(2);
     expect(wrapper.findAll('.router-link')).toHaveLength(2);
+    await wrapper.findAll('.router-link')[0].trigger('click');
+    expect(wrapper.emitted('select')).toBeUndefined();
   });
 
   it('does not autoplay in reduced-motion mode but keeps an explicit control', async () => {

--- a/src/components/common/ShowcaseGrid.vue
+++ b/src/components/common/ShowcaseGrid.vue
@@ -43,6 +43,13 @@
         />
         <span class="shade" />
         <button
+          v-if="detailPreview"
+          type="button"
+          class="detail-trigger"
+          :aria-label="$t('intro.home.showcase.preview', { title: item.title })"
+          @click="$emit('select', item)"
+        />
+        <button
           v-if="item.mediaType === 'Audio' || reducedMotion"
           type="button"
           class="preview-button"
@@ -84,10 +91,20 @@ withDefaults(
     showCapability?: boolean;
     compact?: boolean;
     masonry?: boolean;
+    detailPreview?: boolean;
   }>(),
-  { title: '', eyebrow: '', subtitle: '', ariaLabel: '', showCapability: true, compact: false, masonry: false }
+  {
+    title: '',
+    eyebrow: '',
+    subtitle: '',
+    ariaLabel: '',
+    showCapability: true,
+    compact: false,
+    masonry: false,
+    detailPreview: false
+  }
 );
-defineEmits<{ 'icon-error': [item: ResolvedShowcase] }>();
+defineEmits<{ 'icon-error': [item: ResolvedShowcase]; select: [item: ResolvedShowcase] }>();
 
 const media = new Map<string, HTMLMediaElement>();
 const cards = new Map<string, HTMLElement>();
@@ -317,6 +334,21 @@ defineExpose({ playingId, startPreview, stopPreview, togglePreview, reducedMotio
   }
 }
 
+.detail-trigger {
+  position: absolute;
+  z-index: 1;
+  inset: 0;
+  border: 0;
+  border-radius: inherit;
+  background: transparent;
+  cursor: pointer;
+
+  &:focus-visible {
+    outline: 0;
+    box-shadow: inset 0 0 0 3px var(--el-color-primary);
+  }
+}
+
 .preview-button {
   position: absolute;
   z-index: 2;
@@ -341,11 +373,12 @@ defineExpose({ playingId, startPreview, stopPreview, togglePreview, reducedMotio
 
 .showcase-copy {
   position: absolute;
-  z-index: 1;
+  z-index: 2;
   right: 16px;
   bottom: 15px;
   left: 16px;
   text-shadow: 0 2px 15px rgba(0, 0, 0, 0.8);
+  pointer-events: none;
 
   > strong {
     display: block;
@@ -382,12 +415,15 @@ defineExpose({ playingId, startPreview, stopPreview, togglePreview, reducedMotio
 }
 
 .create-link {
+  position: relative;
+  z-index: 3;
   display: inline-flex;
   min-height: 30px;
   align-items: center;
   color: #fff;
   font-size: 12px;
   font-weight: 800;
+  pointer-events: auto;
 
   &:focus-visible {
     outline: 3px solid var(--el-color-primary);

--- a/src/components/common/ShowcaseResultTabs.test.ts
+++ b/src/components/common/ShowcaseResultTabs.test.ts
@@ -15,8 +15,17 @@ vi.mock('vue-i18n', async (importOriginal) => ({
 vi.mock('./ShowcaseGrid.vue', () => ({
   default: {
     name: 'ShowcaseGrid',
-    props: { items: Array, compact: Boolean, masonry: Boolean },
-    template: '<div class="showcase-grid-stub" :data-compact="compact" :data-masonry="masonry" />'
+    props: { items: Array, compact: Boolean, masonry: Boolean, detailPreview: Boolean },
+    emits: ['select'],
+    template: `<button class="showcase-grid-stub" :data-compact="compact" :data-masonry="masonry" :data-detail="detailPreview" @click="$emit('select', items[0])" />`
+  }
+}));
+vi.mock('@/pages/inspiration/components/InspirationDetailDialog.vue', () => ({
+  default: {
+    name: 'InspirationDetailDialog',
+    props: { item: Object },
+    emits: ['close'],
+    template: `<button class="detail-dialog-stub" @click="$emit('close')" />`
   }
 }));
 
@@ -71,13 +80,36 @@ describe('ShowcaseResultTabs', () => {
     await vi.waitFor(() => expect((wrapper.vm as any).resolvedItems).toHaveLength(1));
     expect(wrapper.getComponent({ name: 'ShowcaseGrid' }).props()).toMatchObject({
       compact: true,
-      masonry: true
+      masonry: true,
+      detailPreview: true
     });
     expect(wrapper.find('.task-sentinel').exists()).toBe(true);
     (wrapper.vm as any).activeTab = 'tasks';
     (wrapper.vm as any).activeTab = 'gallery';
     await wrapper.vm.$nextTick();
     expect(showcaseOperator.list).toHaveBeenCalledOnce();
+  });
+
+  it('opens the resolved showcase in the shared detail dialog and clears it on close', async () => {
+    vi.mocked(showcaseOperator.list).mockResolvedValue({ data: [showcase] } as any);
+    const wrapper = mountTabs();
+    (wrapper.vm as any).activeTab = 'gallery';
+    await vi.waitFor(() => expect((wrapper.vm as any).resolvedItems).toHaveLength(1));
+
+    await wrapper.get('.showcase-grid-stub').trigger('click');
+    const dialog = wrapper.getComponent({ name: 'InspirationDetailDialog' });
+    expect(dialog.props('item')).toMatchObject({
+      id: showcase.id,
+      prompt: 'Original glass pavilion',
+      model: 'nano-banana-pro',
+      parameters: expect.arrayContaining([
+        { key: 'model', value: 'nano-banana-pro' },
+        { key: 'aspect_ratio', value: '16:9' }
+      ])
+    });
+
+    await wrapper.get('.detail-dialog-stub').trigger('click');
+    expect(dialog.props('item')).toBeUndefined();
   });
 
   it('isolates gallery failure and retries without unmounting tasks', async () => {

--- a/src/components/common/ShowcaseResultTabs.vue
+++ b/src/components/common/ShowcaseResultTabs.vue
@@ -15,11 +15,14 @@
         :show-capability="false"
         compact
         masonry
+        detail-preview
+        @select="selectedItem = $event"
         @icon-error="$emit('icon-error', $event)"
       />
       <div v-else class="gallery-state">{{ $t('intro.serviceGallery.empty') }}</div>
     </el-tab-pane>
   </el-tabs>
+  <inspiration-detail-dialog :item="selectedItem" @close="selectedItem = undefined" />
 </template>
 
 <script setup lang="ts">
@@ -30,6 +33,7 @@ import { ElButton, ElTabPane, ElTabs } from 'element-plus';
 import type { IShowcase, ResolvedShowcase } from '@/models';
 import { showcaseOperator } from '@/operators';
 import { resolveShowcase } from '@/utils/showcase';
+import InspirationDetailDialog from '@/pages/inspiration/components/InspirationDetailDialog.vue';
 import ShowcaseGrid from './ShowcaseGrid.vue';
 
 const props = defineProps<{ service: string }>();
@@ -42,6 +46,7 @@ const items = ref<IShowcase[]>([]);
 const loading = ref(false);
 const error = ref(false);
 const loaded = ref(false);
+const selectedItem = ref<ResolvedShowcase>();
 
 const resolvedItems = computed(() =>
   items.value
@@ -68,7 +73,7 @@ watch(activeTab, (name) => {
   if (name === 'gallery' && !loaded.value) void load();
 });
 
-defineExpose({ activeTab, resolvedItems, loading, error, loaded, load });
+defineExpose({ activeTab, resolvedItems, loading, error, loaded, selectedItem, load });
 </script>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
## Summary
- restore shared detail dialogs when users click Gallery card bodies in Nano Banana, GPT Image, and Seedream
- reuse the existing Inspiration detail UI for images, videos, audio, full prompts, models, and parameters
- keep media preview controls and create-similar links independent from card detail activation
- add native-button keyboard access and focus restoration without reusing the `showcase` replay query for dialog state

## Validation
- focused Gallery and dialog tests: 12 passed
- changed-file ESLint: passed
- `vue-tsc -b`: passed
- `npm run build:web`: passed
- browser with live production Showcase data:
  - Nano Banana, GPT Image, and Seedream each loaded 30 service-local cards
  - mouse click, Enter, and Space opened the correct detail dialog
  - Escape closed the dialog and returned focus to the card trigger
  - opening and closing previews did not alter the URL
  - card create-similar links bypassed the dialog, hydrated the generator, and showed no unavailable warning
  - 390px mobile dialog kept the sticky create-similar action visible with no horizontal overflow
  - Home retained 102 showcase cards and rendered zero detail triggers

## Rollback
Revert this commit. No API, database, route, or persisted-state migration is involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)