### PR TITLE
feat: add Maestro showcase gallery

### DIFF
--- a/change/maestro-showcase-gallery-7c9e2a41.json
+++ b/change/maestro-showcase-gallery-7c9e2a41.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add Maestro Showcase cards, service Gallery browsing, and safe Create similar configuration replay.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/pages/maestro/Index.vue
+++ b/src/pages/maestro/Index.vue
@@ -4,7 +4,11 @@
       <config-panel @generate="onGenerate" />
     </template>
     <template #result>
-      <recent-panel ref="recentPanel" :loading="loadingMore" @reach-top="onReachTop" />
+      <showcase-result-tabs service="maestro">
+        <template #tasks>
+          <recent-panel ref="recentPanel" :loading="loadingMore" @reach-top="onReachTop" />
+        </template>
+      </showcase-result-tabs>
     </template>
   </layout>
 </template>
@@ -15,8 +19,10 @@ import { defineComponent } from 'vue';
 import Layout from '@/layouts/Maestro.vue';
 import ConfigPanel from '@/components/maestro/ConfigPanel.vue';
 import RecentPanel from '@/components/maestro/RecentPanel.vue';
+import ShowcaseResultTabs from '@/components/common/ShowcaseResultTabs.vue';
 import { buildMaestroRequest, maestroOperator } from '@/operators/maestro';
 import { ensureLoggedIn } from '@/utils';
+import { showcaseRecreateMixin } from '@/utils/showcaseRecreateMixin';
 import { instrumentGeneration } from '@/plugins/telemetry';
 import { Status } from '@/models';
 import { ElMessage, ElMessageBox } from 'element-plus';
