### PR TITLE
fix: route MCP OAuth through white-label handoff

### DIFF
--- a/change/mcp-white-label-handoff-7c2e4a91.json
+++ b/change/mcp-white-label-handoff-7c2e4a91.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Preserve white-label sessions and branding across first-party MCP OAuth redirects.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/chat/ConnectorConsentCard.vue
+++ b/src/components/chat/ConnectorConsentCard.vue
@@ -78,6 +78,7 @@
 </template>
 
 <script lang="ts">
+import { prepareConnectorAuthorizationUrl } from '@/utils/authHandoff';
 import { SecurityIcon } from '@acedatacloud/core/icons/components';
 import { defineComponent, PropType } from 'vue';
 import { ElButton, ElCheckbox, ElCheckboxGroup, ElDialog, ElMessage } from 'element-plus';
@@ -366,7 +367,7 @@ export default defineComponent({
           return_url: returnUrl.toString()
         });
         if (result.type === 'redirect' && result.authorization_url) {
-          window.location.href = result.authorization_url;
+          window.location.href = await prepareConnectorAuthorizationUrl(result.authorization_url, result.handoff_token);
           return;
         }
         // `form` (BYOC schema returned inline) or `active` (zero-step) —

--- a/src/components/chat/connectorCatalogCache.ts
+++ b/src/components/chat/connectorCatalogCache.ts
@@ -25,7 +25,8 @@
  * PlatformBackend for this single endpoint.
  */
 import { httpClient } from '@/operators/common';
-import { getBaseUrlAuth } from '@/utils';
+import { getBaseUrlAuth } from '@/utils/baseUrl';
+import { getConnectorSiteOrigin } from '@/utils/authHandoff';
 import type { AxiosResponse } from 'axios';
 
 /** Localized permission entry on a catalog row — mirrors AuthBackend's
@@ -67,6 +68,7 @@ export interface IConnectorCatalogInstallResponse {
   /** Present iff `type === 'redirect'` — the upstream provider's OAuth
    *  authorize URL the browser should navigate to. */
   authorization_url?: string;
