### PR TITLE
fix(x402): restore Solana scenario signing

### DIFF
--- a/change/fix-solana-x402-signer.json
+++ b/change/fix-solana-x402-signer.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix Solana wallet signing for X402 generation across Studio scenarios.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/operators/x402.test.ts
+++ b/src/operators/x402.test.ts
@@ -37,7 +37,7 @@ vi.mock('@/utils/x402/continuousPayment', () => ({
   continuousPaymentHeaders: mocks.continuousPaymentHeaders
 }));
 
-import { formatAtomicUsdc, postWithX402, quoteX402, X402PaymentCancelledError } from './x402';
+import { formatAtomicUsdc, postWithX402, quoteX402, resolveX402WalletContext, X402PaymentCancelledError } from './x402';
 
 const requirement = {
   scheme: 'exact',
@@ -75,6 +75,31 @@ function challengeError(withHeader = false, accepts = [requirement]) {
     }
   };
 }
+
+describe('resolveX402WalletContext', () => {
+  beforeEach(() => {
+    mocks.activeWalletRail.mockReturnValue('solana');
+  });
+
+  it('uses the top-level solana-wallets-vue signer ref', async () => {
+    const signTransaction = vi.fn(async (transaction) => transaction);
+    const context = resolveX402WalletContext({
+      publicKey: { value: wallet.publicKey },
+      signTransaction: { value: signTransaction },
+      wallet: { value: { adapter: { name: 'Phantom' } } }
+    });
+    const transaction = { id: 'transaction' };
+
+    expect(context?.publicKey).toBe(wallet.publicKey);
+    await expect(context?.signTransaction(transaction)).resolves.toBe(transaction);
+    expect(signTransaction).toHaveBeenCalledWith(transaction);
+  });
+
+  it('rejects an incomplete Solana wallet store', () => {
+    expect(resolveX402WalletContext({ signTransaction: { value: vi.fn() } })).toBeUndefined();
+    expect(resolveX402WalletContext({ publicKey: { value: wallet.publicKey } })).toBeUndefined();
+  });
+});
 
 describe('postWithX402', () => {
   beforeEach(() => {

--- a/src/operators/x402.ts
+++ b/src/operators/x402.ts
@@ -27,9 +27,9 @@ export function resolveX402WalletContext(walletApi: any): X402WalletContext | un
     };
   }
   const publicKey = walletApi?.publicKey?.value;
-  const adapter = walletApi?.wallet?.value?.adapter;
-  if (!publicKey || !adapter?.signTransaction) return undefined;
-  return { publicKey, signTransaction: adapter.signTransaction.bind(adapter) };
+  const signTransaction = walletApi?.signTransaction?.value;
+  if (!publicKey || typeof signTransaction !== 'function') return undefined;
+  return { publicKey, signTransaction };
 }
 
 export interface X402PaymentQuote {


### PR DESCRIPTION
## Bug
When a Studio user connects a Solana wallet, selects wallet payment, and clicks Generate in OpenAI Image or Nano Banana, the UI only performs the background unsigned quote request and receives HTTP 402; it does not show the payment confirmation, request a wallet signature, or retry with `PAYMENT-SIGNATURE`.

## Root cause
`resolveX402WalletContext()` checked connection state through `walletApi.publicKey.value`, but looked for the signer at `walletApi.wallet.value.adapter.signTransaction`. `solana-wallets-vue` exposes the active signer through the top-level `WalletStore.signTransaction: Ref<fn>`. This split let the UI display a connected address while the shared scenario resolver returned `undefined` before the paid request started. Every scenario reusing this resolver was affected, including OpenAI Image and Nano Banana.

## Fix
- read the Solana signer from `walletApi.signTransaction.value`, matching the library contract and the existing continuous-payment implementation
- add regression coverage for the real WalletStore shape where the top-level signer exists but the wallet descriptor adapter has no signer
- preserve Base, cancellation, continuous-payment, and 402→sign→`PAYMENT-SIGNATURE` behavior

## Verification
- failing-before/fixed-after resolver regression: old code returned `undefined`; fixed code resolves and forwards the transaction
- 5 focused X402 files / 32 tests passed after rebase on latest main
- `npm run lint:check` passed
- `npx vue-tsc -b --pretty false` passed
- `npm run build:web` passed
- `npx beachball check --branch origin/main` passed

## Production validation
After deploy, confirm the live bundle reads the top-level signer, then perform a user-controlled UI attempt: confirmation dialog and wallet signature request must appear, followed by a second POST with `PAYMENT-SIGNATURE`. No automated real payment is authorized by this PR.

## Security
A credential was pasted into the incident report. It is not used or recorded by this change and must be revoked/rotated separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)