### PR TITLE
feat: make Usage History service-first

### DIFF
--- a/change/usage-service-first.json
+++ b/change/usage-service-first.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Make Usage History service-first with operation drilldown and consistent filtering.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/i18n/ar/usage.json
+++ b/src/i18n/ar/usage.json
@@ -222,5 +222,21 @@
   "value.accountDiscount": {
     "message": "خصم الحساب {percent}%",
     "description": "علامة محايدة لخصم استخدام الحساب اليدوي."
+  },
+  "field.service": {
+    "message": "الخدمة",
+    "description": "The service associated with the usage record."
+  },
+  "field.operation": {
+    "message": "العملية",
+    "description": "The endpoint or operation called within a service."
+  },
+  "option.allServices": {
+    "message": "جميع الخدمات",
+    "description": "Show usage across all services when none is selected."
+  },
+  "option.allOperations": {
+    "message": "جميع العمليات",
+    "description": "Show all operations for the selected services when none is selected."
   }
 }

--- a/src/i18n/de/usage.json
+++ b/src/i18n/de/usage.json
@@ -15,6 +15,22 @@
     "message": "Status",
     "description": "Der Status des Antragsverfahrens."
   },
+  "field.service": {
+    "message": "Dienst",
+    "description": "Der Geschäftsservice, zu dem die Nutzungshistorie gehört."
+  },
+  "field.operation": {
+    "message": "Vorgang",
+    "description": "Die tatsächlich aufgerufene Schnittstelle oder Operation im Dienst."
+  },
+  "option.allServices": {
+    "message": "Alle Dienste",
+    "description": "Zeigt die Nutzungshistorie aller Dienste an, wenn kein Dienst ausgewählt ist."
+  },
+  "option.allOperations": {
+    "message": "Alle Vorgänge",
+    "description": "Zeigt die Nutzungshistorie aller Schnittstellen des ausgewählten Dienstes an, wenn keine Schnittstelle ausgewählt ist."
+  },
   "field.api": {
     "message": "API",
     "description": "Aufgerufene API, keine Übersetzung erforderlich."

--- a/src/i18n/en/usage.json
+++ b/src/i18n/en/usage.json
@@ -15,6 +15,22 @@
     "message": "Status",
     "description": "The status of the application process."
   },
+  "field.service": {
+    "message": "Service",
+    "description": "The service associated with the usage record."
+  },
+  "field.operation": {
+    "message": "Operation",
+    "description": "The endpoint or operation called within a service."
+  },
+  "option.allServices": {
+    "message": "All Services",
+    "description": "Show usage across all services when none is selected."
+  },
+  "option.allOperations": {
+    "message": "All Operations",
+    "description": "Show all operations for the selected services when none is selected."
+  },
   "field.api": {
     "message": "API",
     "description": "The called API, no translation needed."

--- a/src/i18n/es/usage.json
+++ b/src/i18n/es/usage.json
@@ -15,6 +15,22 @@
     "message": "Estado",
     "description": "Estado de la solicitud."
   },
+  "field.service": {
+    "message": "Servicio",
+    "description": "El servicio comercial al que pertenece el registro de uso."
+  },
+  "field.operation": {
+    "message": "Operación",
+    "description": "La interfaz o operación que se llama realmente dentro del servicio."
+  },
+  "option.allServices": {
+    "message": "Todos los servicios",
+    "description": "Muestra todos los registros de uso de los servicios cuando no se ha seleccionado ningún servicio."
+  },
+  "option.allOperations": {
+    "message": "Todas las operaciones",
+    "description": "Muestra todos los registros de uso de las interfaces bajo el servicio seleccionado cuando no se ha seleccionado ninguna interfaz."
+  },
   "field.api": {
     "message": "API",
     "description": "API llamada, no necesita traducción."

--- a/src/i18n/fr/usage.json
+++ b/src/i18n/fr/usage.json
@@ -222,5 +222,21 @@
   "value.accountDiscount": {
     "message": "Remise sur le compte {percent}%",
     "description": "Étiquette neutre pour la remise appliquée sur les comptes manuels."
+  },
+  "field.service": {
+    "message": "Service utilisé",
+    "description": "The service associated with the usage record."
+  },
+  "field.operation": {
+    "message": "Opération",
+    "description": "The endpoint or operation called within a service."
+  },
+  "option.allServices": {
+    "message": "Tous les services",
+    "description": "Show usage across all services when none is selected."
+  },
+  "option.allOperations": {
+    "message": "Toutes les opérations",
+    "description": "Show all operations for the selected services when none is selected."
   }
 }

