### PR TITLE
fix: show services in Usage History

### DIFF
--- a/change/usage-service-display.json
+++ b/change/usage-service-display.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Show service favicons and resolved service names throughout Usage History.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/pages/console/usage/List.vue
+++ b/src/pages/console/usage/List.vue
@@ -23,7 +23,18 @@
             class="w-full"
             @change="onServicesChange"
           >
-            <el-option v-for="item in services" :key="item.id" :label="item.title" :value="item.id" />
+            <template #label="{ label, value }">
+              <span class="usage-service-label">
+                <img v-if="serviceIcon(value)" :src="serviceIcon(value)" class="usage-service-icon" alt="" />
+                <span>{{ label }}</span>
+              </span>
+            </template>
+            <el-option v-for="item in services" :key="item.id" :label="item.title" :value="item.id">
+              <span class="usage-service-label">
+                <img v-if="item.icon_url" :src="item.icon_url" class="usage-service-icon" alt="" />
+                <span>{{ item.title }}</span>
+              </span>
+            </el-option>
           </el-select>
         </el-col>
         <el-col v-if="type === serviceType.API" :lg="5" :md="12" :xs="24" class="usage-filter">
@@ -181,7 +192,15 @@
             >
               <el-table-column :label="$t('usage.field.service')" width="180px">
                 <template #default="scope">
-                  <span>{{ scope.row?.service?.title || '-' }}</span>
+                  <span class="usage-service-label">
+                    <img
+                      v-if="scope.row?.service?.icon_url"
+                      :src="scope.row.service.icon_url"
+                      class="usage-service-icon"
+                      alt=""
+                    />
+                    <span>{{ scope.row?.service?.title || '-' }}</span>
+                  </span>
                 </template>
               </el-table-column>
               <el-table-column :label="$t('usage.field.operation')" width="180px">
@@ -1002,6 +1021,9 @@ export default defineComponent({
         this.autoRefreshTimer = null;
       }
     },
+    serviceIcon(serviceId: unknown) {
+      return this.services.find((service) => service.id === serviceId)?.icon_url;
+    },
     async onServicesChange(serviceIds: string[]) {
       if (!serviceIds.length) this.apiIds = [];
       this.apis = [];
@@ -1522,6 +1544,19 @@ export default defineComponent({
 </script>
 
 <style lang="scss" scoped>
+.usage-service-label {
+  display: inline-flex;
+  min-width: 0;
+  align-items: center;
+  gap: 6px;
+}
+.usage-service-icon {
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+  border-radius: 4px;
+  object-fit: contain;
+}
 .usage-filters {
   margin: 0 -8px 20px;
   align-items: end;

--- a/src/pages/console/usage/usageContract.test.ts
+++ b/src/pages/console/usage/usageContract.test.ts
@@ -35,6 +35,14 @@ describe('API usage page contract', () => {
     expect(usageSource).toContain('if (serviceId) services.add(serviceId)');
   });
 
+  it('renders service icons in options, selected labels, and usage rows', () => {
+    expect(usageSource).toContain('<template #label="{ label, value }">');
+    expect(usageSource).toContain('serviceIcon(value)');
+    expect(usageSource).toContain('v-if="item.icon_url"');
+    expect(usageSource).toContain('scope.row?.service?.icon_url');
+    expect(usageSource).toContain("scope.row?.service?.title || '-'");
+  });
+
   it('shows service and operation as separate usage columns', () => {
     expect(usageSource).toContain('<el-table-column :label="$t(\'usage.field.service\')"');
     expect(usageSource).toContain('<el-table-column :label="$t(\'usage.field.operation\')"');


### PR DESCRIPTION
## Summary
- show Service `icon_url` in the Usage History filter options
- render the favicon in selected Service tags and collapsed labels
- show the same favicon next to Service titles in usage rows

## Dependency
Depends on https://github.com/AceDataCloud/PlatformBackend/pull/1583 for Global Application rows to receive their API's enabled primary Service instead of an empty Service object.

## Verification
- `npm run test:run -- src/pages/console/usage` — 8 passed
- `npm run lint:check` — 0 errors (2 pre-existing warnings)
- `npm run build:web` — passed with Node 22 and the current lockfile
- `npx beachball check --branch origin/main` — passed
- production Service catalog: 47/49 API Services have `icon_url`; 10 sampled icons returned 200 image responses

## Rollout
Deploy PlatformBackend first, validate a Global Application usage row has Service title/icon, then deploy this frontend and verify dropdown/selected tag/table favicons in Studio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)