### PR TITLE
feat(scheduled): complete template test and enable flow

### DIFF
--- a/change/@acedatacloud-nexior-53df008b-48ee-4115-a55b-ad1b19e32bcf.json
+++ b/change/@acedatacloud-nexior-53df008b-48ee-4115-a55b-ad1b19e32bcf.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add the guided test-and-enable flow for scheduled templates.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/scheduledTemplates/ScheduledTemplateWizard.test.ts
+++ b/src/components/scheduledTemplates/ScheduledTemplateWizard.test.ts
@@ -1,176 +1,165 @@
 // @vitest-environment jsdom
-import { shallowMount } from '@vue/test-utils';
-import { ElMessage } from 'element-plus';
+import { shallowMount, flushPromises } from '@vue/test-utils';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-
 import { scheduledTasksOperator } from '@/operators/scheduledTasks';
 import ScheduledTemplateWizard from './ScheduledTemplateWizard.vue';
 
 const template = {
-  id: 'daily-ai-promo-pack',
-  version: 1,
-  title: 'Daily AI promotion pack',
-  summary: 'Three formats',
+  id: 'weekly-learning-plan',
+  version: 2,
+  title: 'Weekly learning plan',
+  summary: 'A safe plan',
   description: 'Description',
-  categories: ['marketing'],
+  categories: ['personal'],
   tags: [],
   featured: true,
-  form_schema: [
-    { key: 'topic', type: 'text' as const, label: 'Topic', required: true },
-    { key: 'audience', type: 'text' as const, label: 'Audience', required: true }
-  ],
+  form_schema: [{ key: 'topic', type: 'text' as const, label: 'Topic', required: true }],
   requirements: { skills: [], mcp_servers: [], connections: [], local_tools: [] },
-  defaults: { model: 'gpt-5.6-sol', schedule: { type: 'cron' as const, cron: '0 9 * * *', tz: 'UTC' }, max_turns: 50 },
+  dependencies: {
+    required: { skills: [], mcp_servers: [], connections: [], local_tools: [] },
+    optional: { skills: [], mcp_servers: [], connections: [], local_tools: [] }
+  },
+  defaults: { model: 'gpt-5.6-sol', schedule: { type: 'cron' as const, cron: '0 7 * * 1', tz: 'UTC' }, max_turns: 50 },
   test_strategy: { mode: 'preview_only' as const },
   available: true,
-  missing_connections: []
+  missing_connections: [],
+  risk: { level: 'low' as const, unattended_eligible: true, reasons: [] },
+  side_effects: [],
+  budget: {
+    unit: 'credits' as const,
+    estimated_upper_bound: 3,
+    basis: 'catalog_conservative_v1',
+    max_tool_actions: 12,
+    max_paid_actions: 0,
+    exact_charge_available: false as const
+  }
 };
