### PR TITLE
fix(x402): broadcast recurring setup in wallet

### DIFF
--- a/change/fix-solana-continuous-wallet-broadcast.json
+++ b/change/fix-solana-continuous-wallet-broadcast.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Broadcast Solana continuous-payment setup transactions directly from the wallet before Backend verification so Phantom Lighthouse assertions remain fresh.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/utils/x402/continuousPayment.test.ts
+++ b/src/utils/x402/continuousPayment.test.ts
@@ -205,6 +205,85 @@ describe('continuous payment Backend orchestration', () => {
     expect(wallet.signTransaction).not.toHaveBeenCalled();
   });
 
+  it('registers an uncertain broadcast after a provider timeout instead of replaying', async () => {
+    vi.useFakeTimers();
+    const wallet = walletApi();
+    const signAndSendTransaction = vi.fn().mockRejectedValue(new Error('RPC timeout'));
+    (window as any).phantom = {
+      solana: { isPhantom: true, publicKey: wallet.keypair.publicKey, signAndSendTransaction }
+    };
+    mockedAxios.post
+      .mockResolvedValueOnce({
+        data: {
+          setup_token: 'setup',
+          wallet: wallet.keypair.publicKey.toBase58(),
+          authority_init_id: 42,
+          wallet_broadcast_supported: true
+        }
+      })
+      .mockResolvedValueOnce({
+        data: { action: 'create_delegation', transaction: unsignedTransaction(wallet.keypair) }
+      })
+      .mockResolvedValueOnce({ data: { signature: '', status: 'uncertain' } })
+      .mockResolvedValueOnce({ data: { signature: 'recovered-signature', status: 'confirmed' } })
+      .mockResolvedValueOnce({ data: { authorization: { id: 'auth', state: 'active' } } });
+
+    const pending = enableContinuousPayment({
+      token: 'token',
+      walletApi: wallet.api,
+      dailyLimitAtomic: '100000',
+      expiryTs: 1_900_000_000
+    });
+    await vi.runAllTimersAsync();
+    await pending;
+    vi.useRealTimers();
+
+    expect(signAndSendTransaction).toHaveBeenCalledTimes(1);
+    expect(wallet.signTransaction).not.toHaveBeenCalled();
+    expect(mockedAxios.post.mock.calls[2][1]).toEqual({
+      setup_token: 'setup',
+      action: 'create_delegation',
+      broadcast_uncertain: true
+    });
+    expect(track).toHaveBeenCalledWith('x402_continuous_payment_submit', {
+      action: 'create_delegation:uncertain'
+    });
+  });
+
+  it('does not mark an explicit wallet rejection as an uncertain broadcast', async () => {
+    const wallet = walletApi();
+    const rejected: any = new Error('User rejected the request');
+    rejected.code = 4001;
+    const signAndSendTransaction = vi.fn().mockRejectedValue(rejected);
+    (window as any).phantom = {
+      solana: { isPhantom: true, publicKey: wallet.keypair.publicKey, signAndSendTransaction }
+    };
+    mockedAxios.post
+      .mockResolvedValueOnce({
+        data: {
+          setup_token: 'setup',
+          wallet: wallet.keypair.publicKey.toBase58(),
+          authority_init_id: 42,
+          wallet_broadcast_supported: true
+        }
+      })
+      .mockResolvedValueOnce({
+        data: { action: 'create_delegation', transaction: unsignedTransaction(wallet.keypair) }
+      });
+
+    await expect(
+      enableContinuousPayment({
+        token: 'token',
+        walletApi: wallet.api,
+        dailyLimitAtomic: '100000',
+        expiryTs: 1_900_000_000
+      })
+    ).rejects.toThrow('User rejected');
+
+    expect(mockedAxios.post).toHaveBeenCalledTimes(2);
+    expect(wallet.signTransaction).not.toHaveBeenCalled();
+  });
+
   it('does not use an installed provider for a different connected wallet', async () => {
     const wallet = walletApi();
     const signAndSendTransaction = vi.fn();

--- a/src/utils/x402/continuousPayment.test.ts
+++ b/src/utils/x402/continuousPayment.test.ts
@@ -21,7 +21,8 @@ function walletApi() {
     signTransaction,
     api: {
       publicKey: { value: keypair.publicKey },
-      signTransaction: { value: signTransaction }
+      signTransaction: { value: signTransaction },
+      wallet: { value: { adapter: { name: 'Phantom' } } }
     }
   };
 }
@@ -39,6 +40,7 @@ function unsignedTransaction(wallet: Keypair): string {
 describe('continuous payment Backend orchestration', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.stubGlobal('window', {});
   });
 
   it('uses the public wallet signer and submits Backend-prepared transactions in order', async () => {
@@ -72,7 +74,170 @@ describe('continuous payment Backend orchestration', () => {
       '/api/v1/x402/payment-authorization/transaction/submit/',
       '/api/v1/x402/payment-authorization/confirm/'
     ]);
+    expect(mockedAxios.post.mock.calls[2][1]).toEqual(
+      expect.objectContaining({
+        setup_token: 'setup',
+        action: 'init_authority',
+        signed_transaction: expect.any(String)
+      })
+    );
+    expect(mockedAxios.post.mock.calls[2][1]).not.toHaveProperty('signature');
     expect(track).toHaveBeenCalledWith('x402_continuous_payment_success', { action: 'enable:confirm' });
+  });
+
+  it('uses Phantom sign-and-send and registers only the returned signature', async () => {
+    const wallet = walletApi();
+    const signAndSendTransaction = vi.fn().mockResolvedValue({ signature: 'wallet-signature' });
+    (window as any).phantom = {
+      solana: { isPhantom: true, publicKey: wallet.keypair.publicKey, signAndSendTransaction }
+    };
+    mockedAxios.post
+      .mockResolvedValueOnce({
+        data: {
+          setup_token: 'setup',
+          wallet: wallet.keypair.publicKey.toBase58(),
+          authority_init_id: 42,
+          wallet_broadcast_supported: true
+        }
+      })
+      .mockResolvedValueOnce({
+        data: { action: 'create_delegation', transaction: unsignedTransaction(wallet.keypair) }
+      })
+      .mockResolvedValueOnce({ data: { signature: 'wallet-signature', status: 'confirmed' } })
+      .mockResolvedValueOnce({ data: { authorization: { id: 'auth', state: 'active' } } });
+
+    await enableContinuousPayment({
+      token: 'token',
+      walletApi: wallet.api,
+      dailyLimitAtomic: '100000',
+      expiryTs: 1_900_000_000
+    });
+
+    expect(signAndSendTransaction).toHaveBeenCalledTimes(1);
+    expect(wallet.signTransaction).not.toHaveBeenCalled();
+    const submitCall = mockedAxios.post.mock.calls.find(
+      (call) => call[0] === '/api/v1/x402/payment-authorization/transaction/submit/'
+    );
+    expect(submitCall?.[1]).toEqual({
+      setup_token: 'setup',
+      action: 'create_delegation',
+      signature: 'wallet-signature'
+    });
+    expect(submitCall?.[1]).not.toHaveProperty('signed_transaction');
+    expect(track).toHaveBeenCalledWith('x402_continuous_payment_submit', {
+      action: 'create_delegation:wallet_send'
+    });
+    expect(track).toHaveBeenCalledWith('x402_continuous_payment_submit', {
+      action: 'create_delegation:register'
+    });
+  });
+
+  it('keeps legacy submission when Backend does not advertise wallet broadcast support', async () => {
+    const wallet = walletApi();
+    const signAndSendTransaction = vi.fn();
+    (window as any).phantom = {
+      solana: { isPhantom: true, publicKey: wallet.keypair.publicKey, signAndSendTransaction }
+    };
+    mockedAxios.post
+      .mockResolvedValueOnce({
+        data: { setup_token: 'setup', wallet: wallet.keypair.publicKey.toBase58(), authority_init_id: 42 }
+      })
+      .mockResolvedValueOnce({
+        data: { action: 'create_delegation', transaction: unsignedTransaction(wallet.keypair) }
+      })
+      .mockResolvedValueOnce({ data: { signature: 'legacy-signature', status: 'confirmed' } })
+      .mockResolvedValueOnce({ data: { authorization: { id: 'auth', state: 'active' } } });
+
+    await enableContinuousPayment({
+      token: 'token',
+      walletApi: wallet.api,
+      dailyLimitAtomic: '100000',
+      expiryTs: 1_900_000_000
+    });
+
+    expect(signAndSendTransaction).not.toHaveBeenCalled();
+    expect(wallet.signTransaction).toHaveBeenCalledTimes(1);
+    expect(mockedAxios.post.mock.calls[2][1]).toEqual(
+      expect.objectContaining({ signed_transaction: expect.any(String) })
+    );
+  });
+
+  it('uses the selected provider when Phantom and Solflare share an address', async () => {
+    const wallet = walletApi();
+    const phantomSend = vi.fn();
+    const solflareSend = vi.fn().mockResolvedValue({ signature: 'solflare-signature' });
+    (window as any).phantom = {
+      solana: { isPhantom: true, publicKey: wallet.keypair.publicKey, signAndSendTransaction: phantomSend }
+    };
+    (window as any).solflare = {
+      isSolflare: true,
+      publicKey: wallet.keypair.publicKey,
+      signAndSendTransaction: solflareSend
+    };
+    const api = {
+      ...wallet.api,
+      wallet: { value: { adapter: { name: 'Solflare' } } }
+    };
+    mockedAxios.post
+      .mockResolvedValueOnce({
+        data: {
+          setup_token: 'setup',
+          wallet: wallet.keypair.publicKey.toBase58(),
+          authority_init_id: 42,
+          wallet_broadcast_supported: true
+        }
+      })
+      .mockResolvedValueOnce({
+        data: { action: 'create_delegation', transaction: unsignedTransaction(wallet.keypair) }
+      })
+      .mockResolvedValueOnce({ data: { signature: 'solflare-signature', status: 'confirmed' } })
+      .mockResolvedValueOnce({ data: { authorization: { id: 'auth', state: 'active' } } });
+
+    await enableContinuousPayment({
+      token: 'token',
+      walletApi: api,
+      dailyLimitAtomic: '100000',
+      expiryTs: 1_900_000_000
+    });
+
+    expect(solflareSend).toHaveBeenCalledTimes(1);
+    expect(phantomSend).not.toHaveBeenCalled();
+    expect(wallet.signTransaction).not.toHaveBeenCalled();
+  });
+
+  it('does not use an installed provider for a different connected wallet', async () => {
+    const wallet = walletApi();
+    const signAndSendTransaction = vi.fn();
+    (window as any).phantom = {
+      solana: { isPhantom: true, publicKey: Keypair.generate().publicKey, signAndSendTransaction }
+    };
+    mockedAxios.post
+      .mockResolvedValueOnce({
+        data: {
+          setup_token: 'setup',
+          wallet: wallet.keypair.publicKey.toBase58(),
+          authority_init_id: 42,
+          wallet_broadcast_supported: true
+        }
+      })
+      .mockResolvedValueOnce({
+        data: { action: 'create_delegation', transaction: unsignedTransaction(wallet.keypair) }
+      })
+      .mockResolvedValueOnce({ data: { signature: 'legacy-signature', status: 'confirmed' } })
+      .mockResolvedValueOnce({ data: { authorization: { id: 'auth', state: 'active' } } });
+
+    await enableContinuousPayment({
+      token: 'token',
+      walletApi: wallet.api,
+      dailyLimitAtomic: '100000',
+      expiryTs: 1_900_000_000
+    });
+
+    expect(signAndSendTransaction).not.toHaveBeenCalled();
+    expect(wallet.signTransaction).toHaveBeenCalledTimes(1);
+    expect(mockedAxios.post.mock.calls[2][1]).toEqual(
+      expect.objectContaining({ signed_transaction: expect.any(String) })
+    );
   });
 
   it('skips authority initialization when Backend reports an existing authority', async () => {

--- a/src/utils/x402/continuousPayment.ts
+++ b/src/utils/x402/continuousPayment.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 import { Buffer } from 'buffer';
 import { Transaction } from '@solana/web3.js';
 import { reactive } from 'vue';
-import { BASE_URL_PLATFORM } from '@/constants';
+import { BASE_URL_PLATFORM } from '@/constants/endpoint';
 import { track } from '@/plugins/telemetry';
 
 export const CONTINUOUS_PAYMENT_PROFILE = 'solana-recurring-delegation-v1';
@@ -26,6 +26,7 @@ export interface SetupResponse {
   setup_token: string;
   wallet: string;
   authority_init_id?: number | null;
+  wallet_broadcast_supported?: boolean;
   transactions?: Partial<Record<TransactionAction, SubmittedTransaction>>;
 }
 
@@ -40,6 +41,7 @@ interface PreparedTransaction {
 interface SubmittedTransaction {
   signature: string;
   status: 'pending' | 'confirmed' | 'failed';
+  broadcast_source?: 'wallet' | 'backend';
 }
 
 type TransactionAction = 'init_authority' | 'create_delegation' | 'revoke_delegation';
@@ -94,15 +96,47 @@ export async function refreshContinuousPaymentAuthorization(token?: string) {
 function walletSigner(walletApi: any) {
   const wallet = walletApi?.publicKey?.value?.toBase58?.();
   const signTransaction = walletApi?.signTransaction?.value;
-  if (!wallet || typeof signTransaction !== 'function') throw new Error('Connect a Solana wallet first');
+  if (!wallet) throw new Error('Connect a Solana wallet first');
   return { wallet, signTransaction };
+}
+
+function normalizeSignature(result: any): string {
+  const signature = typeof result === 'string' ? result : result?.signature || result?.txid || result?.transactionId;
+  if (!signature || typeof signature !== 'string') throw new Error('Wallet did not return a transaction signature');
+  return signature;
+}
+
+function walletBroadcaster(walletApi: any, wallet: string): ((transaction: Transaction) => Promise<any>) | undefined {
+  if (typeof window === 'undefined') return undefined;
+  const selectedWallet = walletApi?.wallet?.value;
+  const selectedName = String(selectedWallet?.adapter?.name || '').toLowerCase();
+  const provider =
+    selectedName === 'phantom'
+      ? (window as any).phantom?.solana || ((window as any).solana?.isPhantom ? (window as any).solana : undefined)
+      : selectedName === 'solflare'
+        ? (window as any).solflare
+        : undefined;
+  if (provider?.publicKey?.toBase58?.() === wallet && typeof provider.signAndSendTransaction === 'function') {
+    return provider.signAndSendTransaction.bind(provider);
+  }
+  return undefined;
 }
 
 async function signPreparedTransaction(walletApi: any, encoded: string): Promise<string> {
   const { signTransaction } = walletSigner(walletApi);
+  if (typeof signTransaction !== 'function') throw new Error('Wallet does not support signing transactions');
   const transaction = Transaction.from(Buffer.from(encoded, 'base64'));
   const signed = await signTransaction(transaction);
   return Buffer.from(signed.serialize()).toString('base64');
+}
+
+async function broadcastPreparedTransaction(walletApi: any, encoded: string): Promise<string | undefined> {
+  const { wallet } = walletSigner(walletApi);
+  const broadcast = walletBroadcaster(walletApi, wallet);
+  if (!broadcast) return undefined;
+  const transaction = Transaction.from(Buffer.from(encoded, 'base64'));
+  // A provider error may happen after broadcast. Never auto-sign a replacement transaction.
+  return normalizeSignature(await broadcast(transaction));
 }
 
 async function prepare(token: string, setupToken: string, action: TransactionAction): Promise<PreparedTransaction> {
@@ -119,12 +153,12 @@ async function submit(
   token: string,
   setupToken: string,
   action: TransactionAction,
-  signedTransaction: string
+  transaction: { signature: string } | { signed_transaction: string }
 ): Promise<SubmittedTransaction> {
   return (
     await axios.post<SubmittedTransaction>(
       '/api/v1/x402/payment-authorization/transaction/submit/',
-      { setup_token: setupToken, action, signed_transaction: signedTransaction },
+      { setup_token: setupToken, action, ...transaction },
       { baseURL: BASE_URL_PLATFORM, headers: headers(token) }
     )
   ).data;
@@ -160,15 +194,26 @@ async function signAndSubmit(
   setupToken: string,
   action: TransactionAction,
   walletApi: any,
-  existing?: SubmittedTransaction
+  existing?: SubmittedTransaction,
+  walletBroadcastSupported = false
 ) {
-  if (existing) return waitForConfirmation(token, setupToken, action, existing);
+  if (existing && existing.status !== 'failed') return waitForConfirmation(token, setupToken, action, existing);
   event('x402_continuous_payment_submit', `${action}:prepare`);
   const prepared = await prepare(token, setupToken, action);
-  event('x402_continuous_payment_submit', `${action}:sign`);
-  const signed = await signPreparedTransaction(walletApi, prepared.transaction);
-  event('x402_continuous_payment_submit', `${action}:submit`);
-  const result = await submit(token, setupToken, action, signed);
+  event('x402_continuous_payment_submit', `${action}:wallet_send`);
+  const signature = walletBroadcastSupported
+    ? await broadcastPreparedTransaction(walletApi, prepared.transaction)
+    : undefined;
+  let result: SubmittedTransaction;
+  if (signature) {
+    event('x402_continuous_payment_submit', `${action}:register`);
+    result = await submit(token, setupToken, action, { signature });
+  } else {
+    event('x402_continuous_payment_submit', `${action}:sign`);
+    const signed = await signPreparedTransaction(walletApi, prepared.transaction);
+    event('x402_continuous_payment_submit', `${action}:submit`);
+    result = await submit(token, setupToken, action, { signed_transaction: signed });
+  }
   return waitForConfirmation(token, setupToken, action, result);
 }
 
@@ -194,7 +239,8 @@ export async function enableContinuousPayment(options: {
         setup.setup_token,
         'init_authority',
         options.walletApi,
-        setup.transactions?.init_authority
+        setup.transactions?.init_authority,
+        setup.wallet_broadcast_supported === true
       );
     }
     await signAndSubmit(
@@ -202,7 +248,8 @@ export async function enableContinuousPayment(options: {
       setup.setup_token,
       'create_delegation',
       options.walletApi,
-      setup.transactions?.create_delegation
+      setup.transactions?.create_delegation,
+      setup.wallet_broadcast_supported === true
     );
     const confirmed = await axios.post<{ authorization: ContinuousPaymentAuthorization }>(
       '/api/v1/x402/payment-authorization/confirm/',
@@ -251,7 +298,14 @@ export async function revokeContinuousPayment(token: string, walletApi: any) {
         { baseURL: BASE_URL_PLATFORM, headers: headers(token) }
       )
     ).data;
-    await signAndSubmit(token, setup.setup_token, 'revoke_delegation', walletApi);
+    await signAndSubmit(
+      token,
+      setup.setup_token,
+      'revoke_delegation',
+      walletApi,
+      undefined,
+      setup.wallet_broadcast_supported === true
+    );
     const response = await axios.post<{ authorization: ContinuousPaymentAuthorization }>(
       '/api/v1/x402/payment-authorization/revoke-confirm/',
       { setup_token: setup.setup_token },

--- a/src/utils/x402/continuousPayment.ts
+++ b/src/utils/x402/continuousPayment.ts
@@ -40,7 +40,7 @@ interface PreparedTransaction {
 
 interface SubmittedTransaction {
   signature: string;
-  status: 'pending' | 'confirmed' | 'failed';
+  status: 'pending' | 'confirmed' | 'failed' | 'uncertain';
   broadcast_source?: 'wallet' | 'backend';
 }
 
@@ -130,6 +130,14 @@ async function signPreparedTransaction(walletApi: any, encoded: string): Promise
   return Buffer.from(signed.serialize()).toString('base64');
 }
 
+function walletRejected(error: any): boolean {
+  const code = String(error?.code || error?.name || '').toLowerCase();
+  const message = String(error?.message || '').toLowerCase();
+  return (
+    code === '4001' || code.includes('reject') || message.includes('user rejected') || message.includes('declined')
+  );
+}
+
 async function broadcastPreparedTransaction(walletApi: any, encoded: string): Promise<string | undefined> {
   const { wallet } = walletSigner(walletApi);
   const broadcast = walletBroadcaster(walletApi, wallet);
@@ -153,7 +161,7 @@ async function submit(
   token: string,
   setupToken: string,
   action: TransactionAction,
-  transaction: { signature: string } | { signed_transaction: string }
+  transaction: { signature: string } | { signed_transaction: string } | { broadcast_uncertain: true }
 ): Promise<SubmittedTransaction> {
   return (
     await axios.post<SubmittedTransaction>(
@@ -181,7 +189,7 @@ async function waitForConfirmation(
   initial: SubmittedTransaction
 ) {
   let result = initial;
-  for (let attempt = 0; result.status === 'pending' && attempt < 30; attempt += 1) {
+  for (let attempt = 0; ['pending', 'uncertain'].includes(result.status) && attempt < 30; attempt += 1) {
     await new Promise((resolve) => globalThis.setTimeout(resolve, 2_000));
     result = await status(token, setupToken, action);
   }
@@ -201,9 +209,17 @@ async function signAndSubmit(
   event('x402_continuous_payment_submit', `${action}:prepare`);
   const prepared = await prepare(token, setupToken, action);
   event('x402_continuous_payment_submit', `${action}:wallet_send`);
-  const signature = walletBroadcastSupported
-    ? await broadcastPreparedTransaction(walletApi, prepared.transaction)
-    : undefined;
+  let signature: string | undefined;
+  if (walletBroadcastSupported) {
+    try {
+      signature = await broadcastPreparedTransaction(walletApi, prepared.transaction);
+    } catch (error) {
+      if (walletRejected(error)) throw error;
+      event('x402_continuous_payment_submit', `${action}:uncertain`);
+      const uncertain = await submit(token, setupToken, action, { broadcast_uncertain: true });
+      return waitForConfirmation(token, setupToken, action, uncertain);
+    }
+  }
   let result: SubmittedTransaction;
   if (signature) {
     event('x402_continuous_payment_submit', `${action}:register`);


### PR DESCRIPTION
## Problem

Phantom injects Lighthouse account-state assertions while signing continuous-payment setup transactions. The old `signTransaction -> upload signed bytes -> Backend sendTransaction` flow adds an HTTP/RPC relay delay; the production request reached Lighthouse with a stale `VerifyDatahash` assertion and failed before the subscription instruction ran.

## Fix

- use the selected Phantom/Solflare provider's `signAndSendTransaction`, binding native provider identity and public key to the wallet selected in Studio
- register only the returned signature; Backend retrieves and verifies the confirmed transaction against its durable challenge
- require `wallet_broadcast_supported === true` before direct broadcast; old Backend responses use the legacy relay path
- retain legacy `signTransaction` relay for unsupported wallets
- on non-rejection provider errors, register `broadcast_uncertain` instead of signing a replacement transaction
- poll Backend while it recovers the exact transaction from authority/delegation history
- never auto-fallback after an ambiguous provider error, preventing duplicate non-idempotent authorizations

## Dependency

Backend PR: https://github.com/AceDataCloud/PlatformBackend/pull/1618

Do not merge/deploy this PR until the Backend PR is deployed to all production pods. The capability gate is an additional rolling-version safeguard.

## Validation

- continuous-payment + contract/error tests: **17 passed**
- ESLint and diff checks: passed
- no public RPC was added to the continuous-payment helper

## 🤖 对抗评审 (reviewer: codex, 3 rounds)
- RISK: direct broadcast could hit an old Backend → fixed with explicit capability negotiation and Backend-first rollout
- RISK: installed Phantom could be used while another wallet was selected → fixed by binding to selected adapter identity plus matching public key
- RISK: two providers sharing one address could select the wrong extension → fixed by adapter-name binding; dedicated Solflare-vs-Phantom test added
- RISK: provider timeout could cause a replacement transaction → fixed by `broadcast_uncertain` registration and Backend exact recovery
- RISK: provider errors should fall back to relay → not adopted; the error may occur after broadcast, so fallback can duplicate authorization

🤖 Generated with [Claude Code](https://claude.com/claude-code)

