### PR TITLE
fix: isolate white-label brand identity

### DIFF
--- a/change/white-label-brand-spacing-7f4c2a91.json
+++ b/change/white-label-brand-spacing-7f4c2a91.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Keep white-label branding and structured data separate from Ace Data Cloud identity.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.365.0",
       "license": "MIT",
       "dependencies": {
-        "@acedatacloud/core": "^0.20.1",
+        "@acedatacloud/core": "^0.21.0",
         "@acedatacloud/x402-client": "^2026.726.1",
         "@capacitor-community/apple-sign-in": "^7.1.0",
         "@capacitor-community/stripe": "^8.1.1",
@@ -128,9 +128,9 @@
       }
     },
     "node_modules/@acedatacloud/core": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@acedatacloud/core/-/core-0.20.1.tgz",
-      "integrity": "sha512-0asg4N+aO9yrj+IbAVl3DlXZ7C3zFgeTwLx/dxTRqX5fzb8rtTIqkMOlmDmYrnNLvkQHXicI8r/wVf99fRZJvw==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@acedatacloud/core/-/core-0.21.0.tgz",
+      "integrity": "sha512-qYELZXIzCXzyWUIi/Lyq3q32sO42K7AgU3wdUxbQpfE8kx8+Eu35u7rsq0FvTbQ1MMJAOr1PSIHbOGN5PdcZYQ==",
       "license": "UNLICENSED",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "build:ssg": "cross-env VITE_SURFACE=web vite-ssg build"
   },
   "dependencies": {
-    "@acedatacloud/core": "^0.20.1",
+    "@acedatacloud/core": "^0.21.0",
     "@acedatacloud/x402-client": "^2026.726.1",
     "@capacitor-community/apple-sign-in": "^7.1.0",
     "@capacitor-community/stripe": "^8.1.1",

--- a/src/i18n/brandTranslation.test.ts
+++ b/src/i18n/brandTranslation.test.ts
@@ -1,0 +1,30 @@
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { i18n, loadLocaleMessages, setBrandSiteResolver } from './index';
+
+let site: { title: string } | undefined;
+
+beforeAll(async () => {
+  await loadLocaleMessages('zh-CN');
+});
+
+beforeEach(() => {
+  site = undefined;
+  setBrandSiteResolver(() => site as never);
+  i18n.global.locale = 'zh-CN';
+});
+
+describe('brand post-translation', () => {
+  it('uses the latest Site without rebuilding i18n', () => {
+    expect(i18n.global.t('common.customers.comment3')).toContain('Ace Data Cloud');
+    site = { title: '知数云' };
+    expect(i18n.global.t('common.customers.comment3')).toContain('我喜欢知数云的服务');
+  });
+
+  it('normalizes Chinese boundaries but keeps Latin brands spaced', () => {
+    site = { title: '知数云' };
+    expect(i18n.global.t('common.customers.comment1')).toMatch(/^知数云为/);
+    expect(i18n.global.t('common.settings.apiServiceTip')).toBe('本站 API 服务由知数云提供。');
+    site = { title: 'Zhishu Cloud' };
+    expect(i18n.global.t('common.settings.apiServiceTip')).toBe('本站 API 服务由 Zhishu Cloud 提供。');
+  });
+});

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -3,9 +3,18 @@ import { makeGetLocale } from '@acedatacloud/core';
 import { makeFlatLoader, createSetI18nLanguage } from '@acedatacloud/core/i18n';
 import { I18N_DEFAULT_LOCALE, I18N_SCOPES, I18N_SUPPORTED_LOCALES } from '@/constants/i18n';
 import axios from 'axios';
+import type { ISite } from '@/models';
+import { replaceBrandName } from '@/utils/site';
+
+let resolveBrandSite: () => ISite | null | undefined = () => undefined;
+
+export const setBrandSiteResolver = (resolver: () => ISite | null | undefined): void => {
+  resolveBrandSite = resolver;
+};
 
 export const i18n = createI18n({
-  legacy: true
+  legacy: true,
+  postTranslation: (value) => (typeof value === 'string' ? replaceBrandName(value, resolveBrandSite()) : value)
 });
 
 // Locale resolution now lives in @acedatacloud/core; the supported-locale list

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,7 @@ import { Capacitor } from '@capacitor/core';
 import App from './App.vue';
 import { routes, setupRouterGuards, setActiveRouter } from './router';
 import store from './store';
-import i18n, { setI18nLanguage } from './i18n';
+import i18n, { setBrandSiteResolver, setI18nLanguage } from './i18n';
 import { I18N_DEFAULT_LOCALE } from '@/constants/i18n';
 import { getCookie, setCookie } from 'typescript-cookie';
 import { handleChunkLoadError, initializeChunkLoadErrorHandler } from './utils/chunkLoadError';
@@ -43,6 +43,8 @@ import {
   initializeRedirect,
   initializeFingerprint
 } from './utils/initializer';
+
+setBrandSiteResolver(() => store.state.site);
 
 const applyBootLocale = async (site?: Parameters<typeof resolveBootLocaleCookie>[1]) => {
   const savedLocale = getCookie('LOCALE');

--- a/src/utils/seo.test.ts
+++ b/src/utils/seo.test.ts
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  official: true,
+  site: { title: 'Ace Data Cloud', description: 'Official description' } as Record<string, unknown>
+}));
+
+vi.mock('@/store', () => ({
+  default: {
+    state: {
+      get site() {
+        return mocks.site;
+      }
+    }
+  }
+}));
+vi.mock('@/utils/siteLocales', () => ({ getSiteLocaleOptions: () => [] }));
+vi.mock('@/utils/is', () => ({ isMainOfficial: () => mocks.official }));
+
+import { setOrganization } from './seo';
+
+function organization(): Record<string, unknown> {
+  const script = document.getElementById('seo-org-ld');
+  expect(script?.textContent).toBeTruthy();
+  return JSON.parse(script!.textContent!);
+}
+
+describe('Organization structured data ownership', () => {
+  beforeEach(() => {
+    document.head.innerHTML = '';
+    mocks.official = true;
+    mocks.site = { title: 'Ace Data Cloud', description: 'Official description' };
+  });
+
+  it('keeps official social identity on the first-party site', () => {
+    setOrganization();
+    expect(organization().sameAs).toEqual([
+      'https://github.com/AceDataCloud',
+      'https://x.com/AceDataCloud',
+      'https://hub.acedata.cloud'
+    ]);
+  });
+
+  it('does not attribute official social profiles to a white-label tenant', () => {
+    mocks.official = false;
+    mocks.site = { title: '知数云', description: '租户描述' };
+    setOrganization();
+    const data = organization();
+    expect(data.name).toBe('知数云');
+    expect(data.description).toBe('租户描述');
+    expect(data).not.toHaveProperty('sameAs');
+  });
+});

