### PR TITLE
perf: lazy load Home showcases

### DIFF
--- a/change/showcase-progressive-loading-5e8a3c1f.json
+++ b/change/showcase-progressive-loading-5e8a3c1f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Load Home showcases progressively and defer audio and video requests until media approaches the viewport.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/common/ShowcaseGrid.test.ts
+++ b/src/components/common/ShowcaseGrid.test.ts
@@ -73,9 +73,11 @@ describe('ShowcaseGrid', () => {
   it('renders posters, metadata-only previews, and create-similar links', () => {
     const { wrapper } = mountGrid();
     expect(wrapper.findAll('.showcase-card')).toHaveLength(2);
-    expect(wrapper.get('video').attributes()).toMatchObject({ preload: 'metadata', loop: '' });
+    expect(wrapper.get('video').attributes()).toMatchObject({ preload: 'none', loop: '' });
+    expect(wrapper.get('video').attributes('src')).toBeUndefined();
     expect((wrapper.get('video').element as HTMLVideoElement).muted).toBe(true);
-    expect(wrapper.get('audio').attributes('preload')).toBe('metadata');
+    expect(wrapper.get('audio').attributes('preload')).toBe('none');
+    expect(wrapper.get('audio').attributes('src')).toBeUndefined();
     expect(wrapper.findAll('.router-link')[0].text()).toContain('intro.home.showcase.createSimilar');
     expect(wrapper.find('.detail-trigger').exists()).toBe(false);
   });
@@ -110,6 +112,44 @@ describe('ShowcaseGrid', () => {
     expect(video.pause).toHaveBeenCalled();
   });
 
+  it('binds media sources only when cards approach the viewport and keeps them after exit', async () => {
+    let callback: IntersectionObserverCallback = () => undefined;
+    const observe = vi.fn();
+    class MockIntersectionObserver {
+      constructor(handler: IntersectionObserverCallback) {
+        callback = handler;
+      }
+      observe = observe;
+      unobserve = vi.fn();
+      disconnect = vi.fn();
+    }
+    vi.stubGlobal('IntersectionObserver', MockIntersectionObserver);
+    const { wrapper } = mountGrid();
+    const cards = wrapper.findAll('.showcase-card');
+    const video = wrapper.get('video');
+    expect(video.attributes('src')).toBeUndefined();
+
+    callback([{ isIntersecting: true, target: cards[0].element } as IntersectionObserverEntry], {} as any);
+    await wrapper.vm.$nextTick();
+    expect(video.attributes('src')).toBe('preview.mp4');
+    expect(video.attributes('preload')).toBe('metadata');
+
+    callback([{ isIntersecting: false, target: cards[0].element } as IntersectionObserverEntry], {} as any);
+    await wrapper.vm.$nextTick();
+    expect(video.attributes('src')).toBe('preview.mp4');
+  });
+
+  it('does not start a lazy preview after the pointer has already left', async () => {
+    const { wrapper, video } = mountGrid();
+    const card = wrapper.findAll('.showcase-card')[0];
+    const entering = card.trigger('mouseenter');
+    await card.trigger('mouseleave');
+    await entering;
+    await wrapper.vm.$nextTick();
+    await Promise.resolve();
+    expect(video.play).not.toHaveBeenCalled();
+  });
+
   it('falls back to the poster without removing the create-similar action', async () => {
     const { wrapper } = mountGrid();
     await wrapper.get('video').trigger('error');
@@ -127,8 +167,7 @@ describe('ShowcaseGrid', () => {
     expect(wrapper.findAll('.preview-button').length).toBeGreaterThan(0);
 
     await wrapper.findAll('.preview-button')[0].trigger('click');
-    await Promise.resolve();
+    await vi.waitFor(() => expect(wrapper.findAll('.showcase-card')[0].classes()).toContain('preview-playing'));
     expect(video.play).toHaveBeenCalled();
-    expect(wrapper.findAll('.showcase-card')[0].classes()).toContain('preview-playing');
   });
 });

--- a/src/components/common/ShowcaseGrid.vue
+++ b/src/components/common/ShowcaseGrid.vue
@@ -25,19 +25,19 @@
         <video
           v-if="item.mediaType === 'Video' && item.previewUrl && !failedMedia.has(item.id)"
           :ref="(element) => rememberMedia(item.id, element)"
-          :src="item.previewUrl"
+          :src="loadedMediaIds.has(item.id) ? item.previewUrl : undefined"
           muted
           loop
           playsinline
-          preload="metadata"
+          :preload="loadedMediaIds.has(item.id) ? 'metadata' : 'none'"
           :aria-label="$t('intro.home.showcase.preview', { title: item.title })"
           @error="onMediaError(item.id)"
         />
         <audio
           v-else-if="item.mediaType === 'Audio' && item.previewUrl && !failedMedia.has(item.id)"
           :ref="(element) => rememberMedia(item.id, element)"
-          :src="item.previewUrl"
-          preload="metadata"
+          :src="loadedMediaIds.has(item.id) ? item.previewUrl : undefined"
+          :preload="loadedMediaIds.has(item.id) ? 'metadata' : 'none'"
           loop
           @error="onMediaError(item.id)"
         />
@@ -77,7 +77,7 @@
 </template>
 
 <script setup lang="ts">
-import { onBeforeUnmount, onMounted, ref } from 'vue';
+import { nextTick, onBeforeUnmount, onMounted, ref } from 'vue';
 import type { ComponentPublicInstance } from 'vue';
 import type { ResolvedShowcase } from '@/models';
 
@@ -109,7 +109,9 @@ defineEmits<{ 'icon-error': [item: ResolvedShowcase]; select: [item: ResolvedSho
 const media = new Map<string, HTMLMediaElement>();
 const cards = new Map<string, HTMLElement>();
 const failedMedia = ref(new Set<string>());
+const loadedMediaIds = ref(new Set<string>());
 const playingId = ref<string>();
+const requestedPlayingId = ref<string>();
 const reducedMotion = ref(false);
 let motionQuery: MediaQueryList | undefined;
 let observer: IntersectionObserver | undefined;
@@ -128,7 +130,16 @@ function rememberMedia(id: string, element: Element | ComponentPublicInstance | 
   else media.delete(id);
 }
 
+async function ensureMediaLoaded(id: string): Promise<HTMLMediaElement | undefined> {
+  if (!loadedMediaIds.value.has(id)) {
+    loadedMediaIds.value = new Set(loadedMediaIds.value).add(id);
+    await nextTick();
+  }
+  return media.get(id);
+}
+
 function stopAll(except?: string): void {
+  if (!except) requestedPlayingId.value = undefined;
   for (const [id, element] of media) {
     if (id === except) continue;
     element.pause();
@@ -139,18 +150,22 @@ function stopAll(except?: string): void {
 
 async function startPreview(id: string, force = false): Promise<void> {
   if (reducedMotion.value && !force) return;
-  const element = media.get(id);
-  if (!element) return;
+  requestedPlayingId.value = id;
+  const element = await ensureMediaLoaded(id);
+  if (!element || requestedPlayingId.value !== id) return;
   stopAll(id);
   try {
     await element.play();
-    playingId.value = id;
+    if (requestedPlayingId.value === id) playingId.value = id;
+    else element.pause();
   } catch {
+    if (requestedPlayingId.value === id) requestedPlayingId.value = undefined;
     playingId.value = undefined;
   }
 }
 
 function stopPreview(id: string): void {
+  if (requestedPlayingId.value === id) requestedPlayingId.value = undefined;
   const element = media.get(id);
   element?.pause();
   if (element instanceof HTMLVideoElement) element.currentTime = 0;
@@ -188,13 +203,17 @@ onMounted(() => {
   motionQuery.addEventListener('change', onMotionChange);
   document.addEventListener('visibilitychange', onVisibility);
   if ('IntersectionObserver' in window) {
-    observer = new IntersectionObserver((entries) => {
-      for (const entry of entries) {
-        if (entry.isIntersecting) continue;
-        const id = [...cards].find(([, element]) => element === entry.target)?.[0];
-        if (id) stopPreview(id);
-      }
-    });
+    observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          const id = [...cards].find(([, element]) => element === entry.target)?.[0];
+          if (!id) continue;
+          if (entry.isIntersecting) loadedMediaIds.value = new Set(loadedMediaIds.value).add(id);
+          else stopPreview(id);
+        }
+      },
+      { rootMargin: '300px 0px' }
+    );
     for (const card of cards.values()) observer.observe(card);
   }
 });
@@ -206,7 +225,7 @@ onBeforeUnmount(() => {
   document.removeEventListener('visibilitychange', onVisibility);
 });
 
-defineExpose({ playingId, startPreview, stopPreview, togglePreview, reducedMotion });
+defineExpose({ playingId, loadedMediaIds, startPreview, stopPreview, togglePreview, reducedMotion });
 </script>
 
 <style lang="scss" scoped>

--- a/src/i18n/ar/intro.json
+++ b/src/i18n/ar/intro.json
@@ -658,5 +658,9 @@
   "inspiration.showLess": {
     "message": "طيّ البرومبت",
     "description": "收起精选作品的完整 Prompt"
+  },
+  "home.showcase.loadMore": {
+    "message": "تحميل المزيد",
+    "description": "زر تحميل المزيد من الأعمال المختارة"
   }
 }

--- a/src/i18n/de/intro.json
+++ b/src/i18n/de/intro.json
@@ -658,5 +658,9 @@
   "inspiration.showLess": {
     "message": "Prompt einklappen",
     "description": "收起精选作品的完整 Prompt"
+  },
+  "home.showcase.loadMore": {
+    "message": "Mehr laden",
+    "description": "Button zum Laden weiterer ausgewählter Werke"
   }
 }

--- a/src/i18n/en/intro.json
+++ b/src/i18n/en/intro.json
@@ -658,5 +658,9 @@
   "inspiration.showLess": {
     "message": "Collapse prompt",
     "description": "收起精选作品的完整 Prompt"
+  },
+  "home.showcase.loadMore": {
+    "message": "Load more",
+    "description": "Load more curated creations action"
   }
 }

--- a/src/i18n/es/intro.json
+++ b/src/i18n/es/intro.json
@@ -658,5 +658,9 @@
   "inspiration.showLess": {
     "message": "Contraer prompt",
     "description": "收起精选作品的完整 Prompt"
+  },
+  "home.showcase.loadMore": {
+    "message": "Cargar más",
+    "description": "Botón para cargar más obras seleccionadas"
   }
 }

--- a/src/i18n/fr/intro.json
+++ b/src/i18n/fr/intro.json
@@ -658,5 +658,9 @@
   "inspiration.showLess": {
     "message": "Réduire le prompt",
     "description": "收起精选作品的完整 Prompt"
+  },
+  "home.showcase.loadMore": {
+    "message": "Charger plus",
+    "description": "Bouton pour charger plus de sélections."
   }
 }