-
-const disabledTask = {
+const task = {
   id: 'task-1',
-  name: 'Template',
+  name: 'Plan',
   state: 'disabled' as const,
   schedule: template.defaults.schedule,
-  template: { model: 'gpt-5.6-sol', question: 'Preview' },
+  template: { model: 'gpt-5.6-sol', question: 'Plan' },
   run_count: 0,
   created_at: 1,
   updated_at: 1
 };
+const terminalRun = {
+  id: 'manual-1',
+  task_id: task.id,
+  status: 'success' as const,
+  scheduled_at: Math.floor(Date.now() / 1000),
+  conversation_id: 'c1'
+};
 
-const mountWizard = () =>
-  shallowMount(ScheduledTemplateWizard, {
+function mountWizard() {
+  return shallowMount(ScheduledTemplateWizard, {
     props: { modelValue: true, token: 'tok' },
     global: {
       mocks: { $t: (key: string) => key },
       stubs: {
         BrowseConnectors: true,
-        ElDialog: { template: '<div><slot /><slot name="footer" /></div>' },
-        ElSteps: { template: '<div><slot /></div>' },
+        ElDialog: { template: '<div><slot/><slot name="footer"/></div>' },
+        ElSteps: { template: '<div><slot/></div>' },
         ElStep: { props: ['title'], template: '<span class="step-title">{{ title }}</span>' }
       }
     }
   });
+}
 
 describe('ScheduledTemplateWizard', () => {
-  afterEach(() => vi.restoreAllMocks());
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
 
-  it('renders only the choose, configure, and connect steps', () => {
-    const wrapper = mountWizard();
-    const titles = wrapper.findAll('.step-title').map((step) => step.text());
+  it('renders the complete five-step lifecycle', () => {
+    const titles = mountWizard()
+      .findAll('.step-title')
+      .map((node) => node.text());
     expect(titles).toEqual([
       'chat.scheduledTemplates.step.choose',
       'chat.scheduledTemplates.step.configure',
-      'chat.scheduledTemplates.step.connect'
+      'chat.scheduledTemplates.step.connect',
+      'chat.scheduledTemplates.step.test',
+      'chat.scheduledTemplates.step.enable'
     ]);
   });
 
-  it('does not bind remote MCP connections as skill accounts', () => {
-    const mcpTemplate = {
-      ...template,
-      requirements: {
-        skills: [],
-        mcp_servers: ['AceDataCloud'],
-        connections: ['acedatacloud/acedatacloud'],
-        local_tools: []
-      },
-      connection_accounts: {
-        'acedatacloud/acedatacloud': [
-          {
-            connection_id: 'mcp-1',
-            connector_identifier: 'acedatacloud/acedatacloud',
-            label: 'AceDataCloud',
-            is_default: true,
-            account_name: 'AceDataCloud',
-            execution_type: 'remote_mcp',
-            supports_task_binding: false
-          }
-        ]
-      }
-    };
+  it('preserves the weekly cadence when editing only wall-clock time', () => {
     const wrapper = mountWizard();
-    const vm = wrapper.vm as unknown as {
-      selectTemplate: (value: typeof mcpTemplate) => void;
-      connectionReady: (identifier: string) => boolean;
-      bindings: () => unknown[];
-    };
-    vm.selectTemplate(mcpTemplate);
-    expect(vm.connectionReady('acedatacloud/acedatacloud')).toBe(true);
-    expect(vm.bindings()).toEqual([]);
+    const vm = wrapper.vm as any;
+    vm.selectTemplate(template);
+    vm.scheduleTime = '08:25';
+    expect(vm.buildSchedule()).toMatchObject({ type: 'cron', cron: '25 08 * * 1' });
   });
 
-  it('shows the backend message and keeps the wizard open when creation fails', async () => {
-    vi.spyOn(scheduledTasksOperator, 'instantiateTemplate').mockRejectedValue({
-      response: { data: { message: 'remote MCP connectors cannot be account-bound' } }
-    });
-    const error = vi.spyOn(ElMessage, 'error');
+  it('instantiates one disabled task and polls the exact returned run id', async () => {
+    vi.spyOn(scheduledTasksOperator, 'instantiateTemplate').mockResolvedValue(task as any);
+    vi.spyOn(scheduledTasksOperator, 'triggerTask').mockResolvedValue({ run_id: 'manual-1' });
+    const retrieve = vi.spyOn(scheduledTasksOperator, 'retrieveRun').mockResolvedValue(terminalRun as any);
     const wrapper = mountWizard();
-    const vm = wrapper.vm as unknown as {
-      selectTemplate: (value: typeof template) => void;
-      inputs: Record<string, string>;
-      step: number;
-      visible: boolean;
-      createTask: () => Promise<void>;
-    };
+    const vm = wrapper.vm as any;
     vm.selectTemplate(template);
-    vm.inputs = { topic: 'AI', audience: 'developers' };
-    vm.step = 2;
-    await vm.createTask();
-    expect(error).toHaveBeenCalledWith('remote MCP connectors cannot be account-bound');
-    expect(vm.visible).toBe(true);
-    expect(wrapper.emitted('created')).toBeUndefined();
+    vm.inputs = { topic: 'TypeScript' };
+    vm.step = 3;
+    await vm.startTest();
+    expect(scheduledTasksOperator.instantiateTemplate).toHaveBeenCalledTimes(1);
+    expect(retrieve).toHaveBeenCalledWith('tok', task.id, 'manual-1');
+    expect(wrapper.emitted('created')?.[0]).toEqual([task]);
+    expect(vm.run.status).toBe('success');
+    await vm.retryTest();
+    expect(scheduledTasksOperator.instantiateTemplate).toHaveBeenCalledTimes(1);
+    expect(scheduledTasksOperator.triggerTask).toHaveBeenCalledTimes(2);
   });
 
-  it('requires declared inputs without adding growth-specific state', () => {
+  it('fails closed when activation readiness is unavailable', async () => {
+    vi.spyOn(scheduledTasksOperator, 'activationStatus').mockRejectedValue({ response: { status: 400 } });
     const wrapper = mountWizard();
-    const vm = wrapper.vm as unknown as {
-      selectTemplate: (value: typeof template) => void;
-      inputs: Record<string, string>;
-      step: number;
-      canContinue: boolean;
-    };
+    const vm = wrapper.vm as any;
     vm.selectTemplate(template);
-    vm.step = 1;
-    expect(Object.keys(wrapper.vm)).not.toContain('referral' + 'Enabled');
-    expect(vm.canContinue).toBe(false);
-    vm.inputs = { topic: 'AI', audience: 'developers' };
-    expect(vm.canContinue).toBe(true);
+    vm.task = task;
+    vm.run = terminalRun;
+    vm.step = 3;
+    await vm.prepareEnable();
+    expect(vm.step).toBe(4);
+    expect(vm.backendBlocked).toBe(true);
+    expect(vm.activation).toBeNull();
   });
 
-  it('creates a disabled task without previewing, running, or enabling it', async () => {
-    const instantiate = vi.spyOn(scheduledTasksOperator, 'instantiateTemplate').mockResolvedValue(disabledTask);
-    const preview = vi.spyOn(scheduledTasksOperator, 'previewTemplate');
-    const trigger = vi.spyOn(scheduledTasksOperator, 'triggerTask');
-    const listRuns = vi.spyOn(scheduledTasksOperator, 'listRuns');
-    const enable = vi.spyOn(scheduledTasksOperator, 'enableTemplateTask');
+  it('enables only after the backend returns ready for the current config', async () => {
+    vi.spyOn(scheduledTasksOperator, 'activationStatus').mockResolvedValue({
+      ready: true,
+      blockers: [],
+      evidence: { mode: 'run_success', satisfied: true, artifacts: [] },
+      risk: template.risk,
+      side_effects: [],
+      budget: template.budget
+    } as any);
+    const enable = vi
+      .spyOn(scheduledTasksOperator, 'enableTemplateTask')
+      .mockResolvedValue({ ...task, state: 'enabled' } as any);
     const wrapper = mountWizard();
-    const vm = wrapper.vm as unknown as {
-      selectTemplate: (value: typeof template) => void;
-      inputs: Record<string, string>;
-      step: number;
-      visible: boolean;
-      selected: typeof template | null;
-      createTask: () => Promise<void>;
-    };
+    const vm = wrapper.vm as any;
     vm.selectTemplate(template);
-    vm.inputs = { topic: 'AI', audience: 'developers' };
-    vm.step = 2;
+    vm.task = task;
+    vm.run = terminalRun;
+    await vm.prepareEnable();
+    await vm.enableTask();
+    await flushPromises();
+    expect(enable).toHaveBeenCalledWith('tok', task.id);
+    expect(wrapper.emitted('created')?.at(-1)).toEqual([{ ...task, state: 'enabled' }]);
+  });
 
-    await vm.createTask();
-
-    expect(instantiate).toHaveBeenCalledWith('tok', {
-      template_id: template.id,
-      version: template.version,
-      inputs: { topic: 'AI', audience: 'developers' },
-      schedule: { type: 'cron', cron: '00 09 * * *', tz: expect.any(String) },
-      connection_bindings: []
-    });
-    expect(preview).not.toHaveBeenCalled();
-    expect(trigger).not.toHaveBeenCalled();
-    expect(listRuns).not.toHaveBeenCalled();
-    expect(enable).not.toHaveBeenCalled();
-    expect(wrapper.emitted('created')?.[0]).toEqual([disabledTask]);
-    expect(vm.visible).toBe(false);
-    expect(vm.step).toBe(0);
-    expect(vm.selected).toBeNull();
+  it('stops polling when the dialog closes', async () => {
+    vi.useFakeTimers();
+    const wrapper = mountWizard();
+    const vm = wrapper.vm as any;
+    vm.pollTimer = setTimeout(() => undefined, 1000);
+    const before = vm.pollGeneration;
+    await wrapper.setData({ visible: false });
+    await flushPromises();
+    expect(vm.pollTimer).toBeNull();
+    expect(vm.pollGeneration).toBeGreaterThan(before);
   });
 });

--- a/src/components/scheduledTemplates/ScheduledTemplateWizard.vue
+++ b/src/components/scheduledTemplates/ScheduledTemplateWizard.vue
@@ -2,8 +2,8 @@
   <el-dialog
     v-model="visible"
     :title="$t('chat.scheduledTemplates.title')"
-    width="min(820px, 94vw)"
-    top="6vh"
+    width="min(900px, 95vw)"
+    top="4vh"
     :close-on-click-modal="false"
     class="scheduled-template-wizard"
   >
@@ -11,6 +11,8 @@
       <el-step :title="$t('chat.scheduledTemplates.step.choose')" />
       <el-step :title="$t('chat.scheduledTemplates.step.configure')" />
       <el-step :title="$t('chat.scheduledTemplates.step.connect')" />
+      <el-step :title="$t('chat.scheduledTemplates.step.test')" />
+      <el-step :title="$t('chat.scheduledTemplates.step.enable')" />
     </el-steps>
 
     <section v-if="step === 0" v-loading="loading" class="wizard-body">
@@ -32,12 +34,12 @@
           :key="`${item.id}-${item.version}`"
           type="button"
           class="template-card"
-          :class="{ selected: selected?.id === item.id }"
+          :class="{ selected: selected?.id === item.id && selected?.version === item.version }"
           @click="selectTemplate(item)"
         >
           <div class="template-card-top">
-            <strong>{{ item.title }}</strong>
-            <el-tag v-if="item.featured" size="small" type="warning">{{
+            <strong>{{ item.title }}</strong
+            ><el-tag v-if="item.featured" size="small" type="warning">{{
               $t('chat.scheduledTemplates.featured')
             }}</el-tag>
           </div>
@@ -45,18 +47,19 @@
           <div class="template-tags">
             <el-tag v-for="tag in item.categories" :key="tag" size="small" type="info">{{ categoryLabel(tag) }}</el-tag>
           </div>
-          <span :class="['availability', { ready: item.available }]">
-            {{
+          <div class="template-status">
+            <el-tag size="small" :type="riskTag(item)">{{ riskLabel(item) }}</el-tag>
+            <span :class="['availability', { ready: item.available }]">{{
               item.available
                 ? $t('chat.scheduledTemplates.ready')
                 : $t('chat.scheduledTemplates.missingCount', { count: item.missing_connections.length })
-            }}
-          </span>
+            }}</span>
+          </div>
         </button>
       </div>
     </section>
 
-    <section v-else-if="step === 1 && selected" class="wizard-body configure-step">
+    <section v-else-if="step === 1 && selected" class="wizard-body">
       <div class="template-intro">
         <h3>{{ selected.title }}</h3>
         <p>{{ selected.description }}</p>
@@ -68,14 +71,9 @@
           :label="field.label"
           :required="field.required"
         >
-          <el-select v-if="field.type === 'select'" v-model="inputs[field.key]" style="width: 100%">
-            <el-option
-              v-for="option in field.options"
-              :key="option.value"
-              :label="option.label"
-              :value="option.value"
-            />
-          </el-select>
+          <el-select v-if="field.type === 'select'" v-model="inputs[field.key]" style="width: 100%"
+            ><el-option v-for="option in field.options" :key="option.value" :label="option.label" :value="option.value"
+          /></el-select>
           <el-switch
             v-else-if="field.type === 'boolean'"
             :model-value="inputs[field.key] === true"
@@ -95,9 +93,9 @@
             @update:model-value="(value: string) => (inputs[field.key] = value)"
           />
         </el-form-item>
-        <el-form-item :label="$t('chat.scheduledTemplates.schedule')">
-          <el-time-picker v-model="scheduleTime" value-format="HH:mm" format="HH:mm" />
-        </el-form-item>
+        <el-form-item :label="$t('chat.scheduledTemplates.schedule')"
+          ><el-time-picker v-model="scheduleTime" value-format="HH:mm" format="HH:mm"
+        /></el-form-item>
       </el-form>
     </section>
 
@@ -107,9 +105,9 @@
           <h3>{{ $t('chat.scheduledTemplates.connectionTitle') }}</h3>
           <p>{{ $t('chat.scheduledTemplates.connectionDescription') }}</p>
         </div>
-        <el-tag type="info" round>{{ selected.requirements.connections.length }}</el-tag>
+        <el-tag type="info">{{ requiredConnections.length }}</el-tag>
       </div>
-      <div v-if="!selected.requirements.connections.length" class="requirement-empty ready">
+      <div v-if="!requiredConnections.length" class="requirement-empty ready">
         <success-icon :size="20" />
         <div>
           <strong>{{ $t('chat.scheduledTemplates.noConnections') }}</strong>
@@ -118,62 +116,110 @@
       </div>
       <div class="requirement-list">
         <article
-          v-for="connection in selected.requirements.connections"
+          v-for="connection in requiredConnections"
           :key="connection"
           :class="['requirement-card', { ready: connectionReady(connection) }]"
         >
-          <div class="requirement-icon">
-            <connection-icon :size="22" aria-hidden="true" focusable="false" />
-          </div>
-          <div class="requirement-content">
-            <div class="requirement-title-row">
-              <strong>{{ connectionName(connection) }}</strong>
-              <el-tag :type="connectionReady(connection) ? 'success' : 'warning'" size="small" round>
-                {{
-                  connectionReady(connection)
-                    ? $t('chat.scheduledTemplates.connected')
-                    : $t('chat.scheduledTemplates.notConnected')
-                }}
-              </el-tag>
-            </div>
+          <connection-icon :size="22" />
+          <div>
+            <strong>{{ connectionName(connection) }}</strong>
             <p>{{ connectionDescription(connection) }}</p>
-            <div v-if="connectionReady(connection)" class="account-summary">
-              {{ connectionAccountSummary(connection) }}
-            </div>
+            <small v-if="connectionReady(connection)">{{ connectionAccountSummary(connection) }}</small>
           </div>
-          <div class="requirement-action">
-            <el-select
-              v-if="bindableAccounts(connection).length > 1"
-              v-model="connectionBindings[connection]"
-              :placeholder="$t('chat.scheduledTemplates.chooseAccount')"
-            >
-              <el-option
-                v-for="account in bindableAccounts(connection)"
-                :key="account.connection_id"
-                :label="account.label || account.account_name"
-                :value="account.connection_id"
-              />
-            </el-select>
-            <el-button v-else-if="!connectionReady(connection)" type="primary" plain @click="browseConnections = true">
-              {{ $t('chat.scheduledTemplates.connect') }}
-            </el-button>
-            <success-icon v-else class="success" :size="22" />
-          </div>
+          <el-select
+            v-if="bindableAccounts(connection).length > 1"
+            v-model="connectionBindings[connection]"
+            :placeholder="$t('chat.scheduledTemplates.chooseAccount')"
+            ><el-option
+              v-for="account in bindableAccounts(connection)"
+              :key="account.connection_id"
+              :label="account.label || account.account_name"
+              :value="account.connection_id"
+          /></el-select>
+          <el-button v-else-if="!connectionReady(connection)" type="primary" plain @click="startConnection">{{
+            $t('chat.scheduledTemplates.connect')
+          }}</el-button
+          ><success-icon v-else class="success" :size="22" />
         </article>
+      </div>
+      <div v-if="optionalConnections.length" class="optional-note">
+        {{ $t('chat.scheduledTemplates.optionalConnections', { count: optionalConnections.length }) }}
       </div>
       <browse-connectors v-model="browseConnections" @installed="reloadTemplates" />
     </section>
 
+    <section v-else-if="step === 3 && selected" class="wizard-body test-step">
+      <h3>{{ $t('chat.scheduledTemplates.testTitle') }}</h3>
+      <p>{{ $t('chat.scheduledTemplates.testDescription') }}</p>
+      <div v-if="!task" class="test-panel">
+        <el-button type="primary" :loading="working" @click="startTest">{{
+          $t('chat.scheduledTemplates.startTest')
+        }}</el-button>
+      </div>
+      <div v-else class="test-panel">
+        <el-tag :type="runTagType">{{
+          run ? $t(`chat.scheduledTasks.run.${run.status}`) : $t('chat.scheduledTemplates.testStarting')
+        }}</el-tag>
+        <p v-if="run?.outcome_reason">{{ run.outcome_reason }}</p>
+        <p v-else-if="run?.error_message">{{ run.error_message }}</p>
+        <p v-if="run?.conversation_preview">{{ run.conversation_preview }}</p>
+        <div v-if="runTerminal" class="test-actions">
+          <el-button @click="retryTest">{{ $t('chat.scheduledTemplates.retryTest') }}</el-button
+          ><el-button @click="fixConfiguration">{{ $t('chat.scheduledTemplates.fixConfiguration') }}</el-button>
+        </div>
+      </div>
+    </section>
+
+    <section v-else-if="step === 4 && selected" class="wizard-body enable-step">
+      <h3>{{ $t('chat.scheduledTemplates.enableTitle') }}</h3>
+      <div class="summary-grid">
+        <span>{{ $t('chat.scheduledTemplates.schedule') }}</span
+        ><strong>{{ scheduleTime }} · {{ buildSchedule().tz }}</strong
+        ><span>{{ $t('chat.scheduledTemplates.risk') }}</span
+        ><strong>{{ riskLabel(selected) }}</strong
+        ><span>{{ $t('chat.scheduledTemplates.estimatedBudget') }}</span
+        ><strong
+          >{{ activation?.budget?.estimated_upper_bound ?? selected.budget?.estimated_upper_bound ?? '—' }} Credits ·
+          {{ $t('chat.scheduledTemplates.estimateOnly') }}</strong
+        ><span>{{ $t('chat.scheduledTemplates.actions') }}</span
+        ><strong>{{
+          (activation?.side_effects ?? selected.side_effects ?? []).join(', ') || $t('chat.scheduledTemplates.readOnly')
+        }}</strong>
+      </div>
+      <div v-if="backendBlocked" class="activation-blocker">{{ $t('chat.scheduledTemplates.backendRequired') }}</div>
+      <div v-else-if="activation && !activation.ready" class="activation-blocker">
+        {{ activation.blockers.map((b) => b.code).join(', ') }}
+      </div>
+      <div v-else-if="activation?.ready" class="activation-ready">
+        <success-icon :size="20" /> {{ $t('chat.scheduledTemplates.readyToEnable') }}
+      </div>
+    </section>
+
     <template #footer>
-      <el-button v-if="step > 0" :disabled="working" @click="step -= 1">
-        {{ $t('chat.scheduledTemplates.previous') }}
-      </el-button>
-      <el-button v-if="step < 2" type="primary" :disabled="!canContinue" @click="step += 1">
-        {{ $t('chat.scheduledTemplates.next') }}
-      </el-button>
-      <el-button v-if="step === 2" type="primary" :loading="working" :disabled="!canContinue" @click="createTask">
-        {{ $t('chat.scheduledTemplates.create') }}
-      </el-button>
+      <el-button v-if="step > 0 && step < 3" :disabled="working" @click="step -= 1">{{
+        $t('chat.scheduledTemplates.previous')
+      }}</el-button>
+      <el-button v-if="step < 2" type="primary" :disabled="!canContinue" @click="nextStep">{{
+        $t('chat.scheduledTemplates.next')
+      }}</el-button>
+      <el-button v-if="step === 2" type="primary" :disabled="!canContinue" @click="step = 3">{{
+        $t('chat.scheduledTemplates.next')
+      }}</el-button>
+      <el-button
+        v-if="step === 3 && run?.status === 'success'"
+        type="primary"
+        :loading="working"
+        @click="prepareEnable"
+        >{{ $t('chat.scheduledTemplates.reviewEnable') }}</el-button
+      >
+      <el-button
+        v-if="step === 4"
+        type="primary"
+        :loading="working"
+        :disabled="!activation?.ready"
+        @click="enableTask"
+        >{{ $t('chat.scheduledTemplates.enableNow') }}</el-button
+      >
     </template>
   </el-dialog>
 </template>
@@ -197,18 +243,26 @@ import {
 } from 'element-plus';
 import { ConnectionIcon, SuccessIcon } from '@acedatacloud/core/icons/components';
 import BrowseConnectors from '@/components/connections/BrowseConnectors.vue';
+import { track } from '@/plugins/telemetry';
+import { getSurface } from '@/utils/surface';
 import {
   scheduledTasksOperator,
+  isRunWorthPolling,
   type IAuthorizableConnectionAccount,
+  type IScheduledRun,
+  type IScheduledTask,
   type IScheduledTaskTemplateDefinition,
+  type IScheduledTemplateActivationStatus,
   type IScheduleSpec
 } from '@/operators/scheduledTasks';
 
+const POLL_MS = 3000;
 export default defineComponent({
   name: 'ScheduledTemplateWizard',
   components: {
     BrowseConnectors,
     ConnectionIcon,
+    SuccessIcon,
     ElButton,
     ElDialog,
     ElForm,
@@ -220,8 +274,7 @@ export default defineComponent({
     ElSteps,
     ElSwitch,
     ElTag,
-    ElTimePicker,
-    SuccessIcon
+    ElTimePicker
   },
   props: {
     modelValue: { type: Boolean as PropType<boolean>, default: false },
@@ -243,31 +296,74 @@ export default defineComponent({
       inputs: {} as Record<string, string | number | boolean>,
       scheduleTime: '09:00',
       connectionBindings: {} as Record<string, string>,
-      browseConnections: false
+      browseConnections: false,
+      task: null as IScheduledTask | null,
+      run: null as IScheduledRun | null,
+      runId: '',
+      activation: null as IScheduledTemplateActivationStatus | null,
+      backendBlocked: false,
+      pollTimer: null as ReturnType<typeof setTimeout> | null,
+      pollGeneration: 0
     };
   },
   computed: {
+    requiredConnections(): string[] {
+      return this.selected?.dependencies?.required.connections ?? this.selected?.requirements.connections ?? [];
+    },
+    optionalConnections(): string[] {
+      return this.selected?.dependencies?.optional.connections ?? [];
+    },
     canContinue(): boolean {
       if (this.step === 0) return !!this.selected;
-      if (this.step === 1 && this.selected) {
+      if (this.step === 1 && this.selected)
         return this.selected.form_schema.every(
-          (field) => !field.required || String(this.inputs[field.key] ?? '').trim()
+          (f) =>
+            !f.required ||
+            (f.type === 'boolean' ? typeof this.inputs[f.key] === 'boolean' : String(this.inputs[f.key] ?? '').trim())
         );
-      }
-      if (this.step === 2 && this.selected) return this.selected.requirements.connections.every(this.connectionReady);
+      if (this.step === 2) return this.requiredConnections.every(this.connectionReady);
       return true;
+    },
+    runTerminal(): boolean {
+      return !!this.run && !isRunWorthPolling(this.run, Date.now());
+    },
+    runTagType(): 'success' | 'danger' | 'warning' | 'info' {
+      return this.run?.status === 'success'
+        ? 'success'
+        : this.run?.status === 'failed'
+          ? 'danger'
+          : this.run?.status === 'indeterminate'
+            ? 'warning'
+            : 'info';
     }
   },
   watch: {
-    modelValue(value: boolean) {
-      this.visible = value;
-      if (value) void this.loadTemplates();
+    modelValue(v: boolean) {
+      this.visible = v;
+      if (v) {
+        void this.loadTemplates();
+        track('scheduled_template_gallery_viewed', { surface: getSurface(), category: this.category });
+      }
     },
-    visible(value: boolean) {
-      this.$emit('update:modelValue', value);
+    visible(v: boolean) {
+      this.$emit('update:modelValue', v);
+      if (!v) this.stopPolling();
     }
   },
+  unmounted() {
+    this.stopPolling();
+  },
   methods: {
+    safeTrack(name: string, extra: Record<string, string | number | boolean> = {}) {
+      if (!this.selected) return;
+      track(name, {
+        template: this.selected.id,
+        version: this.selected.version,
+        category: this.selected.categories[0] ?? '',
+        surface: getSurface(),
+        ...extra
+      });
+    },
     async loadTemplates() {
       this.loading = true;
       try {
@@ -277,7 +373,6 @@ export default defineComponent({
         });
         this.templates = data.items;
         this.categories = data.categories;
-        if (this.selected) this.selected = data.items.find((item) => item.id === this.selected?.id) ?? this.selected;
       } catch {
         ElMessage.error(this.$t('chat.scheduledTemplates.loadError') as string);
       } finally {
@@ -287,116 +382,215 @@ export default defineComponent({
     filterTemplates() {
       void this.loadTemplates();
     },
-    categoryLabel(category: string) {
-      const key = `chat.scheduledTemplates.category.${category}`;
-      const translated = String(this.$t(key));
-      return translated === key ? category : translated;
+    categoryLabel(c: string) {
+      const key = `chat.scheduledTemplates.category.${c}`;
+      const t = String(this.$t(key));
+      return t === key ? c : t;
     },
-    selectTemplate(template: IScheduledTaskTemplateDefinition) {
-      this.selected = template;
+    selectTemplate(t: IScheduledTaskTemplateDefinition) {
+      this.selected = t;
       this.inputs = Object.fromEntries(
-        template.form_schema.filter((field) => field.default !== undefined).map((field) => [field.key, field.default!])
+        t.form_schema.filter((f) => f.default !== undefined).map((f) => [f.key, f.default!])
       );
-      this.scheduleTime = this.scheduleTimeFromSpec(template.defaults.schedule);
+      this.scheduleTime = this.scheduleTimeFromSpec(t.defaults.schedule);
       this.connectionBindings = {};
-      for (const connection of template.requirements.connections) {
-        const accounts = this.bindableAccounts(connection);
-        const account = accounts.find((item) => item.is_default) ?? accounts[0];
-        if (account) this.connectionBindings[connection] = account.connection_id;
-      }
+      this.safeTrack('scheduled_template_selected', { risk: t.risk?.level ?? 'unknown' });
     },
-    connectionAccounts(connection: string): IAuthorizableConnectionAccount[] {
-      return this.selected?.connection_accounts?.[connection] ?? [];
+    riskLabel(t: IScheduledTaskTemplateDefinition) {
+      return this.$t(`chat.scheduledTemplates.risk.${t.risk?.level ?? 'high'}`) as string;
     },
-    bindableAccounts(connection: string): IAuthorizableConnectionAccount[] {
-      return this.connectionAccounts(connection).filter((account) => account.supports_task_binding);
+    riskTag(t: IScheduledTaskTemplateDefinition) {
+      return t.risk?.level === 'low' ? 'success' : t.risk?.level === 'medium' ? 'warning' : 'danger';
     },
-    connectionReady(connection: string): boolean {
-      const accounts = this.connectionAccounts(connection);
-      const bindable = accounts.filter((account) => account.supports_task_binding);
-      if (!accounts.length) return false;
-      if (!bindable.length) return true;
-      return bindable.length === 1 || !!this.connectionBindings[connection];
+    connectionAccounts(c: string): IAuthorizableConnectionAccount[] {
+      return this.selected?.connection_accounts?.[c] ?? [];
     },
-    connectionName(connection: string): string {
-      const account = this.connectionAccounts(connection)[0];
-      return account?.account_name || account?.label || connection.split('/').pop() || connection;
+    bindableAccounts(c: string) {
+      return this.connectionAccounts(c).filter((a) => a.supports_task_binding);
     },
-    connectionDescription(connection: string): string {
-      const accounts = this.connectionAccounts(connection);
-      if (!accounts.length) return this.$t('chat.scheduledTemplates.connectionMissingHint') as string;
-      return accounts[0].supports_task_binding
-        ? (this.$t('chat.scheduledTemplates.connectionBoundHint') as string)
-        : (this.$t('chat.scheduledTemplates.connectionMcpHint') as string);
+    connectionReady(c: string) {
+      const all = this.connectionAccounts(c),
+        bindable = this.bindableAccounts(c);
+      return !!all.length && (!bindable.length || bindable.length === 1 || !!this.connectionBindings[c]);
     },
-    connectionAccountSummary(connection: string): string {
-      const accounts = this.connectionAccounts(connection);
-      const selectedId = this.connectionBindings[connection];
-      const selected = accounts.find((account) => account.connection_id === selectedId) ?? accounts[0];
-      return selected?.label || selected?.account_name || this.$t('chat.scheduledTemplates.connected');
+    connectionName(c: string) {
+      const a = this.connectionAccounts(c)[0];
+      return a?.account_name || a?.label || c.split('/').pop() || c;
+    },
+    connectionDescription(c: string) {
+      const a = this.connectionAccounts(c);
+      return !a.length
+        ? (this.$t('chat.scheduledTemplates.connectionMissingHint') as string)
+        : a[0].supports_task_binding
+          ? (this.$t('chat.scheduledTemplates.connectionBoundHint') as string)
+          : (this.$t('chat.scheduledTemplates.connectionMcpHint') as string);
+    },
+    connectionAccountSummary(c: string) {
+      const a = this.connectionAccounts(c),
+        chosen = a.find((x) => x.connection_id === this.connectionBindings[c]) ?? a[0];
+      return chosen?.label || chosen?.account_name || '';
+    },
+    startConnection() {
+      this.safeTrack('scheduled_template_connection_started');
+      this.browseConnections = true;
     },
     async reloadTemplates() {
       this.browseConnections = false;
       await this.loadTemplates();
-      if (this.selected) this.selectTemplate(this.selected);
+      this.safeTrack('scheduled_template_connection_completed');
     },
-    scheduleTimeFromSpec(schedule: IScheduleSpec) {
-      if (schedule.type !== 'cron') return '09:00';
-      const [minute, hour] = schedule.cron.split(' ');
-      return `${hour.padStart(2, '0')}:${minute.padStart(2, '0')}`;
+    scheduleTimeFromSpec(s: IScheduleSpec) {
+      if (s.type !== 'cron') return '09:00';
+      const [m, h] = s.cron.split(' ');
+      return `${h.padStart(2, '0')}:${m.padStart(2, '0')}`;
     },
     buildSchedule(): IScheduleSpec {
-      const [hour, minute] = this.scheduleTime.split(':');
-      return { type: 'cron', cron: `${minute} ${hour} * * *`, tz: Intl.DateTimeFormat().resolvedOptions().timeZone };
+      const [h, m] = this.scheduleTime.split(':');
+      const original = this.selected?.defaults.schedule;
+      if (original?.type === 'cron') {
+        const parts = original.cron.split(' ');
+        parts[0] = m;
+        parts[1] = h;
+        return { ...original, cron: parts.join(' '), tz: Intl.DateTimeFormat().resolvedOptions().timeZone };
+      }
+      return { type: 'cron', cron: `${m} ${h} * * *`, tz: Intl.DateTimeFormat().resolvedOptions().timeZone };
     },
     bindings() {
-      if (!this.selected) return [];
-      return this.selected.requirements.connections.flatMap((connection) => {
-        const accounts = this.bindableAccounts(connection);
-        const id = this.connectionBindings[connection] || accounts[0]?.connection_id;
-        const account = accounts.find((item) => item.connection_id === id);
+      return this.requiredConnections.flatMap((c) => {
+        const accounts = this.bindableAccounts(c),
+          id = this.connectionBindings[c] || accounts[0]?.connection_id,
+          account = accounts.find((a) => a.connection_id === id);
         return account
           ? [{ connector_identifier: account.connector_identifier, connection_id: account.connection_id }]
           : [];
       });
     },
-    errorMessage(error: unknown): string {
-      const response = (error as { response?: { data?: { message?: string; error?: string } } })?.response?.data;
-      return (
-        response?.message ||
-        response?.error ||
-        (error as Error)?.message ||
-        String(this.$t('chat.scheduledTemplates.createFailed'))
-      );
+    async nextStep() {
+      if (this.step === 1 && this.selected) {
+        this.working = true;
+        try {
+          await scheduledTasksOperator.previewTemplate(
+            this.token,
+            this.selected.id,
+            this.selected.version,
+            this.inputs
+          );
+          this.safeTrack('scheduled_template_preview_completed');
+        } catch (e) {
+          ElMessage.error(this.errorMessage(e));
+          return;
+        } finally {
+          this.working = false;
+        }
+      }
+      this.step += 1;
     },
-    resetWizard() {
-      this.step = 0;
-      this.selected = null;
-      this.inputs = {};
-      this.scheduleTime = '09:00';
-      this.connectionBindings = {};
-      this.browseConnections = false;
-    },
-    async createTask() {
-      if (!this.selected || !this.canContinue) return;
+    async startTest() {
+      if (!this.selected) return;
       this.working = true;
+      this.safeTrack('scheduled_template_test_started');
       try {
-        const task = await scheduledTasksOperator.instantiateTemplate(this.token, {
-          template_id: this.selected.id,
-          version: this.selected.version,
-          inputs: this.inputs,
-          schedule: this.buildSchedule(),
-          connection_bindings: this.bindings()
-        });
-        this.$emit('created', task);
-        this.visible = false;
-        this.resetWizard();
-        ElMessage.success(this.$t('chat.scheduledTemplates.createdDisabled') as string);
-      } catch (error) {
-        ElMessage.error(this.errorMessage(error));
+        if (this.task) {
+          await this.reconfigureExisting();
+        } else {
+          this.task = await scheduledTasksOperator.instantiateTemplate(this.token, {
+            template_id: this.selected.id,
+            version: this.selected.version,
+            inputs: this.inputs,
+            schedule: this.buildSchedule(),
+            connection_bindings: this.bindings()
+          });
+          this.$emit('created', this.task);
+        }
+        await this.triggerAndPoll();
+      } catch (e) {
+        ElMessage.error(this.errorMessage(e));
       } finally {
         this.working = false;
       }
+    },
+    async triggerAndPoll() {
+      if (!this.task) return;
+      const result = await scheduledTasksOperator.triggerTask(this.token, this.task.id);
+      if (!result.run_id) throw new Error('run_id missing');
+      this.runId = result.run_id;
+      this.run = null;
+      const generation = ++this.pollGeneration;
+      await this.pollRun(generation);
+    },
+    async pollRun(generation: number) {
+      if (!this.task || generation !== this.pollGeneration) return;
+      try {
+        const run = await scheduledTasksOperator.retrieveRun(this.token, this.task.id, this.runId);
+        if (generation !== this.pollGeneration) return;
+        this.run = run;
+        if (isRunWorthPolling(run, Date.now()))
+          this.pollTimer = setTimeout(() => void this.pollRun(generation), POLL_MS);
+        else this.safeTrack('scheduled_template_test_completed', { result: run.status });
+      } catch {
+        this.pollTimer = setTimeout(() => void this.pollRun(generation), POLL_MS);
+      }
+    },
+    stopPolling() {
+      this.pollGeneration += 1;
+      if (this.pollTimer) clearTimeout(this.pollTimer);
+      this.pollTimer = null;
+    },
+    async retryTest() {
+      this.stopPolling();
+      this.safeTrack('scheduled_template_test_retried');
+      await this.triggerAndPoll();
+    },
+    async fixConfiguration() {
+      this.stopPolling();
+      this.safeTrack('scheduled_template_fix_returned');
+      this.step = 1;
+    },
+    async prepareEnable() {
+      if (!this.task) return;
+      this.working = true;
+      try {
+        this.activation = await scheduledTasksOperator.activationStatus(this.token, this.task.id);
+        this.backendBlocked = false;
+        this.step = 4;
+      } catch {
+        this.backendBlocked = true;
+        this.activation = null;
+        this.step = 4;
+      } finally {
+        this.working = false;
+      }
+    },
+    async enableTask() {
+      if (!this.task || !this.activation?.ready) return;
+      this.working = true;
+      try {
+        const enabled = await scheduledTasksOperator.enableTemplateTask(this.token, this.task.id);
+        this.$emit('created', enabled);
+        this.safeTrack('scheduled_template_enabled');
+        ElMessage.success(this.$t('chat.scheduledTemplates.enabled') as string);
+        this.visible = false;
+      } catch (e) {
+        ElMessage.error(this.errorMessage(e));
+        await this.prepareEnable();
+      } finally {
+        this.working = false;
+      }
+    },
+    async reconfigureExisting() {
+      if (!this.task) return;
+      this.task = await scheduledTasksOperator.reconfigureTemplate(this.token, this.task.id, {
+        inputs: this.inputs,
+        schedule: this.buildSchedule(),
+        connection_bindings: this.bindings()
+      });
+      this.$emit('created', this.task);
+      this.run = null;
+      this.activation = null;
+    },
+    errorMessage(e: unknown) {
+      const d = (e as { response?: { data?: { message?: string; error?: string } } })?.response?.data;
+      return d?.message || d?.error || (e as Error)?.message || String(this.$t('chat.scheduledTemplates.createFailed'));
     }
   }
 });
@@ -404,42 +598,16 @@ export default defineComponent({
 
 <style scoped lang="scss">
 :deep(.scheduled-template-wizard) {
-  .el-dialog__header {
-    padding-bottom: 14px;
-  }
   .el-dialog__body {
     padding-top: 8px;
   }
-  .el-dialog__footer {
-    padding-top: 14px;
-  }
 }
 .wizard-steps {
-  margin-bottom: 18px;
-
-  :deep(.el-step__head.is-finish) {
-    color: var(--el-color-primary);
-    border-color: var(--el-color-primary);
-  }
-  :deep(.el-step__title.is-finish) {
-    color: var(--el-color-primary);
-  }
-  :deep(.el-step__line) {
-    top: 13px;
-  }
-  :deep(.el-step__icon) {
-    width: 28px;
-    height: 28px;
-    font-size: 14px;
-  }
-  :deep(.el-step__title) {
-    font-size: 14px;
-    line-height: 28px;
-  }
+  margin-bottom: 20px;
 }
 .wizard-body {
-  min-height: 340px;
-  max-height: 62vh;
+  min-height: 360px;
+  max-height: 65vh;
   overflow-y: auto;
   padding: 4px;
 }
@@ -466,53 +634,45 @@ export default defineComponent({
 .template-card:hover,
 .template-card.selected {
   border-color: var(--el-color-primary);
-  box-shadow: 0 8px 24px rgb(39 113 134 / 10%);
+  box-shadow: var(--app-shadow-md);
 }
-.template-card-top {
+.template-card-top,
+.template-status,
+.requirement-heading {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
+  gap: 10px;
 }
 .template-card p,
 .requirement-card p,
-.requirement-heading p,
-.requirement-empty p {
+.requirement-heading p {
   color: var(--el-text-color-secondary);
-  margin: 8px 0;
 }
 .template-tags {
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
-  margin-bottom: 12px;
+  margin: 10px 0;
 }
 .availability {
   color: var(--el-color-warning);
   font-size: 13px;
 }
 .availability.ready,
-.success {
+.success,
+.activation-ready {
   color: var(--el-color-success);
-}
-.template-intro {
-  margin-bottom: 22px;
-}
-.requirement-heading {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  margin-bottom: 18px;
-}
-.requirement-heading h3 {
-  margin: 0;
 }
 .requirement-list {
   display: grid;
   gap: 12px;
 }
 .requirement-card,
-.requirement-empty {
+.requirement-empty,
+.test-panel,
+.activation-blocker,
+.activation-ready {
   display: grid;
   grid-template-columns: auto minmax(0, 1fr) auto;
   align-items: center;
@@ -520,55 +680,51 @@ export default defineComponent({
   padding: 18px;
   border: 1px solid var(--el-border-color-lighter);
   border-radius: 14px;
-  background: var(--el-fill-color-blank);
+  margin: 12px 0;
 }
-.requirement-card.ready {
-  border-color: var(--el-color-success-light-5);
+.requirement-card.ready,
+.activation-ready {
   background: var(--el-color-success-light-9);
 }
-.requirement-empty {
-  grid-template-columns: auto 1fr;
+.optional-note {
+  color: var(--el-text-color-secondary);
+  margin-top: 14px;
 }
-.requirement-icon {
-  display: grid;
-  place-items: center;
-  width: 44px;
-  height: 44px;
-  border-radius: 12px;
-  color: var(--el-color-primary);
-  background: var(--el-color-primary-light-9);
+.test-panel {
+  grid-template-columns: 1fr;
 }
-.requirement-title-row {
+.test-actions {
   display: flex;
-  align-items: center;
   gap: 10px;
 }
-.account-summary {
-  color: var(--el-text-color-regular);
-  font-size: 13px;
+.summary-grid {
+  display: grid;
+  grid-template-columns: minmax(140px, auto) 1fr;
+  gap: 12px;
+  padding: 18px;
+  background: var(--el-fill-color-light);
+  border-radius: 14px;
 }
-.requirement-action {
-  min-width: 160px;
-  text-align: right;
+.summary-grid span {
+  color: var(--el-text-color-secondary);
 }
-.requirement-action .el-select {
-  width: 200px;
+.activation-blocker {
+  grid-template-columns: 1fr;
+  color: var(--el-color-warning);
 }
 @media (max-width: 720px) {
   .template-grid,
   .template-toolbar {
     grid-template-columns: 1fr;
   }
+  .wizard-steps:deep(.el-step__title) {
+    font-size: 11px;
+  }
   .requirement-card {
     grid-template-columns: auto 1fr;
   }
-  .requirement-action {
-    grid-column: 1 / -1;
-    width: 100%;
-  }
-  .requirement-action .el-select,
-  .requirement-action .el-button {
-    width: 100%;
+  .summary-grid {
+    grid-template-columns: 1fr;
   }
 }
 </style>

--- a/src/i18n/ar/chat.json
+++ b/src/i18n/ar/chat.json
@@ -1770,5 +1770,109 @@
   "model.deepseekV4ProDescription": {
     "message": "الجيل الأحدث من الرائد عالي الأداء، 1M سياق",
     "description": "وصف نموذج DeepSeek V4 Pro"
+  },
+  "scheduledTemplates.category.product": {
+    "message": "منتج",
+    "description": "معالج القالب المجدول: scheduledTemplates.category.product"
+  },
+  "scheduledTemplates.step.test": {
+    "message": "تشغيل تجريبي",
+    "description": "معالج القالب المجدول: scheduledTemplates.step.test"
+  },
+  "scheduledTemplates.risk.medium": {
+    "message": "يتطلب مراجعة",
+    "description": "معالج القالب المجدول: scheduledTemplates.risk.medium"
+  },
+  "scheduledTemplates.optionalConnections": {
+    "message": "يوجد {count} اتصال اختياري، يمكن أن تعمل المهمة بدونها",
+    "description": "معالج القالب المجدول: scheduledTemplates.optionalConnections"
+  },
+  "scheduledTemplates.startTest": {
+    "message": "إنشاء وتشغيل تجريبي",
+    "description": "معالج القالب المجدول: scheduledTemplates.startTest"
+  },
+  "scheduledTemplates.category.video": {
+    "message": "فيديو",
+    "description": "معالج القالب المجدول: scheduledTemplates.category.video"
+  },
+  "scheduledTemplates.category.developer": {
+    "message": "مطور",
+    "description": "معالج القالب المجدول: scheduledTemplates.category.developer"
+  },
+  "scheduledTemplates.testDescription": {
+    "message": "ستظل المهمة معطلة؛ يجب تأكيد هذه النتائج والأدلة قبل تفعيل الجدولة الدورية.",
+    "description": "معالج القالب المجدول: scheduledTemplates.testDescription"
+  },
+  "scheduledTemplates.fixConfiguration": {
+    "message": "تعديل الإعدادات",
+    "description": "معالج القالب المجدول: scheduledTemplates.fixConfiguration"
+  },
+  "scheduledTemplates.testStarting": {
+    "message": "جارٍ البدء",
+    "description": "معالج القالب المجدول: scheduledTemplates.testStarting"
+  },
+  "scheduledTemplates.backendRequired": {
+    "message": "لم يتم نشر عقد الأمان الخلفي؛ لتجنب تجاوز بوابة التشغيل التجريبي، لا يمكن تفعيله حالياً.",
+    "description": "معالج القالب المجدول: scheduledTemplates.backendRequired"
+  },
+  "scheduledTemplates.enabled": {
+    "message": "تم تفعيل المهمة المجدولة",
+    "description": "معالج القالب المجدول: scheduledTemplates.enabled"
+  },
+  "scheduledTemplates.risk": {
+    "message": "خطر",
+    "description": "معالج القالب المجدول: scheduledTemplates.risk"
+  },
+  "scheduledTemplates.estimatedBudget": {
+    "message": "حد تقدير لمرة واحدة",
+    "description": "معالج القالب المجدول: scheduledTemplates.estimatedBudget"
+  },
+  "scheduledTemplates.risk.low": {
+    "message": "خطر منخفض",
+    "description": "معالج القالب المجدول: scheduledTemplates.risk.low"
+  },
+  "scheduledTemplates.testTitle": {
+    "message": "جرب التشغيل مرة واحدة",
+    "description": "معالج القالب المجدول: scheduledTemplates.testTitle"
+  },
+  "scheduledTemplates.estimateOnly": {
+    "message": "تقدير محافظ، ليس خصماً فعلياً",
+    "description": "معالج القالب المجدول: scheduledTemplates.estimateOnly"
+  },
+  "scheduledTemplates.readOnly": {
+    "message": "للقراءة فقط",
+    "description": "معالج القالب المجدول: scheduledTemplates.readOnly"
+  },
+  "scheduledTemplates.retryTest": {
+    "message": "إعادة التشغيل التجريبي",
+    "description": "معالج القالب المجدول: scheduledTemplates.retryTest"
+  },
+  "scheduledTemplates.actions": {
+    "message": "إجراءات خارجية",
+    "description": "معالج القالب المجدول: scheduledTemplates.actions"
+  },
+  "scheduledTemplates.enableTitle": {
+    "message": "تأكيد التفويض بدون مراقب",
+    "description": "معالج القالب المجدول: scheduledTemplates.enableTitle"
+  },
+  "scheduledTemplates.enableNow": {
+    "message": "تأكيد وتفعيل",
+    "description": "معالج القالب المجدول: scheduledTemplates.enableNow"
+  },
+  "scheduledTemplates.risk.high": {
+    "message": "خطر عالي",
+    "description": "معالج القالب المجدول: scheduledTemplates.risk.high"
+  },
+  "scheduledTemplates.readyToEnable": {
+    "message": "تمت الموافقة على التشغيل التجريبي والأدلة الحالية",
+    "description": "معالج القالب المجدول: scheduledTemplates.readyToEnable"
+  },
+  "scheduledTemplates.step.enable": {
+    "message": "تأكيد التفعيل",
+    "description": "معالج القالب المجدول: scheduledTemplates.step.enable"
+  },
+  "scheduledTemplates.reviewEnable": {
+    "message": "عرض وتأكيد التفعيل",
+    "description": "معالج القالب المجدول: scheduledTemplates.reviewEnable"
   }
 }

--- a/src/i18n/de/chat.json
+++ b/src/i18n/de/chat.json
@@ -1770,5 +1770,109 @@
   "model.deepseekV4ProDescription": {
     "message": "Die neueste Generation des leistungsstarken Flaggschiffs, 1M Kontext",
     "description": "Beschreibung des DeepSeek V4 Pro Modells"
+  },
+  "scheduledTemplates.step.enable": {
+    "message": "Bestätigen aktivieren",
+    "description": "Geplanter Vorlagenassistent: scheduledTemplates.step.enable"
+  },
+  "scheduledTemplates.testStarting": {
+    "message": "Wird gestartet",
+    "description": "Geplanter Vorlagenassistent: scheduledTemplates.testStarting"
+  },
+  "scheduledTemplates.category.developer": {
+    "message": "Entwickler",
+    "description": "Geplanter Template-Assistent: scheduledTemplates.category.developer"
+  },
+  "scheduledTemplates.risk.low": {
+    "message": "Geringes Risiko",
+    "description": "Geplanter Template-Assistent: scheduledTemplates.risk.low"
+  },
+  "scheduledTemplates.fixConfiguration": {
+    "message": "Konfiguration ändern",
+    "description": "Geplanter Template-Assistent: scheduledTemplates.fixConfiguration"
+  },
+  "scheduledTemplates.estimatedBudget": {
+    "message": "Maximales Schätzlimit pro Vorgang",
+    "description": "Geplanter Template-Assistent: scheduledTemplates.estimatedBudget"
+  },
+  "scheduledTemplates.enableTitle": {
+    "message": "Unbeaufsichtigte Genehmigung bestätigen",
+    "description": "Geplanter Template-Assistent: scheduledTemplates.enableTitle"
+  },
+  "scheduledTemplates.estimateOnly": {
+    "message": "Konservative Schätzung, keine tatsächlichen Kosten",
+    "description": "Geplanter Template-Assistent: scheduledTemplates.estimateOnly"
+  },
+  "scheduledTemplates.category.product": {
+    "message": "Produkt",
+    "description": "Geplanter Template-Assistent: scheduledTemplates.category.product"
+  },
+  "scheduledTemplates.startTest": {
+    "message": "Erstellen und Testlauf",
+    "description": "Geplanter Vorlagenassistent: scheduledTemplates.startTest"
+  },
+  "scheduledTemplates.step.test": {
+    "message": "Testlauf",
+    "description": "Geplanter Vorlagenassistent: scheduledTemplates.step.test"
+  },
+  "scheduledTemplates.readyToEnable": {
+    "message": "Die aktuelle Konfiguration und die Nachweise sind genehmigt",
+    "description": "Geplanter Template-Assistent: scheduledTemplates.readyToEnable"
+  },
+  "scheduledTemplates.risk.high": {
+    "message": "Hohes Risiko",
+    "description": "Geplanter Template-Assistent: scheduledTemplates.risk.high"
+  },
+  "scheduledTemplates.risk.medium": {
+    "message": "Überprüfung erforderlich",
+    "description": "Geplanter Template-Assistent: scheduledTemplates.risk.medium"
+  },
+  "scheduledTemplates.retryTest": {
+    "message": "Erneut testen",
+    "description": "Geplanter Template-Assistent: scheduledTemplates.retryTest"
+  },
+  "scheduledTemplates.category.video": {
+    "message": "Videoinhalte",
+    "description": "Geplanter Vorlagen-Assistent: scheduledTemplates.category.video"
+  },
+  "scheduledTemplates.risk": {
+    "message": "Risiko",
+    "description": "Geplanter Template-Assistent: scheduledTemplates.risk"
+  },
+  "scheduledTemplates.actions": {
+    "message": "Externe Aktionen",
+    "description": "Geplanter Template-Assistent: scheduledTemplates.actions"
+  },
+  "scheduledTemplates.optionalConnections": {
+    "message": "Es gibt {count} optionale Verbindungen, die Aufgabe kann auch ohne sie ausgeführt werden",
+    "description": "Geplanter Template-Assistent: scheduledTemplates.optionalConnections"
+  },
+  "scheduledTemplates.enableNow": {
+    "message": "Bestätigen und aktivieren",
+    "description": "Geplanter Template-Assistent: scheduledTemplates.enableNow"
+  },
+  "scheduledTemplates.backendRequired": {
+    "message": "Backend-Sicherheitsvertrag ist noch nicht bereitgestellt; zur Vermeidung von Umgehungen kann es derzeit nicht aktiviert werden.",
+    "description": "Geplanter Template-Assistent: scheduledTemplates.backendRequired"
+  },
+  "scheduledTemplates.testTitle": {
+    "message": "Zuerst einen Testlauf durchführen",
+    "description": "Geplanter Vorlagenassistent: scheduledTemplates.testTitle"
+  },
+  "scheduledTemplates.reviewEnable": {
+    "message": "Überprüfen und aktivieren",
+    "description": "Geplanter Template-Assistent: scheduledTemplates.reviewEnable"
+  },
+  "scheduledTemplates.enabled": {
+    "message": "Geplante Aufgabe aktiviert",
+    "description": "Geplanter Template-Assistent: scheduledTemplates.enabled"
+  },
+  "scheduledTemplates.readOnly": {
+    "message": "Nur lesen",
+    "description": "Geplanter Template-Assistent: scheduledTemplates.readOnly"
+  },
+  "scheduledTemplates.testDescription": {
+    "message": "Die Aufgabe bleibt deaktiviert; die Aktivierung des wiederkehrenden Zeitplans erfolgt erst nach Bestätigung der Ergebnisse und Nachweise.",
+    "description": "Geplanter Vorlagenassistent: scheduledTemplates.testDescription"
   }
 }

--- a/src/i18n/en/chat.json
+++ b/src/i18n/en/chat.json
@@ -1683,5 +1683,109 @@
   "model.deepseekV4ProDescription": {
     "message": "Latest high-performance flagship, 1M context",
     "description": "Description of the DeepSeek V4 Pro model"
+  },
+  "scheduledTemplates.actions": {
+    "message": "External actions",
+    "description": "Scheduled template wizard: scheduledTemplates.actions"
+  },
+  "scheduledTemplates.backendRequired": {
+    "message": "The backend safety contract is not deployed yet. Activation stays blocked rather than bypassing the test gate.",
+    "description": "Scheduled template wizard: scheduledTemplates.backendRequired"
+  },
+  "scheduledTemplates.category.developer": {
+    "message": "Developer",
+    "description": "Scheduled template wizard: scheduledTemplates.category.developer"
+  },
+  "scheduledTemplates.category.product": {
+    "message": "Product",
+    "description": "Scheduled template wizard: scheduledTemplates.category.product"
+  },
+  "scheduledTemplates.category.video": {
+    "message": "Video",
+    "description": "Scheduled template wizard: scheduledTemplates.category.video"
+  },
+  "scheduledTemplates.enableNow": {
+    "message": "Confirm and enable",
+    "description": "Scheduled template wizard: scheduledTemplates.enableNow"
+  },
+  "scheduledTemplates.enableTitle": {
+    "message": "Confirm unattended authorization",
+    "description": "Scheduled template wizard: scheduledTemplates.enableTitle"
+  },
+  "scheduledTemplates.enabled": {
+    "message": "Scheduled task enabled",
+    "description": "Scheduled template wizard: scheduledTemplates.enabled"
+  },
+  "scheduledTemplates.estimateOnly": {
+    "message": "Conservative estimate, not the actual charge",
+    "description": "Scheduled template wizard: scheduledTemplates.estimateOnly"
+  },
+  "scheduledTemplates.estimatedBudget": {
+    "message": "Estimated per-run ceiling",
+    "description": "Scheduled template wizard: scheduledTemplates.estimatedBudget"
+  },
+  "scheduledTemplates.fixConfiguration": {
+    "message": "Fix configuration",
+    "description": "Scheduled template wizard: scheduledTemplates.fixConfiguration"
+  },
+  "scheduledTemplates.optionalConnections": {
+    "message": "{count} optional connections; the task can run without them",
+    "description": "Scheduled template wizard: scheduledTemplates.optionalConnections"
+  },
+  "scheduledTemplates.readOnly": {
+    "message": "Read only",
+    "description": "Scheduled template wizard: scheduledTemplates.readOnly"
+  },
+  "scheduledTemplates.readyToEnable": {
+    "message": "The current configuration passed its test and evidence checks",
+    "description": "Scheduled template wizard: scheduledTemplates.readyToEnable"
+  },
+  "scheduledTemplates.retryTest": {
+    "message": "Run again",
+    "description": "Scheduled template wizard: scheduledTemplates.retryTest"
+  },
+  "scheduledTemplates.reviewEnable": {
+    "message": "Review activation",
+    "description": "Scheduled template wizard: scheduledTemplates.reviewEnable"
+  },
+  "scheduledTemplates.risk": {
+    "message": "Risk",
+    "description": "Scheduled template wizard: scheduledTemplates.risk"
+  },
+  "scheduledTemplates.risk.high": {
+    "message": "High risk",
+    "description": "Scheduled template wizard: scheduledTemplates.risk.high"
+  },
+  "scheduledTemplates.risk.low": {
+    "message": "Low risk",
+    "description": "Scheduled template wizard: scheduledTemplates.risk.low"
+  },
+  "scheduledTemplates.risk.medium": {
+    "message": "Review required",
+    "description": "Scheduled template wizard: scheduledTemplates.risk.medium"
+  },
+  "scheduledTemplates.startTest": {
+    "message": "Create and test",
+    "description": "Scheduled template wizard: scheduledTemplates.startTest"
+  },
+  "scheduledTemplates.step.enable": {
+    "message": "Confirm",
+    "description": "Scheduled template wizard: scheduledTemplates.step.enable"
+  },
+  "scheduledTemplates.step.test": {
+    "message": "Test run",
+    "description": "Scheduled template wizard: scheduledTemplates.step.test"
+  },
+  "scheduledTemplates.testDescription": {
+    "message": "The task stays disabled until this run and its evidence are verified.",
+    "description": "Scheduled template wizard: scheduledTemplates.testDescription"
+  },
+  "scheduledTemplates.testStarting": {
+    "message": "Starting",
+    "description": "Scheduled template wizard: scheduledTemplates.testStarting"
+  },
+  "scheduledTemplates.testTitle": {
+    "message": "Run one safe test",
+    "description": "Scheduled template wizard: scheduledTemplates.testTitle"
   }
 }

--- a/src/i18n/es/chat.json
+++ b/src/i18n/es/chat.json
@@ -1771,5 +1771,109 @@
   "model.deepseekV4ProDescription": {
     "message": "La última generación de buque insignia de alto rendimiento, 1M contexto",
     "description": "Descripción del modelo DeepSeek V4 Pro"
+  },
+  "scheduledTemplates.risk.low": {
+    "message": "Bajo riesgo",
+    "description": "Asistente de plantilla programada: scheduledTemplates.risk.low"
+  },
+  "scheduledTemplates.startTest": {
+    "message": "Crear y probar",
+    "description": "Asistente de plantillas programadas: scheduledTemplates.startTest"
+  },
+  "scheduledTemplates.step.enable": {
+    "message": "Confirmar habilitación",
+    "description": "Asistente de plantillas programadas: scheduledTemplates.step.enable"
+  },
+  "scheduledTemplates.risk.medium": {
+    "message": "Requiere revisión",
+    "description": "Asistente de plantilla programada: scheduledTemplates.risk.medium"
+  },
+  "scheduledTemplates.testTitle": {
+    "message": "Probar una vez primero",
+    "description": "Asistente de plantillas programadas: scheduledTemplates.testTitle"
+  },
+  "scheduledTemplates.testDescription": {
+    "message": "La tarea permanecerá desactivada; se debe confirmar el resultado y la evidencia antes de habilitar la programación periódica.",
+    "description": "Asistente de plantillas programadas: scheduledTemplates.testDescription"
+  },
+  "scheduledTemplates.risk": {
+    "message": "Riesgo",
+    "description": "Asistente de plantilla programada: scheduledTemplates.risk"
+  },
+  "scheduledTemplates.estimatedBudget": {
+    "message": "Límite de estimación por única vez",
+    "description": "Asistente de plantilla programada: scheduledTemplates.estimatedBudget"
+  },
+  "scheduledTemplates.category.product": {
+    "message": "Producto",
+    "description": "Asistente de plantilla programada: scheduledTemplates.category.product"
+  },
+  "scheduledTemplates.enabled": {
+    "message": "Tarea programada habilitada",
+    "description": "Asistente de plantilla programada: scheduledTemplates.enabled"
+  },
+  "scheduledTemplates.readyToEnable": {
+    "message": "La prueba y evidencia de la configuración actual han sido aprobadas",
+    "description": "Asistente de plantilla programada: scheduledTemplates.readyToEnable"
+  },
+  "scheduledTemplates.fixConfiguration": {
+    "message": "Modificar configuración",
+    "description": "Asistente de plantilla programada: scheduledTemplates.fixConfiguration"
+  },
+  "scheduledTemplates.actions": {
+    "message": "Acciones externas",
+    "description": "Asistente de plantilla programada: scheduledTemplates.actions"
+  },
+  "scheduledTemplates.retryTest": {
+    "message": "Reintentar prueba",
+    "description": "Asistente de plantilla programada: scheduledTemplates.retryTest"
+  },
+  "scheduledTemplates.testStarting": {
+    "message": "Iniciando",
+    "description": "Asistente de plantillas programadas: scheduledTemplates.testStarting"
+  },
+  "scheduledTemplates.enableNow": {
+    "message": "Confirmar y habilitar",
+    "description": "Asistente de plantilla programada: scheduledTemplates.enableNow"
+  },
+  "scheduledTemplates.backendRequired": {
+    "message": "El contrato de seguridad del backend no ha sido desplegado; para evitar eludir el acceso de prueba, no se puede habilitar por el momento.",
+    "description": "Asistente de plantilla programada: scheduledTemplates.backendRequired"
+  },
+  "scheduledTemplates.estimateOnly": {
+    "message": "Estimación conservadora, no se cobrará realmente",
+    "description": "Asistente de plantilla programada: scheduledTemplates.estimateOnly"
+  },
+  "scheduledTemplates.readOnly": {
+    "message": "Solo lectura",
+    "description": "Asistente de plantilla programada: scheduledTemplates.readOnly"
+  },
+  "scheduledTemplates.category.developer": {
+    "message": "Desarrollador",
+    "description": "Asistente de plantilla programada: scheduledTemplates.category.developer"
+  },
+  "scheduledTemplates.step.test": {
+    "message": "Probar",
+    "description": "Asistente de plantillas programadas: scheduledTemplates.step.test"
+  },
+  "scheduledTemplates.reviewEnable": {
+    "message": "Revisar y confirmar habilitación",
+    "description": "Asistente de plantilla programada: scheduledTemplates.reviewEnable"
+  },
+  "scheduledTemplates.risk.high": {
+    "message": "Alto riesgo",
+    "description": "Asistente de plantilla programada: scheduledTemplates.risk.high"
+  },
+  "scheduledTemplates.category.video": {
+    "message": "Contenido de vídeo",
+    "description": "Asistente de plantillas programadas: scheduledTemplates.category.video"
+  },
+  "scheduledTemplates.optionalConnections": {
+    "message": "Hay {count} conexiones opcionales, la tarea aún puede ejecutarse si faltan",
+    "description": "Asistente de plantilla programada: scheduledTemplates.optionalConnections"
+  },
+  "scheduledTemplates.enableTitle": {
+    "message": "Confirmar autorización sin supervisión",
+    "description": "Asistente de plantilla programada: scheduledTemplates.enableTitle"
   }
 }

--- a/src/i18n/fr/chat.json
+++ b/src/i18n/fr/chat.json
@@ -1770,5 +1770,109 @@
   "model.deepseekV4ProDescription": {
     "message": "Dernière génération de flagship haute performance, 1M contexte",
     "description": "Description du modèle DeepSeek V4 Pro"
+  },
+  "scheduledTemplates.actions": {
+    "message": "Actions externes",
+    "description": "Assistant de modèle programmé : scheduledTemplates.actions"
+  },
+  "scheduledTemplates.backendRequired": {
+    "message": "Le contrat de sécurité backend n'est pas encore déployé ; pour éviter de contourner l'accès aux essais, il ne peut pas être activé pour le moment.",
+    "description": "Assistant de modèle programmé : scheduledTemplates.backendRequired"
+  },
+  "scheduledTemplates.category.developer": {
+    "message": "Développeur",
+    "description": "Assistant de modèle programmé : scheduledTemplates.category.developer"
+  },
+  "scheduledTemplates.category.product": {
+    "message": "Produit",
+    "description": "Assistant de modèle programmé : scheduledTemplates.category.product"
+  },
+  "scheduledTemplates.category.video": {
+    "message": "Vidéo",
+    "description": "Assistant de modèle programmé : scheduledTemplates.category.video"
+  },
+  "scheduledTemplates.enableNow": {
+    "message": "Confirmer et activer",
+    "description": "Assistant de modèle programmé : scheduledTemplates.enableNow"
+  },
+  "scheduledTemplates.enableTitle": {
+    "message": "Confirmer l'autorisation sans surveillance",
+    "description": "Assistant de modèle programmé : scheduledTemplates.enableTitle"
+  },
+  "scheduledTemplates.enabled": {
+    "message": "Tâches programmées activées",
+    "description": "Assistant de modèle programmé : scheduledTemplates.enabled"
+  },
+  "scheduledTemplates.estimateOnly": {
+    "message": "Estimation conservatrice, non facturée",
+    "description": "Assistant de modèle programmé : scheduledTemplates.estimateOnly"
+  },
+  "scheduledTemplates.estimatedBudget": {
+    "message": "Plafond d'estimation par occurrence",
+    "description": "Assistant de modèle programmé : scheduledTemplates.estimatedBudget"
+  },
+  "scheduledTemplates.fixConfiguration": {
+    "message": "Modifier la configuration",
+    "description": "Assistant de modèle programmé : scheduledTemplates.fixConfiguration"
+  },
+  "scheduledTemplates.optionalConnections": {
+    "message": "Il y a {count} connexions optionnelles, la tâche peut toujours s'exécuter en cas d'absence",
+    "description": "Assistant de modèle programmé : scheduledTemplates.optionalConnections"
+  },
+  "scheduledTemplates.readOnly": {
+    "message": "Lecture seule",
+    "description": "Assistant de modèle programmé : scheduledTemplates.readOnly"
+  },
+  "scheduledTemplates.readyToEnable": {
+    "message": "La configuration actuelle des essais et des preuves a été validée",
+    "description": "Assistant de modèle programmé : scheduledTemplates.readyToEnable"
+  },
+  "scheduledTemplates.retryTest": {
+    "message": "Réessayer l'exécution",
+    "description": "Assistant de modèle programmé : scheduledTemplates.retryTest"
+  },
+  "scheduledTemplates.reviewEnable": {
+    "message": "Voir et confirmer l'activation",
+    "description": "Assistant de modèle programmé : scheduledTemplates.reviewEnable"
+  },
+  "scheduledTemplates.risk": {
+    "message": "Risque",
+    "description": "Assistant de modèle programmé : scheduledTemplates.risk"
+  },
+  "scheduledTemplates.risk.high": {
+    "message": "Risque élevé",
+    "description": "Assistant de modèle programmé : scheduledTemplates.risk.high"
+  },
+  "scheduledTemplates.risk.low": {
+    "message": "Risque faible",
+    "description": "Assistant de modèle programmé : scheduledTemplates.risk.low"
+  },
+  "scheduledTemplates.risk.medium": {
+    "message": "À vérifier",
+    "description": "Assistant de modèle programmé : scheduledTemplates.risk.medium"
+  },
+  "scheduledTemplates.startTest": {
+    "message": "Créer et exécuter un test",
+    "description": "Assistant de modèle programmé : scheduledTemplates.startTest"
+  },
+  "scheduledTemplates.step.enable": {
+    "message": "Confirmer l'activation",
+    "description": "Assistant de modèle programmé : scheduledTemplates.step.enable"
+  },
+  "scheduledTemplates.step.test": {
+    "message": "Exécuter un test",
+    "description": "Assistant de modèle programmé : scheduledTemplates.step.test"
+  },
+  "scheduledTemplates.testDescription": {
+    "message": "La tâche restera désactivée ; l'activation de la planification périodique ne pourra se faire qu'après confirmation des résultats et des preuves.",
+    "description": "Assistant de modèle programmé : scheduledTemplates.testDescription"
+  },
+  "scheduledTemplates.testStarting": {
+    "message": "Démarrage en cours",
+    "description": "Assistant de modèle programmé : scheduledTemplates.testStarting"
+  },
+  "scheduledTemplates.testTitle": {
+    "message": "Exécutez d'abord un test",
+    "description": "Assistant de modèle programmé : scheduledTemplates.testTitle"
   }
 }

--- a/src/i18n/it/chat.json
+++ b/src/i18n/it/chat.json
@@ -1770,5 +1770,109 @@
   "model.deepseekV4ProDescription": {
     "message": "Ultima generazione di flagship ad alte prestazioni, 1M contesto",
     "description": "Descrizione del modello DeepSeek V4 Pro"
+  },
+  "scheduledTemplates.testTitle": {
+    "message": "Esegui prima un test",
+    "description": "Procedura guidata del modello programmato: scheduledTemplates.testTitle"
+  },
+  "scheduledTemplates.enableTitle": {
+    "message": "Conferma autorizzazione senza supervisione",
+    "description": "Wizard dei modelli programmati: scheduledTemplates.enableTitle"
+  },
+  "scheduledTemplates.estimateOnly": {
+    "message": "Stima conservativa, non addebito reale",
+    "description": "Wizard dei modelli programmati: scheduledTemplates.estimateOnly"
+  },
+  "scheduledTemplates.risk.low": {
+    "message": "Basso rischio",
+    "description": "Wizard dei modelli programmati: scheduledTemplates.risk.low"
+  },
+  "scheduledTemplates.readOnly": {
+    "message": "Sola lettura",
+    "description": "Wizard dei modelli programmati: scheduledTemplates.readOnly"
+  },
+  "scheduledTemplates.backendRequired": {
+    "message": "Il contratto di sicurezza backend non è ancora stato distribuito; per evitare di bypassare l'accesso alla prova, non può essere attivato al momento.",
+    "description": "Wizard dei modelli programmati: scheduledTemplates.backendRequired"
+  },
+  "scheduledTemplates.actions": {
+    "message": "Azioni esterne",
+    "description": "Wizard dei modelli programmati: scheduledTemplates.actions"
+  },
+  "scheduledTemplates.fixConfiguration": {
+    "message": "Modifica configurazione",
+    "description": "Wizard dei modelli programmati: scheduledTemplates.fixConfiguration"
+  },
+  "scheduledTemplates.category.developer": {
+    "message": "Sviluppatore",
+    "description": "Wizard dei modelli programmati: scheduledTemplates.category.developer"
+  },
+  "scheduledTemplates.risk": {
+    "message": "Rischio",
+    "description": "Wizard dei modelli programmati: scheduledTemplates.risk"
+  },
+  "scheduledTemplates.enableNow": {
+    "message": "Conferma e attiva",
+    "description": "Wizard dei modelli programmati: scheduledTemplates.enableNow"
+  },
+  "scheduledTemplates.category.video": {
+    "message": "Contenuti video",
+    "description": "Wizard dei modelli programmati: scheduledTemplates.category.video"
+  },
+  "scheduledTemplates.risk.high": {
+    "message": "Alto rischio",
+    "description": "Wizard dei modelli programmati: scheduledTemplates.risk.high"
+  },
+  "scheduledTemplates.reviewEnable": {
+    "message": "Visualizza e conferma attivazione",
+    "description": "Wizard dei modelli programmati: scheduledTemplates.reviewEnable"
+  },
+  "scheduledTemplates.step.enable": {
+    "message": "Conferma attivazione",
+    "description": "Procedura guidata del modello programmato: scheduledTemplates.step.enable"
+  },
+  "scheduledTemplates.optionalConnections": {
+    "message": "Ci sono {count} connessioni opzionali, il compito può comunque funzionare in assenza di esse",
+    "description": "Wizard dei modelli programmati: scheduledTemplates.optionalConnections"
+  },
+  "scheduledTemplates.step.test": {
+    "message": "Esegui test",
+    "description": "Procedura guidata del modello programmato: scheduledTemplates.step.test"
+  },
+  "scheduledTemplates.testDescription": {
+    "message": "Il compito rimarrà disattivato; è necessario confermare i risultati e le prove prima di attivare la pianificazione periodica.",
+    "description": "Procedura guidata del modello programmato: scheduledTemplates.testDescription"
+  },
+  "scheduledTemplates.estimatedBudget": {
+    "message": "Limite massimo di stima per singola esecuzione",
+    "description": "Wizard dei modelli programmati: scheduledTemplates.estimatedBudget"
+  },
+  "scheduledTemplates.risk.medium": {
+    "message": "Richiede revisione",
+    "description": "Procedura guidata del modello programmato: scheduledTemplates.risk.medium"
+  },
+  "scheduledTemplates.readyToEnable": {
+    "message": "La prova e le evidenze della configurazione attuale sono state superate",
+    "description": "Wizard dei modelli programmati: scheduledTemplates.readyToEnable"
+  },
+  "scheduledTemplates.enabled": {
+    "message": "Il compito programmato è stato attivato",
+    "description": "Wizard dei modelli programmati: scheduledTemplates.enabled"
+  },
+  "scheduledTemplates.category.product": {
+    "message": "Prodotto",
+    "description": "Wizard dei modelli programmati: scheduledTemplates.category.product"
+  },
+  "scheduledTemplates.startTest": {
+    "message": "Crea e avvia test",
+    "description": "Procedura guidata del modello programmato: scheduledTemplates.startTest"
+  },
+  "scheduledTemplates.retryTest": {
+    "message": "Riprova l'esecuzione",
+    "description": "Wizard dei modelli programmati: scheduledTemplates.retryTest"
+  },
+  "scheduledTemplates.testStarting": {
+    "message": "Avvio in corso",
+    "description": "Procedura guidata del modello programmato: scheduledTemplates.testStarting"
   }
 }

--- a/src/i18n/ja/chat.json
+++ b/src/i18n/ja/chat.json
@@ -1731,5 +1731,109 @@
   "model.deepseekV4ProDescription": {
     "message": "最新世代の高性能フラッグシップ、1M コンテキスト",
     "description": "DeepSeek V4 Pro モデルの説明"
+  },
+  "scheduledTemplates.enabled": {
+    "message": "スケジュールタスクが有効になりました",
+    "description": "スケジュールテンプレートウィザード: scheduledTemplates.enabled"
+  },
+  "scheduledTemplates.testStarting": {
+    "message": "起動中",
+    "description": "スケジュールテンプレートウィザード: scheduledTemplates.testStarting"
+  },
+  "scheduledTemplates.enableTitle": {
+    "message": "無人運用の承認を確認",
+    "description": "スケジュールテンプレートウィザード: scheduledTemplates.enableTitle"
+  },
+  "scheduledTemplates.backendRequired": {
+    "message": "バックエンドのセキュリティ契約がまだデプロイされていません；試運転のアクセス制限を回避しないために、現在は有効にできません。",
+    "description": "スケジュールテンプレートウィザード: scheduledTemplates.backendRequired"
+  },
+  "scheduledTemplates.step.enable": {
+    "message": "有効にすることを確認",
+    "description": "スケジュールテンプレートウィザード: scheduledTemplates.step.enable"
+  },
+  "scheduledTemplates.category.video": {
+    "message": "ビデオ",
+    "description": "スケジュールテンプレートウィザード: scheduledTemplates.category.video"
+  },
+  "scheduledTemplates.risk.medium": {
+    "message": "要レビュー",
+    "description": "スケジュールテンプレートウィザード: scheduledTemplates.risk.medium"
+  },
+  "scheduledTemplates.estimatedBudget": {
+    "message": "単回の見積もり上限",
+    "description": "スケジュールテンプレートウィザード: scheduledTemplates.estimatedBudget"
+  },
+  "scheduledTemplates.reviewEnable": {
+    "message": "確認して有効にする",
+    "description": "スケジュールテンプレートウィザード: scheduledTemplates.reviewEnable"
+  },
+  "scheduledTemplates.category.developer": {
+    "message": "開発者",
+    "description": "スケジュールテンプレートウィザード: scheduledTemplates.category.developer"
+  },
+  "scheduledTemplates.enableNow": {
+    "message": "確認して有効にする",
+    "description": "スケジュールテンプレートウィザード: scheduledTemplates.enableNow"
+  },
+  "scheduledTemplates.readyToEnable": {
+    "message": "現在の設定の試運転と証拠が承認されました",
+    "description": "スケジュールテンプレートウィザード: scheduledTemplates.readyToEnable"
+  },
+  "scheduledTemplates.retryTest": {
+    "message": "再試行",
+    "description": "スケジュールテンプレートウィザード: scheduledTemplates.retryTest"
+  },
+  "scheduledTemplates.risk.low": {
+    "message": "低リスク",
+    "description": "スケジュールテンプレートウィザード: scheduledTemplates.risk.low"
+  },
+  "scheduledTemplates.testTitle": {
+    "message": "先試運転を行う",
+    "description": "スケジュールされたテンプレートウィザード: scheduledTemplates.testTitle"
+  },
+  "scheduledTemplates.fixConfiguration": {
+    "message": "設定を修正",
+    "description": "スケジュールテンプレートウィザード: scheduledTemplates.fixConfiguration"
+  },
+  "scheduledTemplates.category.product": {
+    "message": "製品",
+    "description": "スケジュールテンプレートウィザード: scheduledTemplates.category.product"
+  },
+  "scheduledTemplates.testDescription": {
+    "message": "タスクは無効のままです；結果と証拠を確認した後に周期的スケジュールを有効にできます。",
+    "description": "スケジュールテンプレートウィザード: scheduledTemplates.testDescription"
+  },
+  "scheduledTemplates.estimateOnly": {
+    "message": "保守的な見積もり、実際の請求ではありません",
+    "description": "スケジュールテンプレートウィザード: scheduledTemplates.estimateOnly"
+  },
+  "scheduledTemplates.readOnly": {
+    "message": "読み取り専用",
+    "description": "スケジュールテンプレートウィザード: scheduledTemplates.readOnly"
+  },
+  "scheduledTemplates.risk": {
+    "message": "リスク",
+    "description": "スケジュールテンプレートウィザード: scheduledTemplates.risk"
+  },
+  "scheduledTemplates.startTest": {
+    "message": "作成して試運転",
+    "description": "スケジュールテンプレートウィザード: scheduledTemplates.startTest"
+  },
+  "scheduledTemplates.step.test": {
+    "message": "試運転",
+    "description": "スケジュールテンプレートウィザード: scheduledTemplates.step.test"
+  },
+  "scheduledTemplates.risk.high": {
+    "message": "高リスク",
+    "description": "スケジュールテンプレートウィザード: scheduledTemplates.risk.high"
+  },
+  "scheduledTemplates.optionalConnections": {
+    "message": "{count} のオプション接続がありますが、欠落してもタスクは実行可能です",
+    "description": "スケジュールテンプレートウィザード: scheduledTemplates.optionalConnections"
+  },
+  "scheduledTemplates.actions": {
+    "message": "外部アクション",
+    "description": "スケジュールテンプレートウィザード: scheduledTemplates.actions"
   }
 }

--- a/src/i18n/ko/chat.json
+++ b/src/i18n/ko/chat.json
@@ -1770,5 +1770,109 @@
   "model.deepseekV4ProDescription": {
     "message": "최신 세대 고성능 플래그십, 1M 컨텍스트",
     "description": "DeepSeek V4 Pro 모델의 설명"
+  },
+  "scheduledTemplates.risk.low": {
+    "message": "낮은 위험",
+    "description": "예약 템플릿 마법사: scheduledTemplates.risk.low"
+  },
+  "scheduledTemplates.step.enable": {
+    "message": "활성화 확인",
+    "description": "예약 템플릿 마법사: scheduledTemplates.step.enable"
+  },
+  "scheduledTemplates.fixConfiguration": {
+    "message": "구성 수정",
+    "description": "예약 템플릿 마법사: scheduledTemplates.fixConfiguration"
+  },
+  "scheduledTemplates.actions": {
+    "message": "외부 동작",
+    "description": "예약 템플릿 마법사: scheduledTemplates.actions"
+  },
+  "scheduledTemplates.estimatedBudget": {
+    "message": "단일 추정 한도",
+    "description": "예약 템플릿 마법사: scheduledTemplates.estimatedBudget"
+  },
+  "scheduledTemplates.readyToEnable": {
+    "message": "현재 구성의 테스트 실행과 증거가 통과되었습니다",
+    "description": "예약 템플릿 마법사: scheduledTemplates.readyToEnable"
+  },
+  "scheduledTemplates.category.video": {
+    "message": "비디오",
+    "description": "예약 템플릿 마법사: scheduledTemplates.category.video"
+  },
+  "scheduledTemplates.testStarting": {
+    "message": "시작 중",
+    "description": "예약 템플릿 마법사: scheduledTemplates.testStarting"
+  },
+  "scheduledTemplates.testTitle": {
+    "message": "한 번 시험 실행하기",
+    "description": "예약된 템플릿 마법사: scheduledTemplates.testTitle"
+  },
+  "scheduledTemplates.optionalConnections": {
+    "message": "{count}개의 선택적 연결이 있으며, 누락 시에도 작업이 실행될 수 있습니다",
+    "description": "예약 템플릿 마법사: scheduledTemplates.optionalConnections"
+  },
+  "scheduledTemplates.risk.medium": {
+    "message": "검토 필요",
+    "description": "예약 템플릿 마법사: scheduledTemplates.risk.medium"
+  },
+  "scheduledTemplates.risk.high": {
+    "message": "높은 위험",
+    "description": "예약 템플릿 마법사: scheduledTemplates.risk.high"
+  },
+  "scheduledTemplates.testDescription": {
+    "message": "작업은 비활성 상태를 유지합니다; 이번 결과와 증거를 확인한 후 주기적 예약을 활성화할 수 있습니다.",
+    "description": "예약 템플릿 마법사: scheduledTemplates.testDescription"
+  },
+  "scheduledTemplates.risk": {
+    "message": "위험",
+    "description": "예약 템플릿 마법사: scheduledTemplates.risk"
+  },
+  "scheduledTemplates.retryTest": {
+    "message": "테스트 다시 실행",
+    "description": "예약 템플릿 마법사: scheduledTemplates.retryTest"
+  },
+  "scheduledTemplates.estimateOnly": {
+    "message": "보수적인 추정, 실제 요금이 아님",
+    "description": "예약 템플릿 마법사: scheduledTemplates.estimateOnly"
+  },
+  "scheduledTemplates.backendRequired": {
+    "message": "백엔드 보안 계약이 아직 배포되지 않았습니다; 테스트 실행 접근을 우회하지 않기 위해 현재 활성화할 수 없습니다.",
+    "description": "예약 템플릿 마법사: scheduledTemplates.backendRequired"
+  },
+  "scheduledTemplates.category.developer": {
+    "message": "개발자",
+    "description": "예약 템플릿 마법사: scheduledTemplates.category.developer"
+  },
+  "scheduledTemplates.reviewEnable": {
+    "message": "활성화 확인 및 검토",
+    "description": "예약 템플릿 마법사: scheduledTemplates.reviewEnable"
+  },
+  "scheduledTemplates.enableTitle": {
+    "message": "무인 승인 확인",
+    "description": "예약 템플릿 마법사: scheduledTemplates.enableTitle"
+  },
+  "scheduledTemplates.category.product": {
+    "message": "제품",
+    "description": "예약 템플릿 마법사: scheduledTemplates.category.product"
+  },
+  "scheduledTemplates.enableNow": {
+    "message": "확인 및 활성화",
+    "description": "예약 템플릿 마법사: scheduledTemplates.enableNow"
+  },
+  "scheduledTemplates.readOnly": {
+    "message": "읽기 전용",
+    "description": "예약 템플릿 마법사: scheduledTemplates.readOnly"
+  },
+  "scheduledTemplates.enabled": {
+    "message": "예약 작업이 활성화되었습니다",
+    "description": "예약 템플릿 마법사: scheduledTemplates.enabled"
+  },
+  "scheduledTemplates.step.test": {
+    "message": "테스트 실행",
+    "description": "예약 템플릿 마법사: scheduledTemplates.step.test"
+  },
+  "scheduledTemplates.startTest": {
+    "message": "생성 및 테스트 실행",
+    "description": "예약 템플릿 마법사: scheduledTemplates.startTest"
   }
 }

--- a/src/i18n/pt/chat.json
+++ b/src/i18n/pt/chat.json
@@ -1770,5 +1770,109 @@
   "model.deepseekV4ProDescription": {
     "message": "A mais recente geração de flagship de alto desempenho, 1M de contexto",
     "description": "Descrição do modelo DeepSeek V4 Pro"
+  },
+  "scheduledTemplates.actions": {
+    "message": "Ações externas",
+    "description": "Assistente de modelo agendado: scheduledTemplates.actions"
+  },
+  "scheduledTemplates.backendRequired": {
+    "message": "O contrato de segurança do backend ainda não foi implantado; para evitar contornar o acesso ao teste, não pode ser ativado no momento.",
+    "description": "Assistente de modelo agendado: scheduledTemplates.backendRequired"
+  },
+  "scheduledTemplates.category.developer": {
+    "message": "Desenvolvedor",
+    "description": "Assistente de modelo agendado: scheduledTemplates.category.developer"
+  },
+  "scheduledTemplates.category.product": {
+    "message": "Produto",
+    "description": "Assistente de modelo agendado: scheduledTemplates.category.product"
+  },
+  "scheduledTemplates.category.video": {
+    "message": "Vídeo",
+    "description": "Assistente de modelo agendado: scheduledTemplates.category.video"
+  },
+  "scheduledTemplates.enableNow": {
+    "message": "Confirmar e ativar",
+    "description": "Assistente de modelo agendado: scheduledTemplates.enableNow"
+  },
+  "scheduledTemplates.enableTitle": {
+    "message": "Confirmar autorização não supervisionada",
+    "description": "Assistente de modelo agendado: scheduledTemplates.enableTitle"
+  },
+  "scheduledTemplates.enabled": {
+    "message": "Tarefas agendadas ativadas",
+    "description": "Assistente de modelo agendado: scheduledTemplates.enabled"
+  },
+  "scheduledTemplates.estimateOnly": {
+    "message": "Estimativa conservadora, não cobrança real",
+    "description": "Assistente de modelo agendado: scheduledTemplates.estimateOnly"
+  },
+  "scheduledTemplates.estimatedBudget": {
+    "message": "Limite máximo de estimativa por execução",
+    "description": "Assistente de modelo agendado: scheduledTemplates.estimatedBudget"
+  },
+  "scheduledTemplates.fixConfiguration": {
+    "message": "Modificar configuração",
+    "description": "Assistente de modelo agendado: scheduledTemplates.fixConfiguration"
+  },
+  "scheduledTemplates.optionalConnections": {
+    "message": "Há {count} conexões opcionais, a tarefa ainda pode ser executada se ausente",
+    "description": "Assistente de modelo agendado: scheduledTemplates.optionalConnections"
+  },
+  "scheduledTemplates.readOnly": {
+    "message": "Somente leitura",
+    "description": "Assistente de modelo agendado: scheduledTemplates.readOnly"
+  },
+  "scheduledTemplates.readyToEnable": {
+    "message": "A execução de teste e as evidências atuais foram aprovadas",
+    "description": "Assistente de modelo agendado: scheduledTemplates.readyToEnable"
+  },
+  "scheduledTemplates.retryTest": {
+    "message": "Reexecutar teste",
+    "description": "Assistente de modelo agendado: scheduledTemplates.retryTest"
+  },
+  "scheduledTemplates.reviewEnable": {
+    "message": "Verificar e confirmar ativação",
+    "description": "Assistente de modelo agendado: scheduledTemplates.reviewEnable"
+  },
+  "scheduledTemplates.risk": {
+    "message": "Risco",
+    "description": "Assistente de modelo agendado: scheduledTemplates.risk"
+  },
+  "scheduledTemplates.risk.high": {
+    "message": "Alto risco",
+    "description": "Assistente de modelo agendado: scheduledTemplates.risk.high"
+  },
+  "scheduledTemplates.risk.low": {
+    "message": "Baixo risco",
+    "description": "Assistente de modelo agendado: scheduledTemplates.risk.low"
+  },
+  "scheduledTemplates.risk.medium": {
+    "message": "Requer revisão",
+    "description": "Assistente de modelo agendado: scheduledTemplates.risk.medium"
+  },
+  "scheduledTemplates.startTest": {
+    "message": "Criar e executar teste",
+    "description": "Assistente de modelo agendado: scheduledTemplates.startTest"
+  },
+  "scheduledTemplates.step.enable": {
+    "message": "Confirmar ativação",
+    "description": "Assistente de modelo agendado: scheduledTemplates.step.enable"
+  },
+  "scheduledTemplates.step.test": {
+    "message": "Executar teste",
+    "description": "Assistente de modelo agendado: scheduledTemplates.step.test"
+  },
+  "scheduledTemplates.testDescription": {
+    "message": "A tarefa permanecerá desativada; confirme os resultados e evidências antes de ativar o agendamento periódico.",
+    "description": "Assistente de modelo agendado: scheduledTemplates.testDescription"
+  },
+  "scheduledTemplates.testStarting": {
+    "message": "Iniciando",
+    "description": "Assistente de modelo agendado: scheduledTemplates.testStarting"
+  },
+  "scheduledTemplates.testTitle": {
+    "message": "Execute um teste primeiro",
+    "description": "Assistente de modelo agendado: scheduledTemplates.testTitle"
   }
 }

--- a/src/i18n/ru/chat.json
+++ b/src/i18n/ru/chat.json
@@ -1770,5 +1770,109 @@
   "model.deepseekV4ProDescription": {
     "message": "Новейшее поколение высокопроизводительного флагмана, 1M контекста",
     "description": "Описание модели DeepSeek V4 Pro"
+  },
+  "scheduledTemplates.step.enable": {
+    "message": "Подтвердить включение",
+    "description": "Мастер шаблонов расписания: scheduledTemplates.step.enable"
+  },
+  "scheduledTemplates.category.developer": {
+    "message": "Разработчик",
+    "description": "Мастер шаблонов расписания: scheduledTemplates.category.developer"
+  },
+  "scheduledTemplates.step.test": {
+    "message": "Пробный запуск",
+    "description": "Мастер шаблонов расписания: scheduledTemplates.step.test"
+  },
+  "scheduledTemplates.testDescription": {
+    "message": "Задача останется отключенной; можно включить периодическое расписание только после подтверждения результатов и доказательств.",
+    "description": "Мастер шаблонов расписания: scheduledTemplates.testDescription"
+  },
+  "scheduledTemplates.risk.low": {
+    "message": "Низкий риск",
+    "description": "Мастер шаблонов расписания: scheduledTemplates.risk.low"
+  },
+  "scheduledTemplates.estimateOnly": {
+    "message": "Ориентировочная оценка, не фактическое списание",
+    "description": "Мастер шаблонов расписания: scheduledTemplates.estimateOnly"
+  },
+  "scheduledTemplates.risk": {
+    "message": "Риск",
+    "description": "Мастер шаблонов расписания: scheduledTemplates.risk"
+  },
+  "scheduledTemplates.fixConfiguration": {
+    "message": "Изменить настройки",
+    "description": "Мастер шаблонов расписания: scheduledTemplates.fixConfiguration"
+  },
+  "scheduledTemplates.reviewEnable": {
+    "message": "Просмотреть и подтвердить включение",
+    "description": "Мастер шаблонов расписания: scheduledTemplates.reviewEnable"
+  },
+  "scheduledTemplates.category.product": {
+    "message": "Продукт",
+    "description": "Мастер шаблонов расписания: scheduledTemplates.category.product"
+  },
+  "scheduledTemplates.actions": {
+    "message": "Внешние действия",
+    "description": "Мастер шаблонов расписания: scheduledTemplates.actions"
+  },
+  "scheduledTemplates.testStarting": {
+    "message": "Запуск...",
+    "description": "Мастер шаблонов расписания: scheduledTemplates.testStarting"
+  },
+  "scheduledTemplates.enableNow": {
+    "message": "Подтвердить и включить",
+    "description": "Мастер шаблонов расписания: scheduledTemplates.enableNow"
+  },
+  "scheduledTemplates.testTitle": {
+    "message": "Сначала запустите тест",
+    "description": "Мастер шаблонов по расписанию: scheduledTemplates.testTitle"
+  },
+  "scheduledTemplates.optionalConnections": {
+    "message": "Есть {count} необязательных подключений, задача все равно может выполняться при их отсутствии",
+    "description": "Мастер шаблонов расписания: scheduledTemplates.optionalConnections"
+  },
+  "scheduledTemplates.readOnly": {
+    "message": "Только для чтения",
+    "description": "Мастер шаблонов расписания: scheduledTemplates.readOnly"
+  },
+  "scheduledTemplates.readyToEnable": {
+    "message": "Текущая конфигурация пробного запуска и доказательства прошли проверку",
+    "description": "Мастер шаблонов расписания: scheduledTemplates.readyToEnable"
+  },
+  "scheduledTemplates.risk.high": {
+    "message": "Высокий риск",
+    "description": "Мастер шаблонов расписания: scheduledTemplates.risk.high"
+  },
+  "scheduledTemplates.category.video": {
+    "message": "Видео",
+    "description": "Мастер шаблонов расписания: scheduledTemplates.category.video"
+  },
+  "scheduledTemplates.risk.medium": {
+    "message": "Требует проверки",
+    "description": "Мастер шаблонов расписания: scheduledTemplates.risk.medium"
+  },
+  "scheduledTemplates.retryTest": {
+    "message": "Попробовать снова",
+    "description": "Мастер шаблонов расписания: scheduledTemplates.retryTest"
+  },
+  "scheduledTemplates.estimatedBudget": {
+    "message": "Максимум для одной оценки",
+    "description": "Мастер шаблонов расписания: scheduledTemplates.estimatedBudget"
+  },
+  "scheduledTemplates.backendRequired": {
+    "message": "Безопасный контракт на сервере еще не развернут; чтобы избежать обхода контроля доступа к пробному запуску, включить нельзя.",
+    "description": "Мастер шаблонов расписания: scheduledTemplates.backendRequired"
+  },
+  "scheduledTemplates.enableTitle": {
+    "message": "Подтвердить авторизацию без участия человека",
+    "description": "Мастер шаблонов расписания: scheduledTemplates.enableTitle"
+  },
+  "scheduledTemplates.startTest": {
+    "message": "Создать и протестировать",
+    "description": "Мастер шаблонов расписания: scheduledTemplates.startTest"
+  },
+  "scheduledTemplates.enabled": {
+    "message": "Запланированная задача включена",
+    "description": "Мастер шаблонов расписания: scheduledTemplates.enabled"
   }
 }

--- a/src/i18n/zh-CN/chat.json
+++ b/src/i18n/zh-CN/chat.json
@@ -1751,5 +1751,109 @@
   "model.deepseekV4ProDescription": {
     "message": "最新一代高性能旗舰，1M 上下文",
     "description": "DeepSeek V4 Pro 模型的描述"
+  },
+  "scheduledTemplates.actions": {
+    "message": "外部动作",
+    "description": "Scheduled template wizard: scheduledTemplates.actions"
+  },
+  "scheduledTemplates.backendRequired": {
+    "message": "后端安全契约尚未部署；为避免绕过试运行门禁，暂不能启用。",
+    "description": "Scheduled template wizard: scheduledTemplates.backendRequired"
+  },
+  "scheduledTemplates.category.developer": {
+    "message": "开发者",
+    "description": "Scheduled template wizard: scheduledTemplates.category.developer"
+  },
+  "scheduledTemplates.category.product": {
+    "message": "产品",
+    "description": "Scheduled template wizard: scheduledTemplates.category.product"
+  },
+  "scheduledTemplates.category.video": {
+    "message": "视频",
+    "description": "Scheduled template wizard: scheduledTemplates.category.video"
+  },
+  "scheduledTemplates.enableNow": {
+    "message": "确认并启用",
+    "description": "Scheduled template wizard: scheduledTemplates.enableNow"
+  },
+  "scheduledTemplates.enableTitle": {
+    "message": "确认无人值守授权",
+    "description": "Scheduled template wizard: scheduledTemplates.enableTitle"
+  },
+  "scheduledTemplates.enabled": {
+    "message": "定时任务已启用",
+    "description": "Scheduled template wizard: scheduledTemplates.enabled"
+  },
+  "scheduledTemplates.estimateOnly": {
+    "message": "保守估算，非实际扣费",
+    "description": "Scheduled template wizard: scheduledTemplates.estimateOnly"
+  },
+  "scheduledTemplates.estimatedBudget": {
+    "message": "单次估算上限",
+    "description": "Scheduled template wizard: scheduledTemplates.estimatedBudget"
+  },
+  "scheduledTemplates.fixConfiguration": {
+    "message": "修改配置",
+    "description": "Scheduled template wizard: scheduledTemplates.fixConfiguration"
+  },
+  "scheduledTemplates.optionalConnections": {
+    "message": "有 {count} 个可选连接，缺失时任务仍可运行",
+    "description": "Scheduled template wizard: scheduledTemplates.optionalConnections"
+  },
+  "scheduledTemplates.readOnly": {
+    "message": "只读",
+    "description": "Scheduled template wizard: scheduledTemplates.readOnly"
+  },
+  "scheduledTemplates.readyToEnable": {
+    "message": "当前配置的试运行和证据已通过",
+    "description": "Scheduled template wizard: scheduledTemplates.readyToEnable"
+  },
+  "scheduledTemplates.retryTest": {
+    "message": "重新试运行",
+    "description": "Scheduled template wizard: scheduledTemplates.retryTest"
+  },
+  "scheduledTemplates.reviewEnable": {
+    "message": "查看并确认启用",
+    "description": "Scheduled template wizard: scheduledTemplates.reviewEnable"
+  },
+  "scheduledTemplates.risk": {
+    "message": "风险",
+    "description": "Scheduled template wizard: scheduledTemplates.risk"
+  },
+  "scheduledTemplates.risk.high": {
+    "message": "高风险",
+    "description": "Scheduled template wizard: scheduledTemplates.risk.high"
+  },
+  "scheduledTemplates.risk.low": {
+    "message": "低风险",
+    "description": "Scheduled template wizard: scheduledTemplates.risk.low"
+  },
+  "scheduledTemplates.risk.medium": {
+    "message": "需审核",
+    "description": "Scheduled template wizard: scheduledTemplates.risk.medium"
+  },
+  "scheduledTemplates.startTest": {
+    "message": "创建并试运行",
+    "description": "Scheduled template wizard: scheduledTemplates.startTest"
+  },
+  "scheduledTemplates.step.enable": {
+    "message": "确认启用",
+    "description": "Scheduled template wizard: scheduledTemplates.step.enable"
+  },
+  "scheduledTemplates.step.test": {
+    "message": "试运行",
+    "description": "Scheduled template wizard: scheduledTemplates.step.test"
+  },
+  "scheduledTemplates.testDescription": {
+    "message": "任务会保持停用；确认本次结果和证据后才能启用周期调度。",
+    "description": "Scheduled template wizard: scheduledTemplates.testDescription"
+  },
+  "scheduledTemplates.testStarting": {
+    "message": "正在启动",
+    "description": "Scheduled template wizard: scheduledTemplates.testStarting"
+  },
+  "scheduledTemplates.testTitle": {
+    "message": "先试运行一次",
+    "description": "Scheduled template wizard: scheduledTemplates.testTitle"
   }
 }

--- a/src/i18n/zh-TW/chat.json
+++ b/src/i18n/zh-TW/chat.json
@@ -1731,5 +1731,109 @@
   "model.deepseekV4ProDescription": {
     "message": "最新一代高性能旗舰，1M 上下文",
     "description": "DeepSeek V4 Pro 模型的描述"
+  },
+  "scheduledTemplates.testDescription": {
+    "message": "任務會保持停用；確認本次結果和證據後才能啟用周期調度。",
+    "description": "排程模板精靈：scheduledTemplates.testDescription"
+  },
+  "scheduledTemplates.optionalConnections": {
+    "message": "有 {count} 個可選連接，缺失時任務仍可運行",
+    "description": "排程模板精靈：scheduledTemplates.optionalConnections"
+  },
+  "scheduledTemplates.step.enable": {
+    "message": "確認啟用",
+    "description": "排程模板精靈：scheduledTemplates.step.enable"
+  },
+  "scheduledTemplates.readOnly": {
+    "message": "只讀",
+    "description": "排程模板精靈：scheduledTemplates.readOnly"
+  },
+  "scheduledTemplates.reviewEnable": {
+    "message": "查看並確認啟用",
+    "description": "排程模板精靈：scheduledTemplates.reviewEnable"
+  },
+  "scheduledTemplates.risk.low": {
+    "message": "低風險",
+    "description": "排程模板精靈：scheduledTemplates.risk.low"
+  },
+  "scheduledTemplates.risk": {
+    "message": "風險",
+    "description": "排程模板精靈：scheduledTemplates.risk"
+  },
+  "scheduledTemplates.fixConfiguration": {
+    "message": "修改配置",
+    "description": "排程模板精靈：scheduledTemplates.fixConfiguration"
+  },
+  "scheduledTemplates.category.product": {
+    "message": "產品",
+    "description": "排程模板精靈：scheduledTemplates.category.product"
+  },
+  "scheduledTemplates.estimatedBudget": {
+    "message": "單次估算上限",
+    "description": "排程模板精靈：scheduledTemplates.estimatedBudget"
+  },
+  "scheduledTemplates.retryTest": {
+    "message": "重新試運行",
+    "description": "排程模板精靈：scheduledTemplates.retryTest"
+  },
+  "scheduledTemplates.enableNow": {
+    "message": "確認並啟用",
+    "description": "排程模板精靈：scheduledTemplates.enableNow"
+  },
+  "scheduledTemplates.estimateOnly": {
+    "message": "保守估算，非實際扣費",
+    "description": "排程模板精靈：scheduledTemplates.estimateOnly"
+  },
+  "scheduledTemplates.startTest": {
+    "message": "創建並試運行",
+    "description": "排程模板精靈：scheduledTemplates.startTest"
+  },
+  "scheduledTemplates.readyToEnable": {
+    "message": "當前配置的試運行和證據已通過",
+    "description": "排程模板精靈：scheduledTemplates.readyToEnable"
+  },
+  "scheduledTemplates.enabled": {
+    "message": "定時任務已啟用",
+    "description": "排程模板精靈：scheduledTemplates.enabled"
+  },
+  "scheduledTemplates.actions": {
+    "message": "外部動作",
+    "description": "排程模板精靈：scheduledTemplates.actions"
+  },
+  "scheduledTemplates.testStarting": {
+    "message": "正在啟動",
+    "description": "排程模板精靈：scheduledTemplates.testStarting"
+  },
+  "scheduledTemplates.category.video": {
+    "message": "視頻",
+    "description": "排程模板精靈：scheduledTemplates.category.video"
+  },
+  "scheduledTemplates.step.test": {
+    "message": "試運行",
+    "description": "排程模板精靈：scheduledTemplates.step.test"
+  },
+  "scheduledTemplates.risk.medium": {
+    "message": "需審核",
+    "description": "排程模板精靈：scheduledTemplates.risk.medium"
+  },
+  "scheduledTemplates.risk.high": {
+    "message": "高風險",
+    "description": "排程模板精靈：scheduledTemplates.risk.high"
+  },
+  "scheduledTemplates.enableTitle": {
+    "message": "確認無人值守授權",
+    "description": "排程模板精靈：scheduledTemplates.enableTitle"
+  },
+  "scheduledTemplates.testTitle": {
+    "message": "先試運行一次",
+    "description": "排程模板精靈：scheduledTemplates.testTitle"
+  },
+  "scheduledTemplates.category.developer": {
+    "message": "開發者",
+    "description": "排程模板精靈：scheduledTemplates.category.developer"
+  },
+  "scheduledTemplates.backendRequired": {
+    "message": "後端安全契約尚未部署；為避免繞過試運行門禁，暫不能啟用。",
+    "description": "排程模板精靈：scheduledTemplates.backendRequired"
   }
 }

--- a/src/operators/scheduledTasks.test.ts
+++ b/src/operators/scheduledTasks.test.ts
@@ -66,3 +66,24 @@ describe('operators/scheduledTasks', () => {
     });
   });
 });
+
+describe('scheduled template catalog compatibility', () => {
+  it('deduplicates historical versions defensively and keeps the newest', async () => {
+    const post = vi.spyOn(axios, 'post').mockResolvedValue({
+      data: {
+        items: [
+          { id: 'spotlight', version: 1 },
+          { id: 'brief', version: 1 },
+          { id: 'spotlight', version: 11 }
+        ],
+        categories: ['video']
+      }
+    } as never);
+    const result = await scheduledTasksOperator.listTemplates('tok');
+    expect(result.items).toEqual([
+      { id: 'spotlight', version: 11 },
+      { id: 'brief', version: 1 }
+    ]);
+    expect(post).toHaveBeenCalled();
+  });
+});

--- a/src/operators/scheduledTasks.ts
+++ b/src/operators/scheduledTasks.ts
@@ -92,6 +92,9 @@ export interface IScheduledRun {
    *  started. Absent on runs that used each connector's default account, and
    *  on runs predating the snapshot. */
   run_accounts?: IRunConnectionAccount[];
+  config_fingerprint?: string;
+  config_revision?: number;
+  execution_guard?: { tool_actions: number; paid_actions: number; estimated_credits_upper_bound: number };
 }
 
 /** One connector account a run ran as. `label` / `account_name` are resolved at
@@ -303,6 +306,27 @@ export interface IScheduledTaskTemplateDefinition {
   tags: string[];
   featured: boolean;
   form_schema: IScheduledTemplateField[];
+  schema_version?: 2;
+  lifecycle?: { status: 'published' | 'superseded' | 'disabled' };
+  risk?: { level: 'low' | 'medium' | 'high'; unattended_eligible: boolean; reasons: string[] };
+  side_effects?: Array<'external_draft' | 'external_send' | 'external_publish' | 'paid_media'>;
+  output?: { kind: string; expected_status?: 'draft' | 'delivered'; max_items: number };
+  evidence?: { mode: 'run_success' | 'artifact'; artifacts: Array<{ kind: string; status: string; channel?: string }> };
+  budget?: {
+    unit: 'credits';
+    estimated_upper_bound: number;
+    basis: string;
+    max_tool_actions: number;
+    max_paid_actions: number;
+    exact_charge_available: false;
+  };
+  dependencies?: {
+    required: IScheduledTaskTemplateDefinition['requirements'];
+    optional: IScheduledTaskTemplateDefinition['requirements'];
+  };
+  availability?: 'ready' | 'degraded' | 'blocked';
+  missing_required_connections?: string[];
+  missing_optional_connections?: string[];
   requirements: {
     skills: string[];
     mcp_servers: string[];
@@ -314,6 +338,30 @@ export interface IScheduledTaskTemplateDefinition {
   available: boolean;
   missing_connections: string[];
   connection_accounts?: Record<string, IAuthorizableConnectionAccount[]>;
+}
+
+export interface IScheduledTemplateActivationStatus {
+  ready: boolean;
+  config_fingerprint?: string;
+  config_revision?: number;
+  tested_run_id?: string;
+  tested_at?: number;
+  blockers: Array<{ code: string; detail?: Record<string, unknown> }>;
+  evidence: {
+    mode: 'run_success' | 'artifact';
+    satisfied: boolean;
+    artifacts: Array<{ kind: string; status: string; channel?: string }>;
+  };
+  risk: { level: 'low' | 'medium' | 'high'; unattended_eligible: boolean; reasons: string[] };
+  side_effects: string[];
+  budget: {
+    unit: 'credits';
+    estimated_upper_bound: number;
+    basis: string;
+    max_tool_actions: number;
+    max_paid_actions: number;
+    exact_charge_available: false;
+  };
 }
 
 export type ScheduledTaskPayload = {
@@ -405,7 +453,12 @@ class ScheduledTasksOperator {
       { action: 'retrieve_template_batch', ...filter },
       { headers: headers(token) }
     );
-    return { items: data?.items ?? [], categories: data?.categories ?? [] };
+    const latest = new Map<string, IScheduledTaskTemplateDefinition>();
+    for (const item of (data?.items ?? []) as IScheduledTaskTemplateDefinition[]) {
+      const current = latest.get(item.id);
+      if (!current || item.version > current.version) latest.set(item.id, item);
+    }
+    return { items: [...latest.values()], categories: data?.categories ?? [] };
   }
 
   async previewTemplate(
@@ -436,6 +489,45 @@ class ScheduledTasksOperator {
     const { data } = await axios.post(
       BASE,
       { action: 'instantiate_template', ...payload },
+      { headers: headers(token) }
+    );
+    return data;
+  }
+
+  async retrieveRun(token: string, id: string, runId: string): Promise<IScheduledRun> {
+    try {
+      const { data } = await axios.post(
+        BASE,
+        { action: 'retrieve_run', id, run_id: runId },
+        { headers: headers(token), timeout: RUN_REQUEST_TIMEOUT_MS }
+      );
+      return data;
+    } catch (error) {
+      if ((error as { response?: { status?: number } }).response?.status !== 400) throw error;
+      const runs = await this.listRuns(token, id);
+      const run = runs.find((candidate) => candidate.id === runId);
+      if (!run) throw error;
+      return run;
+    }
+  }
+
+  async activationStatus(token: string, id: string): Promise<IScheduledTemplateActivationStatus> {
+    const { data } = await axios.post(BASE, { action: 'retrieve_activation_status', id }, { headers: headers(token) });
+    return data;
+  }
+
+  async reconfigureTemplate(
+    token: string,
+    id: string,
+    payload: {
+      inputs: Record<string, string | number | boolean>;
+      schedule: IScheduleSpec;
+      connection_bindings: IScheduledConnectionBinding[];
+    }
+  ): Promise<IScheduledTask> {
+    const { data } = await axios.post(
+      BASE,
+      { action: 'reconfigure_template', id, ...payload },
       { headers: headers(token) }
     );
     return data;


### PR DESCRIPTION
## Summary
- replace the three-step template creator with choose → configure → connect → exact test run → confirm enable
- instantiate one disabled task, correlate the returned run ID, retry the same task, and reconfigure instead of creating hidden duplicates
- fail closed when the backend activation/fingerprint API is unavailable during rolling deployment
- show risk, side effects, evidence and conservative Credits disclosure; add privacy-safe RUM funnel events
- hand-author zh-CN/en and generate real translations for all other locales

## Backend dependencies
- https://github.com/AceDataCloud/PlatformService/pull/2120
- https://github.com/AceDataCloud/PlatformService/pull/2121
- https://github.com/AceDataCloud/PlatformService/pull/2122
- certified template-pack PR follows PR 2122

## Verification
- full Vitest: 232 files / 1731 tests passed
- web production build passed
- `vue-tsc -b` passed
- lint: 0 errors (2 pre-existing warnings)
- i18n coverage: 11 locales × 49 namespaces passed with no English placeholders
- Beachball check passed
- `git diff --check`

## Preview safety
The Cloudflare branch preview calls production APIs. Review with a read-only template only; do not run or enable Spotlight, Zhihu, Blogger, or WeChat delivery tasks. Until the backend stack is deployed, activation readiness intentionally displays a backend-update blocker.

Do not merge without authorization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)