--- a/src/utils/seo.ts
+++ b/src/utils/seo.ts
@@ -1,6 +1,7 @@
 import store from '@/store';
 import { getSiteLocaleOptions } from '@/utils/siteLocales';
 import { isMainOfficial } from '@/utils/is';
+import { replaceBrandName } from '@/utils/site';
 
 // Resolve the current site origin at runtime so that the same bundle can be
 // served independently from multiple official hostnames (e.g. hub.acedata.cloud,
@@ -137,11 +138,12 @@ function removeHreflang() {
 
 export function setWebApplicationSchema(options: { name: string; description: string; url: string; category: string }) {
   const { brandName } = brand();
+  const site = store.state.site;
   setJsonLd('seo-webapp-ld', {
     '@context': 'https://schema.org',
     '@type': 'WebApplication',
-    name: options.name,
-    description: options.description,
+    name: replaceBrandName(options.name, site),
+    description: replaceBrandName(options.description, site),
     url: options.url,
     applicationCategory: options.category,
     operatingSystem: 'Web',
@@ -177,8 +179,9 @@ export function setOrganization() {
 
 export function updateSeo(options: SeoOptions) {
   const { siteName, brandName, description: brandDescription, image: brandImage } = brand();
-  const title = options.title ? `${options.title} - ${siteName}` : siteName;
-  const description = options.description || brandDescription;
+  const authoredTitle = options.title ? replaceBrandName(options.title, store.state.site) : '';
+  const title = authoredTitle ? `${authoredTitle} - ${siteName}` : siteName;
+  const description = options.description ? replaceBrandName(options.description, store.state.site) : brandDescription;
   const url = options.url || `${getCurrentOrigin()}${window.location.pathname}`;
   const image = options.image || brandImage;
   const ogType = options.type || 'website';

--- a/src/utils/seo.ts
+++ b/src/utils/seo.ts
@@ -1,5 +1,6 @@
 import store from '@/store';
 import { getSiteLocaleOptions } from '@/utils/siteLocales';
+import { isMainOfficial } from '@/utils/is';
 
 // Resolve the current site origin at runtime so that the same bundle can be
 // served independently from multiple official hostnames (e.g. hub.acedata.cloud,
@@ -166,7 +167,9 @@ export function setOrganization() {
     url: getCurrentOrigin(),
     logo: image,
     description,
-    sameAs: ['https://github.com/AceDataCloud', 'https://x.com/AceDataCloud', 'https://hub.acedata.cloud']
+    ...(isMainOfficial()
+      ? { sameAs: ['https://github.com/AceDataCloud', 'https://x.com/AceDataCloud', 'https://hub.acedata.cloud'] }
+      : {})
   });
 }
 

--- a/src/utils/site.test.ts
+++ b/src/utils/site.test.ts
@@ -8,6 +8,7 @@ import {
   applyMarkup,
   isBrandingHidden,
   getBrandName,
+  replaceBrandName,
   getBrandCopyright,
   getBrandSupportUrl,
   getBrandContacts,
@@ -155,6 +156,12 @@ describe('brand footer values', () => {
     expect(getBrandName({ title: '  turboclaw  ' } as never)).toBe('turboclaw');
     expect(getBrandName({ title: '   ' } as never)).toBe('Ace Data Cloud');
     expect(getBrandName(null)).toBe('Ace Data Cloud');
+  });
+
+  it('rebrands translated copy without claiming technical identifiers', () => {
+    const site = { title: '知数云' } as never;
+    expect(replaceBrandName('我喜欢 Ace Data Cloud 的服务', site)).toBe('我喜欢知数云的服务');
+    expect(replaceBrandName('AceDataCloud on GitHub', site)).toBe('AceDataCloud on GitHub');
   });
 
   it('returns only a non-empty custom copyright', () => {

--- a/src/utils/site.ts
+++ b/src/utils/site.ts
@@ -2,6 +2,7 @@ import { IApplication, ISite, ISiteContact } from '@/models';
 import { v4 as uuid } from 'uuid';
 import { BASE_HOST_HUB } from '@/constants/endpoint';
 import { isNative, isDesktop } from './surface';
+import { replaceBrandText } from '@acedatacloud/core/brand-spacing';
 import { getSiteLocaleValues, serializeSiteLocales } from './siteLocales';
 
 /**
@@ -98,6 +99,12 @@ export const isBrandingHidden = (site: ISite | null | undefined, key: 'powered_b
 
 export const getBrandName = (site?: ISite | null): string => {
   return site?.title?.trim() || 'Ace Data Cloud';
+};
+
+const BRAND_NAME_VARIANTS = ['Ace Data Cloud', 'AceData Cloud'] as const;
+
+export const replaceBrandName = (text: string, site?: ISite | null): string => {
+  return replaceBrandText(text, getBrandName(site), BRAND_NAME_VARIANTS);
 };
 
 export const getBrandCopyright = (site?: ISite | null): string | undefined => {


### PR DESCRIPTION
## Summary
- stop white-label Organization JSON-LD from claiming Ace Data Cloud social profiles
- preserve official `sameAs` identity on the first-party Studio host
- add DOM behavior tests and a Beachball patch change file

## Dependency / next phase
- Draft: blocked by https://github.com/AceDataCloud/CommonFrontend/pull/29 and the publication of `@acedatacloud/core@0.21.0`
- after the package is available from npm, this same PR will add `@acedatacloud/core/brand-spacing`, Vue i18n `postTranslation`, and shared SEO brand replacement without copying the Unicode algorithm
- no unpublished, `file:`, Git, or temporary tarball dependency is committed

## Validation
- `npx vitest run src/utils/seo.test.ts` — 2 passed
- `npx eslint src/utils/seo.ts src/utils/seo.test.ts`
- `npx beachball check --branch origin/main`
- `git diff --check`

## Review
- Adversarial review not requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)