--- a/src/i18n/it/usage.json
+++ b/src/i18n/it/usage.json
@@ -222,5 +222,21 @@
   "value.accountDiscount": {
     "message": "Sconto account {percent}%",
     "description": "Etichetta neutra per lo sconto sull'uso manuale dell'account."
+  },
+  "field.service": {
+    "message": "Servizio",
+    "description": "The service associated with the usage record."
+  },
+  "field.operation": {
+    "message": "Operazione",
+    "description": "The endpoint or operation called within a service."
+  },
+  "option.allServices": {
+    "message": "Tutti i servizi",
+    "description": "Show usage across all services when none is selected."
+  },
+  "option.allOperations": {
+    "message": "Tutte le operazioni",
+    "description": "Show all operations for the selected services when none is selected."
   }
 }

--- a/src/i18n/ja/usage.json
+++ b/src/i18n/ja/usage.json
@@ -222,5 +222,21 @@
   "value.accountDiscount": {
     "message": "アカウント割引 {percent}%",
     "description": "手動アカウントで使用する割引の中立的なラベルです。"
+  },
+  "field.service": {
+    "message": "サービス",
+    "description": "The service associated with the usage record."
+  },
+  "field.operation": {
+    "message": "操作",
+    "description": "The endpoint or operation called within a service."
+  },
+  "option.allServices": {
+    "message": "すべてのサービス",
+    "description": "Show usage across all services when none is selected."
+  },
+  "option.allOperations": {
+    "message": "すべての操作",
+    "description": "Show all operations for the selected services when none is selected."
   }
 }

--- a/src/i18n/ko/usage.json
+++ b/src/i18n/ko/usage.json
@@ -222,5 +222,21 @@
   "value.accountDiscount": {
     "message": "계정 할인 {percent}%",
     "description": "수동 계정 사용 시 할인에 대한 중립적인 레이블입니다."
+  },
+  "field.service": {
+    "message": "서비스",
+    "description": "The service associated with the usage record."
+  },
+  "field.operation": {
+    "message": "작업",
+    "description": "The endpoint or operation called within a service."
+  },
+  "option.allServices": {
+    "message": "모든 서비스",
+    "description": "Show usage across all services when none is selected."
+  },
+  "option.allOperations": {
+    "message": "모든 작업",
+    "description": "Show all operations for the selected services when none is selected."
   }
 }

--- a/src/i18n/pt/usage.json
+++ b/src/i18n/pt/usage.json
@@ -15,6 +15,22 @@
     "message": "Status",
     "description": "O status do processo de solicitação."
   },
+  "field.service": {
+    "message": "Serviço",
+    "description": "O serviço de negócios ao qual os registros de uso pertencem."
+  },
+  "field.operation": {
+    "message": "Operação",
+    "description": "Interface ou operação que é chamada internamente pelo serviço."
+  },
+  "option.allServices": {
+    "message": "Todos os serviços",
+    "description": "Exibe todos os registros de uso de serviços quando nenhum serviço é escolhido."
+  },
+  "option.allOperations": {
+    "message": "Todas as operações",
+    "description": "Exibe todos os registros de uso de interfaces sob o serviço selecionado quando nenhuma interface é escolhida."
+  },
   "field.api": {
     "message": "API",
     "description": "API chamada, sem necessidade de tradução."

--- a/src/i18n/ru/usage.json
+++ b/src/i18n/ru/usage.json
@@ -222,5 +222,21 @@
   "value.accountDiscount": {
     "message": "Скидка на аккаунт {percent}%",
     "description": "Нейтральная метка для скидки, применяемой к аккаунту вручную."
+  },
+  "field.service": {
+    "message": "Сервис",
+    "description": "The service associated with the usage record."
+  },
+  "field.operation": {
+    "message": "Операция",
+    "description": "The endpoint or operation called within a service."
+  },
+  "option.allServices": {
+    "message": "Все сервисы",
+    "description": "Show usage across all services when none is selected."
+  },
+  "option.allOperations": {
+    "message": "Все операции",
+    "description": "Show all operations for the selected services when none is selected."
   }
 }

--- a/src/i18n/zh-CN/usage.json
+++ b/src/i18n/zh-CN/usage.json
@@ -15,6 +15,22 @@
     "message": "状态",
     "description": "申请程序的状态。"
   },
