### PR TITLE
fix: hide pricing links in wallet mode

### DIFF
--- a/change/hide-pricing-usdc-wallet-3c8f2a71.json
+++ b/change/hide-pricing-usdc-wallet-3c8f2a71.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Hide service pricing links while USDC wallet payment is selected.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/digitalhuman/ConfigPanel.vue
+++ b/src/components/digitalhuman/ConfigPanel.vue
@@ -92,7 +92,7 @@
         {{ missing[0].message }}
       </p>
       <scenario-payment-mode scenario="digitalhuman" />
-      <service-pricing-summary :show-consumption="!walletMode" :value="consumption" :service="service" />
+      <service-pricing-summary v-if="!walletMode" :value="consumption" :service="service" />
       <el-button type="primary" class="btn w-full" round @click="onGenerate">
         <magic-icon class="mr-2" :size="'1em' as any" aria-hidden="true" focusable="false" />
         {{ $t('digitalhuman.button.generateVideo') }}

--- a/src/components/flux/ConfigPanel.vue
+++ b/src/components/flux/ConfigPanel.vue
@@ -10,7 +10,7 @@
     </div>
     <div class="flex flex-col items-center justify-center px-5 pb-5">
       <scenario-payment-mode scenario="flux" />
-      <service-pricing-summary :show-consumption="!walletMode" :value="consumption" :service="service" />
+      <service-pricing-summary v-if="!walletMode" :value="consumption" :service="service" />
       <el-button type="primary" class="btn w-full" round @click="onGenerate">
         <magic-icon class="mr-2" :size="'1em' as any" aria-hidden="true" focusable="false" />
         {{ $t('flux.button.generate') }}

--- a/src/components/grokvideo/ConfigPanel.vue
+++ b/src/components/grokvideo/ConfigPanel.vue
@@ -11,7 +11,7 @@
     </div>
     <div class="flex flex-col items-center justify-center px-5 pb-5">
       <scenario-payment-mode scenario="grokvideo" />
-      <service-pricing-summary :show-consumption="!walletMode" :value="consumption" :service="service" />
+      <service-pricing-summary v-if="!walletMode" :value="consumption" :service="service" />
       <el-button type="primary" class="btn w-full" round @click="onGenerate">
         <magic-icon class="mr-2" :size="'1em' as any" aria-hidden="true" focusable="false" />
         {{ $t('grokvideo.button.generate') }}

--- a/src/components/hailuo/ConfigPanel.vue
+++ b/src/components/hailuo/ConfigPanel.vue
@@ -7,7 +7,7 @@
     </div>
     <div class="flex flex-col items-center justify-center px-5 pb-5">
       <scenario-payment-mode scenario="hailuo" />
-      <service-pricing-summary :show-consumption="!walletMode" :value="consumption" :service="service" />
+      <service-pricing-summary v-if="!walletMode" :value="consumption" :service="service" />
       <el-button
         v-if="config?.video_url !== undefined || config?.custom"
         type="primary"

--- a/src/components/kling/ConfigPanel.vue
+++ b/src/components/kling/ConfigPanel.vue
@@ -18,7 +18,7 @@
     <div class="flex flex-col items-center justify-center px-5 pb-5">
       <summary-chip />
       <scenario-payment-mode scenario="kling" />
-      <service-pricing-summary :show-consumption="!walletMode" :value="consumption" :service="service" />
+      <service-pricing-summary v-if="!walletMode" :value="consumption" :service="service" />
       <el-button
         v-if="config?.video_url !== undefined || config?.custom"
         type="primary"

--- a/src/components/kling/TalkingPhotoPanel.vue
+++ b/src/components/kling/TalkingPhotoPanel.vue
@@ -91,7 +91,7 @@
 
     <div class="flex flex-col items-center justify-center px-5 pb-5">
       <scenario-payment-mode scenario="kling" />
-      <service-pricing-summary :show-consumption="!walletMode" :value="consumption" :service="service" />
+      <service-pricing-summary v-if="!walletMode" :value="consumption" :service="service" />
       <el-button type="primary" class="btn w-full" round :disabled="!canGenerate" @click="onGenerate">
         <magic-icon class="mr-2" :size="'1em' as any" aria-hidden="true" focusable="false" />
         {{ $t('kling.button.generateTalkingPhoto') }}

