### PR TITLE
refactor: use shared locale catalog

### DIFF
--- a/change/use-shared-locale-catalog.json
+++ b/change/use-shared-locale-catalog.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Use the shared product locale catalog for language options and hreflang metadata.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.365.0",
       "license": "MIT",
       "dependencies": {
-        "@acedatacloud/core": "^0.21.0",
+        "@acedatacloud/core": "^0.21.1",
         "@acedatacloud/x402-client": "^2026.726.1",
         "@capacitor-community/apple-sign-in": "^7.1.0",
         "@capacitor-community/stripe": "^8.1.1",
@@ -128,9 +128,9 @@
       }
     },
     "node_modules/@acedatacloud/core": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/@acedatacloud/core/-/core-0.21.0.tgz",
-      "integrity": "sha512-qYELZXIzCXzyWUIi/Lyq3q32sO42K7AgU3wdUxbQpfE8kx8+Eu35u7rsq0FvTbQ1MMJAOr1PSIHbOGN5PdcZYQ==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@acedatacloud/core/-/core-0.21.1.tgz",
+      "integrity": "sha512-jhdHkKbi5nUR3Xtovv/69dwIdN/Ru2UzKTDrevwRYuIRtpBPmb0gWlVMQ2Pbo4x5F0GEK2Bj1tWSorgsxlm5uw==",
       "license": "UNLICENSED",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "build:ssg": "cross-env VITE_SURFACE=web vite-ssg build"
   },
   "dependencies": {
-    "@acedatacloud/core": "^0.21.0",
+    "@acedatacloud/core": "^0.21.1",
     "@acedatacloud/x402-client": "^2026.726.1",
     "@capacitor-community/apple-sign-in": "^7.1.0",
     "@capacitor-community/stripe": "^8.1.1",

--- a/src/constants/i18n.ts
+++ b/src/constants/i18n.ts
@@ -1,20 +1,7 @@
-export const I18N_DEFAULT_LOCALE = 'en';
+import { DEFAULT_LOCALE, PRODUCT_LOCALES } from '@acedatacloud/core/constants';
 
-export const I18N_SUPPORTED_LOCALES = [
-  { value: 'en', label: 'English' },
-  { value: 'de', label: 'Deutsch' },
-  { value: 'pt', label: 'Português' },
-  { value: 'es', label: 'Español' },
-  { value: 'fr', label: 'Français' },
-  { value: 'zh-CN', label: '简体中文' },
-  { value: 'zh-TW', label: '繁體中文' },
-  { value: 'it', label: 'Italiano' },
-  { value: 'ko', label: '한국어' },
-  { value: 'ja', label: '日本語' },
-  { value: 'ru', label: 'Русский' },
-  { value: 'ar', label: 'العربية' }
-];
-
+export const I18N_DEFAULT_LOCALE = DEFAULT_LOCALE;
+export const I18N_SUPPORTED_LOCALES = PRODUCT_LOCALES;
 export type I18nLocaleOption = (typeof I18N_SUPPORTED_LOCALES)[number];
 
 export const I18N_SCOPES = [

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,7 +1,7 @@
 import { createI18n } from 'vue-i18n';
-import { makeGetLocale } from '@acedatacloud/core';
+import { getProductLocale } from '@acedatacloud/core/constants';
 import { makeFlatLoader, createSetI18nLanguage } from '@acedatacloud/core/i18n';
-import { I18N_DEFAULT_LOCALE, I18N_SCOPES, I18N_SUPPORTED_LOCALES } from '@/constants/i18n';
+import { I18N_SCOPES } from '@/constants/i18n';
 import axios from 'axios';
 import type { ISite } from '@/models';
 import { replaceBrandName } from '@/utils/site';
@@ -17,12 +17,7 @@ export const i18n = createI18n({
   postTranslation: (value) => (typeof value === 'string' ? replaceBrandName(value, resolveBrandSite()) : value)
 });
 
-// Locale resolution now lives in @acedatacloud/core; the supported-locale list
-// and default stay owned here so Nexior keeps control of its locale matrix.
-export const getLocale = makeGetLocale({
-  supportedLocales: I18N_SUPPORTED_LOCALES,
-  defaultLocale: I18N_DEFAULT_LOCALE
-});
+export const getLocale = getProductLocale;
 
 const messageLoaders = import.meta.glob('./**/*.json');
 

--- a/src/utils/seo.ts
+++ b/src/utils/seo.ts
@@ -2,6 +2,7 @@ import store from '@/store';
 import { getSiteLocaleOptions } from '@/utils/siteLocales';
 import { isMainOfficial } from '@/utils/is';
 import { replaceBrandName } from '@/utils/site';
+import { PRODUCT_LOCALES } from '@acedatacloud/core/constants';
 
 // Resolve the current site origin at runtime so that the same bundle can be
 // served independently from multiple official hostnames (e.g. hub.acedata.cloud,
@@ -42,22 +43,6 @@ function brand() {
     image: getShareImage()
   };
 }
-
-// Locale code → hreflang value mapping (BCP 47)
-const HREFLANG_MAP: Record<string, string> = {
-  en: 'en',
-  de: 'de',
-  pt: 'pt',
-  es: 'es',
-  fr: 'fr',
-  'zh-CN': 'zh-Hans',
-  'zh-TW': 'zh-Hant',
-  it: 'it',
-  ko: 'ko',
-  ja: 'ja',
-  ru: 'ru',
-  ar: 'ar'
-};
 
 interface SeoOptions {
   title?: string;
@@ -111,7 +96,7 @@ function setHreflang(url: string) {
   removeHreflang();
   const baseUrl = new URL(url);
   for (const { value: locale } of getSiteLocaleOptions(store.state.site?.supported_locales)) {
-    const hreflang = HREFLANG_MAP[locale];
+    const hreflang = PRODUCT_LOCALES.find((option) => option.value === locale)?.hreflang;
     if (!hreflang) continue;
     const link = document.createElement('link');
     link.rel = 'alternate';

--- a/src/utils/siteLocales.ts
+++ b/src/utils/siteLocales.ts
@@ -1,7 +1,7 @@
 import type { ISite } from '@/models';
 import { I18N_DEFAULT_LOCALE, I18N_SUPPORTED_LOCALES, type I18nLocaleOption } from '@/constants/i18n';
 
-export const getSiteLocaleOptions = (supportedLocales?: string[] | null): I18nLocaleOption[] => {
+export const getSiteLocaleOptions = (supportedLocales?: string[] | null): readonly I18nLocaleOption[] => {
   if (!Array.isArray(supportedLocales) || supportedLocales.length === 0) return I18N_SUPPORTED_LOCALES;
   const selected = new Set(supportedLocales);
   const options = I18N_SUPPORTED_LOCALES.filter((locale) => selected.has(locale.value));
@@ -32,7 +32,7 @@ export const resolveSiteLocale = (currentLocale: string, site?: ISite | null): s
   const forced = getForcedLocale(site);
   if (forced) return forced;
   const options = getSiteLocaleOptions(site?.supported_locales);
-  const allowed = new Set(options.map((locale) => locale.value));
+  const allowed = new Set<string>(options.map((locale) => locale.value));
   if (allowed.has(currentLocale)) return currentLocale;
   if (site?.language && allowed.has(site.language)) return site.language;
   if (allowed.has(I18N_DEFAULT_LOCALE)) return I18N_DEFAULT_LOCALE;


### PR DESCRIPTION
## Summary

- consume the shared immutable product catalog, `getProductLocale`, and hreflang metadata from core 0.21.1
- keep only Nexior-specific namespace scopes and tenant allowed/forced/default policy locally
- preserve locale-aware bootstrap ordering and flat message resources

## Dependency

Depends on https://github.com/AceDataCloud/CommonFrontend/pull/30 and remains draft until core 0.21.1 is published.

## Validation

- 1629 application assertions plus 11 Electron assertions
- 23 locale-focused tests, i18n coverage, lint, production build, Beachball

## 🤖 对抗评审
Shared catalog/resolver integration reviewed CLEAN. Readonly tenant-policy adaptation compiled and passed focused tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)