### PR TITLE
fix: include owned services in Usage History

### DIFF
--- a/change/usage-owned-services.json
+++ b/change/usage-owned-services.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Include owned hidden services such as Coding Plan in Usage History filters.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/pages/console/usage/List.vue
+++ b/src/pages/console/usage/List.vue
@@ -1280,13 +1280,20 @@ export default defineComponent({
     async onFetchServices() {
       this.servicesLoading = true;
       try {
-        const { data } = (await serviceOperator.getAll({
-          limit: 1000,
-          offset: 0,
-          ordering: '-rank',
-          type: [IServiceType.API, IServiceType.Agent]
-        })) as { data: IServiceListResponse };
-        this.services = data.items;
+        const [{ data: catalog }, { data: applications }] = await Promise.all([
+          serviceOperator.getAll({
+            limit: 1000,
+            offset: 0,
+            ordering: '-rank',
+            type: [IServiceType.API, IServiceType.Agent]
+          }) as Promise<{ data: IServiceListResponse }>,
+          applicationOperator.getAll({ limit: 1000, offset: 0, ordering: '-created_at', user_id: 'me' })
+        ]);
+        const services = new Map(catalog.items.map((service) => [service.id, service]));
+        applications.items.forEach((application) => {
+          if (application.service?.id) services.set(application.service.id, application.service);
+        });
+        this.services = Array.from(services.values());
       } catch {
         this.services = [];
       } finally {

--- a/src/pages/console/usage/usageContract.test.ts
+++ b/src/pages/console/usage/usageContract.test.ts
@@ -16,6 +16,10 @@ describe('API usage page contract', () => {
     );
     expect(usageSource).toContain('v-model="serviceIds"');
     expect(usageSource).toContain('type: [IServiceType.API, IServiceType.Agent]');
+    expect(usageSource).toContain(
+      "applicationOperator.getAll({ limit: 1000, offset: 0, ordering: '-created_at', user_id: 'me' })"
+    );
+    expect(usageSource).toContain('const services = new Map(catalog.items.map((service) => [service.id, service]))');
     expect(usageSource).toContain(':disabled="!serviceIds.length && !apiIds.length"');
     expect(usageSource).toContain('apiOperator.getAllForService(serviceId');
     expect(usageSource).not.toContain(


### PR DESCRIPTION
## Summary
- merge the public Service catalog with the current user's owned Application Services
- expose owned catalog-hidden Services such as AceDataCloud Coding Plan in Usage History
- deduplicate by Service ID while retaining public API/Agent Services

## Why
The Service request correctly asked for `type=Api&type=Agent`, but catalog visibility rules still omit Coding Plan. The authenticated Applications endpoint already returns the user's Coding Plan Service. Merging those owned Services makes the filter complete without exposing hidden Services the user does not own.

## Verification
- `npm run test:run -- src/pages/console/usage` — 8 passed
- `npm run lint:check` — 0 errors (2 pre-existing warnings)
- `npm run build:web` — passed
- `npx beachball check --branch origin/main` — passed
- production backend validation for shared Claude Messages API: Coding Plan returned 16 rows only from its Application; Claude AI returned 16 rows only from its Application

🤖 Generated with [Claude Code](https://claude.com/claude-code)