### PR TITLE
fix(x402): show continuous payment errors

### DIFF
--- a/change/x402-error-message-83e1c4a2.json
+++ b/change/x402-error-message-83e1c4a2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Show actionable continuous-payment errors and trace IDs.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/application/ContinuousPaymentCard.vue
+++ b/src/components/application/ContinuousPaymentCard.vue
@@ -46,6 +46,7 @@
 import { defineComponent } from 'vue';
 import { ElButton, ElInputNumber, ElMessage, ElRadioButton, ElRadioGroup } from 'element-plus';
 import { formatAtomicUsdc } from '@/operators/x402';
+import { continuousPaymentErrorMessage } from '@/utils/x402/error';
 import {
   continuousPaymentAuthorization,
   disableContinuousPayment,
@@ -119,7 +120,7 @@ export default defineComponent({
         });
         ElMessage.success(String(this.$t('common.x402Scenario.continuousPaymentsEnabled')));
       } catch (error: any) {
-        ElMessage.error(error?.response?.data?.detail || error?.message || String(error));
+        ElMessage.error(continuousPaymentErrorMessage(error, String(this.$t('order.message.x402PaymentFailed'))));
       } finally {
         this.busy = false;
       }
@@ -142,7 +143,7 @@ export default defineComponent({
         await revokeContinuousPayment(this.token, walletApi);
         this.method = 'confirm';
       } catch (error: any) {
-        ElMessage.error(error?.response?.data?.detail || error?.message || String(error));
+        ElMessage.error(continuousPaymentErrorMessage(error, String(this.$t('order.message.x402PaymentFailed'))));
       } finally {
         this.busy = false;
       }

--- a/src/utils/x402/error.test.ts
+++ b/src/utils/x402/error.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { continuousPaymentErrorMessage } from './error';
+
+describe('continuousPaymentErrorMessage', () => {
+  it('renders the first DRF detail and trace id', () => {
+    expect(
+      continuousPaymentErrorMessage(
+        { response: { data: { detail: ['transaction_message_mismatch'], trace_id: 'trace-1' } } },
+        'fallback'
+      )
+    ).toBe('transaction_message_mismatch (trace-1)');
+  });
+
+  it('uses nested API errors and fallback text', () => {
+    expect(
+      continuousPaymentErrorMessage({ response: { data: { error: { message: 'RPC unavailable' } } } }, 'fallback')
+    ).toBe('RPC unavailable');
+    expect(continuousPaymentErrorMessage({}, 'fallback')).toBe('fallback');
+  });
+});

--- a/src/utils/x402/error.ts
+++ b/src/utils/x402/error.ts
@@ -1,0 +1,11 @@
+export function continuousPaymentErrorMessage(error: any, fallback: string): string {
+  const detail = error?.response?.data?.detail;
+  const message = Array.isArray(detail) ? detail.find((value) => typeof value === 'string') : detail;
+  const resolved =
+    (typeof message === 'string' && message) ||
+    (typeof error?.response?.data?.error?.message === 'string' && error.response.data.error.message) ||
+    (typeof error?.message === 'string' && error.message) ||
+    fallback;
+  const traceId = error?.response?.data?.trace_id;
+  return typeof traceId === 'string' && traceId ? `${resolved} (${traceId})` : resolved;
+}


### PR DESCRIPTION
## Problem
Continuous-payment failures return DRF `detail` as an array, but the component passed that array directly to `ElMessage.error`. Element Plus rendered an empty-looking error toast instead of the actionable code.

## Fix
- normalize string/array/nested API errors into a readable message
- append the Backend trace ID so the exact request can be investigated
- keep the existing localized x402 failure copy as fallback

## Validation
- focused error/continuous contract tests: 6 passed
- typecheck passed
- lint: 0 errors, 2 pre-existing warnings
- Beachball verification passed

Related production trace: `66831a473a8c4c0a1dc8e40bf3600cc8`

🤖 Generated with [Claude Code](https://claude.com/claude-code)