--- a/src/components/luma/ConfigPanel.vue
+++ b/src/components/luma/ConfigPanel.vue
@@ -12,7 +12,7 @@
     </div>
     <div class="flex flex-col items-center justify-center px-5 pb-5">
       <scenario-payment-mode scenario="luma" />
-      <service-pricing-summary :show-consumption="!walletMode" :value="consumption" :service="service" />
+      <service-pricing-summary v-if="!walletMode" :value="consumption" :service="service" />
       <el-button
         v-if="config?.video_url !== undefined || config?.custom"
         type="primary"

--- a/src/components/maestro/ConfigPanel.vue
+++ b/src/components/maestro/ConfigPanel.vue
@@ -258,7 +258,7 @@
 
     <div class="flex flex-col items-center justify-center px-5 pb-5">
       <scenario-payment-mode scenario="maestro" />
-      <service-pricing-summary :value="estimatedCredits" :service="service" :show-consumption="!walletMode" />
+      <service-pricing-summary v-if="!walletMode" :value="estimatedCredits" :service="service" />
       <el-button type="primary" class="btn w-full" round :disabled="!canGenerate" @click="onGenerate">
         <magic-icon class="mr-2" :size="'1em' as any" aria-hidden="true" focusable="false" />
         {{ $t('maestro.button.generate') }}

--- a/src/components/midjourney/ConfigPanel.vue
+++ b/src/components/midjourney/ConfigPanel.vue
@@ -41,7 +41,7 @@
     </div>
     <div class="flex flex-col px-5 pb-5">
       <scenario-payment-mode scenario="midjourney" />
-      <service-pricing-summary :show-consumption="!walletMode" :value="consumption" :service="service" />
+      <service-pricing-summary v-if="!walletMode" :value="consumption" :service="service" />
       <div class="flex gap-1">
         <mode-selector v-if="type !== 'describe'" />
         <el-button v-if="config.action === 'extend'" type="primary" class="btn w-full" round @click="$emit('generate')">

--- a/src/components/minimax/ConfigPanel.vue
+++ b/src/components/minimax/ConfigPanel.vue
@@ -73,7 +73,7 @@
     </div>
     <div class="flex flex-col items-center justify-center px-5 pb-5">
       <scenario-payment-mode scenario="minimax" />
-      <service-pricing-summary :show-consumption="!walletMode" :value="consumption" :service="service" />
+      <service-pricing-summary v-if="!walletMode" :value="consumption" :service="service" />
       <el-button type="primary" class="btn w-full" round @click="onGenerate">
         <magic-icon class="mr-2" :size="'1em' as any" aria-hidden="true" focusable="false" />
         {{ $t('minimax.button.generate') }}

--- a/src/components/nanobanana/ConfigPanel.vue
+++ b/src/components/nanobanana/ConfigPanel.vue
@@ -10,7 +10,7 @@
     <div class="flex flex-col items-center justify-center px-5 pb-5">
       <scenario-payment-mode scenario="nanobanana" />
       <service-pricing-summary
-        :show-consumption="!walletMode"
+        v-if="!walletMode"
         :value="consumption"
         :service="service"
         :pricing-unit-aliases="{ count: 'image' }"

--- a/src/components/omni/ConfigPanel.vue
+++ b/src/components/omni/ConfigPanel.vue
@@ -9,7 +9,7 @@
     </div>
     <div class="flex flex-col items-center justify-center px-5 pb-5">
       <scenario-payment-mode scenario="omni" />
-      <service-pricing-summary :show-consumption="!walletMode" :value="consumption" :service="service" />
+      <service-pricing-summary v-if="!walletMode" :value="consumption" :service="service" />
       <el-button type="primary" class="btn w-full" round @click="onGenerate">
         <magic-icon class="mr-2" :size="'1em' as any" aria-hidden="true" focusable="false" />
         {{ $t('omni.button.generate') }}

--- a/src/components/openaiimage/ConfigPanel.vue
+++ b/src/components/openaiimage/ConfigPanel.vue
@@ -9,7 +9,7 @@
     <div class="flex flex-col items-center justify-center px-5 pb-5">
       <scenario-payment-mode scenario="openaiimage" />
       <service-pricing-summary