@@ -42,8 +48,10 @@ export default defineComponent({
   components: {
     ConfigPanel,
     Layout,
-    RecentPanel
+    RecentPanel,
+    ShowcaseResultTabs
   },
+  mixins: [showcaseRecreateMixin('maestro')],
   inject: ['initialized'],
   data(): IData {
     return {

--- a/src/pages/serviceGalleryTabs.test.ts
+++ b/src/pages/serviceGalleryTabs.test.ts
@@ -10,7 +10,8 @@ const galleryPages = [
   ['veo/Index.vue', 'veo'],
   ['grokvideo/Index.vue', 'grok'],
   ['suno/Index.vue', 'suno'],
-  ['fish/Tts.vue', 'fish']
+  ['fish/Tts.vue', 'fish'],
+  ['maestro/Index.vue', 'maestro']
 ] as const;
 
 function readPage(path: string): string {

--- a/src/utils/showcase.test.ts
+++ b/src/utils/showcase.test.ts
@@ -6,7 +6,8 @@ const site = {
   features: {
     nanobanana: { enabled: true },
     seedance: { enabled: true },
-    suno: { enabled: true }
+    suno: { enabled: true },
+    maestro: { enabled: true }
   }
 } as any;
 
@@ -84,5 +85,93 @@ describe('resolveShowcase', () => {
       posterUrl: 'cover.jpg',
       previewUrl: 'audio.mp3'
     });
+  });
+
+  it('derives a Maestro video from variants, cover, aspect, and request metadata', () => {
+    const source = {
+      ...item(
+        'maestro',
+        'videos',
+        {
+          action: 'generate',
+          prompt: 'Explain aerodynamic downforce',
+          langs: ['en'],
+          aspect: '9:16',
+          duration: 20,
+          quality: 'lite',
+          scenario: 'narrated',
+          style: 'industrial',
+          voice: 'documentary-male'
+        },
+        {
+          success: true,
+          data: {
+            cover_url: 'poster.webp',
+            variants: [{ lang: 'en', aspect: '9:16', kind: 'video', output_url: 'video.mp4' }]
+          }
+        }
+      ),
+      data: {
+        type: 'videos',
+        request: {
+          action: 'generate',
+          prompt: 'Explain aerodynamic downforce',
+          langs: ['en'],
+          aspect: '9:16',
+          duration: 20,
+          quality: 'lite',
+          scenario: 'narrated',
+          style: 'industrial',
+          voice: 'documentary-male'
+        },
+        response: {
+          success: true,
+          data: {
+            cover_url: 'poster.webp',
+            variants: [{ lang: 'en', aspect: '9:16', kind: 'video', output_url: 'video.mp4' }]
+          }
+        },
+        presentation: { title: 'Air at Speed', description: 'A concise engineering explainer.' }
+      }
+    };
+    const result = resolveShowcase(source, site);
+    expect(result).toMatchObject({
+      capability: 'maestro',
+      routeName: 'maestro-index',
+      mediaType: 'Video',
+      posterUrl: 'poster.webp',
+      previewUrl: 'video.mp4',
+      layout: 'Portrait',
+      title: 'Air at Speed'
+    });
+    expect(result?.parameters).toEqual(
+      expect.arrayContaining([
+        { key: 'langs', value: 'en' },
+        { key: 'aspect', value: '9:16' },
+        { key: 'quality', value: 'lite' },
+        { key: 'scenario', value: 'narrated' },
+        { key: 'voice', value: 'documentary-male' }
+      ])
+    );
+  });
+
+  it('rejects Maestro videos without both a poster and a playable variant', () => {
+    expect(
+      resolveShowcase(
+        item('maestro', 'videos', { prompt: 'Missing video', aspect: '16:9' }, { data: { cover_url: 'poster.webp' } }),
+        site
+      )
+    ).toBeUndefined();
+    expect(
+      resolveShowcase(
+        item(
+          'maestro',
+          'videos',
+          { prompt: 'Missing poster', aspect: '16:9' },
+          { data: { variants: [{ output_url: 'video.mp4' }] } }
+        ),
+        site
+      )
+    ).toBeUndefined();
   });
 });

--- a/src/utils/showcase.ts
+++ b/src/utils/showcase.ts
@@ -4,6 +4,7 @@ import {
   ROUTE_FISH_TTS_INDEX,
   ROUTE_GROKVIDEO_INDEX,
   ROUTE_KLING_INDEX,
+  ROUTE_MAESTRO_INDEX,
   ROUTE_NANOBANANA_INDEX,
   ROUTE_OPENAIIMAGE_INDEX,
   ROUTE_PRODUCER_INDEX,
@@ -92,6 +93,13 @@ const definitions: ShowcaseServiceDefinition[] = [
     routeName: ROUTE_FISH_TTS_INDEX,
     defaultName: 'Fish Audio',
     descriptionKey: 'intro.model.fish'
+  },
+  {
+    service: 'maestro',
+    capability: 'maestro',
+    routeName: ROUTE_MAESTRO_INDEX,
+    defaultName: 'Maestro',
+    descriptionKey: 'intro.home.banner.production.description'
   }
 ];
 
@@ -113,7 +121,7 @@ function stringValue(...values: unknown[]): string {
 }
 
 function deriveLayout(request: Record<string, unknown>): ShowcaseLayout {
-  const ratio = stringValue(request.aspect_ratio, request.ratio);
+  const ratio = stringValue(request.aspect_ratio, request.ratio, request.aspect);
   const size = stringValue(request.size);
   const match = ratio.match(/^(\d+):(\d+)$/) || size.match(/^(\d+)x(\d+)$/);
   if (!match) return 'Square';
@@ -129,7 +137,12 @@ const PARAMETER_KEYS = [
   'size',
   'aspect_ratio',
   'ratio',
+  'aspect',
   'resolution',
+  'quality',
+  'scenario',
+  'voice',
+  'langs',
   'duration',
   'output_format',
   'seed',
@@ -141,7 +154,10 @@ const PARAMETER_KEYS = [
 function deriveParameters(request: Record<string, unknown>): Array<{ key: string; value: string }> {
   return PARAMETER_KEYS.flatMap((key) => {
     const value = request[key];
-    if (value == null || value === '' || typeof value === 'object') return [];
+    if (value == null || value === '') return [];
+    if (key === 'langs' && Array.isArray(value) && value.every((item) => typeof item === 'string'))
+      return [{ key, value: value.join(', ') }];
+    if (typeof value === 'object') return [];
     return [{ key, value: String(value) }];
   });
 }
@@ -157,11 +173,13 @@ function deriveMedia(
   layout: ShowcaseLayout;
 } {
   if (type === 'videos' || result.video_url) {
+    const variants = Array.isArray(result.variants) ? result.variants.map(objectValue) : [];
+    const layout = deriveLayout(request);
     return {
       mediaType: 'Video',
       posterUrl: stringValue(result.last_frame_url, result.cover_url),
-      previewUrl: stringValue(result.video_url),
-      layout: deriveLayout(request) === 'Square' ? 'Landscape' : deriveLayout(request)
+      previewUrl: stringValue(result.video_url, variants[0]?.output_url),
+      layout: layout === 'Square' && !request.aspect ? 'Landscape' : layout
     };
   }
   if (type === 'audios' || result.audio_url || result.file_url) {
@@ -187,7 +205,7 @@ export function resolveShowcase(item: IShowcase, site: ISite): ResolvedShowcase 
   const response = objectValue(item.data.response);
   const result = firstResult(response);
   const media = deriveMedia(item.data.type, request, result);
-  if (!media.posterUrl) return undefined;
+  if (!media.posterUrl || (media.mediaType !== 'Image' && !media.previewUrl)) return undefined;
   const defaultIcon = CAPABILITY_ICONS[definition.capability];
   const capabilityPresentation = resolveCapabilityPresentation(
     site,

--- a/src/utils/showcaseRecreate.test.ts
+++ b/src/utils/showcaseRecreate.test.ts
@@ -18,7 +18,8 @@ const SERVICES: Record<string, string> = {
   grokvideo: 'grok',
   suno: 'suno',
   producer: 'producer',
-  fish: 'fish'
+  fish: 'fish',
+  maestro: 'maestro'
 };
 const item = (capability: string, request: Record<string, unknown>, service = SERVICES[capability]) => ({
   id: ID,
@@ -83,7 +84,23 @@ describe('showcase recreate consumer', () => {
     ['grokvideo', { prompt: 'City', resolution: '720p' }, 'resolution'],
     ['suno', { action: 'generate', prompt: 'Nocturne', instrumental: true }, 'instrumental'],
     ['producer', { prompt: 'Dream pop', style: 'Dream pop' }, 'style'],
-    ['fish', { text: 'Welcome', format: 'mp3', speed: 1 }, 'format']
+    ['fish', { text: 'Welcome', format: 'mp3', speed: 1 }, 'format'],
+    [
+      'maestro',
+      {
+        action: 'generate',
+        prompt: 'Explain aerodynamic downforce',
+        file_urls: [],
+        langs: ['en'],
+        aspect: '16:9',
+        duration: 30,
+        quality: 'standard',
+        scenario: 'narrated',
+        style: 'industrial',
+        voice: 'documentary-male'
+      },
+      'quality'
+    ]
   ])(
     'loads %s once by service and applies safe config without tasks or submit',
     async (capability, request, expectedKey) => {
@@ -241,5 +258,83 @@ describe('showcase recreate consumer', () => {
     const second = context('seedance', { prompt: 'Old prompt', duration: 5, resolution: '720p' });
     expect(await consumeShowcase(second.options)).toBe('applied');
     expect(second.commit).toHaveBeenCalledWith('seedance/setConfig', { prompt: 'New prompt' });
+  });
+
+  it('applies a safe Maestro generate config and never submits it', async () => {
+    const request = {
+      action: 'generate',
+      prompt: 'Original virtual presenter explains future mobility',
+      file_urls: ['https://cdn.acedata.cloud/synthetic-presenter.webp'],
+      langs: ['en'],
+      aspect: '9:16',
+      duration: 30,
+      quality: 'standard',
+      scenario: 'avatar',
+      style: 'modern',
+      voice: 'anchor-female'
+    };
+    vi.mocked(showcaseOperator.list).mockResolvedValue({ data: [item('maestro', request)] } as any);
+    const { options, commit, dispatch } = context('maestro');
+    expect(await consumeShowcase(options)).toBe('applied');
+    expect(commit).toHaveBeenCalledWith(
+      'maestro/setConfig',
+      expect.objectContaining({
+        action: 'generate',
+        prompt: request.prompt,
+        file_urls: request.file_urls,
+        scenario_customization_enabled: true,
+        style_customization_enabled: true,
+        voice_customization_enabled: true,
+        scenario: 'avatar',
+        style: 'modern',
+        voice: 'anchor-female'
+      })
+    );
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { action: 'remix' },
+    { action: 'generate', prompt: '   ' },
+    { action: 'generate', aspect: undefined },
+    { action: 'generate', duration: 20.5 },
+    { action: 'generate', style: undefined },
+    { action: 'generate', voice: undefined },
+    { action: 'generate', quality: 'lite', duration: 31 },
+    { action: 'generate', quality: 'lite', langs: ['zh-cn', 'en'] },
+    { action: 'generate', quality: 'standard', scenario: 'drama' },
+    { action: 'generate', quality: 'standard', scenario: 'avatar', file_urls: [] },
+    {
+      action: 'generate',
+      quality: 'standard',
+      scenario: 'captions',
+      file_urls: ['https://cdn.acedata.cloud/image.webp']
+    },
+    { action: 'generate', quality: 'standard', scenario: 'narrated', file_urls: ['https://example.com/private.mp4'] },
+    {
+      action: 'generate',
+      quality: 'standard',
+      scenario: 'narrated',
+      file_urls: ['https://cdn.acedata.cloud/source.mp4?signature=private']
+    },
+    { action: 'generate', quality: 'standard', scenario: 'narrated', internal_route: 'private' }
+  ])('rejects unsafe Maestro replay fields %#', async (patch) => {
+    const request = {
+      prompt: 'Safe prompt',
+      file_urls: [],
+      langs: ['en'],
+      aspect: '16:9',
+      duration: 30,
+      quality: 'standard',
+      scenario: 'narrated',
+      style: 'modern',
+      voice: 'anchor-female',
+      ...patch
+    };
+    vi.mocked(showcaseOperator.list).mockResolvedValue({ data: [item('maestro', request)] } as any);
+    const { options, commit, dispatch } = context('maestro');
+    expect(await consumeShowcase(options)).toBe('failed');
+    expect(commit).not.toHaveBeenCalled();
+    expect(dispatch).not.toHaveBeenCalled();
   });
 });

--- a/src/utils/showcaseRecreate.ts
+++ b/src/utils/showcaseRecreate.ts
@@ -1,4 +1,14 @@
 import type { CapabilityKey } from '@/constants/capabilities';
+import {
+  MAESTRO_ALLOWED_ASPECTS,
+  MAESTRO_ALLOWED_LANGS,
+  MAESTRO_ALLOWED_QUALITIES,
+  MAESTRO_ALLOWED_SCENARIOS,
+  MAESTRO_ALLOWED_STYLES,
+  MAESTRO_ALLOWED_VOICES,
+  MAESTRO_FILE_LIMIT,
+  MAESTRO_SKU_POLICIES
+} from '@/constants';
 import type { IShowcase, ISite } from '@/models';
 import { showcaseOperator } from '@/operators';
 import { SHOWCASE_CAPABILITIES } from './showcase';
@@ -66,6 +76,7 @@ function cdnUrl(value: unknown, field: string): string {
     !CDN_HOSTS.has(parsed.hostname) ||
     parsed.username ||
     parsed.password ||
+    parsed.search ||
     parsed.hash
   )
     throw new Error(`${field} is invalid`);
@@ -116,6 +127,18 @@ const videoAllowed = new Set([
   'cfg_scale'
 ]);
 const musicAllowed = new Set(['action', 'prompt', 'lyric', 'style', 'title', 'instrumental', 'custom', 'model']);
+const maestroAllowed = new Set([
+  'action',
+  'prompt',
+  'file_urls',
+  'langs',
+  'aspect',
+  'duration',
+  'quality',
+  'scenario',
+  'style',
+  'voice'
+]);
 
 const adapters: Partial<Record<CapabilityKey, Adapter>> = {
   nanobanana: {
@@ -268,6 +291,66 @@ const adapters: Partial<Record<CapabilityKey, Adapter>> = {
         model: text(c.model, 'model', 100),
         continue_at: 0
       })
+  },
+
+  maestro: {
+    allowed: maestroAllowed,
+    activeKeys: ['prompt', 'file_urls'],
+    build: (c) => {
+      if (c.action !== 'generate') throw new Error('action is invalid');
+      const quality = enumValue(c.quality, 'quality', MAESTRO_ALLOWED_QUALITIES) as
+        | keyof typeof MAESTRO_SKU_POLICIES
+        | undefined;
+      if (!quality) throw new Error('quality is invalid');
+      const policy = MAESTRO_SKU_POLICIES[quality];
+      const langs = c.langs;
+      if (
+        !Array.isArray(langs) ||
+        !langs.length ||
+        langs.length > policy.maxLanguages ||
+        new Set(langs).size !== langs.length ||
+        !langs.every((lang) => typeof lang === 'string' && MAESTRO_ALLOWED_LANGS.includes(lang))
+      )
+        throw new Error('langs is invalid');
+      const scenario = enumValue(c.scenario, 'scenario', ['auto', ...MAESTRO_ALLOWED_SCENARIOS]);
+      if (!scenario || !policy.scenarios.includes(scenario)) throw new Error('scenario is invalid');
+      const fileUrls = c.file_urls == null ? [] : urls(c.file_urls, 'file_urls');
+      if (!fileUrls || fileUrls.length > MAESTRO_FILE_LIMIT) throw new Error('file_urls is invalid');
+      const paths = fileUrls.map((url) => new URL(url).pathname.toLowerCase());
+      if (scenario === 'avatar' && !paths.some((path) => /\.(png|jpe?g|webp)$/.test(path)))
+        throw new Error('avatar source is invalid');
+      if (scenario === 'captions' && !paths.some((path) => /\.(mp4|mov|webm)$/.test(path)))
+        throw new Error('captions source is invalid');
+      const prompt = text(c.prompt, 'prompt');
+      if (!prompt?.trim()) throw new Error('prompt is invalid');
+      const aspect = enumValue(c.aspect, 'aspect', MAESTRO_ALLOWED_ASPECTS);
+      if (!aspect) throw new Error('aspect is invalid');
+      const duration = number(c.duration, 'duration', 5, policy.maxDuration);
+      if (duration == null || !Number.isInteger(duration)) throw new Error('duration is invalid');
+      const style = enumValue(c.style, 'style', MAESTRO_ALLOWED_STYLES);
+      if (!style) throw new Error('style is invalid');
+      const voice = enumValue(
+        c.voice,
+        'voice',
+        MAESTRO_ALLOWED_VOICES.map((option) => option.key)
+      );
+      if (!voice) throw new Error('voice is invalid');
+      return compact({
+        action: 'generate',
+        prompt,
+        file_urls: fileUrls,
+        langs: [...langs],
+        aspect,
+        duration,
+        quality,
+        scenario_customization_enabled: scenario !== 'auto',
+        style_customization_enabled: true,
+        voice_customization_enabled: true,
+        scenario: scenario === 'auto' ? undefined : scenario,
+        style,
+        voice
+      });
+    }
   },
   fish: {
     allowed: new Set(['text', 'voice_id', 'model', 'format', 'speed', 'volume']),


### PR DESCRIPTION
## Summary
- register Maestro as a Showcase video capability and resolve its `variants[].output_url` + `cover_url` response shape
- add a lazy-loaded Gallery tab to `/maestro` without changing Current Tasks behavior
- add strict, SKU-aware Create similar replay that only prefills safe config and never submits generation
- reject malformed, internal, external-host, signed-query, wrong-scenario, or incomplete Maestro replay data

## Dependency
- merge/deploy https://github.com/AceDataCloud/PlatformBackend/pull/1603 first
- do not merge this PR until the production `service=maestro` feed returns exactly 20 rows

## Validation
- `npm ci`
- `npm run test:run` — 232 files / 1748 tests passed
- `npm run build:web` — passed
- `npm run lint:check` — 0 errors, 2 pre-existing warnings in `dropUploadMixin.test.ts`
- `python3 scripts/check_i18n_coverage.py` — passed
- `npm run verify` — passed
- `git diff --check` — passed

## Rollout
- after Backend feed proof, deploy Nexior and verify desktop/mobile Gallery, mixed aspect cards, lazy media, and Create similar with zero generation POSTs