--- a/src/i18n/it/intro.json
+++ b/src/i18n/it/intro.json
@@ -658,5 +658,9 @@
   "inspiration.showLess": {
     "message": "Comprimi il prompt",
     "description": "收起精选作品的完整 Prompt"
+  },
+  "home.showcase.loadMore": {
+    "message": "Carica di più",
+    "description": "Pulsante per caricare più opere selezionate"
   }
 }

--- a/src/i18n/ja/intro.json
+++ b/src/i18n/ja/intro.json
@@ -658,5 +658,9 @@
   "inspiration.showLess": {
     "message": "プロンプトを折りたたむ",
     "description": "收起精选作品的完整 Prompt"
+  },
+  "home.showcase.loadMore": {
+    "message": "もっと読み込む",
+    "description": "もっと読み込む選ばれた作品のボタン"
   }
 }

--- a/src/i18n/ko/intro.json
+++ b/src/i18n/ko/intro.json
@@ -658,5 +658,9 @@
   "inspiration.showLess": {
     "message": "프롬프트 접기",
     "description": "收起精选作品的完整 Prompt"
+  },
+  "home.showcase.loadMore": {
+    "message": "더 보기",
+    "description": "더 많은 추천 작품을 로드하는 버튼"
   }
 }

--- a/src/i18n/pt/intro.json
+++ b/src/i18n/pt/intro.json
@@ -658,5 +658,9 @@
   "inspiration.showLess": {
     "message": "Recolher prompt",
     "description": "收起精选作品的完整 Prompt"
+  },
+  "home.showcase.loadMore": {
+    "message": "Carregar mais",
+    "description": "Botão para carregar mais obras selecionadas"
   }
 }

