### PR TITLE
fix: make video players safe for SSG

### DIFF
--- a/change/video-player-ssg-safe-4b7d1e2a.json
+++ b/change/video-player-ssg-safe-4b7d1e2a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Load browser-only video players after mount so production SSG builds succeed.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/common/VideoPlayer.ssr.test.ts
+++ b/src/components/common/VideoPlayer.ssr.test.ts
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+import { shallowMount } from '@vue/test-utils';
+import { renderToString } from '@vue/server-renderer';
+import { createSSRApp, type Component } from 'vue';
+import { describe, expect, it, vi } from 'vitest';
+import CommonVideoPlayer from './VideoPlayer.vue';
+import PikaVideoPlayer from '@/components/pika/VideoPlayer.vue';
+
+vi.mock('@skjnldsv/vue-plyr', () => ({ default: { name: 'VuePlyr', template: '<div><slot /></div>' } }));
+
+const pikaVideo = { video_url: 'https://cdn.example.com/video.mp4', image_url: 'https://cdn.example.com/poster.webp' };
+
+const render = (component: Component, props: Record<string, unknown>) => {
+  const app = createSSRApp(component, props);
+  app.config.globalProperties.$t = (key: string) => key;
+  return renderToString(app);
+};
+
+const mountOptions = {
+  global: {
+    mocks: { $t: (key: string) => key },
+    stubs: { VuePlyr: true }
+  }
+};
+
+describe('VideoPlayer SSR boundary', () => {
+  it('renders both players on the server without loading the browser-only player', async () => {
+    await expect(render(CommonVideoPlayer, { src: pikaVideo.video_url })).resolves.toContain('common.button.download');
+    await expect(render(PikaVideoPlayer, { modelValue: pikaVideo })).resolves.not.toContain('<video');
+  });
+
+  it('enables the async player after mounting in a browser', () => {
+    const common = shallowMount(CommonVideoPlayer, { props: { src: pikaVideo.video_url }, ...mountOptions });
+    const pika = shallowMount(PikaVideoPlayer, { props: { modelValue: pikaVideo }, ...mountOptions });
+    expect((common.vm as unknown as { clientReady: boolean }).clientReady).toBe(true);
+    expect((pika.vm as unknown as { clientReady: boolean }).clientReady).toBe(true);
+  });
+});

--- a/src/components/common/VideoPlayer.vue
+++ b/src/components/common/VideoPlayer.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="video max-w-[800px] max-h-[450px] rounded-[15px] overflow-hidden">
-    <vue-plyr v-if="!failed && safeSrc" :key="safeSrc" :options="mergedOptions">
+    <vue-plyr v-if="clientReady && !failed && safeSrc" :key="safeSrc" :options="mergedOptions">
       <video controls playsinline preload="metadata" class="w-full h-full aspect-[16/9]" @error="onError">
         <source size="1080" :src="safeSrc" type="video/mp4" />
       </video>
@@ -16,10 +16,9 @@
 
 <script lang="ts">
 import { ExternalLinkIcon } from '@acedatacloud/core/icons/components';
-import { defineComponent } from 'vue';
+import { defineAsyncComponent, defineComponent } from 'vue';
 import { ElButton } from 'element-plus';
-// @ts-ignore
-import VuePlyr from '@skjnldsv/vue-plyr';
+const VuePlyr = defineAsyncComponent(() => import('@skjnldsv/vue-plyr'));
 // @ts-ignore
 import '@skjnldsv/vue-plyr/dist/vue-plyr.css';
 
@@ -40,6 +39,7 @@ export default defineComponent({
   data() {
     return {
       failed: false,
+      clientReady: false,
       mergedOptions: {
         controls: [
           'play-large',
@@ -68,6 +68,9 @@ export default defineComponent({
     safeSrc() {
       this.failed = false;
     }
+  },
+  mounted() {
+    this.clientReady = true;
   },
   methods: {
     onError() {

--- a/src/components/pika/VideoPlayer.vue
+++ b/src/components/pika/VideoPlayer.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <vue-plyr :options="options" class="video">
+    <vue-plyr v-if="clientReady" :options="options" class="video">
       <video controls playsinline preload="metadata" :data-poster="modelValue?.image_url">
         <source size="1080" :src="modelValue?.video_url" type="video/mp4" />
       </video>
@@ -9,9 +9,8 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue';
-// @ts-ignore
-import VuePlyr from '@skjnldsv/vue-plyr';
+import { defineAsyncComponent, defineComponent } from 'vue';
+const VuePlyr = defineAsyncComponent(() => import('@skjnldsv/vue-plyr'));
 // @ts-ignore
 import { IPikaVideo } from '@/models';
 import '@skjnldsv/vue-plyr/dist/vue-plyr.css';
@@ -26,8 +25,12 @@ export default defineComponent({
   },
   data() {
     return {
+      clientReady: false,
       options: { quality: { default: 1080, options: [1080] } }
     };
+  },
+  mounted() {
+    this.clientReady = true;
   }
 });
 </script>

--- a/src/types/vue-plyr.d.ts
+++ b/src/types/vue-plyr.d.ts
@@ -1,0 +1,6 @@
+declare module '@skjnldsv/vue-plyr' {
+  import type { Component } from 'vue';
+
+  const VuePlyr: Component;
+  export default VuePlyr;
+}


### PR DESCRIPTION
## Summary
- defer both `vue-plyr` components until browser mount so Node SSG never evaluates its `document` access
- add a local module declaration for the dynamically imported player
- add SSR/client regression coverage for both shared and Pika video players

## Release blocker
- production deploy run failed in Docker `npm run build:ssg` with `ReferenceError: document is not defined` from `@skjnldsv/vue-plyr`
- failed deploy: https://github.com/AceDataCloud/Nexior/actions/runs/32578436636
- the pre-Banner main baseline reproduces the same failure, so this is an existing deployment-chain blocker rather than a regression in PR 1652

## Validation
- pre-fix `npm run build:ssg`: fails consistently with `document is not defined`
- post-fix `npm run build:ssg`: succeeds and renders `dist/auth/login/index.html`
- `npm run test:run`: 224 files / 1,658 tests passed
- `npm run lint:check`: 0 errors (2 pre-existing warnings)
- `npx vue-tsc -b --pretty false`
- `npm run build:web`
- `python3 scripts/check_i18n_coverage.py`
- `npm run verify`

🤖 Generated with [Claude Code](https://claude.com/claude-code)