### PR TITLE
fix: include Agent services in Usage History

### DIFF
--- a/change/usage-agent-services.json
+++ b/change/usage-agent-services.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Include Agent services such as Coding Plan in Usage History filtering.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/models/service.ts
+++ b/src/models/service.ts
@@ -3,6 +3,7 @@ import { IApi, IPackage } from './api';
 
 export enum IServiceType {
   API = 'Api',
+  Agent = 'Agent',
   Proxy = 'Proxy',
   Dataset = 'Dataset'
 }

--- a/src/pages/console/usage/List.vue
+++ b/src/pages/console/usage/List.vue
@@ -1284,7 +1284,7 @@ export default defineComponent({
           limit: 1000,
           offset: 0,
           ordering: '-rank',
-          type: IServiceType.API
+          type: [IServiceType.API, IServiceType.Agent]
         })) as { data: IServiceListResponse };
         this.services = data.items;
       } catch {

--- a/src/pages/console/usage/usageContract.test.ts
+++ b/src/pages/console/usage/usageContract.test.ts
@@ -15,6 +15,7 @@ describe('API usage page contract', () => {
       usageSource.indexOf("$t('usage.field.operation')")
     );
     expect(usageSource).toContain('v-model="serviceIds"');
+    expect(usageSource).toContain('type: [IServiceType.API, IServiceType.Agent]');
     expect(usageSource).toContain(':disabled="!serviceIds.length && !apiIds.length"');
     expect(usageSource).toContain('apiOperator.getAllForService(serviceId');
     expect(usageSource).not.toContain(


### PR DESCRIPTION
## Summary
- include both API and Agent services in the Usage History Service selector
- add the backend-aligned `Agent` member to the typed Service enum
- keep Operation loading service-scoped, so Coding Plan exposes its shared Claude APIs without mixing usage ownership

## Why
AceDataCloud Coding Plan is an Agent Service that shares Claude Messages API with Claude AI. The backend now distinguishes them by Application ownership, but the frontend selector only requested `type=Api`, so Coding Plan could not be selected for verification or normal use.

## Verification
- `npm run test:run -- src/pages/console/usage` — 8 passed
- `npm run lint:check` — 0 errors (2 pre-existing warnings)
- `npm run build:web` — passed
- `npx beachball check --branch origin/main` — passed
- production backend: Coding Plan and Claude AI each returned 16 full-history rows for the same Claude Messages API, exclusively from their own Application IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)