### PR TITLE
fix: preserve explicit Usage History services

### DIFF
--- a/change/usage-explicit-service.json
+++ b/change/usage-explicit-service.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Keep explicit Usage History Service filters authoritative over legacy API inference.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/pages/console/usage/List.vue
+++ b/src/pages/console/usage/List.vue
@@ -1268,13 +1268,15 @@ export default defineComponent({
     async hydrateApiSelection() {
       if (!this.apiIds.length) return;
       const selected = await Promise.allSettled(this.apiIds.map((apiId) => apiOperator.get(apiId)));
-      const services = new Set(this.serviceIds);
       const resolved = selected.filter((result) => result.status === 'fulfilled').map((result) => result.value);
-      resolved.forEach(({ data }) => {
-        const serviceId = data.service_id || data.service?.id;
-        if (serviceId) services.add(serviceId);
-      });
-      this.serviceIds = Array.from(services);
+      if (!this.serviceIds.length) {
+        const services = new Set<string>();
+        resolved.forEach(({ data }) => {
+          const serviceId = data.service_id || data.service?.id;
+          if (serviceId) services.add(serviceId);
+        });
+        this.serviceIds = Array.from(services);
+      }
       this.apis = resolved.map(({ data }) => data);
     },
     async onFetchServices() {

--- a/src/pages/console/usage/usageContract.test.ts
+++ b/src/pages/console/usage/usageContract.test.ts
@@ -36,7 +36,8 @@ describe('API usage page contract', () => {
   it('preserves legacy api_id deep links and hydrates their services', () => {
     expect(usageSource).toContain('async hydrateApiSelection()');
     expect(usageSource).toContain('this.apiIds.map((apiId) => apiOperator.get(apiId))');
-    expect(usageSource).toContain('const services = new Set(this.serviceIds)');
+    expect(usageSource).toContain('if (!this.serviceIds.length)');
+    expect(usageSource).toContain('const services = new Set<string>()');
     expect(usageSource).toContain('if (serviceId) services.add(serviceId)');
   });
 


### PR DESCRIPTION
## Summary
- keep an explicit `service_id` authoritative when hydrating legacy `api_id` links
- infer a Service from the API only when no Service was provided
- prevent shared APIs from silently expanding Coding Plan into `Coding Plan + Claude AI`

## Why
Claude Messages API belongs to both AceDataCloud Coding Plan and Claude AI. The compatibility path for old API-only links always inferred the API's primary Service, even when the URL already named Coding Plan. That broadened the backend Service filter and defeated the Application ownership isolation.

## Verification
- `npm run test:run -- src/pages/console/usage` — 8 passed
- `npm run lint:check` — 0 errors (2 pre-existing warnings)
- `npm run build:web` — passed
- `npx beachball check --branch origin/main` — passed
- production backend: Coding Plan and Claude AI each return 16 full-history Claude Messages rows exclusively from their own Application IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)