### PR TITLE
feat: verify desktop connector callbacks

### DIFF
--- a/change/connector-desktop-flow-7a3d9c21.json
+++ b/change/connector-desktop-flow-7a3d9c21.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Return desktop connector authorization from the system browser to the AceData app.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/electron/connector-state.test.ts
+++ b/electron/connector-state.test.ts
@@ -1,0 +1,22 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { _resetConnectorState, consumeConnectorState, issueConnectorState } from './connector-state';
+
+describe('connector callback state', () => {
+  beforeEach(() => {
+    _resetConnectorState();
+    vi.useRealTimers();
+  });
+
+  it('accepts a state exactly once', () => {
+    const issued = issueConnectorState();
+    expect(consumeConnectorState(issued.state)).toBe(issued.requestId);
+    expect(consumeConnectorState(issued.state)).toBeNull();
+  });
+
+  it('rejects an expired state', () => {
+    vi.useFakeTimers();
+    const issued = issueConnectorState();
+    vi.advanceTimersByTime(10 * 60 * 1000 + 1);
+    expect(consumeConnectorState(issued.state)).toBeNull();
+  });
+});

--- a/electron/connector-state.ts
+++ b/electron/connector-state.ts
@@ -1,0 +1,32 @@
+import { randomUUID } from 'node:crypto';
+
+const TTL_MS = 10 * 60 * 1000;
+const pending = new Map<string, { requestId: string; createdAt: number }>();
+
+function gc(): void {
+  const now = Date.now();
+  for (const [state, entry] of pending) {
+    if (now - entry.createdAt > TTL_MS) pending.delete(state);
+  }
+}
+
+export function issueConnectorState(): { state: string; requestId: string } {
+  gc();
+  const state = randomUUID();
+  const requestId = randomUUID();
+  pending.set(state, { requestId, createdAt: Date.now() });
+  return { state, requestId };
+}
+
+export function consumeConnectorState(state: string | null | undefined): string | null {
+  if (!state) return null;
+  gc();
+  const entry = pending.get(state);
+  if (!entry) return null;
+  pending.delete(state);
+  return Date.now() - entry.createdAt <= TTL_MS ? entry.requestId : null;
+}
+
+export function _resetConnectorState(): void {
+  pending.clear();
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import os from 'node:os';
 import { registerAppProtocol, APP_ORIGIN } from './protocol';
 import { issueState, consumeState } from './auth-state';
+import { consumeConnectorState, issueConnectorState } from './connector-state';
 import { registerLocalExec, disableComputerUse } from './local/ipc';
 import { registry } from './local/registry';
 import { setRoots } from './local/fs';
@@ -242,21 +243,38 @@ function handleDeepLink(rawUrl: string): void {
   } catch {
     return;
   }
-  // acedata-desktop://auth/callback?code=...&state=...
-  if (url.host !== 'auth' || !url.pathname.startsWith('/callback')) return;
-  const code = url.searchParams.get('code');
-  if (!code) return;
-  if (!consumeState(url.searchParams.get('state'))) {
-    console.warn('[auth] deep link rejected: state mismatch/expired');
-    deliverOrQueue('auth:expired', {});
+  if (url.host === 'auth' && url.pathname.startsWith('/callback')) {
+    const code = url.searchParams.get('code');
+    if (!code) return;
+    if (!consumeState(url.searchParams.get('state'))) {
+      console.warn('[auth] deep link rejected: state mismatch/expired');
+      deliverOrQueue('auth:expired', {});
+      focusWindow();
+      return;
+    }
+    deliverOrQueue('auth:callback', { code });
     focusWindow();
     return;
   }
-  deliverOrQueue('auth:callback', { code });
-  focusWindow();
+  if (url.host === 'connections' && url.pathname.startsWith('/callback')) {
+    const requestId = consumeConnectorState(url.searchParams.get('desktop_state'));
+    if (!requestId) return;
+    const rawStatus = url.searchParams.get('status');
+    deliverOrQueue('connections:callback', {
+      requestId,
+      status: rawStatus === 'success' || rawStatus === 'cancelled' ? rawStatus : 'error',
+      connectionId: url.searchParams.get('connection_id') || undefined,
+      errorCode: url.searchParams.get('error') || undefined
+    });
+    focusWindow();
+  }
 }
 
 function focusWindow(): void {
+  if (!app.isReady()) {
+    void app.whenReady().then(() => focusWindow());
+    return;
+  }
   // Once the app can outlive its window (tray residency), "focus" may have to
   // recreate it — otherwise clicking the tray icon after closing the window
   // would do nothing at all.
@@ -272,7 +290,7 @@ function focusWindow(): void {
 // Deliver only once the renderer has SUBSCRIBED (mounted + onAuthCallback
 // attached), signalled via 'renderer:ready'. Queue everything else.
 function deliverOrQueue(channel: string, payload: object): void {
-  if (mainWindow && rendererReady) {
+  if (mainWindow && !mainWindow.isDestroyed() && rendererReady) {
     mainWindow.webContents.send(channel, payload);
   } else {
     pendingDeepLinks.push({ channel, payload });
@@ -324,6 +342,13 @@ ipcMain.handle('shell:openExternal', (_e, url: string) => {
  * `state` is minted here — unlike login, nothing comes back through the
  * renderer for us to bind it to.
  */
+ipcMain.handle('connections:createCallback', () => {
+  const { state, requestId } = issueConnectorState();
+  const callback = new URL('https://auth.acedata.cloud/connections/popup-return');
+  callback.searchParams.set('desktop_state', state);
+  return { requestId, returnUrl: callback.toString() };
+});
+
 ipcMain.handle('connections:openAuthorize', (_e, url: string) => {
   try {
     if (new URL(url).protocol !== 'https:') return;

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -35,6 +35,21 @@ contextBridge.exposeInMainWorld('desktop', {
   // Open an external https link (payment Page, docs) in the system browser.
   openExternal: (url: string): Promise<void> => ipcRenderer.invoke('shell:openExternal', url),
 
+  createConnectorCallback: (): Promise<{ requestId: string; returnUrl: string }> =>
+    ipcRenderer.invoke('connections:createCallback'),
+  onConnectorCallback: (
+    cb: (payload: {
+      requestId: string;
+      status: 'success' | 'cancelled' | 'error';
+      connectionId?: string;
+      errorCode?: string;
+    }) => void
+  ): (() => void) => {
+    const handler = (_e: unknown, payload: Parameters<typeof cb>[0]) => cb(payload);
+    ipcRenderer.on('connections:callback', handler);
+    return () => ipcRenderer.removeListener('connections:callback', handler);
+  },
+
   // Open a connector's OAuth consent page in the system browser. Separate from
   // openExternal because the host is a third-party provider, which must not be
   // added to the external-open allowlist (that set also governs the navigation

--- a/src/components/connections/BrowseConnectors.vue
+++ b/src/components/connections/BrowseConnectors.vue
@@ -208,7 +208,7 @@ import BrowserPairingDialog from '@/components/browser/BrowserPairingDialog.vue'
 import BrowserDevicePicker from '@/components/browser/BrowserDevicePicker.vue';
 import type { IBrowserDevice } from '@/models/browserDevice';
 import { popupReturnUrl } from '@/utils/connections/authorizePopup';
-import { openAuthorizeFlow } from '@/utils/connections/authorizeFlow';
+import { openAuthorizeFlow, prepareAuthorizeFlow } from '@/utils/connections/authorizeFlow';
 
 interface ISourceOption {
   key: 'all' | ConnectorSource | 'featured';
@@ -543,14 +543,29 @@ export default defineComponent({
       }
       this.installingId = item.id;
       try {
+        const prepared =
+          method.credential.type === 'oauth2'
+            ? await prepareAuthorizeFlow(popupReturnUrl())
+            : { returnUrl: popupReturnUrl() };
         const { data } = await connectionOperator.installFromCatalog(item.id, {
-          return_url: popupReturnUrl(),
+          return_url: prepared.returnUrl,
           method_id: method.id
         });
         if (data.type === 'redirect') {
           // Popup (web) / in-app browser (native) / system browser (desktop)
           // all keep this dialog and the page behind it alive.
-          await openAuthorizeFlow(data.authorization_url, data.handoff_token);
+          const result = await openAuthorizeFlow(data.authorization_url, data.handoff_token, prepared.requestId);
+          if (result?.status === 'error' || result?.status === 'cancelled') return;
+          if (result?.status === 'success') {
+            const { data: connections } = await connectionOperator.list();
+            const active =
+              !!result.connectionId &&
+              connections.some(
+                (connection) =>
+                  connection.id === result.connectionId && String(connection.status).toLowerCase() === 'active'
+              );
+            if (!active) throw new Error(this.$t('connection.message.installFailed') as string);
+          }
           this.$emit('installed');
           await this.fetchItems();
           return;

--- a/src/pages/console/connectors/Index.vue
+++ b/src/pages/console/connectors/Index.vue
@@ -658,7 +658,7 @@ import ConnectorMethodPicker from '@/components/connections/ConnectorMethodPicke
 import BrowserPairingDialog from '@/components/browser/BrowserPairingDialog.vue';
 import BrowserDevicePicker from '@/components/browser/BrowserDevicePicker.vue';
 import { popupReturnUrl } from '@/utils/connections/authorizePopup';
-import { openAuthorizeFlow } from '@/utils/connections/authorizeFlow';
+import { openAuthorizeFlow, prepareAuthorizeFlow } from '@/utils/connections/authorizeFlow';
 import type { IBrowserDevice } from '@/models/browserDevice';
 
 /** One row of the connection detail overflow menu. */
@@ -1646,9 +1646,13 @@ export default defineComponent({
       // stamped with ``connector_identifier`` and the right-pane join
       // picks up display fields from the catalog row.
       try {
+        const prepared =
+          method.credential.type === 'oauth2'
+            ? await prepareAuthorizeFlow(popupReturnUrl())
+            : { returnUrl: popupReturnUrl() };
         const { data } = await connectionOperator.installFromCatalog(catalog.id, {
           scopes: scopes && scopes.length ? scopes : undefined,
-          return_url: popupReturnUrl(),
+          return_url: prepared.returnUrl,
           method_id: method.id,
           // Only set when the user explicitly chose "add another account";
           // omitting it keeps the backend on slot 0, i.e. re-authorizing
@@ -1667,7 +1671,7 @@ export default defineComponent({
           return;
         }
         if (data?.type === 'redirect' && data.authorization_url) {
-          await this.runAuthorizePopup(data.authorization_url, data.handoff_token);
+          await this.runAuthorizePopup(data.authorization_url, data.handoff_token, prepared.requestId);
         } else if (data && (data as any).type === 'active') {
           // Zero-step flow (public) — refresh the list.
           await this.fetchConnections();
@@ -1683,9 +1687,27 @@ export default defineComponent({
      * resolve on "the flow ended", and the server is the authority on what
      * actually connected, so we always refetch.
      */
-    async runAuthorizePopup(authorizationUrl: string, handoffToken?: string) {
+    async runAuthorizePopup(authorizationUrl: string, handoffToken?: string, requestId?: string) {
       try {
-        await openAuthorizeFlow(authorizationUrl, handoffToken);
+        const result = await openAuthorizeFlow(authorizationUrl, handoffToken, requestId);
+        if (result?.status === 'error') throw new Error(result.errorCode || 'connector-authorization-failed');
+        if (result?.status === 'cancelled') {
+          this.pendingCreateNew = false;
+          return;
+        }
+        this.pendingCreateNew = false;
+        await this.fetchConnections();
+        if (
+          result?.status === 'success' &&
+          (!result.connectionId ||
+            !this.connections.some(
+              (connection) =>
+                connection.id === result.connectionId && this.normalizedStatus(connection.status) === 'active'
+            ))
+        ) {
+          throw new Error(this.$t('connection.message.installFailed') as string);
+        }
+        return;
       } catch (error: any) {
         this.pendingCreateNew = false;
         ElMessage.error(
@@ -1695,8 +1717,6 @@ export default defineComponent({
         );
         return;
       }
-      this.pendingCreateNew = false;
-      await this.fetchConnections();
     },
     openCustomDialog() {
       this.customDialogVisible = true;
@@ -1824,17 +1844,18 @@ export default defineComponent({
       }
       this.customAuthorizing = true;
       try {
+        const prepared = await prepareAuthorizeFlow(popupReturnUrl());
         const { data } = await connectionOperator.authorizeCustom({
           name: this.customName || undefined,
           server_url: this.customServerUrl,
           client_id: this.customClientId || undefined,
           client_secret: this.customClientSecret || undefined,
           provider: 'mcp',
-          return_url: popupReturnUrl()
+          return_url: prepared.returnUrl
         });
         if (data?.authorization_url) {
           this.customDialogVisible = false;
-          await this.runAuthorizePopup(data.authorization_url, data.handoff_token);
+          await this.runAuthorizePopup(data.authorization_url, data.handoff_token, prepared.requestId);
         }
       } catch (error: any) {
         ElMessage.error(error?.response?.data?.detail || error?.message || 'Failed to start authorization');

--- a/src/utils/connections/authorizeFlow.test.ts
+++ b/src/utils/connections/authorizeFlow.test.ts
@@ -20,7 +20,7 @@ vi.mock('../desktop', () => bridge);
 vi.mock('./authorizePopup', () => popup);
 vi.mock('../authHandoff', () => handoff);
 
-import { openAuthorizeFlow } from './authorizeFlow';
+import { openAuthorizeFlow, prepareAuthorizeFlow } from './authorizeFlow';
 
 const URL_UNDER_TEST = 'https://accounts.google.com/o/oauth2/auth?client_id=x';
 const MCP_URL_UNDER_TEST = 'https://serp.mcp.acedata.cloud/authorize?client_id=dynamic';
@@ -187,45 +187,66 @@ describe('openAuthorizeFlow', () => {
   describe('desktop', () => {
     beforeEach(() => surface.isDesktop.mockReturnValue(true));
 
-    it('hands the url to the main process and resolves on window focus', async () => {
-      const openAuthorizeConnector = vi.fn().mockResolvedValue(undefined);
-      bridge.desktopBridge.mockReturnValue({ openAuthorizeConnector });
+    function desktopCallbackBridge() {
+      let callback: ((result: any) => void) | undefined;
+      const off = vi.fn();
+      const value = {
+        createConnectorCallback: vi.fn().mockResolvedValue({
+          requestId: 'request-1',
+          returnUrl: 'https://auth.acedata.cloud/connections/popup-return?desktop_state=state-1'
+        }),
+        openAuthorizeConnector: vi.fn().mockResolvedValue(undefined),
+        onConnectorCallback: vi.fn((handler: (result: any) => void) => {
+          callback = handler;
+          return off;
+        })
+      };
+      bridge.desktopBridge.mockReturnValue(value);
+      return { value, off, send: (result: any) => callback?.(result) };
+    }
 
-      let settled = false;
-      void openAuthorizeFlow(URL_UNDER_TEST).then(() => {
-        settled = true;
+    it('prepares a nonce-bound desktop return URL', async () => {
+      const { value } = desktopCallbackBridge();
+      await expect(prepareAuthorizeFlow('https://studio.acedata.cloud/return')).resolves.toEqual({
+        requestId: 'request-1',
+        returnUrl: 'https://auth.acedata.cloud/connections/popup-return?desktop_state=state-1'
       });
-      await vi.waitFor(() => expect(openAuthorizeConnector).toHaveBeenCalledWith(URL_UNDER_TEST));
-      expect(settled).toBe(false);
-
-      window.dispatchEvent(new Event('focus'));
-      await vi.waitFor(() => expect(settled).toBe(true));
+      expect(value.createConnectorCallback).toHaveBeenCalledOnce();
     });
 
-    it('hands Auth-hosted authorization through the white-label SSO login', async () => {
-      const openAuthorizeConnector = vi.fn().mockResolvedValue(undefined);
-      bridge.desktopBridge.mockReturnValue({ openAuthorizeConnector });
-
-      const pending = openAuthorizeFlow(AUTH_URL_UNDER_TEST);
-      await vi.waitFor(() =>
-        expect(openAuthorizeConnector).toHaveBeenCalledWith(expect.stringContaining('/auth/login/'))
-      );
-      expect(handoff.prepareConnectorAuthorizationUrl).toHaveBeenCalledWith(AUTH_URL_UNDER_TEST, undefined);
+    it('resolves only on the matching verified callback, not window focus', async () => {
+      const { value, off, send } = desktopCallbackBridge();
+      let settled = false;
+      const pending = openAuthorizeFlow(URL_UNDER_TEST, undefined, 'request-1').then((result) => {
+        settled = true;
+        return result;
+      });
+      await vi.waitFor(() => expect(value.openAuthorizeConnector).toHaveBeenCalledWith(URL_UNDER_TEST));
       window.dispatchEvent(new Event('focus'));
+      expect(settled).toBe(false);
+      send({ requestId: 'other', status: 'success' });
+      expect(settled).toBe(false);
+      send({ requestId: 'request-1', status: 'success', connectionId: 'connection-1' });
+      await expect(pending).resolves.toMatchObject({ status: 'success', connectionId: 'connection-1' });
+      expect(off).toHaveBeenCalledOnce();
+    });
+
+    it('keeps the white-label SSO handoff token separate from callback state', async () => {
+      const { value, send } = desktopCallbackBridge();
+      const pending = openAuthorizeFlow(AUTH_URL_UNDER_TEST, 'handoff-1', 'request-1');
+      await vi.waitFor(() =>
+        expect(value.openAuthorizeConnector).toHaveBeenCalledWith(expect.stringContaining('/auth/login/'))
+      );
+      expect(handoff.prepareConnectorAuthorizationUrl).toHaveBeenCalledWith(AUTH_URL_UNDER_TEST, 'handoff-1');
+      send({ requestId: 'request-1', status: 'success' });
       await pending;
     });
 
-    it('throws on a desktop shell without the IPC instead of silently doing nothing', async () => {
-      // window.open on desktop is denied by setWindowOpenHandler for any host
-      // off EXTERNAL_HOSTS — which lists no OAuth provider — so a fallback
-      // would look identical to a dead click.
+    it('throws on a desktop shell without the callback IPC', async () => {
       bridge.desktopBridge.mockReturnValue({});
-      await expect(openAuthorizeFlow(URL_UNDER_TEST)).rejects.toThrow('desktop-authorize-unsupported');
-    });
-
-    it('never falls back to the web popup', async () => {
-      bridge.desktopBridge.mockReturnValue({});
-      await expect(openAuthorizeFlow(URL_UNDER_TEST)).rejects.toThrow();
+      await expect(prepareAuthorizeFlow('https://studio.acedata.cloud/return')).rejects.toThrow(
+        'desktop-authorize-unsupported'
+      );
       expect(popup.openAuthorizePopup).not.toHaveBeenCalled();
     });
   });

--- a/src/utils/connections/authorizeFlow.ts
+++ b/src/utils/connections/authorizeFlow.ts
@@ -39,6 +39,26 @@ import { desktopBridge } from '../desktop';
 import { isAuthFrontendUrl, prepareConnectorAuthorizationUrl } from '../authHandoff';
 import { openAuthorizePopup } from './authorizePopup';
 
+export interface DesktopConnectorCallback {
+  requestId: string;
+  status: 'success' | 'cancelled' | 'error';
+  connectionId?: string;
+  errorCode?: string;
+}
+
+export interface PreparedAuthorizeFlow {
+  returnUrl: string;
+  requestId?: string;
+}
+
+export async function prepareAuthorizeFlow(fallbackReturnUrl: string): Promise<PreparedAuthorizeFlow> {
+  if (!isDesktop()) return { returnUrl: fallbackReturnUrl };
+  const bridge = desktopBridge();
+  if (!bridge?.createConnectorCallback) throw new Error('desktop-authorize-unsupported');
+  const prepared = await bridge.createConnectorCallback();
+  return { returnUrl: prepared.returnUrl, requestId: prepared.requestId };
+}
+
 /**
  * Run the consent flow on whatever surface we are, and resolve once it ends.
  *
@@ -46,10 +66,18 @@ import { openAuthorizePopup } from './authorizePopup';
  * surface that cannot open the URL at all still resolves, so a spinner never
  * outlives the click.
  */
-export async function openAuthorizeFlow(authorizationUrl: string, handoffToken?: string): Promise<void> {
-  if (isDesktop()) return openOnDesktop(authorizationUrl, handoffToken);
-  if (isNative()) return openOnNative(authorizationUrl, handoffToken);
-  return openOnWeb(authorizationUrl, handoffToken);
+export async function openAuthorizeFlow(
+  authorizationUrl: string,
+  handoffToken?: string,
+  requestId?: string
+): Promise<DesktopConnectorCallback | undefined> {
+  if (isDesktop()) return openOnDesktop(authorizationUrl, handoffToken, requestId);
+  if (isNative()) {
+    await openOnNative(authorizationUrl, handoffToken);
+    return undefined;
+  }
+  await openOnWeb(authorizationUrl, handoffToken);
+  return undefined;
 }
 
 /** Web: popup, falling back to a full-page navigation when it's blocked. */
@@ -101,18 +129,29 @@ async function openOnNative(authorizationUrl: string, handoffToken?: string): Pr
  * next window `focus` — the user coming back is the signal. `visibilitychange`
  * would not do: the Electron window stays visible behind the browser.
  */
-async function openOnDesktop(authorizationUrl: string, handoffToken?: string): Promise<void> {
+async function openOnDesktop(
+  authorizationUrl: string,
+  handoffToken?: string,
+  requestId?: string
+): Promise<DesktopConnectorCallback | undefined> {
   const bridge = desktopBridge();
-  if (!bridge?.openAuthorizeConnector) {
-    // Desktop shell older than this IPC. Falling through to window.open would
-    // be a silent no-op (setWindowOpenHandler denies non-allowlisted hosts),
-    // so say so instead of pretending the click worked.
+  if (!bridge?.openAuthorizeConnector || !bridge.onConnectorCallback || !requestId) {
     throw new Error('desktop-authorize-unsupported');
   }
-  const returned = new Promise<void>((resolve) => {
-    window.addEventListener('focus', () => resolve(), { once: true });
-  });
   const target = await prepareConnectorAuthorizationUrl(authorizationUrl, handoffToken);
-  await bridge.openAuthorizeConnector(target);
-  await returned;
+  let timer: number | undefined;
+  let off: (() => void) | undefined;
+  const callback = new Promise<DesktopConnectorCallback>((resolve, reject) => {
+    off = bridge.onConnectorCallback((result) => {
+      if (result.requestId === requestId) resolve(result);
+    });
+    timer = window.setTimeout(() => reject(new Error('desktop-authorize-expired')), 10 * 60 * 1000);
+  });
+  try {
+    await bridge.openAuthorizeConnector(target);
+    return await callback;
+  } finally {
+    off?.();
+    if (timer !== undefined) window.clearTimeout(timer);
+  }
 }

--- a/src/utils/desktop.ts
+++ b/src/utils/desktop.ts
@@ -16,6 +16,15 @@ export interface DesktopBridge {
   onAuthCallback(cb: (payload: { code: string }) => void): () => void;
   /** Subscribe to a dropped-callback signal (state mismatch/expired). */
   onAuthExpired(cb: () => void): () => void;
+  createConnectorCallback(): Promise<{ requestId: string; returnUrl: string }>;
+  onConnectorCallback(
+    cb: (payload: {
+      requestId: string;
+      status: 'success' | 'cancelled' | 'error';
+      connectionId?: string;
+      errorCode?: string;
+    }) => void
+  ): () => void;
   /** Open an external https link (payment Page, docs) in the system browser. */
   openExternal(url: string): Promise<void>;
   /**


### PR DESCRIPTION
## Summary
- replace the desktop Connector flow's window-focus guess with a verified custom-scheme callback
- generate a single-use, in-memory `desktop_state` with a 10-minute TTL
- receive callbacks through the existing Windows argv/`second-instance` and macOS `open-url` paths
- expose the minimal callback IPC through preload and wait for the matching `requestId` before clearing the loading state
- pass the desktop return URL from the existing Settings and Browse Connector entry points, then reuse their existing connection refresh

## Scope
This PR intentionally does not change Web or mobile behavior, Chat consent, Cookie capture, Connector availability, or durable recovery. If the app is fully quit during authorization, the user retries the flow.

## Verification
- desktop callback tests: 15 passed
- unrelated previously flaky ScheduledTasks test plus callback tests: 91 passed
- Electron compile passed
- Vue TypeScript check and desktop build passed
- ESLint: 0 errors (2 pre-existing warnings)
- Beachball validation passed
- final net diff: 10 files, 269 insertions, 63 deletions; about 95 changed lines are tests

## 🤖 对抗评审
The original platform-wide implementation was reduced to the minimum Windows/macOS return path. Persistent inboxes, ACKs, native mobile callbacks, Chat recovery, Cookie handoff, protocol markers, method availability, and localization expansion were removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
