### PR TITLE
fix: restore white-label connector auth sessions

### DIFF
--- a/change/connector-auth-sso-handoff-8d3f1a27.json
+++ b/change/connector-auth-sso-handoff-8d3f1a27.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Restore white-label sessions and branding before opening Auth-hosted Connector authorization pages.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/pages/chat/Conversation.vue
+++ b/src/pages/chat/Conversation.vue
@@ -135,6 +135,7 @@ import Layout from '@/layouts/Chat.vue';
 import { isImageUrl } from '@/utils/is';
 import { supportsClientTools, isDesktop, isWeb } from '@/utils/surface';
 import { openAuthorizeFlow } from '@/utils/connections/authorizeFlow';
+import { withAuthFrontendSession } from '@/utils/authHandoff';
 import { ensureLoggedIn } from '@/utils/login';
 import { localExec, type LocalToolSpec } from '@/utils/desktop';
 import { getBaseUrlPlatform } from '@/utils';
@@ -1331,7 +1332,7 @@ export default defineComponent({
       if (isWeb()) {
         // `return_to` navigates the tab back here, so a full-page hop is
         // still the right shape on web.
-        window.location.href = target;
+        window.location.href = await withAuthFrontendSession(target);
         return;
       }
       // On native/desktop that same hop leaves the app shell for good: the

--- a/src/utils/authAccount.ts
+++ b/src/utils/authAccount.ts
@@ -1,39 +1,17 @@
 import { Browser } from '@capacitor/browser';
-import { authOperator } from '@/operators/auth';
 import { getBaseUrlAuth } from './baseUrl';
-import { withCurrentSite } from './crossSiteUser';
 import { isNative } from './surface';
-
-const buildAuthLoginUrl = (path: string): string => {
-  const accountUrl = new URL(withCurrentSite(new URL(path, getBaseUrlAuth()).toString()));
-  const redirect = `${accountUrl.pathname}${accountUrl.search}${accountUrl.hash}`;
-  const url = new URL('/auth/login/', getBaseUrlAuth());
-  url.searchParams.set('redirect', redirect);
-  return withCurrentSite(url.toString());
-};
+import { withAuthFrontendSession } from './authHandoff';
 
 export const openAuthAccountPage = async (path: string): Promise<void> => {
-  const fallbackUrl = buildAuthLoginUrl(path);
+  const targetUrl = new URL(path, getBaseUrlAuth()).toString();
   const targetWindow = isNative() ? null : window.open('about:blank', '_blank');
-  try {
-    const { data } = await authOperator.getCode();
-    const url = new URL(fallbackUrl);
-    url.searchParams.set('code', data.code);
-    if (isNative()) {
-      await Browser.open({ url: url.toString() });
-    } else if (targetWindow) {
-      targetWindow.location.replace(url.toString());
-    } else {
-      window.location.href = url.toString();
-    }
-  } catch (error) {
-    console.warn('failed to open Auth account page with SSO', error);
-    if (isNative()) {
-      await Browser.open({ url: fallbackUrl });
-    } else if (targetWindow) {
-      targetWindow.location.replace(fallbackUrl);
-    } else {
-      window.location.href = fallbackUrl;
-    }
+  const handoffUrl = await withAuthFrontendSession(targetUrl);
+  if (isNative()) {
+    await Browser.open({ url: handoffUrl });
+  } else if (targetWindow) {
+    targetWindow.location.replace(handoffUrl);
+  } else {
+    window.location.href = handoffUrl;
   }
 };

--- a/src/utils/authHandoff.test.ts
+++ b/src/utils/authHandoff.test.ts
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const getCode = vi.hoisted(() => vi.fn());
+
+vi.mock('@/operators/auth', () => ({
+  authOperator: { getCode }
+}));
+vi.mock('./baseUrl', () => ({
+  getBaseUrlAuth: () => 'https://auth.acedata.cloud'
+}));
+vi.mock('./crossSiteUser', () => ({
+  withCurrentSite: (url: string) => {
+    const target = new URL(url);
+    target.searchParams.set('site', 'https://studio.worldai.chat');
+    return target.toString();
+  }
+}));
+
+import { buildAuthLoginUrl, isAuthFrontendUrl, withAuthFrontendSession } from './authHandoff';
+
+const AUTH_TARGET =
+  'https://auth.acedata.cloud/oauth2/authorize?client_id=serp&redirect_uri=https%3A%2F%2Fserp.example%2Fcallback#consent';
+
+describe('AuthFrontend session handoff', () => {
+  beforeEach(() => {
+    getCode.mockReset();
+  });
+
+  it('recognizes only the exact AuthFrontend origin', () => {
+    expect(isAuthFrontendUrl(AUTH_TARGET)).toBe(true);
+    expect(isAuthFrontendUrl('https://auth.acedata.cloud.evil.example/oauth2/authorize')).toBe(false);
+    expect(isAuthFrontendUrl('https://evil.example/?next=https://auth.acedata.cloud')).toBe(false);
+    expect(isAuthFrontendUrl('not a url')).toBe(false);
+  });
+
+  it('puts the white-label site on both the login page and its redirect target', () => {
+    const login = new URL(buildAuthLoginUrl(AUTH_TARGET));
+    const redirect = new URL(login.searchParams.get('redirect') || '', login.origin);
+
+    expect(login.pathname).toBe('/auth/login/');
+    expect(login.searchParams.get('site')).toBe('https://studio.worldai.chat');
+    expect(redirect.pathname).toBe('/oauth2/authorize');
+    expect(redirect.searchParams.get('client_id')).toBe('serp');
+    expect(redirect.searchParams.get('site')).toBe('https://studio.worldai.chat');
+    expect(redirect.hash).toBe('#consent');
+  });
+
+  it('adds a one-time SSO code before entering an Auth-hosted authorize page', async () => {
+    getCode.mockResolvedValue({ data: { code: 'single-use-code' } });
+
+    const login = new URL(await withAuthFrontendSession(AUTH_TARGET));
+
+    expect(getCode).toHaveBeenCalledOnce();
+    expect(login.searchParams.get('code')).toBe('single-use-code');
+  });
+
+  it('falls back to normal Auth login when code minting fails', async () => {
+    getCode.mockRejectedValue(new Error('expired session'));
+
+    const login = new URL(await withAuthFrontendSession(AUTH_TARGET));
+
+    expect(login.pathname).toBe('/auth/login/');
+    expect(login.searchParams.has('code')).toBe(false);
+    expect(login.searchParams.get('redirect')).toContain('/oauth2/authorize');
+  });
+
+  it('leaves external OAuth providers untouched without requesting a code', async () => {
+    const external = 'https://accounts.google.com/o/oauth2/auth?client_id=x';
+
+    await expect(withAuthFrontendSession(external)).resolves.toBe(external);
+    expect(getCode).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/authHandoff.ts
+++ b/src/utils/authHandoff.ts
@@ -1,0 +1,34 @@
+import { authOperator } from '@/operators/auth';
+import { getBaseUrlAuth } from './baseUrl';
+import { withCurrentSite } from './crossSiteUser';
+
+export function isAuthFrontendUrl(value: string): boolean {
+  try {
+    return new URL(value).origin === new URL(getBaseUrlAuth()).origin;
+  } catch {
+    return false;
+  }
+}
+
+export function buildAuthLoginUrl(targetUrl: string): string {
+  const target = new URL(withCurrentSite(targetUrl));
+  const redirect = `${target.pathname}${target.search}${target.hash}`;
+  const login = new URL('/auth/login/', getBaseUrlAuth());
+  login.searchParams.set('redirect', redirect);
+  return withCurrentSite(login.toString());
+}
+
+export async function withAuthFrontendSession(targetUrl: string): Promise<string> {
+  if (!isAuthFrontendUrl(targetUrl)) return targetUrl;
+
+  const fallbackUrl = buildAuthLoginUrl(targetUrl);
+  try {
+    const { data } = await authOperator.getCode();
+    const login = new URL(fallbackUrl);
+    login.searchParams.set('code', data.code);
+    return login.toString();
+  } catch (error) {
+    console.warn('failed to hand off session to AuthFrontend', error);
+    return fallbackUrl;
+  }
+}

--- a/src/utils/connections/authorizeFlow.test.ts
+++ b/src/utils/connections/authorizeFlow.test.ts
@@ -5,15 +5,23 @@ const surface = vi.hoisted(() => ({ isNative: vi.fn(() => false), isDesktop: vi.
 const capBrowser = vi.hoisted(() => ({ open: vi.fn(), addListener: vi.fn() }));
 const bridge = vi.hoisted(() => ({ desktopBridge: vi.fn() }));
 const popup = vi.hoisted(() => ({ openAuthorizePopup: vi.fn() }));
+const handoff = vi.hoisted(() => ({
+  isAuthFrontendUrl: vi.fn((url: string) => new URL(url).origin === 'https://auth.acedata.cloud'),
+  withAuthFrontendSession: vi.fn(
+    async (url: string) => `https://auth.acedata.cloud/auth/login/?redirect=${encodeURIComponent(url)}`
+  )
+}));
 
 vi.mock('../surface', () => surface);
 vi.mock('@capacitor/browser', () => ({ Browser: capBrowser }));
 vi.mock('../desktop', () => bridge);
 vi.mock('./authorizePopup', () => popup);
+vi.mock('../authHandoff', () => handoff);
 
 import { openAuthorizeFlow } from './authorizeFlow';
 
 const URL_UNDER_TEST = 'https://accounts.google.com/o/oauth2/auth?client_id=x';
+const AUTH_URL_UNDER_TEST = 'https://auth.acedata.cloud/oauth2/authorize?client_id=serp';
 
 /** A resolved `browserFinished` subscription, plus the callback it captured. */
 function stubBrowserFinished() {
@@ -31,6 +39,10 @@ describe('openAuthorizeFlow', () => {
     vi.clearAllMocks();
     surface.isNative.mockReturnValue(false);
     surface.isDesktop.mockReturnValue(false);
+    handoff.isAuthFrontendUrl.mockImplementation((url: string) => new URL(url).origin === 'https://auth.acedata.cloud');
+    handoff.withAuthFrontendSession.mockImplementation(
+      async (url: string) => `https://auth.acedata.cloud/auth/login/?redirect=${encodeURIComponent(url)}`
+    );
   });
 
   afterEach(() => {
@@ -42,6 +54,32 @@ describe('openAuthorizeFlow', () => {
       popup.openAuthorizePopup.mockReturnValue(Promise.resolve());
       await expect(openAuthorizeFlow(URL_UNDER_TEST)).resolves.toBeUndefined();
       expect(popup.openAuthorizePopup).toHaveBeenCalledWith(URL_UNDER_TEST);
+    });
+
+    it('pre-opens a blank popup while preparing an AuthFrontend session handoff', async () => {
+      let resolvePopup!: () => void;
+      popup.openAuthorizePopup.mockImplementation((target: Promise<string>) => {
+        expect(target).toBeInstanceOf(Promise);
+        void expect(target).resolves.toContain('/auth/login/');
+        return new Promise<void>((resolve) => {
+          resolvePopup = resolve;
+        });
+      });
+
+      const pending = openAuthorizeFlow(AUTH_URL_UNDER_TEST);
+      expect(popup.openAuthorizePopup).toHaveBeenCalledOnce();
+      expect(handoff.withAuthFrontendSession).toHaveBeenCalledWith(AUTH_URL_UNDER_TEST);
+      resolvePopup();
+      await pending;
+    });
+
+    it('does not prepare an AuthFrontend handoff for an external provider', async () => {
+      popup.openAuthorizePopup.mockReturnValue(Promise.resolve());
+
+      await openAuthorizeFlow(URL_UNDER_TEST);
+
+      expect(popup.openAuthorizePopup).toHaveBeenCalledWith(URL_UNDER_TEST);
+      expect(handoff.withAuthFrontendSession).not.toHaveBeenCalled();
     });
 
     it('falls back to a full-page navigation when the popup is blocked', async () => {
@@ -79,6 +117,19 @@ describe('openAuthorizeFlow', () => {
       // the href fallback would fire the same navigation a second time.
       expect(openSpy).not.toHaveBeenCalled();
       expect(popup.openAuthorizePopup).not.toHaveBeenCalled();
+    });
+
+    it('hands Auth-hosted authorization through the white-label SSO login', async () => {
+      const { finish } = stubBrowserFinished();
+      capBrowser.open.mockResolvedValue(undefined);
+
+      const pending = openAuthorizeFlow(AUTH_URL_UNDER_TEST);
+      await vi.waitFor(() =>
+        expect(capBrowser.open).toHaveBeenCalledWith({ url: expect.stringContaining('/auth/login/') })
+      );
+      expect(handoff.withAuthFrontendSession).toHaveBeenCalledWith(AUTH_URL_UNDER_TEST);
+      finish();
+      await pending;
     });
 
     it('stays pending until the user dismisses the browser', async () => {
@@ -133,6 +184,19 @@ describe('openAuthorizeFlow', () => {
 
       window.dispatchEvent(new Event('focus'));
       await vi.waitFor(() => expect(settled).toBe(true));
+    });
+
+    it('hands Auth-hosted authorization through the white-label SSO login', async () => {
+      const openAuthorizeConnector = vi.fn().mockResolvedValue(undefined);
+      bridge.desktopBridge.mockReturnValue({ openAuthorizeConnector });
+
+      const pending = openAuthorizeFlow(AUTH_URL_UNDER_TEST);
+      await vi.waitFor(() =>
+        expect(openAuthorizeConnector).toHaveBeenCalledWith(expect.stringContaining('/auth/login/'))
+      );
+      expect(handoff.withAuthFrontendSession).toHaveBeenCalledWith(AUTH_URL_UNDER_TEST);
+      window.dispatchEvent(new Event('focus'));
+      await pending;
     });
 
     it('throws on a desktop shell without the IPC instead of silently doing nothing', async () => {

--- a/src/utils/connections/authorizeFlow.ts
+++ b/src/utils/connections/authorizeFlow.ts
@@ -36,6 +36,7 @@
 import { Browser } from '@capacitor/browser';
 import { isNative, isDesktop } from '../surface';
 import { desktopBridge } from '../desktop';
+import { isAuthFrontendUrl, withAuthFrontendSession } from '../authHandoff';
 import { openAuthorizePopup } from './authorizePopup';
 
 /**
@@ -53,11 +54,12 @@ export async function openAuthorizeFlow(authorizationUrl: string): Promise<void>
 
 /** Web: popup, falling back to a full-page navigation when it's blocked. */
 async function openOnWeb(authorizationUrl: string): Promise<void> {
-  const pending = openAuthorizePopup(authorizationUrl);
+  const target = isAuthFrontendUrl(authorizationUrl) ? withAuthFrontendSession(authorizationUrl) : authorizationUrl;
+  const pending = openAuthorizePopup(target);
   if (!pending) {
     // Navigating away — this page is about to be replaced, so there is
     // nothing left to refresh.
-    window.location.href = authorizationUrl;
+    window.location.href = await target;
     return;
   }
   await pending;
@@ -79,7 +81,10 @@ async function openOnNative(authorizationUrl: string): Promise<void> {
         handle = h;
       });
     });
-    await Browser.open({ url: authorizationUrl });
+    const target = isAuthFrontendUrl(authorizationUrl)
+      ? await withAuthFrontendSession(authorizationUrl)
+      : authorizationUrl;
+    await Browser.open({ url: target });
     await finished;
   } catch (error) {
     // A browser that never opened has nothing to wait for; resolving lets the
@@ -108,6 +113,9 @@ async function openOnDesktop(authorizationUrl: string): Promise<void> {
   const returned = new Promise<void>((resolve) => {
     window.addEventListener('focus', () => resolve(), { once: true });
   });
-  await bridge.openAuthorizeConnector(authorizationUrl);
+  const target = isAuthFrontendUrl(authorizationUrl)
+    ? await withAuthFrontendSession(authorizationUrl)
+    : authorizationUrl;
+  await bridge.openAuthorizeConnector(target);
   await returned;
 }

--- a/src/utils/connections/authorizePopup.test.ts
+++ b/src/utils/connections/authorizePopup.test.ts
@@ -35,6 +35,38 @@ describe('openAuthorizePopup', () => {
     expect(openAuthorizePopup('https://provider.example/authorize')).toBeNull();
   });
 
+  it('opens a blank popup synchronously and replaces it when an async target resolves', async () => {
+    const replace = vi.fn();
+    const popup = { ...fakePopup(), location: { replace } };
+    openSpy = vi.spyOn(window, 'open').mockReturnValue(popup as unknown as Window);
+
+    let resolveTarget!: (url: string) => void;
+    const target = new Promise<string>((resolve) => {
+      resolveTarget = resolve;
+    });
+    const pending = openAuthorizePopup(target);
+
+    expect(window.open).toHaveBeenCalledWith('about:blank', 'acedata-connect', expect.any(String));
+    expect(replace).not.toHaveBeenCalled();
+    resolveTarget('https://auth.acedata.cloud/auth/login/?code=one-time');
+    await Promise.resolve();
+    expect(replace).toHaveBeenCalledWith('https://auth.acedata.cloud/auth/login/?code=one-time');
+
+    popup.closed = true;
+    await vi.advanceTimersByTimeAsync(600);
+    await expect(pending).resolves.toBeUndefined();
+  });
+
+  it('closes the blank popup if its async target cannot be prepared', async () => {
+    const popup = { ...fakePopup(), location: { replace: vi.fn() } };
+    openSpy = vi.spyOn(window, 'open').mockReturnValue(popup as unknown as Window);
+
+    openAuthorizePopup(Promise.reject(new Error('handoff failed')));
+    await Promise.resolve();
+
+    expect(popup.close).toHaveBeenCalledOnce();
+  });
+
   it('resolves once the popup closes', async () => {
     const popup = fakePopup();
     openSpy = vi.spyOn(window, 'open').mockReturnValue(popup as unknown as Window);

--- a/src/utils/connections/authorizePopup.ts
+++ b/src/utils/connections/authorizePopup.ts
@@ -37,9 +37,17 @@ const POPUP_FEATURES = 'popup=yes,width=600,height=760,noopener=no,noreferrer=no
  * a full-page redirect. Otherwise the promise resolves when the flow ends,
  * whatever the outcome — callers refetch rather than branch on it.
  */
-export function openAuthorizePopup(authorizationUrl: string): Promise<void> | null {
-  const popup = window.open(authorizationUrl, 'acedata-connect', POPUP_FEATURES);
+export function openAuthorizePopup(authorizationUrl: string | Promise<string>): Promise<void> | null {
+  const initialUrl = typeof authorizationUrl === 'string' ? authorizationUrl : 'about:blank';
+  const popup = window.open(initialUrl, 'acedata-connect', POPUP_FEATURES);
   if (!popup) return null;
+
+  if (typeof authorizationUrl !== 'string') {
+    void authorizationUrl.then(
+      (url) => popup.location.replace(url),
+      () => popup.close()
+    );
+  }
 
   return new Promise<void>((resolve) => {
     const timer = window.setInterval(() => {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -26,3 +26,4 @@ export * from './loginMethod';
 export * from './iap';
 export * from './servicePricing';
 export * from './authAccount';
+export * from './authHandoff';


### PR DESCRIPTION
## Summary

- hand AuthFrontend-hosted Connector authorization pages the current white-label user's session through a one-time SSO code
- preserve the white-label `site` context on both the Auth login page and the resumed authorization target
- pre-open web popups before minting the code, while keeping native and desktop authorization transports intact
- leave external OAuth provider URLs untouched and reuse the same handoff for Auth account pages and chat Connector install deep links

## Validation

- `npm run test:run -- src/utils/authHandoff.test.ts src/utils/authAccount.test.ts src/utils/connections/authorizeFlow.test.ts src/utils/connections/authorizePopup.test.ts` — 29 passed
- `npm run lint:check` — 0 errors; 2 pre-existing `vue/one-component-per-file` warnings in `dropUploadMixin.test.ts`
- `npm run build:web` — passed (`vue-tsc -b` + Vite production build)
- `npm run verify` — passed
- `git diff --check` — passed
- full `npm run test:run` — 1674 passed; one unrelated Electron shell session test timed out, then passed 24/24 when rerun in isolation

## Rollout / rollback

Frontend-only patch. Standard Nexior deployment applies the change. Roll back by reverting this PR; external provider OAuth URLs are not changed by the handoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)