+  "field.service": {
+    "message": "服务",
+    "description": "使用记录所属的业务服务。"
+  },
+  "field.operation": {
+    "message": "接口操作",
+    "description": "服务内部实际调用的接口或操作。"
+  },
+  "option.allServices": {
+    "message": "全部服务",
+    "description": "未选择服务时显示全部服务的使用记录。"
+  },
+  "option.allOperations": {
+    "message": "全部接口",
+    "description": "未选择接口时显示所选服务下全部接口的使用记录。"
+  },
   "field.api": {
     "message": "API",
     "description": "调用的API，无需翻译"

--- a/src/i18n/zh-TW/usage.json
+++ b/src/i18n/zh-TW/usage.json
@@ -222,5 +222,21 @@
   "value.accountDiscount": {
     "message": "帳戶優惠 {percent}%",
     "description": "手工帳戶使用折扣的中性標籤。"
+  },
+  "field.service": {
+    "message": "服務",
+    "description": "The service associated with the usage record."
+  },
+  "field.operation": {
+    "message": "介面操作",
+    "description": "The endpoint or operation called within a service."
+  },
+  "option.allServices": {
+    "message": "全部服務",
+    "description": "Show usage across all services when none is selected."
+  },
+  "option.allOperations": {
+    "message": "全部介面",
+    "description": "Show all operations for the selected services when none is selected."
   }
 }

