### PR TITLE
fix: accept curated music generate actions

### DIFF
--- a/change/showcase-suno-action-7d1a6b2c.json
+++ b/change/showcase-suno-action-7d1a6b2c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Accept validated generate actions when recreating curated Suno and Producer showcases.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/utils/showcaseRecreate.test.ts
+++ b/src/utils/showcaseRecreate.test.ts
@@ -81,7 +81,7 @@ describe('showcase recreate consumer', () => {
     ['kling', { prompt: 'Rain', mode: 'std' }, 'mode'],
     ['veo', { prompt: 'Flower', translation: false }, 'translation'],
     ['grokvideo', { prompt: 'City', resolution: '720p' }, 'resolution'],
-    ['suno', { prompt: 'Nocturne', instrumental: true }, 'instrumental'],
+    ['suno', { action: 'generate', prompt: 'Nocturne', instrumental: true }, 'instrumental'],
     ['producer', { prompt: 'Dream pop', style: 'Dream pop' }, 'style'],
     ['fish', { text: 'Welcome', format: 'mp3', speed: 1 }, 'format']
   ])(
@@ -175,6 +175,16 @@ describe('showcase recreate consumer', () => {
       'suno/setConfig',
       expect.objectContaining({ title: 'Open Window', lyric: '[Verse]\nMorning light' })
     );
+  });
+
+  it('rejects non-generate music actions', async () => {
+    vi.mocked(showcaseOperator.list).mockResolvedValue({
+      data: [item('suno', { action: 'extend', prompt: 'Continue this song' })]
+    } as any);
+    const { options, commit } = context('suno');
+    expect(await consumeShowcase(options)).toBe('failed');
+    expect(commit).not.toHaveBeenCalled();
+    expect(ElMessage.warning).toHaveBeenCalled();
   });
 
   it('chooses Veo image-to-video when curated images are present', async () => {

--- a/src/utils/showcaseRecreate.ts
+++ b/src/utils/showcaseRecreate.ts
@@ -115,7 +115,7 @@ const videoAllowed = new Set([
   'translation',
   'cfg_scale'
 ]);
-const musicAllowed = new Set(['prompt', 'lyric', 'style', 'title', 'instrumental', 'custom', 'model']);
+const musicAllowed = new Set(['action', 'prompt', 'lyric', 'style', 'title', 'instrumental', 'custom', 'model']);
 
 const adapters: Partial<Record<CapabilityKey, Adapter>> = {
   nanobanana: {
@@ -315,6 +315,8 @@ function validateItem(
     throw new Error('unsupported action');
   if (capability === 'seedream' && 'watermark' in request && request.watermark !== false)
     throw new Error('unsupported watermark');
+  if ((capability === 'suno' || capability === 'producer') && 'action' in request && request.action !== 'generate')
+    throw new Error('unsupported action');
   return { adapter, patch: adapter.build(request) };
 }
 


### PR DESCRIPTION
## Summary
- allow the `action` field in curated Suno and Producer Showcase snapshots
- accept only `action: generate`; continue rejecting extend/cover/other replay modes
- cover production-shaped music snapshots and malicious non-generate actions

## Production E2E evidence
The new Suno Showcase detail rendered correctly, but `Create similar` showed “精选作品暂时不可用”. The backend manifest correctly allows `action: generate`; Nexior's music allowlist omitted the field and rejected the otherwise safe snapshot. Kling, Veo, Grok and Fish presets passed.

## Verification
- `vitest run src/utils/showcaseRecreate.test.ts` — 25 passed
- `npm run lint:check` — no errors (2 pre-existing warnings)
- `npm run build:web` — passed
- includes patch Beachball change

🤖 Generated with [Claude Code](https://claude.com/claude-code)