-        :show-consumption="!walletMode"
+        v-if="!walletMode"
         :value="consumption"
         :service="service"
         :pricing-models="OPENAIIMAGE_MODELS"

--- a/src/components/pika/ConfigPanel.vue
+++ b/src/components/pika/ConfigPanel.vue
@@ -10,7 +10,7 @@
     </div>
     <div class="flex flex-col items-center justify-center px-5 pb-5">
       <scenario-payment-mode scenario="pika" />
-      <service-pricing-summary :show-consumption="!walletMode" :value="consumption" :service="service" />
+      <service-pricing-summary v-if="!walletMode" :value="consumption" :service="service" />
       <el-button type="primary" class="btn w-full" round @click="onGenerate">
         <magic-icon class="mr-2" :size="'1em' as any" aria-hidden="true" focusable="false" />
         {{ $t('pika.button.generate') }}

--- a/src/components/pixverse/ConfigPanel.vue
+++ b/src/components/pixverse/ConfigPanel.vue
@@ -13,7 +13,7 @@
     </div>
     <div class="flex flex-col items-center justify-center px-5 pb-5">
       <scenario-payment-mode scenario="pixverse" />
-      <service-pricing-summary :show-consumption="!walletMode" :value="consumption" :service="service" />
+      <service-pricing-summary v-if="!walletMode" :value="consumption" :service="service" />
       <el-button type="primary" class="btn w-full" round @click="onGenerate">
         <magic-icon class="mr-2" :size="'1em' as any" aria-hidden="true" focusable="false" />
         {{ $t('pixverse.button.generate') }}

--- a/src/components/producer/ConfigPanel.vue
+++ b/src/components/producer/ConfigPanel.vue
@@ -31,7 +31,7 @@
     </div>
     <div class="flex flex-col items-center justify-center px-5 pb-5 gap-2">
       <scenario-payment-mode scenario="producer" />
-      <service-pricing-summary :show-consumption="!walletMode" :value="consumption" :service="service" />
+      <service-pricing-summary v-if="!walletMode" :value="consumption" :service="service" />
       <div class="flex gap-2 w-full">
         <el-button class="flex-1" @click="onClearAll">
           <cleanup-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />

--- a/src/components/qrart/ConfigPanel.vue
+++ b/src/components/qrart/ConfigPanel.vue
@@ -21,7 +21,7 @@
     </div>
     <div class="flex flex-col items-center justify-center px-5 pb-5">
       <scenario-payment-mode scenario="qrart" />
-      <service-pricing-summary :show-consumption="!walletMode" :value="consumption" :service="service" />
+      <service-pricing-summary v-if="!walletMode" :value="consumption" :service="service" />
       <el-button type="primary" class="btn w-full" round @click="$emit('generate')">
         <magic-icon class="mr-2" :size="'1em' as any" aria-hidden="true" focusable="false" />
         {{ $t('qrart.button.generate') }}

--- a/src/components/seedance/ConfigPanel.vue
+++ b/src/components/seedance/ConfigPanel.vue
@@ -19,7 +19,7 @@
     </div>
     <div class="flex flex-col items-center justify-center px-5 pb-5">
       <scenario-payment-mode scenario="seedance" />
-      <service-pricing-summary :show-consumption="!walletMode" :value="consumption" :service="service" />
+      <service-pricing-summary v-if="!walletMode" :value="consumption" :service="service" />
       <el-button type="primary" class="btn w-full" round @click="onGenerate">
         <magic-icon class="mr-2" :size="'1em' as any" aria-hidden="true" focusable="false" />
         {{ $t('seedance.button.generate') }}

--- a/src/components/serp/SearchPanel.vue
+++ b/src/components/serp/SearchPanel.vue
@@ -8,7 +8,7 @@
     </div>
     <div class="flex flex-col items-center justify-center px-5 pb-5">
       <scenario-payment-mode scenario="serp" />
-      <service-pricing-summary :show-consumption="!walletMode" :value="consumption" :service="service" />
+      <service-pricing-summary v-if="!walletMode" :value="consumption" :service="service" />
       <el-button type="primary" class="btn w-full" round :loading="searching" @click="onSearch">
         <search-icon class="mr-2" :size="'1em' as any" aria-hidden="true" focusable="false" />
         {{ $t('serp.button.search') }}

