### PR TITLE
fix: persist wallet payment mode

### DIFF
--- a/change/persist-wallet-mode-8a4d1f62.json
+++ b/change/persist-wallet-mode-8a4d1f62.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Persist wallet payment mode globally and apply shared availability rules to credits-only operations.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/application/Status.vue
+++ b/src/components/application/Status.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="status">
     <el-dialog v-model="visible" class="mt-12" width="450px">
-      <el-tabs v-if="x402Enabled" v-model="paymentMode" class="payment-tabs">
+      <el-tabs v-if="walletAvailable" v-model="paymentMode" class="payment-tabs">
         <el-tab-pane :label="$t('common.x402Scenario.credits')" name="credits" />
         <el-tab-pane :label="$t('common.x402Scenario.wallet')" name="wallet" />
       </el-tabs>
@@ -135,12 +135,7 @@ import ContinuousPaymentCard from './ContinuousPaymentCard.vue';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 import SolanaWalletPickerDialog from '@/components/common/SolanaWalletPickerDialog.vue';
 import { getApplicationPurchaseRoute, isNative } from '@/utils';
-import {
-  isScenarioX402Enabled,
-  scenarioPaymentState,
-  setScenarioPaymentMode,
-  type ScenarioPaymentMode
-} from '@/utils/x402/scenarioPayment';
+import { scenarioPaymentState, setPreferredPaymentMode, type ScenarioPaymentMode } from '@/utils/x402/scenarioPayment';
 import { refreshContinuousPaymentAuthorization } from '@/utils/x402/continuousPayment';
 import {
   activeEvmWallet,
@@ -212,8 +207,8 @@ export default defineComponent({
     };
   },
   computed: {
-    x402Enabled(): boolean {
-      return Boolean(this.scenario) && isScenarioX402Enabled();
+    walletAvailable(): boolean {
+      return Boolean(this.scenario) && scenarioPaymentState(this.scenario!).walletAvailable;
     },
     paymentMode: {
       get(): ScenarioPaymentMode {
@@ -221,7 +216,7 @@ export default defineComponent({
       },
       set(value: ScenarioPaymentMode) {
         if (!this.scenario) return;
-        setScenarioPaymentMode(this.scenario, value);
+        setPreferredPaymentMode(value);
         if (value === 'wallet') setActiveWalletRail(this.walletRail);
         if (value === 'wallet' && this.walletRail === 'base' && !this.evmAddress) void this.openEvmWalletPicker();
         if (value === 'wallet' && this.walletRail === 'solana' && !this.solanaConnected)

--- a/src/components/openaiimage/ConfigPanel.vue
+++ b/src/components/openaiimage/ConfigPanel.vue
@@ -89,12 +89,14 @@ export default defineComponent({
     walletMode: {
       handler(enabled: boolean) {
         if (enabled) this.scheduleQuote();
+        else this.cancelQuote();
       },
       immediate: true
     },
     config: {
       handler() {
         if (this.walletMode) this.scheduleQuote();
+        else this.cancelQuote();
       },
       deep: true
     },
@@ -111,6 +113,10 @@ export default defineComponent({
     scheduleQuote() {
       window.clearTimeout(this.quoteTimer);
       this.quoteTimer = window.setTimeout(this.refreshQuote, QUOTE_DEBOUNCE_MS);
+    },
+    cancelQuote() {
+      window.clearTimeout(this.quoteTimer);
+      this.quoteRunId += 1;
     },
     async refreshQuote() {
       const state = scenarioPaymentState('openaiimage');

--- a/src/components/x402ContinuousPaymentContract.test.ts
+++ b/src/components/x402ContinuousPaymentContract.test.ts
@@ -11,7 +11,7 @@ describe('x402 continuous payment contract', () => {
     expect(status).toContain('name="wallet"');
     expect(status).not.toContain('name="autopay"');
     expect(status).toContain(':continuous-only="scenario === \'chat\'"');
-    expect(source('layouts/Main.vue')).toContain("'chat'");
+    expect(source('utils/x402/scenarioPayment.ts')).toContain("'chat'");
   });
 
   it('uses the x402 authorization selector without storing payment material', () => {

--- a/src/components/x402FluxQrContract.test.ts
+++ b/src/components/x402FluxQrContract.test.ts
@@ -6,8 +6,10 @@ const source = (relativePath: string) => fs.readFileSync(path.resolve(process.cw
 
 describe('Flux and QR Art x402 contract', () => {
   it('adds both scenarios to the existing floating payment selector', () => {
-    const main = source('layouts/Main.vue');
-    ['nanobanana', 'openaiimage', 'flux', 'qrart'].forEach((scenario) => expect(main).toContain(`'${scenario}'`));
+    const capabilities = source('utils/x402/scenarioPayment.ts');
+    ['nanobanana', 'openaiimage', 'flux', 'qrart'].forEach((scenario) =>
+      expect(capabilities).toContain(`'${scenario}'`)
+    );
   });
 
   it('quotes and submits each scenario through its own operator', () => {

--- a/src/components/x402MidjourneyContract.test.ts
+++ b/src/components/x402MidjourneyContract.test.ts
@@ -6,9 +6,9 @@ const source = (relativePath: string) => fs.readFileSync(path.resolve(process.cw
 
 describe('Midjourney x402 contract', () => {
   it('registers Midjourney and quotes each selected endpoint with its builder', () => {
-    const main = source('layouts/Main.vue');
+    const capabilities = source('utils/x402/scenarioPayment.ts');
     const panel = source('components/midjourney/ConfigPanel.vue');
-    expect(main).toContain("'midjourney'");
+    expect(capabilities).toContain("'midjourney'");
     expect(panel).toContain('quoteImagine(buildMidjourneyImagineRequest(this.config))');
     expect(panel).toContain('quoteVideos(buildMidjourneyVideosRequest(this.config))');
     expect(panel).toContain('quoteDescribe(buildMidjourneyDescribeRequest(this.config))');

--- a/src/components/x402ProducerContract.test.ts
+++ b/src/components/x402ProducerContract.test.ts
@@ -6,7 +6,7 @@ const source = (relativePath: string) => fs.readFileSync(path.resolve(process.cw
 
 describe('Producer x402 contract', () => {
   it('registers Producer and shares the audio builder between quote and submit', () => {
-    expect(source('layouts/Main.vue')).toContain("'producer'");
+    expect(source('utils/x402/scenarioPayment.ts')).toContain("'producer'");
     expect(source('components/producer/ConfigPanel.vue')).toContain(
       'producerOperator.quoteAudio(buildProducerAudioRequest(this.config))'
     );

--- a/src/components/x402ScenarioContract.test.ts
+++ b/src/components/x402ScenarioContract.test.ts
@@ -9,7 +9,8 @@ describe('x402 image scenario contract', () => {
     const status = source('components/application/Status.vue');
     const selector = source('components/common/ScenarioPaymentMode.vue');
     expect(status).toContain('scenarioPaymentState(this.scenario)');
-    expect(status).toContain('setScenarioPaymentMode(this.scenario, value)');
+    expect(status).toContain('setPreferredPaymentMode(value)');
+    expect(status).toContain('scenarioPaymentState(this.scenario!).walletAvailable');
     expect(status).toContain('solana-wallet-picker-dialog');
     expect(status).toContain('value="base"');
     expect(status).toContain('value="solana"');
@@ -50,7 +51,9 @@ describe('x402 image scenario contract', () => {
     expect(nano).toContain("mode: 'x402'");
     expect(openAI).toContain('openaiimageOperator.generate(generateRequest');
     expect(openAI).toContain("mode: 'x402'");
-    expect(openAI).toContain('gptEditCreditsOnly');
+    expect(openAI).not.toContain('gptEditCreditsOnly');
+    expect(openAI).toContain("setScenarioWalletAvailable('openaiimage', !hasReferenceImages)");
+    expect(source('components/openaiimage/ConfigPanel.vue')).toContain('else this.cancelQuote()');
   });
 
   it('keeps payment generic and never broadcasts before service delivery', () => {

--- a/src/components/x402SerpContract.test.ts
+++ b/src/components/x402SerpContract.test.ts
@@ -6,7 +6,7 @@ const source = (relativePath: string) => fs.readFileSync(path.resolve(process.cw
 
 describe('SERP x402 contract', () => {
   it('registers SERP and uses one request builder for quote and search', () => {
-    expect(source('layouts/Main.vue')).toContain("'serp'");
+    expect(source('utils/x402/scenarioPayment.ts')).toContain("'serp'");
     expect(source('components/serp/SearchPanel.vue')).toContain('serpOperator.quote(buildSerpRequest(this.config))');
     expect(source('store/serp/actions.ts')).toContain('const request = buildSerpRequest(state.config)');
   });

--- a/src/components/x402SpecialVideoContract.test.ts
+++ b/src/components/x402SpecialVideoContract.test.ts
@@ -9,11 +9,12 @@ describe('special video x402 contract', () => {
     const main = source('layouts/Main.vue');
     const klingPage = source('pages/kling/Index.vue');
 
-    expect(main).toContain("'kling'");
-    expect(main).toContain("'digitalhuman'");
-    expect(main).toContain("this.appName === 'kling'");
-    expect(main).toContain("taskType === 'motion'");
-    expect(klingPage).toContain("if (value === 'motion') setScenarioPaymentMode('kling', 'credits')");
+    expect(main).toContain('isScenarioX402Supported(this.appName)');
+    expect(main).not.toContain("this.appName === 'kling'");
+    expect(klingPage).toContain("setScenarioWalletAvailable('kling', value !== 'motion')");
+    expect(klingPage).toContain('taskType: {');
+    expect(klingPage).toContain('immediate: true');
+    expect(klingPage).not.toContain("setPreferredPaymentMode('credits')");
     expect(source('components/kling/MotionPanel.vue')).not.toContain('ScenarioPaymentMode');
     expect(klingPage).toContain('klingOperator.motion(request, { token })');
   });

--- a/src/components/x402SunoContract.test.ts
+++ b/src/components/x402SunoContract.test.ts
@@ -6,7 +6,7 @@ const source = (relativePath: string) => fs.readFileSync(path.resolve(process.cw
 
 describe('Suno x402 contract', () => {
   it('registers Suno and shares the audio builder between quote and submit', () => {
-    expect(source('layouts/Main.vue')).toContain("'suno'");
+    expect(source('utils/x402/scenarioPayment.ts')).toContain("'suno'");
     expect(source('components/suno/ConfigPanel.vue')).toContain(
       'sunoOperator.quoteAudio(buildSunoAudioRequest(this.config))'
     );

--- a/src/components/x402VideoScenariosContract.test.ts
+++ b/src/components/x402VideoScenariosContract.test.ts
@@ -36,8 +36,8 @@ const builders: Record<(typeof scenarios)[number], string> = {
 
 describe('standard video x402 contract', () => {
   it('registers every standard video scenario in the floating payment selector', () => {
-    const main = source('layouts/Main.vue');
-    scenarios.forEach((scenario) => expect(main).toContain(`'${scenario}'`));
+    const capabilities = source('utils/x402/scenarioPayment.ts');
+    scenarios.forEach((scenario) => expect(capabilities).toContain(`'${scenario}'`));
   });
 
   it.each(scenarios)('%s quotes and submits its scenario-owned request', (scenario) => {

--- a/src/layouts/Main.vue
+++ b/src/layouts/Main.vue
@@ -28,7 +28,7 @@ import { applicationOperator } from '@/operators';
 import { ERROR_CODE_DUPLICATION } from '@/constants';
 import ApplicationConfirm from '@/components/application/Confirm.vue';
 import { getFinalApplication } from '@/utils';
-import { isScenarioX402Enabled } from '@/utils/x402/scenarioPayment';
+import { isScenarioX402Supported, scenarioPaymentState } from '@/utils/x402/scenarioPayment';
 
 // How often the floating Credits pill re-syncs the selected application's
 // balance. Generations spend credits server-side at task-creation time, so
@@ -65,38 +65,8 @@ export default defineComponent({
       return Boolean(this.appName);
     },
     x402Scenario(): string | undefined {
-      if (!this.appName) return undefined;
-      if (this.appName === 'kling' && this.$store.state.kling?.taskType === 'motion') return undefined;
-      return this.x402ScenarioEnabled ? String(this.appName) : undefined;
-    },
-    x402ScenarioEnabled(): boolean {
-      return (
-        [
-          'nanobanana',
-          'openaiimage',
-          'flux',
-          'qrart',
-          'luma',
-          'pika',
-          'pixverse',
-          'hailuo',
-          'veo',
-          'seedance',
-          'sora',
-          'wan',
-          'omni',
-          'grokvideo',
-          'minimax',
-          'maestro',
-          'kling',
-          'digitalhuman',
-          'serp',
-          'suno',
-          'midjourney',
-          'producer',
-          'chat'
-        ].includes(String(this.appName)) && isScenarioX402Enabled()
-      );
+      if (!isScenarioX402Supported(this.appName)) return undefined;
+      return scenarioPaymentState(this.appName).walletAvailable ? this.appName : undefined;
     },
     application() {
       if (!this.appName) return undefined;

--- a/src/pages/kling/Index.vue
+++ b/src/pages/kling/Index.vue
@@ -39,7 +39,7 @@ import { IKlingTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
 import { uploadTrackerProviderMixin, ensureNoPendingUpload, ensureLoggedIn } from '@/utils';
 import { showcaseRecreateMixin } from '@/utils/showcaseRecreateMixin';
-import { isScenarioX402Enabled, scenarioPaymentState, setScenarioPaymentMode } from '@/utils/x402/scenarioPayment';
+import { isScenarioX402Enabled, scenarioPaymentState, setScenarioWalletAvailable } from '@/utils/x402/scenarioPayment';
 import {
   X402PaymentCancelledError,
   type OperatorRequestOptions,
@@ -108,6 +108,12 @@ export default defineComponent({
     }
   },
   watch: {
+    taskType: {
+      handler(value: IKlingTaskType) {
+        setScenarioWalletAvailable('kling', value !== 'motion');
+      },
+      immediate: true
+    },
     walletMode: {
       async handler(value: boolean, oldValue: boolean | undefined) {
         if (oldValue === undefined || value === oldValue) return;
@@ -307,7 +313,6 @@ export default defineComponent({
     },
     async onTabChange(value: IKlingTaskType) {
       if (value === this.taskType) return;
-      if (value === 'motion') setScenarioPaymentMode('kling', 'credits');
       await this.$store.dispatch('kling/setTaskType', value);
       // taskType change clears tasks; re-fetch.
       await this.onGetTasks();

--- a/src/pages/openaiimage/Index.vue
+++ b/src/pages/openaiimage/Index.vue
@@ -28,7 +28,7 @@ import ShowcaseResultTabs from '@/components/common/ShowcaseResultTabs.vue';
 import { loadPreviousPage } from '@/utils/pagination';
 import { uploadTrackerProviderMixin, ensureNoPendingUpload, ensureLoggedIn } from '@/utils';
 import { IOpenAIImageTask } from '@/models';
-import { isScenarioX402Enabled, scenarioPaymentState } from '@/utils/x402/scenarioPayment';
+import { isScenarioX402Enabled, scenarioPaymentState, setScenarioWalletAvailable } from '@/utils/x402/scenarioPayment';
 import {
   X402PaymentCancelledError,
   type X402PaymentQuote,
@@ -87,6 +87,14 @@ export default defineComponent({
     }
   },
   watch: {
+    config: {
+      handler(value) {
+        const hasReferenceImages = Array.isArray(value?.image_urls) && value.image_urls.length > 0;
+        setScenarioWalletAvailable('openaiimage', !hasReferenceImages);
+      },
+      deep: true,
+      immediate: true
+    },
     walletMode: {
       async handler(value: boolean, oldValue: boolean | undefined) {
         if (oldValue === undefined || value === oldValue) return;
@@ -178,6 +186,8 @@ export default defineComponent({
       }
       const cfg: any = { ...(this.config || {}) };
       const hasReferenceImages = Array.isArray(cfg?.image_urls) && cfg.image_urls.length > 0;
+      setScenarioWalletAvailable('openaiimage', !hasReferenceImages);
+      const paymentMode = scenarioPaymentState('openaiimage').mode;
 
       if (!this.hasText(cfg.prompt)) {
         ElMessage.error(this.$t('openaiimage.message.promptRequired'));
@@ -204,11 +214,7 @@ export default defineComponent({
       } as IOpenAIImageEditRequest;
 
       let operation: Promise<unknown>;
-      if (this.walletMode) {
-        if (hasReferenceImages) {
-          ElMessage.info(this.$t('common.x402Scenario.gptEditCreditsOnly'));
-          return;
-        }
+      if (paymentMode === 'wallet') {
         const wallet = this.getWalletContext();
         if (!wallet) {
           ElMessage.warning(this.$t('common.x402Scenario.connectWalletFirst'));
@@ -239,7 +245,7 @@ export default defineComponent({
         .then((response: any) => {
           const taskId = response?.data?.task_id;
           console.debug('task accepted', taskId);
-          if (this.walletMode && !this.credential?.token && taskId && !this.walletTaskIds.includes(taskId)) {
+          if (paymentMode === 'wallet' && !this.credential?.token && taskId && !this.walletTaskIds.includes(taskId)) {
             this.walletTaskIds.unshift(taskId);
           }
           ElMessage.success(this.$t('openaiimage.message.startTaskSuccess'));
@@ -248,7 +254,7 @@ export default defineComponent({
           if (error instanceof X402PaymentCancelledError) return;
           const response = error?.response?.data;
           if (showQuotaExhausted(error, 'openaiimage')) return;
-          if (this.walletMode) {
+          if (paymentMode === 'wallet') {
             ElMessage.error(`${this.$t('common.x402Scenario.paymentFailed')} ${error?.message || ''}`.trim());
           } else {
             ElMessage.error(this.$t('openaiimage.message.startTaskFailed') + (response?.error?.message || ''));

--- a/src/utils/x402/scenarioPayment.test.ts
+++ b/src/utils/x402/scenarioPayment.test.ts
@@ -1,0 +1,181 @@
+// @vitest-environment jsdom
+
+import { effectScope, watchEffect } from 'vue';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const gates = vi.hoisted(() => ({ web: true, enabled: true }));
+
+vi.mock('@/utils/surface', () => ({ isWeb: () => gates.web }));
+vi.mock('@/utils/featureFlag', () => ({ isFeatureEnabled: () => gates.enabled }));
+
+const STORAGE_KEY = 'nexior:x402:payment-mode';
+const loadModule = () => import('./scenarioPayment');
+
+describe('scenario payment preference', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+    localStorage.clear();
+    gates.web = true;
+    gates.enabled = true;
+  });
+
+  it('defaults to credits without a stored preference', async () => {
+    const { scenarioPaymentState } = await loadModule();
+
+    expect(scenarioPaymentState('openaiimage').mode).toBe('credits');
+  });
+
+  it('shares wallet mode across scenarios and restores it after reload', async () => {
+    let payment = await loadModule();
+    payment.setPreferredPaymentMode('wallet');
+
+    expect(payment.scenarioPaymentState('openaiimage').mode).toBe('wallet');
+    expect(payment.scenarioPaymentState('nanobanana').mode).toBe('wallet');
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('wallet');
+
+    vi.resetModules();
+    payment = await loadModule();
+    expect(payment.scenarioPaymentState('nanobanana').mode).toBe('wallet');
+  });
+
+  it('reactively updates already initialized scenarios', async () => {
+    const payment = await loadModule();
+    const nano = payment.scenarioPaymentState('nanobanana');
+    const observed: string[] = [];
+    const scope = effectScope();
+    scope.run(() => watchEffect(() => observed.push(nano.mode)));
+
+    payment.setPreferredPaymentMode('wallet');
+    await Promise.resolve();
+
+    expect(observed).toEqual(['credits', 'wallet']);
+    scope.stop();
+  });
+
+  it('keeps quotes isolated and clears them when credits are selected', async () => {
+    const payment = await loadModule();
+    const openAI = payment.scenarioPaymentState('openaiimage');
+    const nano = payment.scenarioPaymentState('nanobanana');
+    openAI.quoteUsdc = '0.1';
+    openAI.quoteLoading = true;
+
+    expect(nano.quoteUsdc).toBeUndefined();
+    expect(nano.quoteLoading).toBe(false);
+
+    payment.setPreferredPaymentMode('credits');
+    expect(openAI.quoteUsdc).toBeUndefined();
+    expect(openAI.quoteLoading).toBe(false);
+  });
+
+  it('temporarily disables a scenario without changing the saved preference', async () => {
+    const payment = await loadModule();
+    payment.setPreferredPaymentMode('wallet');
+    const kling = payment.scenarioPaymentState('kling');
+    kling.quoteUsdc = '0.2';
+    kling.quoteLoading = true;
+
+    payment.setScenarioWalletAvailable('kling', false);
+    expect(kling.walletAvailable).toBe(false);
+    expect(kling.mode).toBe('credits');
+    expect(kling.quoteUsdc).toBeUndefined();
+    expect(kling.quoteLoading).toBe(false);
+    expect(payment.scenarioPaymentState('nanobanana').mode).toBe('wallet');
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('wallet');
+
+    payment.setScenarioWalletAvailable('kling', true);
+    expect(kling.walletAvailable).toBe(true);
+    expect(kling.mode).toBe('wallet');
+  });
+
+  it('reactively applies wallet availability to the effective mode', async () => {
+    const payment = await loadModule();
+    payment.setPreferredPaymentMode('wallet');
+    const openAI = payment.scenarioPaymentState('openaiimage');
+    const observed: string[] = [];
+    const scope = effectScope();
+    scope.run(() => watchEffect(() => observed.push(`${openAI.walletAvailable}:${openAI.mode}`)));
+
+    payment.setScenarioWalletAvailable('openaiimage', false);
+    await Promise.resolve();
+    payment.setScenarioWalletAvailable('openaiimage', true);
+    await Promise.resolve();
+
+    expect(observed).toEqual(['true:wallet', 'false:credits', 'true:wallet']);
+    scope.stop();
+  });
+
+  it('centralizes supported scenarios and fails closed for unknown ones', async () => {
+    const payment = await loadModule();
+    payment.setPreferredPaymentMode('wallet');
+    const supported = [
+      'nanobanana',
+      'openaiimage',
+      'flux',
+      'qrart',
+      'luma',
+      'pika',
+      'pixverse',
+      'hailuo',
+      'veo',
+      'seedance',
+      'sora',
+      'wan',
+      'omni',
+      'grokvideo',
+      'minimax',
+      'maestro',
+      'kling',
+      'digitalhuman',
+      'serp',
+      'suno',
+      'midjourney',
+      'producer',
+      'chat'
+    ];
+
+    expect(supported.every(payment.isScenarioX402Supported)).toBe(true);
+    expect(payment.isScenarioX402Supported('unknown')).toBe(false);
+    expect(payment.scenarioPaymentState('unknown').walletAvailable).toBe(false);
+    expect(payment.scenarioPaymentState('unknown').mode).toBe('credits');
+  });
+
+  it('falls back safely for invalid or unavailable storage', async () => {
+    localStorage.setItem(STORAGE_KEY, 'invalid');
+    let payment = await loadModule();
+    expect(payment.scenarioPaymentState('openaiimage').mode).toBe('credits');
+
+    vi.resetModules();
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('blocked');
+    });
+    payment = await loadModule();
+    expect(payment.scenarioPaymentState('openaiimage').mode).toBe('credits');
+  });
+
+  it('keeps the in-memory preference when storage writes fail', async () => {
+    const payment = await loadModule();
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('blocked');
+    });
+
+    expect(() => payment.setPreferredPaymentMode('wallet')).not.toThrow();
+    expect(payment.scenarioPaymentState('nanobanana').mode).toBe('wallet');
+  });
+
+  it('uses credits while x402 is unavailable without erasing wallet preference', async () => {
+    const payment = await loadModule();
+    payment.setPreferredPaymentMode('wallet');
+
+    gates.enabled = false;
+    expect(payment.scenarioPaymentState('openaiimage').mode).toBe('credits');
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('wallet');
+
+    gates.enabled = true;
+    gates.web = false;
+    expect(payment.scenarioPaymentState('nanobanana').mode).toBe('credits');
+
+    gates.web = true;
+    expect(payment.scenarioPaymentState('nanobanana').mode).toBe('wallet');
+  });
+});

--- a/src/utils/x402/scenarioPayment.ts
+++ b/src/utils/x402/scenarioPayment.ts
@@ -5,27 +5,100 @@ import { isWeb } from '@/utils/surface';
 export type ScenarioPaymentMode = 'credits' | 'wallet';
 
 interface ScenarioPaymentState {
-  mode: ScenarioPaymentMode;
+  readonly mode: ScenarioPaymentMode;
+  readonly walletAvailable: boolean;
   quoteUsdc?: string;
   quoteLoading: boolean;
 }
 
+const PAYMENT_MODE_STORAGE_KEY = 'nexior:x402:payment-mode';
+const X402_SCENARIOS = new Set([
+  'nanobanana',
+  'openaiimage',
+  'flux',
+  'qrart',
+  'luma',
+  'pika',
+  'pixverse',
+  'hailuo',
+  'veo',
+  'seedance',
+  'sora',
+  'wan',
+  'omni',
+  'grokvideo',
+  'minimax',
+  'maestro',
+  'kling',
+  'digitalhuman',
+  'serp',
+  'suno',
+  'midjourney',
+  'producer',
+  'chat'
+]);
+
+function readPreferredMode(): ScenarioPaymentMode {
+  if (typeof window === 'undefined') return 'credits';
+  try {
+    const mode = window.localStorage.getItem(PAYMENT_MODE_STORAGE_KEY);
+    return mode === 'wallet' || mode === 'credits' ? mode : 'credits';
+  } catch {
+    return 'credits';
+  }
+}
+
+function persistPreferredMode(mode: ScenarioPaymentMode): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(PAYMENT_MODE_STORAGE_KEY, mode);
+  } catch {
+    // Private mode or restricted storage: keep the in-memory preference.
+  }
+}
+
+const preferredMode = reactive({ mode: readPreferredMode() });
+const availability = reactive<Record<string, boolean | undefined>>({});
 const states = reactive<Record<string, ScenarioPaymentState>>({});
 
 export function isScenarioX402Enabled(): boolean {
   return isWeb() && isFeatureEnabled('x402');
 }
 
+export function isScenarioX402Supported(scenario: unknown): scenario is string {
+  return typeof scenario === 'string' && X402_SCENARIOS.has(scenario);
+}
+
 export function scenarioPaymentState(scenario: string): ScenarioPaymentState {
-  if (!states[scenario]) states[scenario] = { mode: 'credits', quoteLoading: false };
+  if (!states[scenario]) {
+    states[scenario] = reactive({
+      get walletAvailable(): boolean {
+        return isScenarioX402Enabled() && isScenarioX402Supported(scenario) && availability[scenario] !== false;
+      },
+      get mode(): ScenarioPaymentMode {
+        return this.walletAvailable && preferredMode.mode === 'wallet' ? 'wallet' : 'credits';
+      },
+      quoteLoading: false
+    });
+  }
   return states[scenario];
 }
 
-export function setScenarioPaymentMode(scenario: string, mode: ScenarioPaymentMode): void {
-  const state = scenarioPaymentState(scenario);
-  state.mode = mode;
+export function setPreferredPaymentMode(mode: ScenarioPaymentMode): void {
+  preferredMode.mode = mode;
+  persistPreferredMode(mode);
   if (mode === 'credits') {
-    state.quoteUsdc = undefined;
-    state.quoteLoading = false;
+    Object.values(states).forEach(clearScenarioQuote);
   }
+}
+
+export function setScenarioWalletAvailable(scenario: string, available: boolean): void {
+  const state = scenarioPaymentState(scenario);
+  availability[scenario] = available;
+  if (!available) clearScenarioQuote(state);
+}
+
+function clearScenarioQuote(state: ScenarioPaymentState): void {
+  state.quoteUsdc = undefined;
+  state.quoteLoading = false;
 }


### PR DESCRIPTION
## Summary
- persist one global Credits/Wallet preference across supported services and page reloads
- centralize x402 scenario support and derive an effective mode from shared wallet availability
- make Kling Motion and OpenAI Image Edit temporarily credits-only without overwriting the saved preference
- keep per-service USDC quote/loading state isolated and cancel stale OpenAI generation quotes on edit transitions

## Validation
- `npm exec vitest -- run --maxWorkers=1 --fileParallelism=false` (231 files, 1728 tests passed)
- `npm run lint:check` (0 errors; 2 existing warnings in `dropUploadMixin.test.ts`)
- `npx vue-tsc -b --noEmit`
- `npm run build:web`
- `python3 scripts/check_release_workflows.py`
- `python3 scripts/check_i18n_coverage.py`
- `npm run verify`

Note: default parallel Vitest runs exposed an existing Electron shell-session timeout; the same 24-test file passes independently, and the complete suite passes with one worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)