### PR TITLE
fix: hide private services from Usage History

### DIFF
--- a/change/usage-public-services.json
+++ b/change/usage-public-services.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Hide private services from the Usage History Service picker.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/operators/service.ts
+++ b/src/operators/service.ts
@@ -8,6 +8,7 @@ export interface IServiceQuery {
   ordering?: string;
   id?: string | string[];
   type?: string | string[];
+  private?: boolean;
 }
 
 class ServiceOperator extends BaseOperator<IService, IServiceListResponse, IServiceDetailResponse> {

--- a/src/pages/console/usage/List.vue
+++ b/src/pages/console/usage/List.vue
@@ -1287,13 +1287,16 @@ export default defineComponent({
             limit: 1000,
             offset: 0,
             ordering: '-rank',
-            type: [IServiceType.API, IServiceType.Agent]
+            type: [IServiceType.API, IServiceType.Agent],
+            private: false
           }) as Promise<{ data: IServiceListResponse }>,
           applicationOperator.getAll({ limit: 1000, offset: 0, ordering: '-created_at', user_id: 'me' })
         ]);
         const services = new Map(catalog.items.map((service) => [service.id, service]));
         applications.items.forEach((application) => {
-          if (application.service?.id) services.set(application.service.id, application.service);
+          if (application.service?.id && application.service.private !== true) {
+            services.set(application.service.id, application.service);
+          }
         });
         this.services = Array.from(services.values());
       } catch {

--- a/src/pages/console/usage/usageContract.test.ts
+++ b/src/pages/console/usage/usageContract.test.ts
@@ -16,6 +16,8 @@ describe('API usage page contract', () => {
     );
     expect(usageSource).toContain('v-model="serviceIds"');
     expect(usageSource).toContain('type: [IServiceType.API, IServiceType.Agent]');
+    expect(usageSource).toContain('private: false');
+    expect(usageSource).toContain('application.service.private !== true');
     expect(usageSource).toContain(
       "applicationOperator.getAll({ limit: 1000, offset: 0, ordering: '-created_at', user_id: 'me' })"
     );


### PR DESCRIPTION
## Summary
- request only `private=false` Services for the Usage History catalog
- also exclude private Services when merging the current user's Application Services
- keep public owned Agent Services such as Coding Plan visible

## Why
The selector combines the public catalog with owned Application Services. Without filtering both sources, internal/private Services could appear through either path. `private=false` is the public Service contract; Coding Plan remains visible because it is public.

## Verification
- `npm run test:run -- src/pages/console/usage` — 8 passed
- `npm run lint:check` — 0 errors (2 pre-existing warnings)
- `npm run build:web` — passed
- `npx beachball check --branch origin/main` — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)