--- a/src/components/servicePricingScenarioContract.test.ts
+++ b/src/components/servicePricingScenarioContract.test.ts
@@ -63,10 +63,10 @@ describe('service pricing scenario coverage', () => {
       const source = fs.readFileSync(path.join(COMPONENT_ROOT, relativePath), 'utf8');
       return source.includes('<scenario-payment-mode');
     })
-  )('%s keeps pricing available in wallet mode', (relativePath) => {
+  )('%s hides pricing in wallet mode', (relativePath) => {
     const source = fs.readFileSync(path.join(COMPONENT_ROOT, relativePath), 'utf8');
-    expect(source).toContain(':show-consumption="!walletMode"');
-    expect(source).not.toContain('<service-pricing-summary v-if="!walletMode"');
+    expect(source).toMatch(/<service-pricing-summary\s+(?:[^>]*\s)?v-if="!walletMode"/);
+    expect(source).not.toContain(':show-consumption="!walletMode"');
   });
 
   it('does not duplicate the scenario entry in nested or result components', () => {

--- a/src/components/sora/ConfigPanel.vue
+++ b/src/components/sora/ConfigPanel.vue
@@ -11,7 +11,7 @@
     </div>
     <div class="flex flex-col items-center justify-center px-5 pb-5">
       <scenario-payment-mode scenario="sora" />
-      <service-pricing-summary :show-consumption="!walletMode" :value="consumption" :service="service" />
+      <service-pricing-summary v-if="!walletMode" :value="consumption" :service="service" />
       <el-button type="primary" class="btn w-full" round @click="onGenerate">
         <magic-icon class="mr-2" :size="'1em' as any" aria-hidden="true" focusable="false" />
         {{ $t('sora.button.generate') }}

--- a/src/components/suno/ConfigPanel.vue
+++ b/src/components/suno/ConfigPanel.vue
@@ -40,7 +40,7 @@
     </div>
     <div class="flex flex-col items-center justify-center px-5 pb-5 gap-2">
       <scenario-payment-mode scenario="suno" />
-      <service-pricing-summary :show-consumption="!walletMode" :value="consumption" :service="service" />
+      <service-pricing-summary v-if="!walletMode" :value="consumption" :service="service" />
       <div class="flex gap-2 w-full">
         <el-button class="flex-1" @click="onClearAll">
           <cleanup-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />

--- a/src/components/veo/ConfigPanel.vue
+++ b/src/components/veo/ConfigPanel.vue
@@ -17,7 +17,7 @@
     </div>
     <div class="flex flex-col items-center justify-center px-5 pb-5">
       <scenario-payment-mode scenario="veo" />
-      <service-pricing-summary :show-consumption="!walletMode" :value="consumption" :service="service" />
+      <service-pricing-summary v-if="!walletMode" :value="consumption" :service="service" />
       <el-button type="primary" class="btn w-full" round @click="onGenerate">
         <magic-icon class="mr-2" :size="'1em' as any" aria-hidden="true" focusable="false" />
         {{ $t('veo.button.generate') }}

--- a/src/components/wan/ConfigPanel.vue
+++ b/src/components/wan/ConfigPanel.vue
@@ -9,7 +9,7 @@
     </div>
     <div class="flex flex-col items-center justify-center px-5 pb-5">
       <scenario-payment-mode scenario="wan" />
-      <service-pricing-summary :show-consumption="!walletMode" :value="consumption" :service="service" />
+      <service-pricing-summary v-if="!walletMode" :value="consumption" :service="service" />
       <el-button type="primary" class="btn w-full" round @click="onGenerate">
         <magic-icon class="mr-2" :size="'1em' as any" aria-hidden="true" focusable="false" />
         {{ $t('wan.button.generate') }}


### PR DESCRIPTION
## Summary
- hide the service pricing summary when USDC wallet mode is selected
- apply the behavior consistently across all 23 wallet-enabled service panels
- update the shared pricing scenario contract and add release metadata

## Validation
- `npm run test:run` (228 files, 1712 tests passed)
- `npm run lint:check` (0 errors; 2 existing warnings in `dropUploadMixin.test.ts`)
- `npm run build:web`
- `npm run verify`

🤖 Generated with [Claude Code](https://claude.com/claude-code)