--- a/src/i18n/ru/intro.json
+++ b/src/i18n/ru/intro.json
@@ -658,5 +658,9 @@
   "inspiration.showLess": {
     "message": "Свернуть промпт",
     "description": "收起精选作品的完整 Prompt"
+  },
+  "home.showcase.loadMore": {
+    "message": "Загрузить больше",
+    "description": "Кнопка для загрузки дополнительных избранных работ"
   }
 }

--- a/src/i18n/zh-CN/intro.json
+++ b/src/i18n/zh-CN/intro.json
@@ -658,5 +658,9 @@
   "inspiration.showLess": {
     "message": "收起 Prompt",
     "description": "收起精选作品的完整 Prompt"
+  },
+  "home.showcase.loadMore": {
+    "message": "加载更多",
+    "description": "加载更多精选作品按钮"
   }
 }

--- a/src/i18n/zh-TW/intro.json
+++ b/src/i18n/zh-TW/intro.json
@@ -658,5 +658,9 @@
   "inspiration.showLess": {
     "message": "收合提示詞",
     "description": "收起精选作品的完整 Prompt"
+  },
+  "home.showcase.loadMore": {
+    "message": "加載更多",
+    "description": "加載更多精選作品按鈕"
   }
 }

--- a/src/pages/home/Index.test.ts
+++ b/src/pages/home/Index.test.ts
@@ -52,6 +52,7 @@ const mountHome = (site: Record<string, unknown>) =>
 
 describe('Studio workbench home', () => {
   beforeEach(() => {
+    vi.unstubAllGlobals();
     vi.mocked(showcaseOperator.list).mockResolvedValue({ data: [] } as any);
     vi.mocked(siteBannerOperator.getPublic).mockResolvedValue({ data: [] } as any);
   });
@@ -100,6 +101,75 @@ describe('Studio workbench home', () => {
     });
     await vi.waitFor(() => expect(showcaseOperator.list).toHaveBeenCalledWith(undefined, 'en'));
     expect(wrapper.getComponent({ name: 'ShowcaseGrid' }).props('items')[0].capability).toBe('seedance');
+  });
+
+  it('renders Showcases in twelve-item batches with an accessible fallback button', async () => {
+    const feed = Array.from({ length: 30 }, (_, index) => ({ ...showcase, id: `showcase-${index}` }));
+    vi.mocked(showcaseOperator.list).mockResolvedValue({ data: feed } as any);
+    const wrapper = mountHome({ id: 'studio', features: { seedance: { enabled: true } } });
+    await vi.waitFor(() => expect(wrapper.findComponent({ name: 'ShowcaseGrid' }).exists()).toBe(true));
+    expect(wrapper.getComponent({ name: 'ShowcaseGrid' }).props('items')).toHaveLength(12);
+    const button = wrapper.get('button.showcase-load-more');
+    expect(button.attributes('type')).toBe('button');
+
+    await button.trigger('click');
+    expect(wrapper.getComponent({ name: 'ShowcaseGrid' }).props('items')).toHaveLength(24);
+    await wrapper.get('button.showcase-load-more').trigger('click');
+    expect(wrapper.getComponent({ name: 'ShowcaseGrid' }).props('items')).toHaveLength(30);
+    expect(wrapper.find('button.showcase-load-more').exists()).toBe(false);
+  });
+
+  it('keeps manual loading available without IntersectionObserver', async () => {
+    expect('IntersectionObserver' in window).toBe(false);
+    const feed = Array.from({ length: 18 }, (_, index) => ({ ...showcase, id: `showcase-${index}` }));
+    vi.mocked(showcaseOperator.list).mockResolvedValue({ data: feed } as any);
+    const wrapper = mountHome({ id: 'studio', features: { seedance: { enabled: true } } });
+    await vi.waitFor(() => expect(wrapper.find('button.showcase-load-more').exists()).toBe(true));
+
+    await wrapper.get('button.showcase-load-more').trigger('click');
+    expect(wrapper.getComponent({ name: 'ShowcaseGrid' }).props('items')).toHaveLength(18);
+  });
+
+  it('returns to the first batch when the Showcase feed reloads', async () => {
+    const feed = Array.from({ length: 30 }, (_, index) => ({ ...showcase, id: `showcase-${index}` }));
+    vi.mocked(showcaseOperator.list).mockResolvedValue({ data: feed } as any);
+    const wrapper = mountHome({ id: 'studio', features: { seedance: { enabled: true } } });
+    await vi.waitFor(() => expect(wrapper.find('button.showcase-load-more').exists()).toBe(true));
+    await wrapper.get('button.showcase-load-more').trigger('click');
+    expect(wrapper.getComponent({ name: 'ShowcaseGrid' }).props('items')).toHaveLength(24);
+
+    await (wrapper.vm as any).loadShowcases();
+    expect(wrapper.getComponent({ name: 'ShowcaseGrid' }).props('items')).toHaveLength(12);
+  });
+
+  it('automatically appends one batch per sentinel viewport entry', async () => {
+    let callback: IntersectionObserverCallback = () => undefined;
+    class MockIntersectionObserver {
+      constructor(handler: IntersectionObserverCallback) {
+        callback = handler;
+      }
+      observe = vi.fn();
+      unobserve = vi.fn();
+      disconnect = vi.fn();
+    }
+    vi.stubGlobal('IntersectionObserver', MockIntersectionObserver);
+    const feed = Array.from({ length: 30 }, (_, index) => ({ ...showcase, id: `showcase-${index}` }));
+    vi.mocked(showcaseOperator.list).mockResolvedValue({ data: feed } as any);
+    const wrapper = mountHome({ id: 'studio', features: { seedance: { enabled: true } } });
+    await vi.waitFor(() => expect(wrapper.find('button.showcase-load-more').exists()).toBe(true));
+    const target = wrapper.get('button.showcase-load-more').element;
+
+    await wrapper.get('button.showcase-load-more').trigger('click');
+    callback([{ isIntersecting: true, target } as IntersectionObserverEntry], {} as any);
+    await wrapper.vm.$nextTick();
+    expect(wrapper.getComponent({ name: 'ShowcaseGrid' }).props('items')).toHaveLength(24);
+    callback([{ isIntersecting: true, target } as IntersectionObserverEntry], {} as any);
+    await wrapper.vm.$nextTick();
+    expect(wrapper.getComponent({ name: 'ShowcaseGrid' }).props('items')).toHaveLength(24);
+    callback([{ isIntersecting: false, target } as IntersectionObserverEntry], {} as any);
+    callback([{ isIntersecting: true, target } as IntersectionObserverEntry], {} as any);
+    await wrapper.vm.$nextTick();
+    expect(wrapper.getComponent({ name: 'ShowcaseGrid' }).props('items')).toHaveLength(30);
   });
 
   it('applies white-label names and icons to child and showcase cards', async () => {

--- a/src/pages/home/Index.vue
+++ b/src/pages/home/Index.vue
@@ -9,8 +9,8 @@
         @icon-error="onIconError"
       />
       <showcase-grid
-        v-if="showcases.length"
-        :items="showcases"
+        v-if="visibleShowcases.length"
+        :items="visibleShowcases"
         :eyebrow="$t('intro.home.showcase.eyebrow')"
         :title="$t('intro.home.showcase.title')"
         :subtitle="$t('intro.home.showcase.subtitle')"
@@ -19,6 +19,15 @@
         @select="selectedShowcase = $event"
         @icon-error="onShowcaseIconError"
       />
+      <button
+        v-if="hasMoreShowcases"
+        ref="showcaseLoadMore"
+        type="button"
+        class="showcase-load-more"
+        @click="onShowcaseLoadMoreClick"
+      >
+        {{ $t('intro.home.showcase.loadMore') }}
+      </button>
     </div>
     <showcase-detail-dialog :item="selectedShowcase" @close="selectedShowcase = undefined" />
   </main>
@@ -49,6 +58,8 @@ import {
   type ResolvedHomeCategory
 } from './data';
 
+const SHOWCASE_BATCH_SIZE = 12;
+
 export default defineComponent({
   name: 'StudioHome',
   components: {
@@ -67,6 +78,9 @@ export default defineComponent({
       rawShowcases: [] as IShowcase[],
       showcaseLoaded: false,
       showcaseLoadGeneration: 0,
+      visibleShowcaseCount: SHOWCASE_BATCH_SIZE,
+      showcaseLoadObserver: undefined as IntersectionObserver | undefined,
+      showcaseAutoLoadArmed: true,
       selectedShowcase: undefined as ResolvedShowcase | undefined
     };
   },
@@ -129,7 +143,7 @@ export default defineComponent({
       }
       return resolved;
     },
-    showcases(): ResolvedShowcase[] {
+    resolvedShowcases(): ResolvedShowcase[] {
       const site = this.site;
       if (!site) return [];
       return this.rawShowcases
@@ -139,6 +153,12 @@ export default defineComponent({
           ...item,
           icon: this.failedIcons[item.capability] ? item.defaultIcon : item.icon
         }));
+    },
+    visibleShowcases(): ResolvedShowcase[] {
+      return this.resolvedShowcases.slice(0, this.visibleShowcaseCount);
+    },
+    hasMoreShowcases(): boolean {
+      return this.visibleShowcaseCount < this.resolvedShowcases.length;
     }
   },
   watch: {
@@ -151,7 +171,16 @@ export default defineComponent({
     },
     '$i18n.locale'() {
       if (this.siteLoaded) void this.loadShowcases();
+    },
+    hasMoreShowcases() {
+      this.$nextTick(() => this.observeShowcaseLoadMore());
     }
+  },
+  mounted() {
+    this.setupShowcaseLoadObserver();
+  },
+  beforeUnmount() {
+    this.showcaseLoadObserver?.disconnect();
   },
   methods: {
     resolve(item: HomeCapability): ResolvedHomeCapability {
@@ -185,6 +214,8 @@ export default defineComponent({
       const generation = ++this.showcaseLoadGeneration;
       const requestLocale = String(this.$i18n.locale || 'en');
       this.showcaseLoaded = true;
+      this.visibleShowcaseCount = SHOWCASE_BATCH_SIZE;
+      this.showcaseAutoLoadArmed = true;
       this.rawShowcases = [];
       this.selectedShowcase = undefined;
       try {
@@ -195,6 +226,39 @@ export default defineComponent({
       } catch {
         if (generation === this.showcaseLoadGeneration) this.rawShowcases = [];
       }
+    },
+    loadMoreShowcases(): void {
+      this.visibleShowcaseCount = Math.min(
+        this.visibleShowcaseCount + SHOWCASE_BATCH_SIZE,
+        this.resolvedShowcases.length
+      );
+    },
+    onShowcaseLoadMoreClick(): void {
+      this.showcaseAutoLoadArmed = false;
+      this.loadMoreShowcases();
+    },
+    setupShowcaseLoadObserver(): void {
+      if (!('IntersectionObserver' in window)) return;
+      this.showcaseLoadObserver = new IntersectionObserver(
+        (entries) => {
+          for (const entry of entries) {
+            if (!entry.isIntersecting) {
+              this.showcaseAutoLoadArmed = true;
+              continue;
+            }
+            if (!this.showcaseAutoLoadArmed) continue;
+            this.showcaseAutoLoadArmed = false;
+            this.loadMoreShowcases();
+          }
+        },
+        { root: this.$el as HTMLElement, rootMargin: '400px 0px' }
+      );
+      this.observeShowcaseLoadMore();
+    },
+    observeShowcaseLoadMore(): void {
+      this.showcaseLoadObserver?.disconnect();
+      const target = this.$refs.showcaseLoadMore;
+      if (target instanceof HTMLElement) this.showcaseLoadObserver?.observe(target);
     },
     onIconError(item: ResolvedHomeCapability): void {
       if (item.icon !== item.defaultIcon) this.failedIcons[item.capability] = true;
@@ -260,6 +324,26 @@ export default defineComponent({
 @media (prefers-reduced-motion: reduce) {
   .home-loading span {
     animation-duration: 1.8s;
+  }
+}
+</style>
+
+<style lang="scss" scoped>
+.showcase-load-more {
+  display: block;
+  min-height: 44px;
+  margin: 4px auto 28px;
+  padding: 0 24px;
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  border-radius: 999px;
+  color: #fff;
+  background: rgba(255, 255, 255, 0.08);
+  font-weight: 750;
+  cursor: pointer;
+
+  &:focus-visible {
+    outline: 3px solid var(--el-color-primary);
+    outline-offset: 3px;
   }
 }
 </style>


### PR DESCRIPTION
## Summary
- render the Home Showcase feed in 12-card batches with an IntersectionObserver sentinel and accessible Load more fallback
- defer video and audio `src` binding until a card approaches the viewport or the user explicitly starts playback
- preserve loaded media sources to avoid duplicate CDN range requests when users scroll back
- add localized Load more copy across all supported locales

## Validation
- `npm run test:run` — 226 files, 1671 tests passed
- `npm run test:run -- src/pages/home/Index.test.ts src/components/common/ShowcaseGrid.test.ts` — 24 tests passed after rebase
- `python3 scripts/check_i18n_coverage.py` — 11 locales × 49 namespaces passed
- `npm run lint:check` — 0 errors, 2 pre-existing warnings in `dropUploadMixin.test.ts`
- `npm run build:web` — passed
- `npm run verify` — passed
- `git diff --check` — passed

## Rollout and rollback
Frontend-only change; no API, database, or Showcase manifest migration. Roll back by reverting this commit and redeploying Nexior Web.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Local production-build E2E
Isolated system Chrome against `vite preview` and the real public Showcase feed:
- desktop 1440×900: initial 12 cards and 0 Showcase video/audio requests; scrolling to the sentinel appended 24 cards and loaded only 2 nearby videos; 0 console errors
- mobile 390×844: 12 → 24 → 36 cards across progressive loads; initial 0 Showcase video/audio requests, 2 nearby media requests after scrolling; 0 console errors
