### PR TITLE
fix(x402): ship valid Base EIP-712 signing

### DIFF
--- a/change/fix-x402-eip712-domain.json
+++ b/change/fix-x402-eip712-domain.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Upgrade the X402 client so Base wallet signatures include the complete EIP-712 domain.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@acedatacloud/core": "^0.21.1",
-        "@acedatacloud/x402-client": "^2026.726.1",
+        "@acedatacloud/x402-client": "^2026.804.0",
         "@capacitor-community/apple-sign-in": "^7.1.0",
         "@capacitor-community/stripe": "^8.1.1",
         "@capacitor/app": "^8.0.1",
@@ -170,9 +170,9 @@
       }
     },
     "node_modules/@acedatacloud/x402-client": {
-      "version": "2026.726.1",
-      "resolved": "https://registry.npmjs.org/@acedatacloud/x402-client/-/x402-client-2026.726.1.tgz",
-      "integrity": "sha1-bQfffFlr5PcmG8p/gsGyS1A5YMk=",
+      "version": "2026.804.0",
+      "resolved": "https://registry.npmjs.org/@acedatacloud/x402-client/-/x402-client-2026.804.0.tgz",
+      "integrity": "sha512-wA2ylk58oP+Zmbtu6ii4TLWGys9YavjAEiaR/cWcFvDqb6S4312M4MClohNE4QkyOXN+RMMgXuxRMD9sl42Jdg==",
       "license": "MIT",
       "peerDependencies": {
         "@solana/web3.js": "^1.90.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@acedatacloud/core": "^0.21.1",
-    "@acedatacloud/x402-client": "^2026.726.1",
+    "@acedatacloud/x402-client": "^2026.804.0",
     "@capacitor-community/apple-sign-in": "^7.1.0",
     "@capacitor-community/stripe": "^8.1.1",
     "@capacitor/app": "^8.0.1",

--- a/src/operators/x402ClientEvmContract.test.ts
+++ b/src/operators/x402ClientEvmContract.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest';
+import { signEVMPayment, type PaymentRequirement } from '@acedatacloud/x402-client';
+
+const requirement: PaymentRequirement = {
+  scheme: 'exact',
+  network: 'eip155:8453',
+  amount: '12263',
+  maxAmountRequired: '12263',
+  maxTimeoutSeconds: 3600,
+  resource: 'https://x402.acedata.cloud/nano-banana/images',
+  description: 'AceDataCloud API call',
+  payTo: '0x4F0E2D3477a1B94CF33d16E442CEe4733dadCeE7',
+  asset: '0x833589fCD6e08f4c7C32D4f71b54bdA02913',
+  extra: {
+    name: 'USD Coin',
+    version: '2',
+    chainId: 8453,
+    verifyingContract: '0x833589fCD6e08f4c7C32D4f71b54bdA02913'
+  }
+};
+
+describe('@acedatacloud/x402-client EVM contract', () => {
+  it('declares the complete EIP-712 domain for browser wallets', async () => {
+    const request = vi.fn(async (_args: { method: string; params?: unknown[] }) => `0x${'11'.repeat(65)}`);
+
+    await signEVMPayment(requirement, { request }, '0x1111111111111111111111111111111111111111');
+
+    expect(request).toHaveBeenCalledTimes(1);
+    const call = request.mock.calls[0][0];
+    expect(call.method).toBe('eth_signTypedData_v4');
+    const typedData = JSON.parse(String(call.params?.[1]));
+    expect(typedData.types.EIP712Domain).toEqual([
+      { name: 'name', type: 'string' },
+      { name: 'version', type: 'string' },
+      { name: 'chainId', type: 'uint256' },
+      { name: 'verifyingContract', type: 'address' }
+    ]);
+    expect(typedData.domain).toEqual({
+      name: 'USD Coin',
+      version: '2',
+      chainId: 8453,
+      verifyingContract: requirement.asset
+    });
+  });
+});


### PR DESCRIPTION
## Bug
Base wallet generation reached the payment confirmation but the browser wallet rejected `eth_signTypedData_v4` with `Missing or invalid parameters`. Solana succeeded because it does not use EIP-712.

## Root cause
Nexior was still locked to `@acedatacloud/x402-client@2026.726.1`. That published build omitted `types.EIP712Domain` from exact EVM typed data. MetaMask-compatible wallets do not infer this the same way as test signers: they reject the parameters or sign an empty-domain digest. The upstream fix already shipped in `v2026.804.0`, but Nexior never consumed it.

## Fix
- upgrade `@acedatacloud/x402-client` to `^2026.804.0`
- lock the registry tarball with its verified SHA-512 integrity
- add a real package contract test that intercepts `eth_signTypedData_v4` and requires the full EIP-712 domain declaration and USDC domain values

## Verification
- official registry tarball integrity verified against npm metadata
- 19 X402/operator contract tests passed
- ESLint passed with only two pre-existing warnings
- `vue-tsc -b` passed
- web build passed
- Beachball check passed

## Production expectation
After deploy, Base flow becomes: 402 quote → confirmation → wallet EIP-712 prompt → signed `PAYMENT-SIGNATURE` retry. No automated real payment is performed.

## Security
The credential pasted in the incident report is not used or recorded and must be revoked/rotated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)