+  handoff_token?: string;
   /** Present iff `type === 'form'` — credential schema the AuthFrontend
    *  BYOC dialog renders. The consent card does NOT handle this case
    *  inline; the parent emits the legacy `authorize` event and the user
@@ -266,11 +268,12 @@ export async function listEnabledConnectors(
  */
 export async function installFromCatalog(
   catalogId: string,
-  payload: { scopes?: string[]; return_url: string }
+  payload: { scopes?: string[]; return_url: string; site_origin?: string }
 ): Promise<IConnectorCatalogInstallResponse> {
+  const siteOrigin = getConnectorSiteOrigin();
   const response: AxiosResponse<IConnectorCatalogInstallResponse> = await httpClient.post(
     `/connectors/${catalogId}/install/`,
-    payload,
+    { ...payload, ...(siteOrigin ? { site_origin: siteOrigin } : {}) },
     { baseURL: `${getBaseUrlAuth()}/api/v1` }
   );
   return response.data;

--- a/src/components/connections/BrowseConnectors.vue
+++ b/src/components/connections/BrowseConnectors.vue
@@ -550,7 +550,7 @@ export default defineComponent({
         if (data.type === 'redirect') {
           // Popup (web) / in-app browser (native) / system browser (desktop)
           // all keep this dialog and the page behind it alive.
-          await openAuthorizeFlow(data.authorization_url);
+          await openAuthorizeFlow(data.authorization_url, data.handoff_token);
           this.$emit('installed');
           await this.fetchItems();
           return;

--- a/src/operators/connection.ts
+++ b/src/operators/connection.ts
@@ -1,6 +1,7 @@
 import { AxiosResponse } from 'axios';
 import { httpClient } from './common';
-import { getBaseUrlAuth } from '@/utils';
+import { getBaseUrlAuth } from '@/utils/baseUrl';
+import { getConnectorSiteOrigin } from '@/utils/authHandoff';
 import type { IBrowserDevice } from '@/models/browserDevice';
 
 /**
@@ -105,10 +106,12 @@ export interface IConnectionAuthorizeRequest {
    *  the adapter falls back to its ``default_scopes``. */
   scopes?: string[];
   return_url?: string;
+  site_origin?: string;
 }
 
 export interface IConnectionAuthorizeResponse {
   authorization_url: string;
+  handoff_token?: string;
 }
 
 export interface IConnectionAuthorizeCustomRequest {
@@ -117,12 +120,14 @@ export interface IConnectionAuthorizeCustomRequest {
   client_id?: string;
   client_secret?: string;
   return_url?: string;
+  site_origin?: string;
   provider?: 'mcp';
 }
 
 export interface IConnectionAuthorizeCustomResponse {
   authorization_url: string;
   connection_id: string;
+  handoff_token?: string;
 }
 
 export interface IConnectionExchangeCustomRequest {
@@ -316,6 +321,7 @@ export interface IConnectorCatalogCategoriesResponse {
 
 export interface IConnectorCatalogInstallRequest {
   return_url?: string;
+  site_origin?: string;
   /** Raw upstream OAuth scope strings to request at consent time
    *  (subset of the row's ``permissions[].id``). When omitted the
    *  preset adapter falls back to its ``default_scopes``. */
@@ -337,6 +343,7 @@ export type IConnectorCatalogInstallResponse =
   | {
       type: 'redirect';
       authorization_url: string;
+      handoff_token?: string;
       state: string;
       connection_id?: string;
     }
@@ -396,6 +403,11 @@ export function getConnectorMethods(item: IConnectorCatalogItem | null | undefin
   return item?.connection_methods || [];
 }
 
+function withSiteOrigin<T extends { site_origin?: string }>(payload: T): T {
+  const siteOrigin = getConnectorSiteOrigin();
+  return siteOrigin && !payload.site_origin ? { ...payload, site_origin: siteOrigin } : payload;
+}
+
 class ConnectionOperator {
   key = 'connections';
 
@@ -404,13 +416,13 @@ class ConnectionOperator {
   }
 
   async authorize(payload: IConnectionAuthorizeRequest): Promise<AxiosResponse<IConnectionAuthorizeResponse>> {
-    return httpClient.post(`/${this.key}/authorize/`, payload, authApi());
+    return httpClient.post(`/${this.key}/authorize/`, withSiteOrigin(payload), authApi());
   }
 
   async authorizeCustom(
     payload: IConnectionAuthorizeCustomRequest
   ): Promise<AxiosResponse<IConnectionAuthorizeCustomResponse>> {
-    return httpClient.post(`/${this.key}/authorize-custom/`, payload, authApi());
+    return httpClient.post(`/${this.key}/authorize-custom/`, withSiteOrigin(payload), authApi());
   }
 
   async exchangeCustom(
@@ -473,7 +485,7 @@ class ConnectionOperator {
     id: string,
     payload: IConnectorCatalogInstallRequest = {}
   ): Promise<AxiosResponse<IConnectorCatalogInstallResponse>> {
-    return httpClient.post(`/connectors/${id}/install/`, payload, authApi());
+    return httpClient.post(`/connectors/${id}/install/`, withSiteOrigin(payload), authApi());
   }
 
   /** Step 2 of the ``byoc`` install: post the user-filled credential

--- a/src/operators/connectionHandoff.test.ts
+++ b/src/operators/connectionHandoff.test.ts
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const http = vi.hoisted(() => ({ get: vi.fn(), post: vi.fn(), patch: vi.fn(), put: vi.fn(), delete: vi.fn() }));
+const siteOrigin = vi.hoisted(() => vi.fn(() => 'https://studio.zhishuyun.com'));
+
+vi.mock('./common', () => ({ httpClient: http }));
+vi.mock('@/utils/baseUrl', () => ({
+  getBaseUrlAuth: () => 'https://auth.acedata.cloud'
+}));
+vi.mock('@/utils/authHandoff', () => ({
+  getConnectorSiteOrigin: siteOrigin
+}));
+
+import { connectionOperator } from './connection';
+
+describe('Connection OAuth site handoff', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('adds the current web origin to catalog installs', async () => {
+    http.post.mockResolvedValue({ data: { type: 'redirect' } });
+    await connectionOperator.installFromCatalog('catalog-1', { return_url: 'https://auth.acedata.cloud/close' });
+    expect(http.post.mock.calls[0][1]).toEqual({
+      return_url: 'https://auth.acedata.cloud/close',
+      site_origin: 'https://studio.zhishuyun.com'
+    });
+  });
+
+  it('adds the current web origin to custom OAuth starts', async () => {
+    http.post.mockResolvedValue({ data: {} });
+    await connectionOperator.authorizeCustom({ server_url: 'https://mcp.example.com/mcp' });
+    expect(http.post.mock.calls[0][1]).toEqual({
+      server_url: 'https://mcp.example.com/mcp',
+      site_origin: 'https://studio.zhishuyun.com'
+    });
+  });
+
+  it('does not overwrite an explicit site origin', async () => {
+    http.post.mockResolvedValue({ data: {} });
+    await connectionOperator.authorize({ provider: 'google', site_origin: 'https://tenant.example.com' });
+    expect(http.post.mock.calls[0][1].site_origin).toBe('https://tenant.example.com');
+  });
+});

--- a/src/pages/console/connectors/Index.vue
+++ b/src/pages/console/connectors/Index.vue
@@ -1655,7 +1655,7 @@ export default defineComponent({
           // overwrites the existing account instead of duplicating it.
           ...(this.pendingCreateNew ? { create_new: true } : {})
         });
-        if (data && (data as any).type === 'form') {
+        if (data?.type === 'form') {
           // Defensive: an OAuth/public method shouldn't return a form,
           // but if it does, open the credential dialog with the chosen
           // method (its schema drives the form). The dialog handles the
@@ -1666,8 +1666,8 @@ export default defineComponent({
           this.byocDialogVisible = true;
           return;
         }
-        if (data && (data as any).authorization_url) {
-          await this.runAuthorizePopup((data as any).authorization_url);
+        if (data?.type === 'redirect' && data.authorization_url) {
+          await this.runAuthorizePopup(data.authorization_url, data.handoff_token);
         } else if (data && (data as any).type === 'active') {
           // Zero-step flow (public) — refresh the list.
           await this.fetchConnections();
@@ -1683,9 +1683,9 @@ export default defineComponent({
      * resolve on "the flow ended", and the server is the authority on what
      * actually connected, so we always refetch.
      */
-    async runAuthorizePopup(authorizationUrl: string) {
+    async runAuthorizePopup(authorizationUrl: string, handoffToken?: string) {
       try {
-        await openAuthorizeFlow(authorizationUrl);
+        await openAuthorizeFlow(authorizationUrl, handoffToken);
       } catch (error: any) {
         this.pendingCreateNew = false;
         ElMessage.error(
@@ -1834,7 +1834,7 @@ export default defineComponent({
         });
         if (data?.authorization_url) {
           this.customDialogVisible = false;
-          await this.runAuthorizePopup(data.authorization_url);
+          await this.runAuthorizePopup(data.authorization_url, data.handoff_token);
         }
       } catch (error: any) {
         ElMessage.error(error?.response?.data?.detail || error?.message || 'Failed to start authorization');

--- a/src/utils/authHandoff.test.ts
+++ b/src/utils/authHandoff.test.ts
@@ -1,14 +1,14 @@
 // @vitest-environment jsdom
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const getCode = vi.hoisted(() => vi.fn());
+const { getCode, native, desktop } = vi.hoisted(() => ({
+  getCode: vi.fn(),
+  native: { value: false },
+  desktop: { value: false }
+}));
 
-vi.mock('@/operators/auth', () => ({
-  authOperator: { getCode }
-}));
-vi.mock('./baseUrl', () => ({
-  getBaseUrlAuth: () => 'https://auth.acedata.cloud'
-}));
+vi.mock('@/operators/auth', () => ({ authOperator: { getCode } }));
+vi.mock('./baseUrl', () => ({ getBaseUrlAuth: () => 'https://auth.acedata.cloud' }));
 vi.mock('./crossSiteUser', () => ({
   withCurrentSite: (url: string) => {
     const target = new URL(url);
@@ -16,59 +16,88 @@ vi.mock('./crossSiteUser', () => ({
     return target.toString();
   }
 }));
+vi.mock('./surface', () => ({
+  isNative: () => native.value,
+  isDesktop: () => desktop.value
+}));
 
-import { buildAuthLoginUrl, isAuthFrontendUrl, withAuthFrontendSession } from './authHandoff';
+import {
+  buildAuthLoginUrl,
+  buildConnectorContinuationUrl,
+  getConnectorSiteOrigin,
+  isAuthFrontendUrl,
+  prepareConnectorAuthorizationUrl,
+  withAuthFrontendSession
+} from './authHandoff';
 
-const AUTH_TARGET =
-  'https://auth.acedata.cloud/oauth2/authorize?client_id=serp&redirect_uri=https%3A%2F%2Fserp.example%2Fcallback#consent';
+const AUTH_TARGET = 'https://auth.acedata.cloud/oauth2/authorize?client_id=serp';
+const CONTEXT7_TARGET = 'https://clerk.context7.com/oauth/authorize?client_id=context7';
 
 describe('AuthFrontend session handoff', () => {
   beforeEach(() => {
     getCode.mockReset();
+    native.value = false;
+    desktop.value = false;
   });
 
   it('recognizes only the exact AuthFrontend origin', () => {
     expect(isAuthFrontendUrl(AUTH_TARGET)).toBe(true);
     expect(isAuthFrontendUrl('https://auth.acedata.cloud.evil.example/oauth2/authorize')).toBe(false);
-    expect(isAuthFrontendUrl('https://evil.example/?next=https://auth.acedata.cloud')).toBe(false);
     expect(isAuthFrontendUrl('not a url')).toBe(false);
+  });
+
+  it('reports the current web origin but omits native and desktop pseudo-origins', () => {
+    expect(getConnectorSiteOrigin()).toBe(window.location.origin);
+    native.value = true;
+    expect(getConnectorSiteOrigin()).toBeUndefined();
+    native.value = false;
+    desktop.value = true;
+    expect(getConnectorSiteOrigin()).toBeUndefined();
+  });
+
+  it('builds a token-only Auth continuation without exposing the target', () => {
+    const continuation = new URL(buildConnectorContinuationUrl('signed-token') || '');
+    expect(continuation.origin).toBe('https://auth.acedata.cloud');
+    expect(continuation.pathname).toBe('/connections/continue');
+    expect(continuation.searchParams.get('handoff')).toBe('signed-token');
+    expect(continuation.searchParams.get('site')).toBe('https://studio.worldai.chat');
+    expect(continuation.searchParams.has('target')).toBe(false);
   });
 
   it('puts the white-label site on both the login page and its redirect target', () => {
     const login = new URL(buildAuthLoginUrl(AUTH_TARGET));
     const redirect = new URL(login.searchParams.get('redirect') || '', login.origin);
-
-    expect(login.pathname).toBe('/auth/login/');
     expect(login.searchParams.get('site')).toBe('https://studio.worldai.chat');
-    expect(redirect.pathname).toBe('/oauth2/authorize');
-    expect(redirect.searchParams.get('client_id')).toBe('serp');
     expect(redirect.searchParams.get('site')).toBe('https://studio.worldai.chat');
-    expect(redirect.hash).toBe('#consent');
   });
 
-  it('adds a one-time SSO code before entering an Auth-hosted authorize page', async () => {
+  it('routes a signed Context7 target through Auth without leaking code to Clerk', async () => {
     getCode.mockResolvedValue({ data: { code: 'single-use-code' } });
+    const login = new URL(await prepareConnectorAuthorizationUrl(CONTEXT7_TARGET, 'signed-handoff'));
+    const redirect = new URL(login.searchParams.get('redirect') || '', login.origin);
 
+    expect(login.pathname).toBe('/auth/login/');
+    expect(login.searchParams.get('code')).toBe('single-use-code');
+    expect(redirect.pathname).toBe('/connections/continue');
+    expect(redirect.searchParams.get('handoff')).toBe('signed-handoff');
+    expect(CONTEXT7_TARGET).not.toContain('single-use-code');
+  });
+
+  it('keeps old-backend external OAuth responses unchanged without a handoff token', async () => {
+    await expect(prepareConnectorAuthorizationUrl(CONTEXT7_TARGET)).resolves.toBe(CONTEXT7_TARGET);
+    expect(getCode).not.toHaveBeenCalled();
+  });
+
+  it('adds a one-time SSO code before entering a direct Auth-hosted page', async () => {
+    getCode.mockResolvedValue({ data: { code: 'single-use-code' } });
     const login = new URL(await withAuthFrontendSession(AUTH_TARGET));
-
-    expect(getCode).toHaveBeenCalledOnce();
     expect(login.searchParams.get('code')).toBe('single-use-code');
   });
 
   it('falls back to normal Auth login when code minting fails', async () => {
     getCode.mockRejectedValue(new Error('expired session'));
-
     const login = new URL(await withAuthFrontendSession(AUTH_TARGET));
-
     expect(login.pathname).toBe('/auth/login/');
     expect(login.searchParams.has('code')).toBe(false);
-    expect(login.searchParams.get('redirect')).toContain('/oauth2/authorize');
-  });
-
-  it('leaves external OAuth providers untouched without requesting a code', async () => {
-    const external = 'https://accounts.google.com/o/oauth2/auth?client_id=x';
-
-    await expect(withAuthFrontendSession(external)).resolves.toBe(external);
-    expect(getCode).not.toHaveBeenCalled();
   });
 });

--- a/src/utils/authHandoff.ts
+++ b/src/utils/authHandoff.ts
@@ -1,6 +1,7 @@
 import { authOperator } from '@/operators/auth';
 import { getBaseUrlAuth } from './baseUrl';
 import { withCurrentSite } from './crossSiteUser';
+import { isDesktop, isNative } from './surface';
 
 export function isAuthFrontendUrl(value: string): boolean {
   try {
@@ -8,6 +9,18 @@ export function isAuthFrontendUrl(value: string): boolean {
   } catch {
     return false;
   }
+}
+
+export function getConnectorSiteOrigin(): string | undefined {
+  if (typeof window === 'undefined' || isNative() || isDesktop()) return undefined;
+  return ['http:', 'https:'].includes(window.location.protocol) ? window.location.origin : undefined;
+}
+
+export function buildConnectorContinuationUrl(handoffToken: string): string | undefined {
+  if (!handoffToken) return undefined;
+  const continuation = new URL('/connections/continue', getBaseUrlAuth());
+  continuation.searchParams.set('handoff', handoffToken);
+  return withCurrentSite(continuation.toString());
 }
 
 export function buildAuthLoginUrl(targetUrl: string): string {
@@ -31,4 +44,12 @@ export async function withAuthFrontendSession(targetUrl: string): Promise<string
     console.warn('failed to hand off session to AuthFrontend', error);
     return fallbackUrl;
   }
+}
+
+export async function prepareConnectorAuthorizationUrl(
+  authorizationUrl: string,
+  handoffToken?: string
+): Promise<string> {
+  const continuation = handoffToken ? buildConnectorContinuationUrl(handoffToken) : undefined;
+  return withAuthFrontendSession(continuation || authorizationUrl);
 }

--- a/src/utils/connections/authorizeFlow.test.ts
+++ b/src/utils/connections/authorizeFlow.test.ts
@@ -7,8 +7,10 @@ const bridge = vi.hoisted(() => ({ desktopBridge: vi.fn() }));
 const popup = vi.hoisted(() => ({ openAuthorizePopup: vi.fn() }));
 const handoff = vi.hoisted(() => ({
   isAuthFrontendUrl: vi.fn((url: string) => new URL(url).origin === 'https://auth.acedata.cloud'),
-  withAuthFrontendSession: vi.fn(
-    async (url: string) => `https://auth.acedata.cloud/auth/login/?redirect=${encodeURIComponent(url)}`
+  prepareConnectorAuthorizationUrl: vi.fn(async (url: string, token?: string) =>
+    token || new URL(url).origin === 'https://auth.acedata.cloud'
+      ? `https://auth.acedata.cloud/auth/login/?redirect=${encodeURIComponent(url)}`
+      : url
   )
 }));
 
@@ -21,6 +23,7 @@ vi.mock('../authHandoff', () => handoff);
 import { openAuthorizeFlow } from './authorizeFlow';
 
 const URL_UNDER_TEST = 'https://accounts.google.com/o/oauth2/auth?client_id=x';
+const MCP_URL_UNDER_TEST = 'https://serp.mcp.acedata.cloud/authorize?client_id=dynamic';
 const AUTH_URL_UNDER_TEST = 'https://auth.acedata.cloud/oauth2/authorize?client_id=serp';
 
 /** A resolved `browserFinished` subscription, plus the callback it captured. */
@@ -40,8 +43,10 @@ describe('openAuthorizeFlow', () => {
     surface.isNative.mockReturnValue(false);
     surface.isDesktop.mockReturnValue(false);
     handoff.isAuthFrontendUrl.mockImplementation((url: string) => new URL(url).origin === 'https://auth.acedata.cloud');
-    handoff.withAuthFrontendSession.mockImplementation(
-      async (url: string) => `https://auth.acedata.cloud/auth/login/?redirect=${encodeURIComponent(url)}`
+    handoff.prepareConnectorAuthorizationUrl.mockImplementation(async (url: string, token?: string) =>
+      token || new URL(url).origin === 'https://auth.acedata.cloud'
+        ? `https://auth.acedata.cloud/auth/login/?redirect=${encodeURIComponent(url)}`
+        : url
     );
   });
 
@@ -68,9 +73,20 @@ describe('openAuthorizeFlow', () => {
 
       const pending = openAuthorizeFlow(AUTH_URL_UNDER_TEST);
       expect(popup.openAuthorizePopup).toHaveBeenCalledOnce();
-      expect(handoff.withAuthFrontendSession).toHaveBeenCalledWith(AUTH_URL_UNDER_TEST);
+      expect(handoff.prepareConnectorAuthorizationUrl).toHaveBeenCalledWith(AUTH_URL_UNDER_TEST, undefined);
       resolvePopup();
       await pending;
+    });
+
+    it('prepares the same session handoff for a first-party MCP authorize endpoint', async () => {
+      popup.openAuthorizePopup.mockImplementation((target: Promise<string>) => {
+        void expect(target).resolves.toContain('/auth/login/');
+        return Promise.resolve();
+      });
+
+      await openAuthorizeFlow(MCP_URL_UNDER_TEST, 'signed-handoff');
+
+      expect(handoff.prepareConnectorAuthorizationUrl).toHaveBeenCalledWith(MCP_URL_UNDER_TEST, 'signed-handoff');
     });
 
     it('does not prepare an AuthFrontend handoff for an external provider', async () => {
@@ -79,7 +95,7 @@ describe('openAuthorizeFlow', () => {
       await openAuthorizeFlow(URL_UNDER_TEST);
 
       expect(popup.openAuthorizePopup).toHaveBeenCalledWith(URL_UNDER_TEST);
-      expect(handoff.withAuthFrontendSession).not.toHaveBeenCalled();
+      expect(handoff.prepareConnectorAuthorizationUrl).not.toHaveBeenCalled();
     });
 
     it('falls back to a full-page navigation when the popup is blocked', async () => {
@@ -127,7 +143,7 @@ describe('openAuthorizeFlow', () => {
       await vi.waitFor(() =>
         expect(capBrowser.open).toHaveBeenCalledWith({ url: expect.stringContaining('/auth/login/') })
       );
-      expect(handoff.withAuthFrontendSession).toHaveBeenCalledWith(AUTH_URL_UNDER_TEST);
+      expect(handoff.prepareConnectorAuthorizationUrl).toHaveBeenCalledWith(AUTH_URL_UNDER_TEST, undefined);
       finish();
       await pending;
     });
@@ -194,7 +210,7 @@ describe('openAuthorizeFlow', () => {
       await vi.waitFor(() =>
         expect(openAuthorizeConnector).toHaveBeenCalledWith(expect.stringContaining('/auth/login/'))
       );
-      expect(handoff.withAuthFrontendSession).toHaveBeenCalledWith(AUTH_URL_UNDER_TEST);
+      expect(handoff.prepareConnectorAuthorizationUrl).toHaveBeenCalledWith(AUTH_URL_UNDER_TEST, undefined);
       window.dispatchEvent(new Event('focus'));
       await pending;
     });

--- a/src/utils/connections/authorizeFlow.ts
+++ b/src/utils/connections/authorizeFlow.ts
@@ -36,7 +36,7 @@
 import { Browser } from '@capacitor/browser';
 import { isNative, isDesktop } from '../surface';
 import { desktopBridge } from '../desktop';
-import { isAuthFrontendUrl, withAuthFrontendSession } from '../authHandoff';
+import { isAuthFrontendUrl, prepareConnectorAuthorizationUrl } from '../authHandoff';
 import { openAuthorizePopup } from './authorizePopup';
 
 /**
@@ -46,15 +46,16 @@ import { openAuthorizePopup } from './authorizePopup';
  * surface that cannot open the URL at all still resolves, so a spinner never
  * outlives the click.
  */
-export async function openAuthorizeFlow(authorizationUrl: string): Promise<void> {
-  if (isDesktop()) return openOnDesktop(authorizationUrl);
-  if (isNative()) return openOnNative(authorizationUrl);
-  return openOnWeb(authorizationUrl);
+export async function openAuthorizeFlow(authorizationUrl: string, handoffToken?: string): Promise<void> {
+  if (isDesktop()) return openOnDesktop(authorizationUrl, handoffToken);
+  if (isNative()) return openOnNative(authorizationUrl, handoffToken);
+  return openOnWeb(authorizationUrl, handoffToken);
 }
 
 /** Web: popup, falling back to a full-page navigation when it's blocked. */
-async function openOnWeb(authorizationUrl: string): Promise<void> {
-  const target = isAuthFrontendUrl(authorizationUrl) ? withAuthFrontendSession(authorizationUrl) : authorizationUrl;
+async function openOnWeb(authorizationUrl: string, handoffToken?: string): Promise<void> {
+  const needsHandoff = !!handoffToken || isAuthFrontendUrl(authorizationUrl);
+  const target = needsHandoff ? prepareConnectorAuthorizationUrl(authorizationUrl, handoffToken) : authorizationUrl;
   const pending = openAuthorizePopup(target);
   if (!pending) {
     // Navigating away — this page is about to be replaced, so there is
@@ -73,7 +74,7 @@ async function openOnWeb(authorizationUrl: string): Promise<void> {
  * `window.location.href` fallback: on Android that is a second top-level
  * navigation, which Capacitor hands to Chrome all over again.
  */
-async function openOnNative(authorizationUrl: string): Promise<void> {
+async function openOnNative(authorizationUrl: string, handoffToken?: string): Promise<void> {
   let handle: { remove: () => Promise<void> } | undefined;
   try {
     const finished = new Promise<void>((resolve) => {
@@ -81,9 +82,7 @@ async function openOnNative(authorizationUrl: string): Promise<void> {
         handle = h;
       });
     });
-    const target = isAuthFrontendUrl(authorizationUrl)
-      ? await withAuthFrontendSession(authorizationUrl)
-      : authorizationUrl;
+    const target = await prepareConnectorAuthorizationUrl(authorizationUrl, handoffToken);
     await Browser.open({ url: target });
     await finished;
   } catch (error) {
@@ -102,7 +101,7 @@ async function openOnNative(authorizationUrl: string): Promise<void> {
  * next window `focus` — the user coming back is the signal. `visibilitychange`
  * would not do: the Electron window stays visible behind the browser.
  */
-async function openOnDesktop(authorizationUrl: string): Promise<void> {
+async function openOnDesktop(authorizationUrl: string, handoffToken?: string): Promise<void> {
   const bridge = desktopBridge();
   if (!bridge?.openAuthorizeConnector) {
     // Desktop shell older than this IPC. Falling through to window.open would
@@ -113,9 +112,7 @@ async function openOnDesktop(authorizationUrl: string): Promise<void> {
   const returned = new Promise<void>((resolve) => {
     window.addEventListener('focus', () => resolve(), { once: true });
   });
-  const target = isAuthFrontendUrl(authorizationUrl)
-    ? await withAuthFrontendSession(authorizationUrl)
-    : authorizationUrl;
+  const target = await prepareConnectorAuthorizationUrl(authorizationUrl, handoffToken);
   await bridge.openAuthorizeConnector(target);
   await returned;
 }


### PR DESCRIPTION
## Problem

Every Connector OAuth flow launched from a white-label site must establish the matching AuthFrontend session and brand context before leaving for its authorization server. This includes first-party MCP, Context7/Clerk, Google/Microsoft, and custom MCP. Client-side hostname inference cannot cover all providers safely.

## Fix

- send the current Web Site origin to AuthBackend on catalog install, direct authorize, and custom authorize requests
- consume the backend-issued `handoff_token` for every OAuth redirect response
- open token-only AuthFrontend `/connections/continue`, then apply the existing one-time SSO handoff
- cover console, Browse Connectors, custom MCP, and chat consent-card entry points
- never send the SSO code to MCP, Clerk, or provider targets
- keep backward compatibility with an older backend that omits `handoff_token`
- preserve popup pre-open and native/desktop transports

## Dependencies

Merge and deploy in order:

1. https://github.com/AceDataCloud/AuthBackend/pull/460
2. https://github.com/AceDataCloud/AuthFrontend/pull/273
3. this PR

## Validation

- focused handoff/operator/chat tests: 51 passed
- `npm run lint:check` — 0 errors; 2 pre-existing warnings
- `npm run build:web` — passed
- `npm run verify` — passed
- `git diff --check` — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
