### PR TITLE
fix(x402): route continuous setup through Backend

### DIFF
--- a/change/x402-continuous-relay-7f4d2a91.json
+++ b/change/x402-continuous-relay-7f4d2a91.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Route Solana continuous-payment setup through the authenticated Backend relay.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/application/ContinuousPaymentCard.vue
+++ b/src/components/application/ContinuousPaymentCard.vue
@@ -44,7 +44,6 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { Connection } from '@solana/web3.js';
 import { ElButton, ElInputNumber, ElMessage, ElRadioButton, ElRadioGroup } from 'element-plus';
 import { formatAtomicUsdc } from '@/operators/x402';
 import {
@@ -55,11 +54,6 @@ import {
   revokeContinuousPayment,
   selectContinuousPayment
 } from '@/utils/x402/continuousPayment';
-
-const connection = new Connection(
-  import.meta.env.VITE_SOLANA_RPC_URL || 'https://api.mainnet-beta.solana.com',
-  'confirmed'
-);
 
 export default defineComponent({
   name: 'ContinuousPaymentCard',
@@ -120,7 +114,6 @@ export default defineComponent({
         await enableContinuousPayment({
           token: this.token,
           walletApi,
-          connection,
           dailyLimitAtomic: String(Math.round(this.dailyLimit * 1_000_000)),
           expiryTs: Math.floor(Date.now() / 1000) + this.validDays * 86_400
         });
@@ -146,7 +139,7 @@ export default defineComponent({
       if (!this.token) return;
       this.busy = true;
       try {
-        await revokeContinuousPayment(this.token, walletApi, connection);
+        await revokeContinuousPayment(this.token, walletApi);
         this.method = 'confirm';
       } catch (error: any) {
         ElMessage.error(error?.response?.data?.detail || error?.message || String(error));

--- a/src/components/x402ContinuousPaymentContract.test.ts
+++ b/src/components/x402ContinuousPaymentContract.test.ts
@@ -20,6 +20,19 @@ describe('x402 continuous payment contract', () => {
     expect(helper).toContain("CONTINUOUS_PAYMENT_PROFILE = 'solana-recurring-delegation-v1'");
     expect(helper).not.toContain('localStorage');
     expect(helper).not.toContain('sessionStorage');
+    expect(helper).not.toContain('api.mainnet-beta.solana.com');
+    expect(helper).not.toContain('sendRawTransaction');
+    expect(helper).not.toContain('getAccountInfo');
+    expect(helper).not.toContain('wallet?.value?.adapter');
+    expect(helper).toContain('signTransaction?.value');
+    expect(helper).toContain('/transaction/prepare/');
+    expect(helper).toContain('/transaction/submit/');
+    expect(source('components/application/ContinuousPaymentCard.vue')).not.toContain('new Connection(');
+  });
+
+  it('does not use the legacy exemption header for continuous payment setup', () => {
+    expect(source('utils/x402/continuousPayment.ts')).not.toContain('x-record-exempt');
+    expect(source('operators/producer.ts')).toContain("'x-record-exempt': 'true'");
   });
 
   it('routes active Chat through the existing x402 host and preserves SSE', () => {

--- a/src/utils/x402/continuousPayment.test.ts
+++ b/src/utils/x402/continuousPayment.test.ts
@@ -1,23 +1,197 @@
-import { describe, expect, it } from 'vitest';
-import { recurringDelegationData, type SetupResponse } from './continuousPayment';
+import axios from 'axios';
+import { Keypair, Transaction } from '@solana/web3.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const setup = {
-  nonce: '72623859790382856',
-  daily_limit_atomic: '1234567',
-  period_seconds: 86400,
-  expiry_ts: 1_900_000_000
-} as SetupResponse;
+const { track } = vi.hoisted(() => ({ track: vi.fn() }));
+vi.mock('@/plugins/telemetry', () => ({ track }));
+vi.mock('axios');
 
-describe('Solana recurring delegation v0.4 encoding', () => {
-  it('encodes the frozen discriminator and little-endian field layout', () => {
-    const data = recurringDelegationData(setup, 42n);
-    expect(data).toHaveLength(49);
-    expect(data[0]).toBe(2);
-    expect(data.readBigUInt64LE(1)).toBe(72623859790382856n);
-    expect(data.readBigUInt64LE(9)).toBe(1234567n);
-    expect(data.readBigUInt64LE(17)).toBe(86400n);
-    expect(data.readBigInt64LE(25)).toBe(0n);
-    expect(data.readBigInt64LE(33)).toBe(1900000000n);
-    expect(data.readBigInt64LE(41)).toBe(42n);
+import { enableContinuousPayment } from './continuousPayment';
+
+const mockedAxios = vi.mocked(axios, true);
+
+function walletApi() {
+  const keypair = Keypair.generate();
+  const signTransaction = vi.fn(async (transaction: Transaction) => {
+    transaction.partialSign(keypair);
+    return transaction;
+  });
+  return {
+    keypair,
+    signTransaction,
+    api: {
+      publicKey: { value: keypair.publicKey },
+      signTransaction: { value: signTransaction }
+    }
+  };
+}
+
+function unsignedTransaction(wallet: Keypair): string {
+  const transaction = new Transaction({
+    feePayer: wallet.publicKey,
+    recentBlockhash: Keypair.generate().publicKey.toBase58()
+  });
+  return Buffer.from(transaction.serialize({ requireAllSignatures: false, verifySignatures: false })).toString(
+    'base64'
+  );
+}
+
+describe('continuous payment Backend orchestration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('uses the public wallet signer and submits Backend-prepared transactions in order', async () => {
+    const wallet = walletApi();
+    mockedAxios.post
+      .mockResolvedValueOnce({
+        data: { setup_token: 'setup', wallet: wallet.keypair.publicKey.toBase58(), authority_init_id: null }
+      })
+      .mockResolvedValueOnce({ data: { action: 'init_authority', transaction: unsignedTransaction(wallet.keypair) } })
+      .mockResolvedValueOnce({ data: { signature: 'init', status: 'confirmed' } })
+      .mockResolvedValueOnce({
+        data: { action: 'create_delegation', transaction: unsignedTransaction(wallet.keypair) }
+      })
+      .mockResolvedValueOnce({ data: { signature: 'delegation', status: 'confirmed' } })
+      .mockResolvedValueOnce({ data: { authorization: { id: 'auth', state: 'active' } } });
+
+    const result = await enableContinuousPayment({
+      token: 'token',
+      walletApi: wallet.api,
+      dailyLimitAtomic: '100000',
+      expiryTs: 1_900_000_000
+    });
+
+    expect(result?.state).toBe('active');
+    expect(wallet.signTransaction).toHaveBeenCalledTimes(2);
+    expect(mockedAxios.post.mock.calls.map((call) => call[0])).toEqual([
+      '/api/v1/x402/payment-authorization/setup/',
+      '/api/v1/x402/payment-authorization/transaction/prepare/',
+      '/api/v1/x402/payment-authorization/transaction/submit/',
+      '/api/v1/x402/payment-authorization/transaction/prepare/',
+      '/api/v1/x402/payment-authorization/transaction/submit/',
+      '/api/v1/x402/payment-authorization/confirm/'
+    ]);
+    expect(track).toHaveBeenCalledWith('x402_continuous_payment_success', { action: 'enable:confirm' });
+  });
+
+  it('skips authority initialization when Backend reports an existing authority', async () => {
+    const wallet = walletApi();
+    mockedAxios.post
+      .mockResolvedValueOnce({
+        data: { setup_token: 'setup', wallet: wallet.keypair.publicKey.toBase58(), authority_init_id: 42 }
+      })
+      .mockResolvedValueOnce({
+        data: { action: 'create_delegation', transaction: unsignedTransaction(wallet.keypair) }
+      })
+      .mockResolvedValueOnce({ data: { signature: 'delegation', status: 'confirmed' } })
+      .mockResolvedValueOnce({ data: { authorization: { id: 'auth', state: 'active' } } });
+
+    await enableContinuousPayment({
+      token: 'token',
+      walletApi: wallet.api,
+      dailyLimitAtomic: '100000',
+      expiryTs: 1_900_000_000
+    });
+
+    expect(wallet.signTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it('polls status without rebroadcasting while confirmation is pending', async () => {
+    vi.useFakeTimers();
+    const wallet = walletApi();
+    mockedAxios.post
+      .mockResolvedValueOnce({
+        data: { setup_token: 'setup', wallet: wallet.keypair.publicKey.toBase58(), authority_init_id: 42 }
+      })
+      .mockResolvedValueOnce({
+        data: { action: 'create_delegation', transaction: unsignedTransaction(wallet.keypair) }
+      })
+      .mockResolvedValueOnce({ data: { signature: 'delegation', status: 'pending' } })
+      .mockResolvedValueOnce({ data: { signature: 'delegation', status: 'confirmed' } })
+      .mockResolvedValueOnce({ data: { authorization: { id: 'auth', state: 'active' } } });
+
+    const pending = enableContinuousPayment({
+      token: 'token',
+      walletApi: wallet.api,
+      dailyLimitAtomic: '100000',
+      expiryTs: 1_900_000_000
+    });
+    await vi.runAllTimersAsync();
+    await pending;
+    vi.useRealTimers();
+
+    expect(wallet.signTransaction).toHaveBeenCalledTimes(1);
+    const submitCalls = mockedAxios.post.mock.calls.filter(
+      (call) => call[0] === '/api/v1/x402/payment-authorization/transaction/submit/'
+    );
+    const statusCalls = mockedAxios.post.mock.calls.filter(
+      (call) => call[0] === '/api/v1/x402/payment-authorization/transaction/status/'
+    );
+    expect(submitCalls).toHaveLength(1);
+    expect(statusCalls).toHaveLength(1);
+    expect(statusCalls[0][1]).toEqual({ setup_token: 'setup', action: 'create_delegation' });
+  });
+
+  it('resumes a pending Backend challenge without signing a new transaction', async () => {
+    vi.useFakeTimers();
+    const wallet = walletApi();
+    mockedAxios.post
+      .mockResolvedValueOnce({
+        data: {
+          setup_token: 'resumed',
+          wallet: wallet.keypair.publicKey.toBase58(),
+          authority_init_id: 42,
+          transactions: { create_delegation: { signature: 'existing', status: 'pending' } }
+        }
+      })
+      .mockResolvedValueOnce({ data: { signature: 'existing', status: 'confirmed' } })
+      .mockResolvedValueOnce({ data: { authorization: { id: 'auth', state: 'active' } } });
+
+    const resumed = enableContinuousPayment({
+      token: 'token',
+      walletApi: wallet.api,
+      dailyLimitAtomic: '100000',
+      expiryTs: 1_900_000_000
+    });
+    await vi.runAllTimersAsync();
+    await resumed;
+    vi.useRealTimers();
+
+    expect(wallet.signTransaction).not.toHaveBeenCalled();
+    expect(mockedAxios.post.mock.calls.map((call) => call[0])).toEqual([
+      '/api/v1/x402/payment-authorization/setup/',
+      '/api/v1/x402/payment-authorization/transaction/status/',
+      '/api/v1/x402/payment-authorization/confirm/'
+    ]);
+  });
+
+  it('does not confirm after signing or submission fails', async () => {
+    const wallet = walletApi();
+    wallet.signTransaction.mockRejectedValueOnce(new Error('user rejected'));
+    mockedAxios.post
+      .mockResolvedValueOnce({
+        data: { setup_token: 'setup', wallet: wallet.keypair.publicKey.toBase58(), authority_init_id: 42 }
+      })
+      .mockResolvedValueOnce({
+        data: { action: 'create_delegation', transaction: unsignedTransaction(wallet.keypair) }
+      });
+
+    await expect(
+      enableContinuousPayment({
+        token: 'token',
+        walletApi: wallet.api,
+        dailyLimitAtomic: '100000',
+        expiryTs: 1_900_000_000
+      })
+    ).rejects.toThrow('user rejected');
+
+    expect(mockedAxios.post.mock.calls.some((call) => call[0] === '/api/v1/x402/payment-authorization/confirm/')).toBe(
+      false
+    );
+    expect(track).toHaveBeenCalledWith(
+      'x402_continuous_payment_failed',
+      expect.objectContaining({ action: 'enable', error: 'Error' })
+    );
   });
 });

--- a/src/utils/x402/continuousPayment.ts
+++ b/src/utils/x402/continuousPayment.ts
@@ -1,8 +1,9 @@
 import axios from 'axios';
 import { Buffer } from 'buffer';
-import { PublicKey, SystemProgram, Transaction, TransactionInstruction, type Connection } from '@solana/web3.js';
+import { Transaction } from '@solana/web3.js';
 import { reactive } from 'vue';
 import { BASE_URL_PLATFORM } from '@/constants';
+import { track } from '@/plugins/telemetry';
 
 export const CONTINUOUS_PAYMENT_PROFILE = 'solana-recurring-delegation-v1';
 export const CONTINUOUS_PAYMENT_HEADER = 'X-X402-Authorization';
@@ -23,19 +24,25 @@ export interface ContinuousPaymentAuthorization {
 
 export interface SetupResponse {
   setup_token: string;
-  program_id: string;
-  asset: string;
-  token_program: string;
   wallet: string;
-  source_token_account: string;
-  subscription_authority: string;
-  delegatee: string;
-  nonce: string;
-  daily_limit_atomic: string;
-  period_seconds: number;
-  expiry_ts: number;
-  memo: string;
+  authority_init_id?: number | null;
+  transactions?: Partial<Record<TransactionAction, SubmittedTransaction>>;
 }
+
+interface PreparedTransaction {
+  action: TransactionAction;
+  transaction: string;
+  last_valid_block_height: number;
+  authority_init_id?: number | null;
+  delegation?: string | null;
+}
+
+interface SubmittedTransaction {
+  signature: string;
+  status: 'pending' | 'confirmed' | 'failed';
+}
+
+type TransactionAction = 'init_authority' | 'create_delegation' | 'revoke_delegation';
 
 const state = reactive<{ authorization?: ContinuousPaymentAuthorization; selected: boolean }>({ selected: false });
 
@@ -56,182 +63,205 @@ export function continuousPaymentHeaders(token?: string): Record<string, string>
   return { authorization: `Bearer ${token}`, [CONTINUOUS_PAYMENT_HEADER]: CONTINUOUS_PAYMENT_PROFILE };
 }
 
+function headers(token: string) {
+  return { authorization: `Bearer ${token}` };
+}
+
+function errorCode(error: any): string {
+  return String(error?.response?.data?.code || error?.response?.data?.detail || error?.name || 'unknown').slice(0, 120);
+}
+
+function traceId(error: any): string | undefined {
+  return error?.response?.data?.trace_id || error?.response?.headers?.['x-request-id'];
+}
+
+function event(name: string, action: string, error?: any) {
+  track(name, {
+    action,
+    ...(error ? { error: errorCode(error), trace_id: traceId(error) } : {})
+  });
+}
+
 export async function refreshContinuousPaymentAuthorization(token?: string) {
   const response = await axios.get<{ authorization?: ContinuousPaymentAuthorization }>(
     '/api/v1/x402/payment-authorization/',
-    { baseURL: BASE_URL_PLATFORM, headers: token ? { authorization: `Bearer ${token}` } : {} }
+    { baseURL: BASE_URL_PLATFORM, headers: token ? headers(token) : {} }
   );
   state.authorization = response.data.authorization;
   return state.authorization;
 }
 
-function instruction(
-  programId: string,
-  keys: Array<{ pubkey: string; isSigner: boolean; isWritable: boolean }>,
-  data: Uint8Array
+function walletSigner(walletApi: any) {
+  const wallet = walletApi?.publicKey?.value?.toBase58?.();
+  const signTransaction = walletApi?.signTransaction?.value;
+  if (!wallet || typeof signTransaction !== 'function') throw new Error('Connect a Solana wallet first');
+  return { wallet, signTransaction };
+}
+
+async function signPreparedTransaction(walletApi: any, encoded: string): Promise<string> {
+  const { signTransaction } = walletSigner(walletApi);
+  const transaction = Transaction.from(Buffer.from(encoded, 'base64'));
+  const signed = await signTransaction(transaction);
+  return Buffer.from(signed.serialize()).toString('base64');
+}
+
+async function prepare(token: string, setupToken: string, action: TransactionAction): Promise<PreparedTransaction> {
+  return (
+    await axios.post<PreparedTransaction>(
+      '/api/v1/x402/payment-authorization/transaction/prepare/',
+      { setup_token: setupToken, action },
+      { baseURL: BASE_URL_PLATFORM, headers: headers(token) }
+    )
+  ).data;
+}
+
+async function submit(
+  token: string,
+  setupToken: string,
+  action: TransactionAction,
+  signedTransaction: string
+): Promise<SubmittedTransaction> {
+  return (
+    await axios.post<SubmittedTransaction>(
+      '/api/v1/x402/payment-authorization/transaction/submit/',
+      { setup_token: setupToken, action, signed_transaction: signedTransaction },
+      { baseURL: BASE_URL_PLATFORM, headers: headers(token) }
+    )
+  ).data;
+}
+
+async function status(token: string, setupToken: string, action: TransactionAction): Promise<SubmittedTransaction> {
+  return (
+    await axios.post<SubmittedTransaction>(
+      '/api/v1/x402/payment-authorization/transaction/status/',
+      { setup_token: setupToken, action },
+      { baseURL: BASE_URL_PLATFORM, headers: headers(token) }
+    )
+  ).data;
+}
+
+async function waitForConfirmation(
+  token: string,
+  setupToken: string,
+  action: TransactionAction,
+  initial: SubmittedTransaction
 ) {
-  return new TransactionInstruction({
-    programId: new PublicKey(programId),
-    keys: keys.map((key) => ({ ...key, pubkey: new PublicKey(key.pubkey) })),
-    data: Buffer.from(data)
-  });
+  let result = initial;
+  for (let attempt = 0; result.status === 'pending' && attempt < 30; attempt += 1) {
+    await new Promise((resolve) => globalThis.setTimeout(resolve, 2_000));
+    result = await status(token, setupToken, action);
+  }
+  if (result.status === 'confirmed') return result;
+  throw new Error(`Transaction ${result.status}; retry to resume setup`);
 }
 
-async function signAndSend(adapter: any, connection: Connection, transaction: Transaction) {
-  const { blockhash, lastValidBlockHeight } = await connection.getLatestBlockhash('confirmed');
-  transaction.recentBlockhash = blockhash;
-  transaction.lastValidBlockHeight = lastValidBlockHeight;
-  transaction.feePayer = adapter.publicKey;
-  const signed = await adapter.signTransaction(transaction);
-  const signature = await connection.sendRawTransaction(signed.serialize());
-  await connection.confirmTransaction({ signature, blockhash, lastValidBlockHeight }, 'confirmed');
-  return signature;
-}
-
-function authorityInitId(data: Buffer) {
-  if (data.length < 106 || data[0] !== 0) throw new Error('Invalid subscription authority account');
-  return data.readBigInt64LE(98);
-}
-
-export function recurringDelegationData(setup: SetupResponse, initId: bigint) {
-  const data = Buffer.alloc(49);
-  data[0] = 2;
-  data.writeBigUInt64LE(BigInt(setup.nonce), 1);
-  data.writeBigUInt64LE(BigInt(setup.daily_limit_atomic), 9);
-  data.writeBigUInt64LE(BigInt(setup.period_seconds), 17);
-  data.writeBigInt64LE(0n, 25);
-  data.writeBigInt64LE(BigInt(setup.expiry_ts), 33);
-  data.writeBigInt64LE(initId, 41);
-  return data;
-}
-
-function memoInstruction(memo: string) {
-  return new TransactionInstruction({
-    programId: new PublicKey('MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr'),
-    keys: [],
-    data: Buffer.from(memo, 'utf8')
-  });
+async function signAndSubmit(
+  token: string,
+  setupToken: string,
+  action: TransactionAction,
+  walletApi: any,
+  existing?: SubmittedTransaction
+) {
+  if (existing) return waitForConfirmation(token, setupToken, action, existing);
+  event('x402_continuous_payment_submit', `${action}:prepare`);
+  const prepared = await prepare(token, setupToken, action);
+  event('x402_continuous_payment_submit', `${action}:sign`);
+  const signed = await signPreparedTransaction(walletApi, prepared.transaction);
+  event('x402_continuous_payment_submit', `${action}:submit`);
+  const result = await submit(token, setupToken, action, signed);
+  return waitForConfirmation(token, setupToken, action, result);
 }
 
 export async function enableContinuousPayment(options: {
   token: string;
   walletApi: any;
-  connection: Connection;
   dailyLimitAtomic: string;
   expiryTs: number;
 }) {
-  const adapter = options.walletApi?.wallet?.value?.adapter;
-  const wallet = options.walletApi?.publicKey?.value?.toBase58?.();
-  if (!adapter?.signTransaction || !adapter.publicKey || !wallet) throw new Error('Connect a Solana wallet first');
-  const setup = (
-    await axios.post<SetupResponse>(
-      '/api/v1/x402/payment-authorization/setup/',
-      { wallet, daily_limit_atomic: options.dailyLimitAtomic, expiry_ts: options.expiryTs },
-      { baseURL: BASE_URL_PLATFORM, headers: { authorization: `Bearer ${options.token}` } }
-    )
-  ).data;
-
-  let setupTx: string | undefined;
-  let authorityInfo = await options.connection.getAccountInfo(new PublicKey(setup.subscription_authority), 'confirmed');
-  if (!authorityInfo) {
-    const init = instruction(
-      setup.program_id,
-      [
-        { pubkey: setup.wallet, isSigner: true, isWritable: true },
-        { pubkey: setup.subscription_authority, isSigner: false, isWritable: true },
-        { pubkey: setup.asset, isSigner: false, isWritable: false },
-        { pubkey: setup.source_token_account, isSigner: false, isWritable: true },
-        { pubkey: SystemProgram.programId.toBase58(), isSigner: false, isWritable: false },
-        { pubkey: setup.token_program, isSigner: false, isWritable: false }
-      ],
-      Buffer.from([0])
+  const { wallet } = walletSigner(options.walletApi);
+  try {
+    event('x402_continuous_payment_submit', 'enable:setup');
+    const setup = (
+      await axios.post<SetupResponse>(
+        '/api/v1/x402/payment-authorization/setup/',
+        { wallet, daily_limit_atomic: options.dailyLimitAtomic, expiry_ts: options.expiryTs },
+        { baseURL: BASE_URL_PLATFORM, headers: headers(options.token) }
+      )
+    ).data;
+    if (setup.authority_init_id == null) {
+      await signAndSubmit(
+        options.token,
+        setup.setup_token,
+        'init_authority',
+        options.walletApi,
+        setup.transactions?.init_authority
+      );
+    }
+    await signAndSubmit(
+      options.token,
+      setup.setup_token,
+      'create_delegation',
+      options.walletApi,
+      setup.transactions?.create_delegation
     );
-    setupTx = await signAndSend(adapter, options.connection, new Transaction().add(init));
-    authorityInfo = await options.connection.getAccountInfo(new PublicKey(setup.subscription_authority), 'confirmed');
+    const confirmed = await axios.post<{ authorization: ContinuousPaymentAuthorization }>(
+      '/api/v1/x402/payment-authorization/confirm/',
+      { setup_token: setup.setup_token },
+      { baseURL: BASE_URL_PLATFORM, headers: headers(options.token) }
+    );
+    state.authorization = confirmed.data.authorization;
+    event('x402_continuous_payment_success', 'enable:confirm');
+    return state.authorization;
+  } catch (error) {
+    event('x402_continuous_payment_failed', 'enable', error);
+    throw error;
   }
-  if (!authorityInfo) throw new Error('Subscription authority was not created');
-  const initId = authorityInitId(authorityInfo.data);
-  const nonceBytes = Buffer.alloc(8);
-  nonceBytes.writeBigUInt64LE(BigInt(setup.nonce));
-  const [delegation] = PublicKey.findProgramAddressSync(
-    [
-      Buffer.from('delegation'),
-      new PublicKey(setup.subscription_authority).toBuffer(),
-      new PublicKey(setup.wallet).toBuffer(),
-      new PublicKey(setup.delegatee).toBuffer(),
-      nonceBytes
-    ],
-    new PublicKey(setup.program_id)
-  );
-  const data = recurringDelegationData(setup, initId);
-  const create = instruction(
-    setup.program_id,
-    [
-      { pubkey: setup.wallet, isSigner: true, isWritable: true },
-      { pubkey: setup.subscription_authority, isSigner: false, isWritable: false },
-      { pubkey: delegation.toBase58(), isSigner: false, isWritable: true },
-      { pubkey: setup.delegatee, isSigner: false, isWritable: false },
-      { pubkey: SystemProgram.programId.toBase58(), isSigner: false, isWritable: false }
-    ],
-    data
-  );
-  const delegationTx = await signAndSend(
-    adapter,
-    options.connection,
-    new Transaction().add(create, memoInstruction(setup.memo))
-  );
-  const confirmed = await axios.post<{ authorization: ContinuousPaymentAuthorization }>(
-    '/api/v1/x402/payment-authorization/confirm/',
-    {
-      setup_token: setup.setup_token,
-      setup_tx: setupTx,
-      delegation: delegation.toBase58(),
-      delegation_tx: delegationTx
-    },
-    { baseURL: BASE_URL_PLATFORM, headers: { authorization: `Bearer ${options.token}` } }
-  );
-  state.authorization = confirmed.data.authorization;
-  return state.authorization;
 }
 
 export async function enableExistingContinuousPayment(token: string) {
   const response = await axios.post<{ authorization: ContinuousPaymentAuthorization }>(
     '/api/v1/x402/payment-authorization/enable/',
     {},
-    { baseURL: BASE_URL_PLATFORM, headers: { authorization: `Bearer ${token}` } }
+    { baseURL: BASE_URL_PLATFORM, headers: headers(token) }
   );
   state.authorization = response.data.authorization;
+  return state.authorization;
 }
 
 export async function disableContinuousPayment(token: string) {
   const response = await axios.post<{ authorization: ContinuousPaymentAuthorization }>(
     '/api/v1/x402/payment-authorization/disable/',
     {},
-    { baseURL: BASE_URL_PLATFORM, headers: { authorization: `Bearer ${token}` } }
+    { baseURL: BASE_URL_PLATFORM, headers: headers(token) }
   );
   state.authorization = response.data.authorization;
+  return state.authorization;
 }
 
-export async function revokeContinuousPayment(token: string, walletApi: any, connection: Connection) {
-  if (!state.authorization) return;
-  const adapter = walletApi?.wallet?.value?.adapter;
-  if (!adapter?.signTransaction || !adapter.publicKey) throw new Error('Connect the authorized Solana wallet first');
-  if (adapter.publicKey.toBase58() !== state.authorization.wallet) {
+export async function revokeContinuousPayment(token: string, walletApi: any) {
+  const { wallet } = walletSigner(walletApi);
+  if (!state.authorization || wallet !== state.authorization.wallet) {
     throw new Error('Connect the wallet that created this authorization');
   }
-  const revoke = instruction(
-    'De1egAFMkMWZSN5rYXRj9CAdheBamobVNubTsi9avR44',
-    [
-      { pubkey: state.authorization.wallet, isSigner: true, isWritable: false },
-      { pubkey: state.authorization.delegation, isSigner: false, isWritable: true }
-    ],
-    Buffer.from([3])
-  );
-  const revokedTx = await signAndSend(adapter, connection, new Transaction().add(revoke));
-  const response = await axios.post<{ authorization: ContinuousPaymentAuthorization }>(
-    '/api/v1/x402/payment-authorization/revoke-confirm/',
-    { revoked_tx: revokedTx },
-    { baseURL: BASE_URL_PLATFORM, headers: { authorization: `Bearer ${token}` } }
-  );
-  state.authorization = response.data.authorization;
+  try {
+    const setup = (
+      await axios.post<SetupResponse>(
+        '/api/v1/x402/payment-authorization/revoke-setup/',
+        {},
+        { baseURL: BASE_URL_PLATFORM, headers: headers(token) }
+      )
+    ).data;
+    await signAndSubmit(token, setup.setup_token, 'revoke_delegation', walletApi);
+    const response = await axios.post<{ authorization: ContinuousPaymentAuthorization }>(
+      '/api/v1/x402/payment-authorization/revoke-confirm/',
+      { setup_token: setup.setup_token },
+      { baseURL: BASE_URL_PLATFORM, headers: headers(token) }
+    );
+    state.authorization = response.data.authorization;
+    event('x402_continuous_payment_success', 'revoke:confirm');
+    return state.authorization;
+  } catch (error) {
+    event('x402_continuous_payment_failed', 'revoke', error);
+    throw error;
+  }
 }


### PR DESCRIPTION
## Problem
Studio continuous-payment setup directly queried and broadcast through `api.mainnet-beta.solana.com`, which returned browser RPC 403s before wallet signing. The helper also reached into wallet-adapter internals and caught the error without reporting it to RUM.

## Changes
- remove browser `Connection`, account lookup, blockhash, broadcast, and confirmation calls
- consume Backend-prepared canonical transactions and sign them through `solana-wallets-vue` public `signTransaction.value`
- submit signed bytes to the authenticated Backend relay for init, delegation creation, and revoke
- retain `X-X402-Authorization: solana-recurring-delegation-v1` for fixed-price and Chat requests
- add sanitized stage telemetry without tokens, signatures, transactions, or full wallet/PDA values
- preserve existing non-x402 `x-record-exempt` declarations; continuous-payment setup itself does not use the header
- add a patch Beachball entry and regression guards against public RPC/private adapter regressions

## Validation
- full unit suite — 223 files / 1,659 tests passed
- focused continuous/x402/Chat suite — 20 passed
- `npm run lint:check` — 0 errors, 2 pre-existing warnings
- `npx vue-tsc -b --pretty false`
- `npm run build:web`
- `npm run build:electron` + `npm run compile:electron`
- i18n coverage — 11 locales × 49 namespaces, no placeholders
- `npm run verify`

Local environment used Node 24 while the project declares Node 22.x; CI Node 22 is authoritative.

## Dependencies / release order
1. Plan: https://github.com/AceDataCloud/Index/pull/391
2. Gateway billing security: https://github.com/AceDataCloud/PlatformGateway/pull/273
3. Backend durable transaction relay: https://github.com/AceDataCloud/PlatformBackend/pull/1567
4. Gateway selector transport: https://github.com/AceDataCloud/PlatformGateway/pull/271 plus manual TSE custom-auth 0.14.0 activation

No wallet signature, transaction broadcast, authorization, or payment was performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 🤖 对抗评审（Codex，2 个有效轮次）
- RISK: Backend同步确认占用worker → 已修：submit一次，2秒间隔status轮询，不重复广播/签名。
- RISK: 并发prepare覆盖签名 → Backend按action不可变；客户端复用返回结果。
- RISK: pending后丢弃setup → 已修：再次点击恢复Backend同challenge，pending只走status，confirmed继续confirm。
- focused continuous suite 20项通过；第3轮Codex因transport超时未产出结论。

