### PR TITLE
feat(showcase): load localized presentation by locale

### DIFF
--- a/change/showcase-localization-7a94c3e1.json
+++ b/change/showcase-localization-7a94c3e1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Load localized Showcase presentation metadata per locale while preserving original replay prompts.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/common/ShowcaseResultTabs.test.ts
+++ b/src/components/common/ShowcaseResultTabs.test.ts
@@ -4,13 +4,15 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { showcaseOperator } from '@/operators';
 import ShowcaseResultTabs from './ShowcaseResultTabs.vue';
 
+const mocks = vi.hoisted(() => ({ locale: { value: 'en', __v_isRef: true } }));
+
 vi.mock('@/operators', () => ({ showcaseOperator: { list: vi.fn() } }));
 vi.mock('vuex', () => ({
   useStore: () => ({ state: { site: { id: 'studio', features: { nanobanana: { enabled: true } } } } })
 }));
 vi.mock('vue-i18n', async (importOriginal) => ({
   ...(await importOriginal<typeof import('vue-i18n')>()),
-  useI18n: () => ({ locale: { value: 'en' } })
+  useI18n: () => ({ locale: mocks.locale })
 }));
 vi.mock('./ShowcaseGrid.vue', () => ({
   default: {
@@ -61,7 +63,10 @@ function mountTabs() {
 }
 
 describe('ShowcaseResultTabs', () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.locale.value = 'en';
+  });
 
   it('defaults to current tasks and does not fetch the gallery', () => {
     const wrapper = mountTabs();
@@ -76,7 +81,7 @@ describe('ShowcaseResultTabs', () => {
     } as any);
     const wrapper = mountTabs();
     (wrapper.vm as any).activeTab = 'gallery';
-    await vi.waitFor(() => expect(showcaseOperator.list).toHaveBeenCalledWith('nano-banana'));
+    await vi.waitFor(() => expect(showcaseOperator.list).toHaveBeenCalledWith('nano-banana', 'en'));
     await vi.waitFor(() => expect((wrapper.vm as any).resolvedItems).toHaveLength(1));
     expect(wrapper.getComponent({ name: 'ShowcaseGrid' }).props()).toMatchObject({
       compact: true,
@@ -110,6 +115,37 @@ describe('ShowcaseResultTabs', () => {
 
     await wrapper.get('.detail-dialog-stub').trigger('click');
     expect(dialog.props('item')).toBeUndefined();
+  });
+
+  it('discards a stale response after the locale changes', async () => {
+    let resolveEnglish: (value: any) => void = () => undefined;
+    const english = new Promise((resolve) => {
+      resolveEnglish = resolve;
+    });
+    const chinese = {
+      ...showcase,
+      data: {
+        ...showcase.data,
+        presentation: { title: '玻璃亭阁', description: '通透玻璃亭阁坐落于自然光影之间。' }
+      }
+    };
+    vi.mocked(showcaseOperator.list)
+      .mockReturnValueOnce(english as any)
+      .mockResolvedValueOnce({ data: [chinese] } as any);
+    const wrapper = mountTabs();
+
+    const first = (wrapper.vm as any).load();
+    mocks.locale.value = 'zh-CN';
+    const second = (wrapper.vm as any).load();
+    await second;
+    resolveEnglish({ data: [showcase] });
+    await first;
+
+    expect((wrapper.vm as any).resolvedItems[0]).toMatchObject({
+      title: '玻璃亭阁',
+      description: '通透玻璃亭阁坐落于自然光影之间。',
+      prompt: 'Original glass pavilion'
+    });
   });
 
   it('isolates gallery failure and retries without unmounting tasks', async () => {

--- a/src/components/common/ShowcaseResultTabs.vue
+++ b/src/components/common/ShowcaseResultTabs.vue
@@ -47,30 +47,40 @@ const loading = ref(false);
 const error = ref(false);
 const loaded = ref(false);
 const selectedItem = ref<ResolvedShowcase>();
+let loadGeneration = 0;
 
 const resolvedItems = computed(() =>
   items.value
     .filter((item) => item.service === props.service)
-    .map((item) => resolveShowcase(item, store.state.site, locale.value))
+    .map((item) => resolveShowcase(item, store.state.site))
     .filter((item): item is ResolvedShowcase => Boolean(item))
 );
 
 async function load(): Promise<void> {
-  if (loading.value) return;
+  const generation = ++loadGeneration;
+  const requestLocale = locale.value;
   loading.value = true;
   error.value = false;
+  items.value = [];
+  selectedItem.value = undefined;
   try {
-    items.value = (await showcaseOperator.list(props.service)).data;
-    loaded.value = true;
+    const response = await showcaseOperator.list(props.service, requestLocale);
+    if (generation === loadGeneration && locale.value === requestLocale) {
+      items.value = response.data;
+      loaded.value = true;
+    }
   } catch {
-    error.value = true;
+    if (generation === loadGeneration) error.value = true;
   } finally {
-    loading.value = false;
+    if (generation === loadGeneration) loading.value = false;
   }
 }
 
 watch(activeTab, (name) => {
   if (name === 'gallery' && !loaded.value) void load();
+});
+watch(locale, () => {
+  if (loaded.value || activeTab.value === 'gallery') void load();
 });
 
 defineExpose({ activeTab, resolvedItems, loading, error, loaded, selectedItem, load });

--- a/src/models/showcase.ts
+++ b/src/models/showcase.ts
@@ -3,8 +3,14 @@ import type { CapabilityKey } from '@/constants/capabilities';
 export type ShowcaseMediaType = 'Image' | 'Video' | 'Audio';
 export type ShowcaseLayout = 'Portrait' | 'Square' | 'Landscape';
 
+export interface IShowcasePresentation {
+  title?: string;
+  description?: string;
+}
+
 export interface IShowcaseTaskData {
   type?: string;
+  presentation?: IShowcasePresentation;
   request?: Record<string, unknown>;
   response?: Record<string, unknown>;
   created_at?: number;

--- a/src/operators/showcase.test.ts
+++ b/src/operators/showcase.test.ts
@@ -20,10 +20,21 @@ describe('showcaseOperator', () => {
   it('loads the complete list or exact service filter', async () => {
     get.mockResolvedValue({ data: [] });
     await showcaseOperator.list();
-    expect(get).toHaveBeenCalledWith('/showcases/', undefined);
+    expect(get).toHaveBeenCalledWith('/showcases/', { headers: { 'Accept-Language': 'en' }, params: undefined });
     showcaseOperator.clearCache();
-    await showcaseOperator.list('seedance');
-    expect(get).toHaveBeenLastCalledWith('/showcases/', { params: { service: 'seedance' } });
+    await showcaseOperator.list('seedance', 'zh-CN');
+    expect(get).toHaveBeenLastCalledWith('/showcases/', {
+      headers: { 'Accept-Language': 'zh-cn' },
+      params: { service: 'seedance' }
+    });
+  });
+
+  it('isolates cache entries by locale', async () => {
+    get.mockResolvedValue({ data: [] });
+    await showcaseOperator.list('seedance', 'en');
+    await showcaseOperator.list('seedance', 'zh-CN');
+    await showcaseOperator.list('seedance', 'en');
+    expect(get).toHaveBeenCalledTimes(2);
   });
 
   it('expires successful cache entries after the server cache window', async () => {

--- a/src/operators/showcase.ts
+++ b/src/operators/showcase.ts
@@ -16,12 +16,16 @@ interface CacheEntry {
 class ShowcaseOperator {
   private readonly cache = new Map<string, CacheEntry>();
 
-  list(service?: string): Promise<AxiosResponse<IShowcase[]>> {
-    const key = service || '*';
+  list(service?: string, locale = 'en'): Promise<AxiosResponse<IShowcase[]>> {
+    const normalizedLocale = locale.trim().toLowerCase() || 'en';
+    const key = `${normalizedLocale}:${service || '*'}`;
     const now = Date.now();
     const cached = this.cache.get(key);
     if (cached && cached.expiresAt > now) return cached.request;
-    const request = publicClient.get<IShowcase[]>('/showcases/', service ? { params: { service } } : undefined);
+    const request = publicClient.get<IShowcase[]>('/showcases/', {
+      headers: { 'Accept-Language': normalizedLocale },
+      params: service ? { service } : undefined
+    });
     this.cache.set(key, { expiresAt: now + CACHE_TTL_MS, request });
     request.catch(() => this.cache.delete(key));
     return request;

--- a/src/pages/home/Index.test.ts
+++ b/src/pages/home/Index.test.ts
@@ -84,7 +84,7 @@ describe('Studio workbench home', () => {
       id: 'video-only',
       features: { seedance: { enabled: true }, veo: { enabled: true }, kling: { enabled: false } }
     });
-    await vi.waitFor(() => expect(showcaseOperator.list).toHaveBeenCalledWith());
+    await vi.waitFor(() => expect(showcaseOperator.list).toHaveBeenCalledWith(undefined, 'en'));
     expect(wrapper.getComponent({ name: 'ShowcaseGrid' }).props('items')[0].capability).toBe('seedance');
   });
 

--- a/src/pages/home/Index.vue
+++ b/src/pages/home/Index.vue
@@ -56,7 +56,8 @@ export default defineComponent({
       failedImages: {} as Partial<Record<CapabilityKey, boolean>>,
       failedCategoryImages: {} as Record<string, boolean>,
       rawShowcases: [] as IShowcase[],
-      showcaseLoaded: false
+      showcaseLoaded: false,
+      showcaseLoadGeneration: 0
     };
   },
   computed: {
@@ -101,7 +102,7 @@ export default defineComponent({
       const site = this.site;
       if (!site) return [];
       return this.rawShowcases
-        .map((item) => resolveShowcase(item, site, String(this.$i18n.locale || 'en')))
+        .map((item) => resolveShowcase(item, site))
         .filter((item): item is ResolvedShowcase => Boolean(item))
         .map((item) => ({
           ...item,
@@ -115,6 +116,9 @@ export default defineComponent({
       handler(loaded: boolean) {
         if (loaded && !this.showcaseLoaded) void this.loadShowcases();
       }
+    },
+    '$i18n.locale'() {
+      if (this.siteLoaded) void this.loadShowcases();
     }
   },
   methods: {
@@ -133,12 +137,17 @@ export default defineComponent({
       };
     },
     async loadShowcases(): Promise<void> {
+      const generation = ++this.showcaseLoadGeneration;
+      const requestLocale = String(this.$i18n.locale || 'en');
       this.showcaseLoaded = true;
+      this.rawShowcases = [];
       try {
-        const response = await showcaseOperator.list();
-        this.rawShowcases = Array.isArray(response.data) ? response.data : [];
+        const response = await showcaseOperator.list(undefined, requestLocale);
+        if (generation === this.showcaseLoadGeneration && String(this.$i18n.locale || 'en') === requestLocale) {
+          this.rawShowcases = Array.isArray(response.data) ? response.data : [];
+        }
       } catch {
-        this.rawShowcases = [];
+        if (generation === this.showcaseLoadGeneration) this.rawShowcases = [];
       }
     },
     onIconError(item: ResolvedHomeCapability): void {

--- a/src/pages/inspiration/Index.test.ts
+++ b/src/pages/inspiration/Index.test.ts
@@ -6,6 +6,7 @@ import { ROUTE_INSPIRATION_IMAGES } from '@/router/constants';
 import Inspiration from './Index.vue';
 
 const mocks = vi.hoisted(() => ({
+  locale: { value: 'en', __v_isRef: true },
   push: vi.fn(),
   route: { name: 'inspiration-images', query: {} as Record<string, string> },
   store: {
@@ -30,7 +31,7 @@ vi.mock('vuex', async (importOriginal) => ({
 }));
 vi.mock('vue-i18n', async (importOriginal) => ({
   ...(await importOriginal<typeof import('vue-i18n')>()),
-  useI18n: () => ({ locale: { value: 'en' } })
+  useI18n: () => ({ locale: mocks.locale })
 }));
 vi.mock('./components/InspirationDetailDialog.vue', () => ({
   default: { name: 'InspirationDetailDialog', emits: ['close'], template: '<div />' }
@@ -92,8 +93,8 @@ describe('Inspiration gallery page', () => {
   it('loads the anonymous feed once and filters the image route without per-task requests', async () => {
     const { wrapper } = mountPage();
     await vi.waitFor(() => expect(wrapper.findComponent({ name: 'InspirationMasonry' }).exists()).toBe(true));
-    expect(showcaseOperator.list).toHaveBeenCalledWith();
-    expect(showcaseOperator.clearCache).toHaveBeenCalledOnce();
+    expect(showcaseOperator.list).toHaveBeenCalledWith(undefined, 'en');
+    expect(showcaseOperator.clearCache).not.toHaveBeenCalled();
     expect(wrapper.getComponent({ name: 'InspirationMasonry' }).props('items')).toHaveLength(1);
     expect(wrapper.getComponent({ name: 'InspirationMasonry' }).props('items')[0].service).toBe('nano-banana');
   });

--- a/src/pages/inspiration/Index.vue
+++ b/src/pages/inspiration/Index.vue
@@ -67,6 +67,7 @@ const { locale } = useI18n();
 const rawItems = ref<IShowcase[]>([]);
 const loading = ref(false);
 const error = ref(false);
+let loadGeneration = 0;
 
 const site = computed(() => store.state.site);
 const siteLoaded = computed(() => Boolean(site.value?.id));
@@ -79,7 +80,7 @@ const categories = [
 const resolvedItems = computed(() => {
   if (!site.value) return [];
   return rawItems.value
-    .map((item) => resolveShowcase(item, site.value, locale.value))
+    .map((item) => resolveShowcase(item, site.value))
     .filter((item): item is ResolvedShowcase => Boolean(item));
 });
 const categoryType = computed(() => {
@@ -110,16 +111,18 @@ const selectedItem = computed(() => {
 });
 
 async function load(): Promise<void> {
+  const generation = ++loadGeneration;
+  const requestLocale = locale.value;
   loading.value = true;
   error.value = false;
+  rawItems.value = [];
   try {
-    showcaseOperator.clearCache();
-    rawItems.value = (await showcaseOperator.list()).data;
+    const response = await showcaseOperator.list(undefined, requestLocale);
+    if (generation === loadGeneration && locale.value === requestLocale) rawItems.value = response.data;
   } catch {
-    error.value = true;
-    rawItems.value = [];
+    if (generation === loadGeneration) error.value = true;
   } finally {
-    loading.value = false;
+    if (generation === loadGeneration) loading.value = false;
   }
 }
 
@@ -149,6 +152,7 @@ watch([categoryType, availableServices], () => {
 watch([selectedItem, resolvedItems], () => {
   if (route.query.showcase && !loading.value && !selectedItem.value) closeItem();
 });
+watch(locale, () => void load());
 onMounted(() => void load());
 </script>
 

--- a/src/utils/showcase.test.ts
+++ b/src/utils/showcase.test.ts
@@ -18,11 +18,28 @@ const item = (service: string, type: string, request: Record<string, unknown>, r
 });
 
 describe('resolveShowcase', () => {
+  it('uses localized presentation without changing the raw replay prompt', () => {
+    const source = {
+      ...item('nano-banana', 'images', { prompt: 'Crystal garden' }, { data: [{ image_url: 'image.jpg' }] }),
+      data: {
+        type: 'images',
+        request: { prompt: 'Crystal garden' },
+        response: { data: [{ image_url: 'image.jpg' }] },
+        presentation: { title: '水晶花园', description: '透明晶体在柔光中构成宁静花园。' }
+      }
+    };
+    const result = resolveShowcase(source, site);
+    expect(result).toMatchObject({
+      title: '水晶花园',
+      description: '透明晶体在柔光中构成宁静花园。',
+      prompt: 'Crystal garden'
+    });
+  });
+
   it('derives an image card from a normal task response', () => {
     const result = resolveShowcase(
       item('nano-banana', 'images', { prompt: 'Crystal garden' }, { data: [{ image_url: 'image.jpg' }] }),
-      site,
-      'en'
+      site
     );
     expect(result).toMatchObject({
       mediaType: 'Image',
@@ -41,8 +58,7 @@ describe('resolveShowcase', () => {
         { prompt: 'Paper fox' },
         { data: { video_url: 'video.mp4', last_frame_url: 'poster.jpg' } }
       ),
-      site,
-      'en'
+      site
     );
     expect(result).toMatchObject({
       mediaType: 'Video',
@@ -60,8 +76,7 @@ describe('resolveShowcase', () => {
         { prompt: 'Nocturne' },
         { data: [{ title: 'Amber Nocturne', audio_url: 'audio.mp3', image_url: 'cover.jpg' }] }
       ),
-      site,
-      'en'
+      site
     );
     expect(result).toMatchObject({
       mediaType: 'Audio',

--- a/src/utils/showcase.ts
+++ b/src/utils/showcase.ts
@@ -180,7 +180,7 @@ function deriveMedia(
   };
 }
 
-export function resolveShowcase(item: IShowcase, site: ISite, _locale: string): ResolvedShowcase | undefined {
+export function resolveShowcase(item: IShowcase, site: ISite): ResolvedShowcase | undefined {
   const definition = SHOWCASE_SERVICES.get(item.service);
   if (!definition || !site.features?.[definition.capability]?.enabled) return undefined;
   const request = objectValue(item.data.request);
@@ -189,20 +189,27 @@ export function resolveShowcase(item: IShowcase, site: ISite, _locale: string): 
   const media = deriveMedia(item.data.type, request, result);
   if (!media.posterUrl) return undefined;
   const defaultIcon = CAPABILITY_ICONS[definition.capability];
-  const presentation = resolveCapabilityPresentation(site, definition.capability, definition.defaultName, defaultIcon);
+  const capabilityPresentation = resolveCapabilityPresentation(
+    site,
+    definition.capability,
+    definition.defaultName,
+    defaultIcon
+  );
+  const localizedPresentation = objectValue(item.data.presentation);
   const prompt = stringValue(request.prompt, request.text, request.lyric);
-  const title = stringValue(result.title, presentation.displayName);
+  const title = stringValue(localizedPresentation.title, result.title, capabilityPresentation.displayName);
+  const description = stringValue(localizedPresentation.description, prompt);
   return {
     id: item.id,
     service: item.service,
     capability: definition.capability,
     routeName: definition.routeName,
-    name: presentation.displayName,
-    description: prompt,
-    icon: presentation.iconUrl,
+    name: capabilityPresentation.displayName,
+    description,
+    icon: capabilityPresentation.iconUrl,
     defaultIcon,
     title,
-    altText: title || prompt || presentation.displayName,
+    altText: title || description || capabilityPresentation.displayName,
     prompt,
     model: stringValue(request.model, result.model),
     parameters: deriveParameters(request),

--- a/src/utils/showcaseRecreate.test.ts
+++ b/src/utils/showcaseRecreate.test.ts
@@ -47,6 +47,7 @@ function context(capability: string, config: Record<string, unknown> | undefined
       router: { replace } as any,
       store: { state: { site: {}, [capability]: { config } }, commit, dispatch } as any,
       site: { features: { [capability]: { enabled: true } } } as any,
+      locale: 'en',
       t: (key: string) => key
     },
     commit,
@@ -89,7 +90,7 @@ describe('showcase recreate consumer', () => {
       vi.mocked(showcaseOperator.list).mockResolvedValue({ data: [item(capability, request)] } as any);
       const { options, commit, dispatch, replace } = context(capability);
       expect(await consumeShowcase(options)).toBe('applied');
-      expect(showcaseOperator.list).toHaveBeenCalledWith(SERVICES[capability]);
+      expect(showcaseOperator.list).toHaveBeenCalledWith(SERVICES[capability], 'en');
       expect(commit.mock.calls.find(([type]) => type === `${capability}/setConfig`)?.[1]).toHaveProperty(expectedKey);
       expect(dispatch).not.toHaveBeenCalled();
       expect(replace).toHaveBeenCalledWith({ path: `/${capability}`, query: { locale: 'en' }, hash: '#form' });

--- a/src/utils/showcaseRecreate.ts
+++ b/src/utils/showcaseRecreate.ts
@@ -26,6 +26,7 @@ export interface ConsumeShowcaseOptions {
   router: Router;
   store: Store<any>;
   site: ISite | undefined;
+  locale: string;
   t: Translator;
 }
 
@@ -336,7 +337,7 @@ export async function consumeShowcase(options: ConsumeShowcaseOptions): Promise<
   try {
     const definition = SHOWCASE_CAPABILITIES.get(options.capability);
     if (!definition || !options.site?.features?.[options.capability]?.enabled) throw new Error('disabled capability');
-    const response = await showcaseOperator.list(definition.service);
+    const response = await showcaseOperator.list(definition.service, options.locale);
     const item = response.data.find((candidate) => candidate.id === id);
     if (!item) throw new Error('showcase not found');
     const { adapter, patch } = validateItem(item, options.capability, definition.service);

--- a/src/utils/showcaseRecreateMixin.test.ts
+++ b/src/utils/showcaseRecreateMixin.test.ts
@@ -14,7 +14,7 @@ function mountWithQuery(showcase?: string) {
   const wrapper = shallowMount(Component, {
     global: {
       plugins: [createStore({ state: { site: { features: { seedance: { enabled: true } } } } })],
-      mocks: { $route: route, $router: { replace: vi.fn() }, $t: (key: string) => key }
+      mocks: { $route: route, $router: { replace: vi.fn() }, $i18n: { locale: 'en' }, $t: (key: string) => key }
     }
   });
   return { wrapper, route };

--- a/src/utils/showcaseRecreateMixin.ts
+++ b/src/utils/showcaseRecreateMixin.ts
@@ -23,6 +23,7 @@ export function showcaseRecreateMixin(capability: CapabilityKey) {
           router: this.$router,
           store: this.$store,
           site: this.$store.state.site,
+          locale: String(this.$i18n.locale || 'en'),
           t: (key, params) => this.$t(key, params || {}) as string
         });
       }


### PR DESCRIPTION
Depends on https://github.com/AceDataCloud/PlatformBackend/pull/1547

## Summary
- consume localized Showcase presentation titles and descriptions while preserving original replay prompts
- send the active locale on anonymous Showcase requests and isolate the 60-second cache by locale and service
- refetch Home, Inspiration, and service Gallery data when locale changes
- discard stale responses during rapid language switches and thread locale through create-similar lookups

## Compatibility
- presentation metadata is optional, so this remains compatible with the old API during rollout
- localized title/description affect display only; `data.request` remains the source for create-similar hydration
- no Nexior locale JSON is added because the source belongs to PlatformBackend Translation

## Validation
- focused Showcase/operator/page/replay tests: 50 passed
- added stale-response regression for an English request arriving after a newer Chinese response
- changed-file ESLint: passed
- `vue-tsc -b`: passed
- `npm run build:web`: passed
- Beachball verify: passed

## Release order
Merge and deploy the PlatformBackend dependency first, sync 240 zh-cn sources, and let target-language translations populate before releasing this consumer.

## Rollback
Revert this commit. The old UI will continue displaying raw Prompt fallbacks; no persisted client state changes are involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)