--- a/src/operators/service.ts
+++ b/src/operators/service.ts
@@ -7,6 +7,7 @@ export interface IServiceQuery {
   offset?: number;
   ordering?: string;
   id?: string | string[];
+  type?: string | string[];
 }
 
 class ServiceOperator extends BaseOperator<IService, IServiceListResponse, IServiceDetailResponse> {

--- a/src/operators/usage.ts
+++ b/src/operators/usage.ts
@@ -7,6 +7,7 @@ export interface IApiUsageQuery {
   offset?: number;
   limit?: number;
   application_id?: string | string[];
+  service_id?: string | string[];
   api_id?: string | string[];
   ordering?: string;
   created_at_from?: string | Date;
@@ -27,6 +28,7 @@ class ApiUsageOperator {
   async getAggregate(query: {
     user_id?: string;
     application_id?: string | string[];
+    service_id?: string | string[];
     api_id?: string | string[];
     created_at_from?: string | Date;
     created_at_to?: string | Date;
@@ -48,6 +50,7 @@ class ApiUsageOperator {
   async getStatusCodes(query: {
     user_id?: string;
     application_id?: string | string[];
+    service_id?: string | string[];
     api_id?: string | string[];
     created_at_from?: string | Date;
     created_at_to?: string | Date;

--- a/src/pages/console/usage/List.vue
+++ b/src/pages/console/usage/List.vue
@@ -8,35 +8,31 @@
           </h2>
         </el-col>
       </el-row>
-      <el-row>
-        <el-col v-show="false" :md="4" :xs="24" class="mb-5 flex px-2 gap-2 items-center">
-          <span> {{ $t('application.field.type') }} </span>
-          <el-radio-group v-model="type">
-            <el-radio-button :value="serviceType.API" :label="$t('application.field.api')" />
-            <el-radio-button :value="serviceType.Proxy" :label="$t('application.field.proxy')" />
-          </el-radio-group>
-        </el-col>
-        <el-col v-show="false" :md="6" :xs="24" class="mb-5 flex px-2 gap-2 items-center">
-          <span class="inline-block w-9"> {{ $t('usage.field.application') }} </span>
+      <el-row class="usage-filters">
+        <el-col v-if="type === serviceType.API" :lg="5" :md="12" :xs="24" class="usage-filter">
+          <span class="usage-filter-label">{{ $t('usage.field.service') }}</span>
           <el-select
-            v-model="applicationIds"
-            :placeholder="$t('usage.field.application')"
+            v-model="serviceIds"
+            :placeholder="$t('usage.option.allServices')"
+            :loading="servicesLoading"
             clearable
+            filterable
             multiple
             collapse-tags
             collapse-tags-tooltip
             class="w-full"
-            @change="onApplicationsChange"
+            @change="onServicesChange"
           >
-            <el-option v-for="item in applications" :key="item.id" :label="item.service?.title" :value="item?.id!" />
+            <el-option v-for="item in services" :key="item.id" :label="item.title" :value="item.id" />
           </el-select>
         </el-col>
-        <el-col v-if="type === serviceType.API" :md="6" :xs="24" class="mb-5 flex px-2 gap-2 items-center">
-          <span class="inline-block"> {{ $t('usage.field.api') }} </span>
+        <el-col v-if="type === serviceType.API" :lg="5" :md="12" :xs="24" class="usage-filter">
+          <span class="usage-filter-label">{{ $t('usage.field.operation') }}</span>
           <el-select
             v-model="apiIds"
-            :placeholder="$t('usage.field.api')"
+            :placeholder="$t('usage.option.allOperations')"
             :loading="apisLoading"
+            :disabled="!serviceIds.length && !apiIds.length"
             clearable
             filterable
             multiple
@@ -45,10 +41,10 @@
             class="w-full"
             @change="onApisChange"
           >
-            <el-option v-for="item in apis" :key="item?.id" :label="item?.title" :value="item?.id!" />
+            <el-option v-for="item in apis" :key="item.id" :label="item.title || item.id" :value="item.id" />
           </el-select>
         </el-col>
-        <el-col v-if="type === serviceType.API" :md="8" :xs="24" class="mb-5 flex px-2 gap-2 items-center">
+        <el-col v-if="type === serviceType.API" :lg="7" :md="12" :xs="24" class="usage-filter">
           <el-date-picker
             v-model="createdAtRange"
             type="datetimerange"
@@ -63,7 +59,7 @@
         <!-- Status-code filter — narrow because values are 3-digit codes.
              `filterable` + `allow-create` lets the user pick from discovered
              codes or type an unseen one (e.g. a future 503). -->
-        <el-col v-if="type === serviceType.API" :md="3" :xs="24" class="mb-5 flex px-2 gap-2 items-center">
+        <el-col v-if="type === serviceType.API" :lg="3" :md="6" :xs="24" class="usage-filter">
           <el-select
             v-model="statusCodeFilter"
             :placeholder="$t('usage.option.statusCodeAll')"
@@ -78,7 +74,7 @@
             <el-option v-for="code in statusCodeOptions" :key="code" :label="String(code)" :value="String(code)" />
           </el-select>
         </el-col>
-        <el-col v-if="type === serviceType.API" :md="3" :xs="24" class="mb-5 flex px-2 gap-2 items-center justify-end">
+        <el-col v-if="type === serviceType.API" :lg="4" :md="6" :xs="24" class="usage-filter usage-filter-export">
           <el-button type="primary" plain :loading="exporting" class="w-full whitespace-nowrap" @click="onExport">
             <export-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
             {{ $t('usage.button.export') }}
@@ -138,7 +134,7 @@
                   </template>
                   <template v-else>
                     <el-table v-if="apiBreakdown.length" :data="apiBreakdown" size="small" height="300" class="w-full">
-                      <el-table-column :label="$t('usage.field.api')" min-width="160">
+                      <el-table-column :label="$t('usage.field.operation')" min-width="160">
                         <template #default="scope">
                           <span class="color-dot" :style="{ backgroundColor: scope.row.color }" />
                           <span>{{ scope.row.label }}</span>
@@ -183,9 +179,14 @@
               :empty-text="$t('common.message.noData')"
               class="min-h-[calc(100vh-350px)] mb-5"
             >
-              <el-table-column :label="$t('application.field.name')" width="160px">
+              <el-table-column :label="$t('usage.field.service')" width="180px">
                 <template #default="scope">
-                  <span>{{ scope.row?.api?.title }}</span>
+                  <span>{{ scope.row?.service?.title || '-' }}</span>
+                </template>
+              </el-table-column>
+              <el-table-column :label="$t('usage.field.operation')" width="180px">
+                <template #default="scope">
+                  <span>{{ scope.row?.api?.title || '-' }}</span>
                 </template>
               </el-table-column>
               <el-table-column :label="$t('usage.field.statusCode')" width="120px">
@@ -538,18 +539,19 @@ import { ApplicationsIcon, ExportIcon, ExternalLinkIcon } from '@acedatacloud/co
 import { defineComponent } from 'vue';
 import {
   IApi,
-  IApiListResponse,
   IApplication,
   IApplicationListResponse,
   IApplicationType,
   ICredentialType,
+  IService,
+  IServiceListResponse,
   IServiceType,
   IApiUsage,
   IApiUsageListResponse,
   IProxyUsage,
   IProxyUsageListResponse
 } from '@/models';
-import { apiUsageOperator, applicationOperator, apiOperator, proxyUsageOperator } from '@/operators';
+import { apiUsageOperator, applicationOperator, apiOperator, proxyUsageOperator, serviceOperator } from '@/operators';
 import { Pagination } from '@acedatacloud/core/components';
 import {
   ElTable,
@@ -631,13 +633,16 @@ interface IData {
   total: number | undefined;
   shortcuts: { text: string; value: () => [Date, Date] }[];
   applications: IApplication[];
+  services: IService[];
+  serviceIds: string[];
+  servicesLoading: boolean;
   apis: IApi[];
   apisLoading: boolean;
   limit: number;
   createdAtRange: [Date | string, Date | string];
   credentialType: typeof ICredentialType;
-  applicationIds: string[] | undefined;
-  apiIds: string[] | undefined;
+  applicationIds: string[];
+  apiIds: string[];
   type: string | IServiceType;
   serviceType: typeof IServiceType;
   // aggregate
@@ -666,6 +671,7 @@ interface IData {
   autoRefresh: boolean;
   autoRefreshTimer: number | null;
   fetchSeq: number;
+  apiFetchSeq: number;
 }
 
 export default defineComponent({
@@ -704,6 +710,11 @@ export default defineComponent({
         : [],
       apiIds: this.$route.query.api_id?.toString() ? this.$route.query.api_id?.toString().split(',') : [],
       applications: [],
+      services: [],
+      serviceIds: this.$route.query.service_id?.toString()
+        ? this.$route.query.service_id.toString().split(',').filter(Boolean)
+        : [],
+      servicesLoading: false,
       apis: [],
       apisLoading: false,
       credentialType: ICredentialType,
@@ -807,7 +818,8 @@ export default defineComponent({
       statusCodeOptionsLoading: false,
       autoRefresh: true,
       autoRefreshTimer: null,
-      fetchSeq: 0
+      fetchSeq: 0,
+      apiFetchSeq: 0
     };
   },
   computed: {
@@ -933,9 +945,11 @@ export default defineComponent({
       handler() {
         // reset multi-selects when switching type
         this.applicationIds = [];
+        this.serviceIds = [];
         this.apiIds = [];
         this.onApplicationsChange(this.applicationIds);
         this.onFetchApplications();
+        this.onFetchServices();
         this.onFetchApis();
         this.onFetchUsages();
         this.onFetchAggregate();
@@ -952,9 +966,10 @@ export default defineComponent({
       }
     }
   },
-  mounted() {
+  async mounted() {
     this.onFetchApplications();
-    this.onFetchApis();
+    await Promise.all([this.onFetchServices(), this.hydrateApiSelection()]);
+    await this.onFetchApis();
     this.onFetchUsages();
     this.onFetchAggregate();
     this.onFetchStatusCodeOptions();
@@ -987,6 +1002,23 @@ export default defineComponent({
         this.autoRefreshTimer = null;
       }
     },
+    async onServicesChange(serviceIds: string[]) {
+      if (!serviceIds.length) this.apiIds = [];
+      this.apis = [];
+      await this.onFetchApis();
+      await this.$router.push({
+        name: this.$route.name?.toString(),
+        query: {
+          ...this.$route.query,
+          service_id: serviceIds.length ? serviceIds.join(',') : undefined,
+          api_id: this.apiIds.length ? this.apiIds.join(',') : undefined,
+          page: undefined
+        }
+      });
+      this.onFetchApiUsages();
+      this.onFetchAggregate();
+      this.onFetchStatusCodeOptions();
+    },
     async onApiChange(apiId: string) {
       await this.$router.push({
         name: this.$route.name?.toString(),
@@ -1003,7 +1035,8 @@ export default defineComponent({
         name: this.$route.name?.toString(),
         query: {
           ...this.$route.query,
-          api_id: apiIds && apiIds.length ? apiIds.join(',') : ''
+          api_id: apiIds && apiIds.length ? apiIds.join(',') : undefined,
+          page: undefined
         }
       });
       this.onFetchApiUsages();
@@ -1113,7 +1146,8 @@ export default defineComponent({
         const { data } = await apiUsageOperator.getStatusCodes({
           user_id: this.$store.getters.user.id,
           ...(this.applicationIds && this.applicationIds.length ? { application_id: this.applicationIds } : {}),
-          ...(this.apiIds && this.apiIds.length ? { api_id: this.apiIds } : {}),
+          ...(this.serviceIds.length ? { service_id: this.serviceIds } : {}),
+          ...(this.apiIds.length ? { api_id: this.apiIds } : {}),
           ...(this.createdAtRange?.[0] ? { created_at_from: this.createdAtRange[0] } : {}),
           ...(this.createdAtRange?.[1] ? { created_at_to: this.createdAtRange[1] } : {})
         });
@@ -1209,21 +1243,62 @@ export default defineComponent({
         })
         .catch(() => {});
     },
-    onFetchApis() {
-      this.apisLoading = true;
-      apiOperator
-        .getAll({
+    async hydrateApiSelection() {
+      if (!this.apiIds.length) return;
+      const selected = await Promise.allSettled(this.apiIds.map((apiId) => apiOperator.get(apiId)));
+      const services = new Set(this.serviceIds);
+      const resolved = selected.filter((result) => result.status === 'fulfilled').map((result) => result.value);
+      resolved.forEach(({ data }) => {
+        const serviceId = data.service_id || data.service?.id;
+        if (serviceId) services.add(serviceId);
+      });
+      this.serviceIds = Array.from(services);
+      this.apis = resolved.map(({ data }) => data);
+    },
+    async onFetchServices() {
+      this.servicesLoading = true;
+      try {
+        const { data } = (await serviceOperator.getAll({
           limit: 1000,
           offset: 0,
-          ordering: '-created_at'
-        })
-        .then(({ data: data }: { data: IApiListResponse }) => {
-          this.apis = data.items.filter((api: IApi) => api.service?.type === IServiceType.API);
-        })
-        .catch(() => {})
-        .finally(() => {
-          this.apisLoading = false;
-        });
+          ordering: '-rank',
+          type: IServiceType.API
+        })) as { data: IServiceListResponse };
+        this.services = data.items;
+      } catch {
+        this.services = [];
+      } finally {
+        this.servicesLoading = false;
+      }
+    },
+    async onFetchApis() {
+      const seq = ++this.apiFetchSeq;
+      if (!this.serviceIds.length) {
+        this.apis = [];
+        this.apisLoading = false;
+        return;
+      }
+      this.apisLoading = true;
+      try {
+        const responses = await Promise.allSettled(
+          this.serviceIds.map((serviceId) =>
+            apiOperator.getAllForService(serviceId, { limit: 1000, offset: 0, ordering: '-created_at' })
+          )
+        );
+        if (seq !== this.apiFetchSeq) return;
+        const operations = new Map<string, IApi>();
+        this.apis.filter((api) => this.apiIds.includes(api.id)).forEach((api) => operations.set(api.id, api));
+        responses
+          .filter((result) => result.status === 'fulfilled')
+          .forEach((result) => result.value.data.items.forEach((api) => operations.set(api.id, api)));
+        this.apis = Array.from(operations.values());
+        if (this.apiIds.length) {
+          const available = new Set(this.apis.map((api) => api.id));
+          this.apiIds = this.apiIds.filter((apiId) => available.has(apiId));
+        }
+      } finally {
+        if (seq === this.apiFetchSeq) this.apisLoading = false;
+      }
     },
     onFetchApiUsages(silent = false) {
       if (!silent) this.loading = true;
@@ -1237,7 +1312,8 @@ export default defineComponent({
           ...(this.createdAtRange?.[0] ? { created_at_from: this.createdAtRange[0] } : {}),
           ...(this.createdAtRange?.[1] ? { created_at_to: this.createdAtRange[1] } : {}),
           ...(this.applicationIds && this.applicationIds.length ? { application_id: this.applicationIds } : {}),
-          ...(this.apiIds && this.apiIds.length ? { api_id: this.apiIds } : {}),
+          ...(this.serviceIds.length ? { service_id: this.serviceIds } : {}),
+          ...(this.apiIds.length ? { api_id: this.apiIds } : {}),
           ...(this.statusCodeFilter ? { status_code: this.statusCodeFilter } : {}),
           ...(this.traceId ? { trace_id: this.traceId } : {})
         })
@@ -1283,7 +1359,8 @@ export default defineComponent({
         ...(this.createdAtRange?.[0] ? { created_at_from: this.createdAtRange[0] } : {}),
         ...(this.createdAtRange?.[1] ? { created_at_to: this.createdAtRange[1] } : {}),
         ...(this.applicationIds && this.applicationIds.length ? { application_id: this.applicationIds } : {}),
-        ...(this.apiIds && this.apiIds.length ? { api_id: this.apiIds } : {}),
+        ...(this.serviceIds.length ? { service_id: this.serviceIds } : {}),
+        ...(this.apiIds.length ? { api_id: this.apiIds } : {}),
         ...(this.statusCodeFilter ? { status_code: this.statusCodeFilter } : {})
       };
       // Absolute platform URL — raw fetch bypasses httpClient, and the relative
@@ -1344,7 +1421,8 @@ export default defineComponent({
       const params: any = {
         user_id: this.$store.getters.user.id,
         ...(this.applicationIds && this.applicationIds.length ? { application_id: this.applicationIds } : {}),
-        ...(this.apiIds && this.apiIds.length ? { api_id: this.apiIds } : {}),
+        ...(this.serviceIds.length ? { service_id: this.serviceIds } : {}),
+        ...(this.apiIds.length ? { api_id: this.apiIds } : {}),
         ...(this.createdAtRange?.[0] ? { created_at_from: this.createdAtRange[0] } : {}),
         ...(this.createdAtRange?.[1] ? { created_at_to: this.createdAtRange[1] } : {}),
         timezone: Intl.DateTimeFormat().resolvedOptions().timeZone
@@ -1444,6 +1522,33 @@ export default defineComponent({
 </script>
 
 <style lang="scss" scoped>
+.usage-filters {
+  margin: 0 -8px 20px;
+  align-items: end;
+}
+.usage-filter {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 6px;
+  padding: 0 8px;
+}
+.usage-filter :deep(.el-date-editor) {
+  width: 100%;
+  min-width: 0;
+}
+.usage-filter-label {
+  color: var(--el-text-color-regular);
+  font-size: 13px;
+}
+.usage-filter-export {
+  justify-content: end;
+}
+@media (max-width: 767px) {
+  .usage-filter {
+    margin-bottom: 14px;
+  }
+}
 .summary-card {
   width: 25%;
   min-width: 260px;

--- a/src/pages/console/usage/apiSelectLoading.test.ts
+++ b/src/pages/console/usage/apiSelectLoading.test.ts
@@ -3,16 +3,22 @@ import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
 const page = readFileSync(fileURLToPath(new URL('./List.vue', import.meta.url)), 'utf8');
-const apiFilter = page.match(/<el-col v-if="type === serviceType\.API"[^>]*>[\s\S]*?<\/el-col>/)?.[0] || '';
+const operationFilter =
+  page.match(/<el-col v-if="type === serviceType\.API"[^>]*>[\s\S]*?usage\.field\.operation[\s\S]*?<\/el-col>/)?.[0] ||
+  '';
 
-describe('usage API select loading contract', () => {
-  it('keeps the select mounted and shows loading inside its dropdown', () => {
-    expect(apiFilter).toContain(':loading="apisLoading"');
-    expect(apiFilter).not.toContain('<el-skeleton');
-    expect(apiFilter).not.toMatch(/<el-select\s+v-else/);
+describe('usage operation select loading contract', () => {
+  it('keeps the select mounted and shows loading in its dropdown', () => {
+    expect(operationFilter).toContain(':loading="apisLoading"');
+    expect(operationFilter).toContain(':disabled="!serviceIds.length && !apiIds.length"');
+    expect(operationFilter).not.toContain('<el-skeleton');
   });
 
-  it('preloads API options when the page mounts', () => {
-    expect(page).toMatch(/mounted\(\)\s*\{[\s\S]*?this\.onFetchApis\(\)/);
+  it('loads operations after services and ignores stale responses', () => {
+    expect(page).toContain('await Promise.all([this.onFetchServices(), this.hydrateApiSelection()])');
+    expect(page).toContain('await this.onFetchApis()');
+    expect(page).toContain('const seq = ++this.apiFetchSeq');
+    expect(page).toContain('if (seq !== this.apiFetchSeq) return');
+    expect(page).toContain('const operations = new Map<string, IApi>()');
   });
 });

--- a/src/pages/console/usage/usageContract.test.ts
+++ b/src/pages/console/usage/usageContract.test.ts
@@ -6,29 +6,48 @@ const readSource = (path: string): string => readFileSync(fileURLToPath(new URL(
 
 describe('API usage page contract', () => {
   const usageSource = readSource('./List.vue');
+  const usageOperatorSource = readSource('../../../operators/usage.ts');
   const applicationListSource = readSource('../application/List.vue');
   const applicationInfoSource = readSource('../../../components/application/Info.vue');
 
-  it('keeps the usage page in API mode and filters non-API services', () => {
-    expect(usageSource).toContain('<el-col v-show="false" :md="4"');
-    expect(usageSource).toContain('type: IServiceType.API,');
-    expect(usageSource).not.toContain('type: this.$route.query.type');
-    expect(usageSource).toContain('data.items.filter((api: IApi) => api.service?.type === IServiceType.API)');
+  it('uses a service-first filter with operation drilldown', () => {
+    expect(usageSource.indexOf("$t('usage.field.service')")).toBeLessThan(
+      usageSource.indexOf("$t('usage.field.operation')")
+    );
+    expect(usageSource).toContain('v-model="serviceIds"');
+    expect(usageSource).toContain(':disabled="!serviceIds.length && !apiIds.length"');
+    expect(usageSource).toContain('apiOperator.getAllForService(serviceId');
+    expect(usageSource).not.toContain(
+      "limit: 1000,\n          offset: 0,\n          ordering: '-created_at'\n        })\n        .then"
+    );
   });
 
-  it('retains the dormant proxy usage compatibility path', () => {
+  it('sends service_id through every usage data path', () => {
+    expect(usageOperatorSource.match(/service_id\?: string \| string\[\];/g)).toHaveLength(3);
+    expect(usageSource).toContain("service_id: serviceIds.length ? serviceIds.join(',') : undefined");
+    expect(usageSource.match(/\{ service_id: this\.serviceIds \}/g)?.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('preserves legacy api_id deep links and hydrates their services', () => {
+    expect(usageSource).toContain('async hydrateApiSelection()');
+    expect(usageSource).toContain('this.apiIds.map((apiId) => apiOperator.get(apiId))');
+    expect(usageSource).toContain('const services = new Set(this.serviceIds)');
+    expect(usageSource).toContain('if (serviceId) services.add(serviceId)');
+  });
+
+  it('shows service and operation as separate usage columns', () => {
+    expect(usageSource).toContain('<el-table-column :label="$t(\'usage.field.service\')"');
+    expect(usageSource).toContain('<el-table-column :label="$t(\'usage.field.operation\')"');
+    expect(usageSource).toContain("scope.row?.service?.title || '-'");
+    expect(usageSource).toContain("scope.row?.api?.title || '-'");
+  });
+
+  it('retains dormant proxy compatibility and API-only usage actions', () => {
+    expect(usageSource).toContain('type: IServiceType.API,');
     expect(usageSource).toContain('proxyUsageOperator');
     expect(usageSource).toContain('onFetchProxyUsages');
-  });
-
-  it('only exposes individual usage actions for API services', () => {
     expect(applicationListSource).toContain('v-if="scope.row?.service?.type === serviceType.API"');
     expect(applicationListSource).toContain('v-if="app?.service?.type === serviceType.API"');
-    expect(applicationListSource).not.toContain('type: application?.service?.type');
-  });
-
-  it('keeps global usage available while hiding non-API service usage', () => {
-    expect(applicationInfoSource).toContain('v-if="showUsage"');
     expect(applicationInfoSource).toContain(
       'return !this.application?.service || this.application.service.type === IServiceType.API;'
     );


### PR DESCRIPTION
## Summary
- make Service the primary Usage History filter and relabel API as Operation for drilldown
- load Operations only for selected Services while preserving legacy `api_id` deep links
- send `service_id` consistently to list, aggregate, status-code discovery, and CSV export
- show separate Service and Operation columns and use a responsive five-control filter layout
- localize the new UI across all 12 locales

## Dependency
Depends on the OPEN backend contract PR: https://github.com/AceDataCloud/PlatformBackend/pull/1564

Deploy PlatformBackend before Nexior. Until the backend lands, it ignores `service_id`, so the frontend PR must not be released independently. Analytics remain grouped by concrete Operation, matching the backend API-ID filter contract.

## Verification
- `npm run test:run` — 219 files, 1641 tests passed
- `npm run lint:check` — 0 errors (2 pre-existing warnings)
- `npm run build:web` — production build passed
- `python3 scripts/check_i18n_coverage.py` — 11 locales × 49 namespaces passed, no English placeholders
- `npx beachball check --branch origin/main` — passed
- real browser SSO smoke on desktop and 390px mobile
  - Service → Operation order and separate table columns rendered
  - selected Service wrote `service_id` to URL and all list/aggregate/status requests
  - Operation selector loaded 49 scoped options in the sampled service
  - mobile controls measured 382px inside a 390px viewport; no horizontal overflow

## Review notes
- Service filtering expands enabled API relations in the backend; an explicit Operation selection intersects that API set.
- Existing `api_id` links remain valid and hydrate their Operation labels/Services.
- Metadata/catalog failures degrade to empty filter options without blocking usage records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)