### PR TITLE
fix: preserve Inspiration service deep links

### DIFF
--- a/change/inspiration-service-filter-5e4c3a21.json
+++ b/change/inspiration-service-filter-5e4c3a21.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Preserve direct Inspiration service filters until the Showcase feed finishes loading.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/pages/inspiration/Index.test.ts
+++ b/src/pages/inspiration/Index.test.ts
@@ -117,6 +117,24 @@ describe('Inspiration gallery page', () => {
     });
   });
 
+  it('keeps a service deep link until the feed has finished loading', async () => {
+    let resolveFeed: (value: any) => void = () => undefined;
+    vi.mocked(showcaseOperator.list).mockReturnValue(
+      new Promise((resolve) => {
+        resolveFeed = resolve;
+      })
+    );
+    const { push } = mountPage({ service: 'nano-banana' });
+
+    await vi.waitFor(() => expect(showcaseOperator.list).toHaveBeenCalled());
+    expect(push).not.toHaveBeenCalled();
+
+    resolveFeed({ data: [image, video] });
+    await vi.waitFor(() => expect(showcaseOperator.list).toHaveBeenCalledTimes(1));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(push).not.toHaveBeenCalled();
+  });
+
   it('clears an unavailable deep link after loading completes', async () => {
     const { push } = mountPage({ showcase: 'd4ee4644-1246-4d97-802b-384643eb2db2' });
     await vi.waitFor(() => expect(showcaseOperator.list).toHaveBeenCalled());

--- a/src/pages/inspiration/Index.vue
+++ b/src/pages/inspiration/Index.vue
@@ -67,6 +67,7 @@ const { locale } = useI18n();
 const rawItems = ref<IShowcase[]>([]);
 const loading = ref(false);
 const error = ref(false);
+const feedLoaded = ref(false);
 let loadGeneration = 0;
 
 const site = computed(() => store.state.site);
@@ -115,6 +116,7 @@ async function load(): Promise<void> {
   const requestLocale = locale.value;
   loading.value = true;
   error.value = false;
+  feedLoaded.value = false;
   rawItems.value = [];
   try {
     const response = await showcaseOperator.list(undefined, requestLocale);
@@ -122,7 +124,10 @@ async function load(): Promise<void> {
   } catch {
     if (generation === loadGeneration) error.value = true;
   } finally {
-    if (generation === loadGeneration) loading.value = false;
+    if (generation === loadGeneration) {
+      loading.value = false;
+      feedLoaded.value = true;
+    }
   }
 }
 
@@ -144,13 +149,17 @@ function closeItem(): void {
   void router.push({ name: route.name as string, query });
 }
 
-watch([categoryType, availableServices], () => {
-  if (selectedService.value && !availableServices.value.some((item) => item.service === selectedService.value)) {
+watch([categoryType, availableServices, feedLoaded], () => {
+  if (
+    feedLoaded.value &&
+    selectedService.value &&
+    !availableServices.value.some((item) => item.service === selectedService.value)
+  ) {
     setService();
   }
 });
 watch([selectedItem, resolvedItems], () => {
-  if (route.query.showcase && !loading.value && !selectedItem.value) closeItem();
+  if (route.query.showcase && feedLoaded.value && !selectedItem.value) closeItem();
 });
 watch(locale, () => void load());
 onMounted(() => void load());


### PR DESCRIPTION
## Summary
- keep `?service=` and `?showcase=` deep links intact until the asynchronous Showcase feed finishes loading
- clear invalid filters only after the current locale feed reaches a terminal load state
- add a regression test for the direct-link race

## Production E2E evidence
After the Showcase rollout, direct URLs such as `/inspiration?service=kling` briefly saw an empty `availableServices` list and removed the filter before the feed returned. This made every service URL show the full gallery and route `Create similar` to the wrong generator.

## Verification
- focused Vitest: 4 passed
- `npm run lint:check` — no errors (2 pre-existing warnings)
- `npm run build:web` — passed
- `npm run verify` — passed

## Beachball
Includes a patch change file for `@acedatacloud/nexior`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)