### PR TITLE
fix(x402): use v2 order payment envelope

### DIFF
--- a/change/retire-x402-discovery-2c90cb4f.json
+++ b/change/retire-x402-discovery-2c90cb4f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Use the canonical x402 v2 payment envelope for wallet-funded orders.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/order/X402Pay.vue
+++ b/src/components/order/X402Pay.vue
@@ -906,9 +906,8 @@ export default defineComponent({
           nonce: authorization.nonce
         };
         const payload = {
-          x402Version: 1,
-          scheme: requirements.scheme || 'exact',
-          network: requirements.network || this.expectedNetwork || 'base',
+          x402Version: 2,
+          accepted: requirements,
           payload: { authorization: headerAuthorization, signature }
         };
         const header = btoa(JSON.stringify(payload));

--- a/src/components/x402ScenarioContract.test.ts
+++ b/src/components/x402ScenarioContract.test.ts
@@ -68,6 +68,16 @@ describe('x402 image scenario contract', () => {
     expect(payment).not.toContain('this.orderMetadata?.payment_requirements');
   });
 
+  it('uses the canonical v2 payment header for order checkout', () => {
+    const payment = source('components/order/X402Pay.vue');
+    const order = source('operators/order.ts');
+    expect(payment).toContain('x402Version: 2');
+    expect(payment).toContain('accepted: requirements');
+    expect(payment).not.toContain('x402Version: 1');
+    expect(order).toContain("'PAYMENT-SIGNATURE': xPaymentHeader");
+    expect(order).not.toContain("'X-PAYMENT': xPaymentHeader");
+  });
+
   it('uses one shared wallet resolver and prefers Base EIP-3009', () => {
     const operator = source('operators/x402.ts');
     expect(operator).toContain('signEVMPayment');

--- a/src/operators/order.ts
+++ b/src/operators/order.ts
@@ -58,7 +58,7 @@ class OrderService {
   ): Promise<AxiosResponse<IOrderDetailResponse>> {
     return await httpClient.post(`/${this.key}/${id}/pay/`, data, {
       headers: {
-        'X-PAYMENT': xPaymentHeader
+        'PAYMENT-SIGNATURE': xPaymentHeader
       }
     });
   }


### PR DESCRIPTION
## Summary
- send order wallet payments with the canonical `PAYMENT-SIGNATURE` header
- emit the x402 v2 `{ x402Version, accepted, payload }` envelope for Base payments
- add a contract guard and beachball patch entry

## Verification
- `npx vitest run src/components/x402ScenarioContract.test.ts src/operators/x402.test.ts` — 16 passed
- `npx vue-tsc -b --pretty false` — passed
- `npm run lint -- --no-fix` — passed with 2 existing warnings in `dropUploadMixin.test.ts`

## Rollout
This PR is independent of the Bazaar retirement and fixes an existing Studio order-payment protocol mismatch. No real payment was made.

🤖 Generated with [Claude Code](https://claude.com/claude-code)