### PR TITLE
fix: make Studio rollouts asset-compatible

### DIFF
--- a/.github/workflows/check-pr.yaml
+++ b/.github/workflows/check-pr.yaml
@@ -76,3 +76,24 @@ jobs:
 
       - name: Build
         run: npm run build
+
+  docker:
+    name: Docker Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Verify compatible image targets
+        run: bash deploy/test-compatible-images.sh studio-frontend

--- a/.github/workflows/check-pr.yaml
+++ b/.github/workflows/check-pr.yaml
@@ -57,6 +57,9 @@ jobs:
       - name: Studio deployment contract
         run: python3 scripts/check_studio_deployment.py
 
+      - name: Release asset manifest tests
+        run: python3 -m unittest scripts/test_release_assets.py
+
       - name: Set up Python
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/check-pr.yaml
+++ b/.github/workflows/check-pr.yaml
@@ -87,13 +87,5 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build Docker image
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          push: false
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
       - name: Verify compatible image targets
         run: bash deploy/test-compatible-images.sh studio-frontend

--- a/.github/workflows/deploy-web.yaml
+++ b/.github/workflows/deploy-web.yaml
@@ -77,6 +77,10 @@ jobs:
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
 
+      - name: Set release tag
+        if: steps.changes.outputs.deploy == 'true'
+        run: echo "RELEASE_TAG=${BUILD_NUMBER}-${GITHUB_RUN_ATTEMPT}" >> "$GITHUB_ENV"
+
       - name: Compute Docker Hub version tag
         if: steps.changes.outputs.deploy == 'true'
         id: docker_tag
@@ -101,38 +105,48 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build & push image (GHCR + Docker Hub)
+      - name: Lock current production release
         if: steps.changes.outputs.deploy == 'true'
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          push: true
-          tags: |
-            ghcr.io/acedatacloud/studio-frontend:${{ env.BUILD_NUMBER }}
-            acedatacloud/nexior:${{ steps.docker_tag.outputs.version }}
-            acedatacloud/nexior:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+        env:
+          DEPLOYMENT: studio-frontend
+          SERVICE: studio-frontend
+          IMAGE_REPOSITORY: ghcr.io/acedatacloud/studio-frontend
+        run: bash deploy/preflight-release.sh
 
-      - name: Apply manifests
+      - name: Prepare previous release assets
         if: steps.changes.outputs.deploy == 'true'
-        run: sh ./deploy/run.sh
+        env:
+          MAX_RELEASE_FILES: '4000'
+          MAX_RELEASE_BYTES: '268435456'
+        run: bash deploy/prepare-previous-assets.sh
 
-      - name: Verify rollouts and images
+      - name: Build and push bridge and final images
         if: steps.changes.outputs.deploy == 'true'
         run: |
-          kubectl -n acedatacloud rollout status deployment/studio-frontend --timeout=10m
-          expected="ghcr.io/acedatacloud/studio-frontend:$BUILD_NUMBER"
-          test "$(kubectl -n acedatacloud get deployment studio-frontend -o jsonpath='{.spec.template.spec.containers[0].image}')" = "$expected"
-          test "$(kubectl -n acedatacloud get ingress hub-frontend -o jsonpath='{.spec.rules[0].http.paths[0].backend.service.name}')" = "studio-frontend"
-          test "$(kubectl -n acedatacloud get ingress hub-frontend -o jsonpath='{.spec.rules[1].http.paths[0].backend.service.name}')" = "studio-frontend"
-          test "$(curl -fsS -o /dev/null -w '%{http_code}' https://studio.acedata.cloud/health)" = "200" || \
-            test "$(curl -fsS -o /dev/null -w '%{http_code}' https://studio.acedata.cloud/)" = "200"
-          location=$(curl -fsSI 'https://hub.acedata.cloud/retired-check?keep=1' | tr -d '\r' | awk 'tolower($1)=="location:" {print $2; exit}')
-          test "$location" = "https://studio.acedata.cloud/retired-check?keep=1"
+          docker buildx build --target bridge --build-arg "PREVIOUS_IMAGE=$PREVIOUS_IMAGE" \
+            --tag "ghcr.io/acedatacloud/studio-frontend:${RELEASE_TAG}-bridge" --push \
+            --cache-from type=gha --cache-to type=gha,mode=max .
+          docker buildx build --target final --build-arg "PREVIOUS_IMAGE=$PREVIOUS_IMAGE" \
+            --tag "ghcr.io/acedatacloud/studio-frontend:${RELEASE_TAG}" --push \
+            --cache-from type=gha .
 
-      - name: Record successful revision
+      - name: Apply and verify compatible rollout
+        if: steps.changes.outputs.deploy == 'true'
+        run: bash deploy/verify-cutover.sh
+
+      - name: Verify legacy Hub redirects
         if: steps.changes.outputs.deploy == 'true'
         run: |
-          kubectl -n acedatacloud annotate deployment studio-frontend \
-            "acedata.cloud/last-successful-revision=$GITHUB_SHA" --overwrite
+          for legacy_url in \
+            'https://hub.acedata.cloud/retired-check?keep=1' \
+            'https://retired-check.hub.acedata.cloud/retired-check?keep=1'; do
+            location=$(curl -fsSI "$legacy_url" | tr -d '\r' | awk 'tolower($1)=="location:" {print $2; exit}')
+            test "$location" = "https://studio.acedata.cloud/retired-check?keep=1"
+          done
+
+      - name: Publish verified final image to Docker Hub
+        if: steps.changes.outputs.deploy == 'true'
+        run: |
+          docker buildx build --target final --build-arg "PREVIOUS_IMAGE=$PREVIOUS_IMAGE" \
+            --tag "acedatacloud/nexior:${{ steps.docker_tag.outputs.version }}" \
+            --tag acedatacloud/nexior:latest --push --cache-from type=gha .

--- a/.github/workflows/deploy-web.yaml
+++ b/.github/workflows/deploy-web.yaml
@@ -130,6 +130,16 @@ jobs:
             --tag "ghcr.io/acedatacloud/studio-frontend:${RELEASE_TAG}" --push \
             --cache-from type=gha .
 
+      - name: Verify production stayed unchanged during build
+        if: steps.changes.outputs.deploy == 'true'
+        env:
+          EXPECTED_IMAGE: ${{ env.PREVIOUS_IMAGE }}
+          EXPECTED_TAGGED_IMAGE: ${{ env.PREVIOUS_TAGGED_IMAGE }}
+          DEPLOYMENT: studio-frontend
+          SERVICE: studio-frontend
+          IMAGE_REPOSITORY: ghcr.io/acedatacloud/studio-frontend
+        run: bash deploy/verify-release-unchanged.sh
+
       - name: Apply and verify compatible rollout
         if: steps.changes.outputs.deploy == 'true'
         run: bash deploy/verify-cutover.sh

--- a/.github/workflows/deploy-web.yaml
+++ b/.github/workflows/deploy-web.yaml
@@ -144,16 +144,6 @@ jobs:
         if: steps.changes.outputs.deploy == 'true'
         run: bash deploy/verify-cutover.sh
 
-      - name: Verify legacy Hub redirects
-        if: steps.changes.outputs.deploy == 'true'
-        run: |
-          for legacy_url in \
-            'https://hub.acedata.cloud/retired-check?keep=1' \
-            'https://retired-check.hub.acedata.cloud/retired-check?keep=1'; do
-            location=$(curl -fsSI "$legacy_url" | tr -d '\r' | awk 'tolower($1)=="location:" {print $2; exit}')
-            test "$location" = "https://studio.acedata.cloud/retired-check?keep=1"
-          done
-
       - name: Publish verified final image to Docker Hub
         if: steps.changes.outputs.deploy == 'true'
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,8 @@ launch.json
 temp
 
 .pr_body.md
+# Generated from the running production image during deploy
+.previous-assets/
+.previous-release-assets
+
+__pycache__/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,57 @@
-# build stage
-FROM node:26 as build-stage
+ARG PREVIOUS_IMAGE=nginx:stable-alpine
+
+FROM node:26 AS build-stage
 WORKDIR /app
 COPY package.json package-lock.json .npmrc ./
 RUN npm ci
 COPY . .
-# Pre-render the flag-allowlisted routes, then derive a plain SPA shell from
-# each. nginx serves the shell by default and the SSG page only when the runtime
-# `features=ssr` flag is set (URL/cookie) — prod behaviour unchanged until opt-in.
-RUN npm run build:ssg && node scripts/ssg-shell.mjs
+RUN npm run build:ssg && node scripts/ssg-shell.mjs && \
+    mkdir /app/current-assets && cp -a /app/dist/assets/. /app/current-assets/ && \
+    (cd /app/current-assets && find . -type f -printf '%P\n' | LC_ALL=C sort) > /app/release-assets && \
+    test "$(wc -l < /app/release-assets)" -le 4000 && \
+    test "$(du -sb /app/current-assets | cut -f1)" -le 268435456
 
-# production stage
-FROM nginx:stable-alpine as production-stage
-COPY --from=build-stage /app/dist /usr/share/nginx/html
+FROM nginx:stable-alpine AS runtime-base
 COPY nginx.conf /etc/nginx/conf.d/default.conf
-# Included by nginx.conf from every location that sets its own add_header.
 COPY security-headers.conf /etc/nginx/security-headers.conf
+
+FROM runtime-base AS production-stage
+COPY --from=build-stage /app/dist /usr/share/nginx/html
+COPY --from=build-stage /app/release-assets /opt/acedata/release-assets
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]
+
+FROM ${PREVIOUS_IMAGE} AS bridge
+RUN rm -rf /usr/share/nginx/html/assets && mkdir -p /usr/share/nginx/html/assets
+COPY .previous-assets/ /usr/share/nginx/html/assets/
+COPY --from=build-stage /app/current-assets/ /tmp/current-assets/
+RUN set -eu; \
+    cd /tmp/current-assets; \
+    find . -type f -print | while IFS= read -r asset; do \
+      destination="/usr/share/nginx/html/assets/${asset#./}"; \
+      if [ -f "$destination" ]; then cmp -s "$asset" "$destination" || { echo "conflicting immutable asset: ${asset#./}" >&2; exit 1; }; \
+      else mkdir -p "$(dirname "$destination")"; cp "$asset" "$destination"; fi; \
+    done; \
+    rm -rf /tmp/current-assets; \
+    test "$(find /usr/share/nginx/html/assets -type f | wc -l)" -le 8000; \
+    test "$(du -sb /usr/share/nginx/html/assets | cut -f1)" -le 536870912
+COPY .previous-release-assets /opt/acedata/release-assets
+
+FROM runtime-base AS final
+COPY .previous-assets/ /tmp/previous-assets/
+COPY --from=build-stage /app/dist /usr/share/nginx/html
+RUN set -eu; \
+    cd /tmp/previous-assets; \
+    find . -type f -print | while IFS= read -r asset; do \
+      destination="/usr/share/nginx/html/assets/${asset#./}"; \
+      if [ -f "$destination" ]; then cmp -s "$asset" "$destination" || { echo "conflicting immutable asset: ${asset#./}" >&2; exit 1; }; \
+      else mkdir -p "$(dirname "$destination")"; cp "$asset" "$destination"; fi; \
+    done; \
+    rm -rf /tmp/previous-assets; \
+    test "$(find /usr/share/nginx/html/assets -type f | wc -l)" -le 8000; \
+    test "$(du -sb /usr/share/nginx/html/assets | cut -f1)" -le 536870912
+COPY --from=build-stage /app/release-assets /opt/acedata/release-assets
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]
+
+FROM production-stage AS default-stage

--- a/change/rolling-assets.json
+++ b/change/rolling-assets.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Make web rollouts preserve compatible hashed assets across mixed Pods.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "none"
+}

--- a/deploy/preflight-release.sh
+++ b/deploy/preflight-release.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${DEPLOYMENT:?DEPLOYMENT is required}"
+: "${SERVICE:?SERVICE is required}"
+: "${IMAGE_REPOSITORY:?IMAGE_REPOSITORY is required}"
+NAMESPACE=${NAMESPACE:-acedatacloud}
+ENV_FILE=${GITHUB_ENV:-/dev/stdout}
+OUTPUT_PREFIX=${OUTPUT_PREFIX:-PREVIOUS}
+
+desired=$(kubectl get deployment "$DEPLOYMENT" -n "$NAMESPACE" -o jsonpath='{.spec.replicas}')
+generation=$(kubectl get deployment "$DEPLOYMENT" -n "$NAMESPACE" -o jsonpath='{.metadata.generation}')
+observed=$(kubectl get deployment "$DEPLOYMENT" -n "$NAMESPACE" -o jsonpath='{.status.observedGeneration}')
+updated=$(kubectl get deployment "$DEPLOYMENT" -n "$NAMESPACE" -o jsonpath='{.status.updatedReplicas}')
+ready=$(kubectl get deployment "$DEPLOYMENT" -n "$NAMESPACE" -o jsonpath='{.status.readyReplicas}')
+available=$(kubectl get deployment "$DEPLOYMENT" -n "$NAMESPACE" -o jsonpath='{.status.availableReplicas}')
+unavailable=$(kubectl get deployment "$DEPLOYMENT" -n "$NAMESPACE" -o jsonpath='{.status.unavailableReplicas}')
+
+if [ "$observed" != "$generation" ] || [ "$updated" != "$desired" ] || \
+   [ "$ready" != "$desired" ] || [ "$available" != "$desired" ] || \
+   { [ -n "$unavailable" ] && [ "$unavailable" != 0 ]; }; then
+  echo "$DEPLOYMENT is not fully converged" >&2
+  exit 1
+fi
+
+pods=$(kubectl get endpoints "$SERVICE" -n "$NAMESPACE" \
+  -o jsonpath='{range .subsets[*].addresses[*]}{.targetRef.name}{"\n"}{end}')
+if [ "$(printf '%s\n' "$pods" | grep -c . || true)" != "$desired" ]; then
+  echo "$SERVICE endpoint count does not match $DEPLOYMENT replicas" >&2
+  exit 1
+fi
+
+spec_image=
+image_id=
+for pod in $pods; do
+  pod_image=$(kubectl get pod "$pod" -n "$NAMESPACE" -o jsonpath='{.spec.containers[0].image}')
+  pod_image_id=$(kubectl get pod "$pod" -n "$NAMESPACE" -o jsonpath='{.status.containerStatuses[0].imageID}')
+  case "$pod_image" in "$IMAGE_REPOSITORY":*|"$IMAGE_REPOSITORY"@sha256:*) ;; *) echo "Unexpected image: $pod_image" >&2; exit 1 ;; esac
+  case "$pod_image_id" in "$IMAGE_REPOSITORY"@sha256:*) ;; *) echo "Unexpected image ID: $pod_image_id" >&2; exit 1 ;; esac
+  if [ -n "$spec_image" ] && { [ "$pod_image" != "$spec_image" ] || [ "$pod_image_id" != "$image_id" ]; }; then
+    echo "$SERVICE endpoints run mixed images" >&2
+    exit 1
+  fi
+  spec_image=$pod_image
+  image_id=$pod_image_id
+done
+
+first_pod=$(printf '%s\n' "$pods" | sed -n '1p')
+printf '%s_IMAGE=%s\n' "$OUTPUT_PREFIX" "$image_id" >> "$ENV_FILE"
+printf '%s_POD=%s\n' "$OUTPUT_PREFIX" "$first_pod" >> "$ENV_FILE"
+printf '%s_TAGGED_IMAGE=%s\n' "$OUTPUT_PREFIX" "$spec_image" >> "$ENV_FILE"
+printf 'previous_image=%s\n' "$image_id"

--- a/deploy/prepare-previous-assets.sh
+++ b/deploy/prepare-previous-assets.sh
@@ -1,34 +1,25 @@
 #!/usr/bin/env bash
 set -euo pipefail
-
 : "${PREVIOUS_POD:?PREVIOUS_POD is required}"
 : "${MAX_RELEASE_FILES:?MAX_RELEASE_FILES is required}"
 : "${MAX_RELEASE_BYTES:?MAX_RELEASE_BYTES is required}"
-
 output_dir=${OUTPUT_DIR:-.previous-assets}
 manifest_file=${MANIFEST_FILE:-.previous-release-assets}
 tmp_dir=$(mktemp -d)
 cleanup() { rm -rf "$tmp_dir"; }
 trap cleanup EXIT
-
 rm -rf "$output_dir"
 mkdir -p "$output_dir"
+token="${GITHUB_RUN_ID:-local}-$$"
 if kubectl exec -n acedatacloud "$PREVIOUS_POD" -- test -f /opt/acedata/release-assets 2>/dev/null; then
   kubectl exec -n acedatacloud "$PREVIOUS_POD" -- cat /opt/acedata/release-assets > "$manifest_file"
   python3 deploy/release_assets.py check-list "$manifest_file" "$MAX_RELEASE_FILES"
-  kubectl exec -n acedatacloud "$PREVIOUS_POD" -- sh -lc \
-    'cd /usr/share/nginx/html/assets && tar -cf - -T /opt/acedata/release-assets | gzip -c | base64' | \
-    python3 deploy/release_assets.py decode "$tmp_dir/assets.tar"
+  fetch_manifest=--manifest
 else
   echo "Previous image has no release manifest; synthesizing one legacy release"
-  kubectl exec -n acedatacloud "$PREVIOUS_POD" -- sh -lc \
-    'cd /usr/share/nginx/html/assets && tar -cf - . | gzip -c | base64' | \
-    python3 deploy/release_assets.py decode "$tmp_dir/assets.tar"
+  fetch_manifest=
 fi
-
+python3 deploy/release_assets.py fetch "$PREVIOUS_POD" /usr/share/nginx/html/assets "$tmp_dir/assets.tar" "$token" ${fetch_manifest:-}
 tar -xf "$tmp_dir/assets.tar" -C "$output_dir"
-if [ ! -f "$manifest_file" ]; then
-  python3 deploy/release_assets.py manifest "$output_dir" "$manifest_file"
-fi
-python3 deploy/release_assets.py validate \
-  "$output_dir" "$manifest_file" "$MAX_RELEASE_FILES" "$MAX_RELEASE_BYTES"
+if [ ! -f "$manifest_file" ]; then python3 deploy/release_assets.py manifest "$output_dir" "$manifest_file"; fi
+python3 deploy/release_assets.py validate "$output_dir" "$manifest_file" "$MAX_RELEASE_FILES" "$MAX_RELEASE_BYTES"

--- a/deploy/prepare-previous-assets.sh
+++ b/deploy/prepare-previous-assets.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${PREVIOUS_POD:?PREVIOUS_POD is required}"
+: "${MAX_RELEASE_FILES:?MAX_RELEASE_FILES is required}"
+: "${MAX_RELEASE_BYTES:?MAX_RELEASE_BYTES is required}"
+
+output_dir=${OUTPUT_DIR:-.previous-assets}
+manifest_file=${MANIFEST_FILE:-.previous-release-assets}
+tmp_dir=$(mktemp -d)
+cleanup() { rm -rf "$tmp_dir"; }
+trap cleanup EXIT
+
+rm -rf "$output_dir"
+mkdir -p "$output_dir"
+if kubectl exec -n acedatacloud "$PREVIOUS_POD" -- test -f /opt/acedata/release-assets 2>/dev/null; then
+  kubectl exec -n acedatacloud "$PREVIOUS_POD" -- cat /opt/acedata/release-assets > "$manifest_file"
+  python3 deploy/release_assets.py check-list "$manifest_file" "$MAX_RELEASE_FILES"
+  kubectl exec -n acedatacloud "$PREVIOUS_POD" -- sh -lc \
+    'cd /usr/share/nginx/html/assets && tar -cf - -T /opt/acedata/release-assets | gzip -c | base64' | \
+    python3 deploy/release_assets.py decode "$tmp_dir/assets.tar"
+else
+  echo "Previous image has no release manifest; synthesizing one legacy release"
+  kubectl exec -n acedatacloud "$PREVIOUS_POD" -- sh -lc \
+    'cd /usr/share/nginx/html/assets && tar -cf - . | gzip -c | base64' | \
+    python3 deploy/release_assets.py decode "$tmp_dir/assets.tar"
+fi
+
+tar -xf "$tmp_dir/assets.tar" -C "$output_dir"
+if [ ! -f "$manifest_file" ]; then
+  python3 deploy/release_assets.py manifest "$output_dir" "$manifest_file"
+fi
+python3 deploy/release_assets.py validate \
+  "$output_dir" "$manifest_file" "$MAX_RELEASE_FILES" "$MAX_RELEASE_BYTES"

--- a/deploy/production/studio-deployment.yaml
+++ b/deploy/production/studio-deployment.yaml
@@ -8,6 +8,13 @@ metadata:
 spec:
   replicas: 2
   revisionHistoryLimit: 5
+  minReadySeconds: 10
+  progressDeadlineSeconds: 1200
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   selector:
     matchLabels:
       app: studio-frontend
@@ -21,6 +28,14 @@ spec:
           name: studio-frontend
           ports:
             - containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /index.html
+              port: 80
+            initialDelaySeconds: 2
+            periodSeconds: 3
+            failureThreshold: 5
+            timeoutSeconds: 2
           livenessProbe:
             httpGet:
               path: /

--- a/deploy/release_assets.py
+++ b/deploy/release_assets.py
@@ -11,7 +11,6 @@ import shlex
 import re
 import subprocess
 import sys
-import tempfile
 
 
 def safe_path(value: str) -> PurePosixPath:
@@ -72,11 +71,7 @@ def command_fetch(args: argparse.Namespace) -> None:
         actual = hashlib.sha256(archive.read_bytes()).hexdigest()
         if actual != expected:
             raise ValueError(f"archive checksum mismatch: expected {expected}, got {actual}")
-        with tempfile.NamedTemporaryFile(delete=False) as raw:
-            raw.write(gzip.decompress(archive.read_bytes()))
-            raw_path = raw.name
-        Path(args.output).write_bytes(Path(raw_path).read_bytes())
-        Path(raw_path).unlink()
+        Path(args.output).write_bytes(gzip.decompress(archive.read_bytes()))
         print(f"archive_parts={len(parts)}")
         print(f"archive_sha256={actual}")
     finally:

--- a/deploy/release_assets.py
+++ b/deploy/release_assets.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import base64
+import gzip
+import hashlib
+from pathlib import Path, PurePosixPath
+import shutil
+import sys
+
+
+def safe_path(value: str) -> PurePosixPath:
+    path = PurePosixPath(value)
+    if (
+        not value
+        or path.is_absolute()
+        or value.startswith(("./", "-"))
+        or ".." in path.parts
+        or "\\" in value
+        or any(ord(char) < 32 for char in value)
+    ):
+        raise ValueError(f"unsafe release asset path: {value!r}")
+    return path
+
+
+def load_manifest(path: Path, max_files: int) -> list[str]:
+    items = path.read_text().splitlines()
+    if not items or len(items) > max_files:
+        raise ValueError(f"release has {len(items)} files (limit {max_files})")
+    if items != sorted(set(items)):
+        raise ValueError("release manifest must be sorted and unique")
+    for item in items:
+        safe_path(item)
+    return items
+
+
+def command_decode(args: argparse.Namespace) -> None:
+    encoded = sys.stdin.buffer.read()
+    Path(args.output).write_bytes(gzip.decompress(base64.b64decode(encoded)))
+
+
+def command_manifest(args: argparse.Namespace) -> None:
+    root = Path(args.root)
+    items = sorted(path.relative_to(root).as_posix() for path in root.rglob("*") if path.is_file())
+    Path(args.output).write_text("".join(f"{item}\n" for item in items))
+
+
+def command_check_list(args: argparse.Namespace) -> None:
+    load_manifest(Path(args.manifest), args.max_files)
+
+
+def validate_tree(root: Path, manifest: Path, max_files: int, max_bytes: int) -> tuple[list[str], int]:
+    items = load_manifest(manifest, max_files)
+    size = 0
+    actual = []
+    for path in root.rglob("*"):
+        if path.is_symlink():
+            raise ValueError(f"release asset may not be a symlink: {path.relative_to(root)}")
+        if path.is_file():
+            actual.append(path.relative_to(root).as_posix())
+    actual.sort()
+    if actual != items:
+        missing = sorted(set(items) - set(actual))
+        surplus = sorted(set(actual) - set(items))
+        raise ValueError(f"asset tree differs from manifest; missing={missing[:3]} surplus={surplus[:3]}")
+    for item in items:
+        path = root / item
+        if not path.is_file():
+            raise ValueError(f"missing release asset: {item}")
+        size += path.stat().st_size
+    if size > max_bytes:
+        raise ValueError(f"release has {size} bytes (limit {max_bytes})")
+    return items, size
+
+
+def command_validate(args: argparse.Namespace) -> None:
+    items, size = validate_tree(Path(args.root), Path(args.manifest), args.max_files, args.max_bytes)
+    digest = hashlib.sha256(Path(args.manifest).read_bytes()).hexdigest()
+    print(f"release_files={len(items)}")
+    print(f"release_bytes={size}")
+    print(f"release_manifest_sha256={digest}")
+
+
+def command_merge(args: argparse.Namespace) -> None:
+    source = Path(args.source)
+    destination = Path(args.destination)
+    items, size = validate_tree(source, Path(args.manifest), args.max_files, args.max_bytes)
+    destination.mkdir(parents=True, exist_ok=True)
+    for item in items:
+        src = source / item
+        dst = destination / item
+        if dst.exists():
+            if not dst.is_file() or hashlib.sha256(dst.read_bytes()).digest() != hashlib.sha256(src.read_bytes()).digest():
+                raise ValueError(f"conflicting immutable asset: {item}")
+            continue
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, dst)
+    print(f"merged_release_files={len(items)}")
+    print(f"merged_release_bytes={size}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    decode = subparsers.add_parser("decode")
+    decode.add_argument("output")
+    decode.set_defaults(func=command_decode)
+
+    manifest = subparsers.add_parser("manifest")
+    manifest.add_argument("root")
+    manifest.add_argument("output")
+    manifest.set_defaults(func=command_manifest)
+
+    check = subparsers.add_parser("check-list")
+    check.add_argument("manifest")
+    check.add_argument("max_files", type=int)
+    check.set_defaults(func=command_check_list)
+
+    validate = subparsers.add_parser("validate")
+    validate.add_argument("root")
+    validate.add_argument("manifest")
+    validate.add_argument("max_files", type=int)
+    validate.add_argument("max_bytes", type=int)
+    validate.set_defaults(func=command_validate)
+
+    merge = subparsers.add_parser("merge")
+    merge.add_argument("source")
+    merge.add_argument("manifest")
+    merge.add_argument("destination")
+    merge.add_argument("max_files", type=int)
+    merge.add_argument("max_bytes", type=int)
+    merge.set_defaults(func=command_merge)
+
+    args = parser.parse_args()
+    try:
+        args.func(args)
+    except (OSError, ValueError) as error:
+        raise SystemExit(str(error)) from error
+
+
+if __name__ == "__main__":
+    main()

--- a/deploy/release_assets.py
+++ b/deploy/release_assets.py
@@ -7,7 +7,11 @@ import gzip
 import hashlib
 from pathlib import Path, PurePosixPath
 import shutil
+import shlex
+import re
+import subprocess
 import sys
+import tempfile
 
 
 def safe_path(value: str) -> PurePosixPath:
@@ -35,9 +39,48 @@ def load_manifest(path: Path, max_files: int) -> list[str]:
     return items
 
 
-def command_decode(args: argparse.Namespace) -> None:
-    encoded = sys.stdin.buffer.read()
-    Path(args.output).write_bytes(gzip.decompress(base64.b64decode(encoded)))
+def kubectl(*args: str, text: bool = False) -> subprocess.CompletedProcess:
+    return subprocess.run(["kubectl", *args], check=True, capture_output=True, text=text)
+
+
+def command_fetch(args: argparse.Namespace) -> None:
+    if not re.fullmatch(r"[A-Za-z0-9._-]+", args.token):
+        raise ValueError(f"unsafe archive token: {args.token!r}")
+    remote = f"/tmp/acedata-assets-{args.token}"
+    quoted_directory = shlex.quote(args.directory)
+    tar_args = "-T /opt/acedata/release-assets" if args.manifest else "."
+    setup = (
+        f"set -eu; rm -rf {remote}; mkdir -p {remote}; "
+        f"cd {quoted_directory}; tar -cf - {tar_args} | gzip -c > {remote}/archive.tgz; "
+        f"split -b 262144 -a 4 {remote}/archive.tgz {remote}/part-; "
+        f"sha256sum {remote}/archive.tgz | cut -d' ' -f1 > {remote}/sha256; "
+        f"find {remote} -name 'part-*' -type f | sort > {remote}/parts"
+    )
+    kubectl("exec", "-n", args.namespace, args.pod, "--", "sh", "-lc", setup)
+    try:
+        parts_output = kubectl("exec", "-n", args.namespace, args.pod, "--", "cat", f"{remote}/parts", text=True).stdout
+        parts = [part for part in parts_output.splitlines() if part]
+        if not parts or any(not part.startswith(f"{remote}/part-") for part in parts):
+            raise ValueError(f"invalid archive parts: {parts!r}")
+        expected = kubectl("exec", "-n", args.namespace, args.pod, "--", "cat", f"{remote}/sha256", text=True).stdout.strip()
+        archive = Path(args.output)
+        archive.write_bytes(b"")
+        for part in parts:
+            encoded = kubectl("exec", "-n", args.namespace, args.pod, "--", "base64", part).stdout
+            with archive.open("ab") as output:
+                output.write(base64.b64decode(encoded))
+        actual = hashlib.sha256(archive.read_bytes()).hexdigest()
+        if actual != expected:
+            raise ValueError(f"archive checksum mismatch: expected {expected}, got {actual}")
+        with tempfile.NamedTemporaryFile(delete=False) as raw:
+            raw.write(gzip.decompress(archive.read_bytes()))
+            raw_path = raw.name
+        Path(args.output).write_bytes(Path(raw_path).read_bytes())
+        Path(raw_path).unlink()
+        print(f"archive_parts={len(parts)}")
+        print(f"archive_sha256={actual}")
+    finally:
+        subprocess.run(["kubectl", "exec", "-n", args.namespace, args.pod, "--", "rm", "-rf", remote], check=False)
 
 
 def command_manifest(args: argparse.Namespace) -> None:
@@ -104,9 +147,14 @@ def main() -> None:
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(dest="command", required=True)
 
-    decode = subparsers.add_parser("decode")
-    decode.add_argument("output")
-    decode.set_defaults(func=command_decode)
+    fetch = subparsers.add_parser("fetch")
+    fetch.add_argument("pod")
+    fetch.add_argument("directory")
+    fetch.add_argument("--manifest", action="store_true")
+    fetch.add_argument("output")
+    fetch.add_argument("token")
+    fetch.add_argument("--namespace", default="acedatacloud")
+    fetch.set_defaults(func=command_fetch)
 
     manifest = subparsers.add_parser("manifest")
     manifest.add_argument("root")
@@ -136,7 +184,7 @@ def main() -> None:
     args = parser.parse_args()
     try:
         args.func(args)
-    except (OSError, ValueError) as error:
+    except (OSError, ValueError, subprocess.CalledProcessError) as error:
         raise SystemExit(str(error)) from error
 
 

--- a/deploy/test-compatible-images.sh
+++ b/deploy/test-compatible-images.sh
@@ -27,8 +27,9 @@ docker build -q -t "$fixture_image" "$tmp_dir/fixture"
 printf '%s\n' 'console.log("old")' > .previous-assets/old.js
 printf '%s\n' 'old.js' > .previous-release-assets
 
-docker buildx build --load --target bridge --build-arg "PREVIOUS_IMAGE=$fixture_image" -t "$bridge_image" --cache-from type=gha .
-docker buildx build --load --target final --build-arg "PREVIOUS_IMAGE=$fixture_image" -t "$final_image" --cache-from type=gha .
+docker build -q -t "acedata/${app}:compat-default" .
+docker build -q --target bridge --build-arg "PREVIOUS_IMAGE=$fixture_image" -t "$bridge_image" .
+docker build -q --target final --build-arg "PREVIOUS_IMAGE=$fixture_image" -t "$final_image" .
 
 run_image() {
   local name=$1 image=$2

--- a/deploy/test-compatible-images.sh
+++ b/deploy/test-compatible-images.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+app=${1:?app name is required}
+tmp_dir=$(mktemp -d)
+bridge_image="acedata/${app}:compat-bridge"
+final_image="acedata/${app}:compat-final"
+fixture_image="acedata/${app}:compat-previous"
+bridge_container=
+final_container=
+cleanup() {
+  [ -z "$bridge_container" ] || docker rm -f "$bridge_container" >/dev/null 2>&1 || true
+  [ -z "$final_container" ] || docker rm -f "$final_container" >/dev/null 2>&1 || true
+  rm -rf "$tmp_dir" .previous-assets .previous-release-assets
+}
+trap cleanup EXIT
+
+mkdir -p "$tmp_dir/fixture" .previous-assets
+cat > "$tmp_dir/fixture/Dockerfile" <<'DOCKERFILE'
+FROM nginx:stable-alpine
+RUN rm -rf /usr/share/nginx/html/* && mkdir -p /usr/share/nginx/html/assets /opt/acedata && \
+    printf '%s\n' '<!doctype html><script src="/assets/old.js"></script><p>previous-release-marker</p>' > /usr/share/nginx/html/index.html && \
+    printf '%s\n' 'console.log("old")' > /usr/share/nginx/html/assets/old.js && \
+    printf '%s\n' 'old.js' > /opt/acedata/release-assets
+DOCKERFILE
+docker build -q -t "$fixture_image" "$tmp_dir/fixture"
+printf '%s\n' 'console.log("old")' > .previous-assets/old.js
+printf '%s\n' 'old.js' > .previous-release-assets
+
+docker buildx build --load --target bridge --build-arg "PREVIOUS_IMAGE=$fixture_image" -t "$bridge_image" --cache-from type=gha .
+docker buildx build --load --target final --build-arg "PREVIOUS_IMAGE=$fixture_image" -t "$final_image" --cache-from type=gha .
+
+run_image() {
+  local name=$1 image=$2
+  shift 2
+  docker run -d --name "$name" "$@" "$image"
+  for _ in $(seq 1 30); do
+    docker exec "$name" wget -qO- http://127.0.0.1/ >/dev/null 2>&1 && return 0
+    sleep 1
+  done
+  docker logs "$name" >&2
+  return 1
+}
+
+bridge_container="${app}-compat-bridge"
+final_container="${app}-compat-final"
+run_image "$bridge_container" "$bridge_image"
+if [ "$app" = platform-frontend ]; then
+  run_image "$final_container" "$final_image" \
+    -e AUTH_BACKEND_URL=http://127.0.0.1 \
+    -e PLATFORM_BACKEND_URL=http://127.0.0.1 \
+    -e DEBUG_AGENT_URL=http://127.0.0.1 \
+    -e SHORTURL_BACKEND_URL=http://127.0.0.1 \
+    -e AICHAT_BACKEND_URL=http://127.0.0.1 \
+    -e EXCHANGE_RATE_BACKEND_URL=http://127.0.0.1
+else
+  run_image "$final_container" "$final_image"
+fi
+
+docker exec "$bridge_container" wget -qO- http://127.0.0.1/ | grep -q previous-release-marker
+if docker exec "$final_container" wget -qO- http://127.0.0.1/ | grep -q previous-release-marker; then
+  echo 'final image still serves previous HTML' >&2
+  exit 1
+fi
+for container in "$bridge_container" "$final_container"; do
+  docker exec "$container" wget -qO- http://127.0.0.1/assets/old.js | grep -q 'console.log'
+done
+current_asset=$(docker exec "$final_container" sed -n '1p' /opt/acedata/release-assets)
+[ -n "$current_asset" ]
+for container in "$bridge_container" "$final_container"; do
+  docker exec "$container" wget -qO- "http://127.0.0.1/assets/$current_asset" >/dev/null
+done
+
+echo "compatible image targets verified for $app"

--- a/deploy/verify-cutover.sh
+++ b/deploy/verify-cutover.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${RELEASE_TAG:?RELEASE_TAG is required}"
+: "${PREVIOUS_IMAGE:?PREVIOUS_IMAGE is required}"
+: "${PREVIOUS_TAGGED_IMAGE:?PREVIOUS_TAGGED_IMAGE is required}"
+: "${GITHUB_SHA:?GITHUB_SHA is required}"
+NAMESPACE=acedatacloud
+DEPLOYMENT=studio-frontend
+CONTAINER=studio-frontend
+SERVICE=studio-frontend
+MANIFEST=deploy/production/studio-deployment.yaml
+IMAGE_REPOSITORY=ghcr.io/acedatacloud/studio-frontend
+
+wait_converged() {
+  local deployment=$1 service=$2 expected_image=$3 expected_repository
+  expected_repository=${expected_image%@*}
+  if [ "$expected_repository" = "$expected_image" ]; then expected_repository=${expected_image%:*}; fi
+  kubectl rollout status "deployment/$deployment" -n "$NAMESPACE" --timeout=20m
+  local deadline=$(( $(date +%s) + 300 ))
+  while :; do
+    local desired observed generation updated ready available unavailable endpoints pod image image_id expected_image_id all_ready
+    desired=$(kubectl get deployment "$deployment" -n "$NAMESPACE" -o jsonpath='{.spec.replicas}')
+    generation=$(kubectl get deployment "$deployment" -n "$NAMESPACE" -o jsonpath='{.metadata.generation}')
+    observed=$(kubectl get deployment "$deployment" -n "$NAMESPACE" -o jsonpath='{.status.observedGeneration}')
+    updated=$(kubectl get deployment "$deployment" -n "$NAMESPACE" -o jsonpath='{.status.updatedReplicas}')
+    ready=$(kubectl get deployment "$deployment" -n "$NAMESPACE" -o jsonpath='{.status.readyReplicas}')
+    available=$(kubectl get deployment "$deployment" -n "$NAMESPACE" -o jsonpath='{.status.availableReplicas}')
+    unavailable=$(kubectl get deployment "$deployment" -n "$NAMESPACE" -o jsonpath='{.status.unavailableReplicas}')
+    endpoints=$(kubectl get endpoints "$service" -n "$NAMESPACE" -o jsonpath='{range .subsets[*].addresses[*]}{.targetRef.name}{"\n"}{end}' 2>/dev/null || true)
+    all_ready=true
+    [ "$observed" = "$generation" ] || all_ready=false
+    [ "$updated" = "$desired" ] || all_ready=false
+    [ "$ready" = "$desired" ] || all_ready=false
+    [ "$available" = "$desired" ] || all_ready=false
+    [ -z "$unavailable" ] || [ "$unavailable" = 0 ] || all_ready=false
+    [ "$(printf '%s\n' "$endpoints" | grep -c . || true)" = "$desired" ] || all_ready=false
+    for pod in $endpoints; do
+      image=$(kubectl get pod "$pod" -n "$NAMESPACE" -o jsonpath='{.spec.containers[0].image}' 2>/dev/null || true)
+      image_id=$(kubectl get pod "$pod" -n "$NAMESPACE" -o jsonpath='{.status.containerStatuses[0].imageID}' 2>/dev/null || true)
+      [ "$image" = "$expected_image" ] || all_ready=false
+      case "$image_id" in "$expected_repository"@sha256:*) ;; *) all_ready=false ;; esac
+      if [ -n "${expected_image_id:-}" ] && [ "$image_id" != "$expected_image_id" ]; then all_ready=false; fi
+      expected_image_id=$image_id
+    done
+    if [ "$all_ready" = true ]; then
+      return 0
+    fi
+    if [ "$(date +%s)" -ge "$deadline" ]; then
+      echo "$deployment/$service did not converge to $expected_image" >&2
+      kubectl get deployment "$deployment" -n "$NAMESPACE" -o wide || true
+      kubectl get pods -n "$NAMESPACE" -l "app=$deployment" -o wide || true
+      kubectl get endpoints "$service" -n "$NAMESPACE" -o wide || true
+      return 1
+    fi
+    sleep 2
+  done
+}
+
+apply_stage() {
+  local tag=$1
+  sed "s|\${TAG}|$tag|g" "$MANIFEST" | kubectl apply -f -
+}
+
+rollback() {
+  local image=$1
+  echo "Rolling $DEPLOYMENT back to $image" >&2
+  kubectl set image "deployment/$DEPLOYMENT" "$CONTAINER=$image" -n "$NAMESPACE"
+  wait_converged "$DEPLOYMENT" "$SERVICE" "$image" || true
+}
+
+roll_stage() {
+  local tag=$1 fallback=$2 expected="$IMAGE_REPOSITORY:$tag"
+  apply_stage "$tag"
+  if ! wait_converged "$DEPLOYMENT" "$SERVICE" "$expected"; then
+    rollback "$fallback"
+    return 1
+  fi
+}
+
+kubectl apply -f deploy/production/studio-service.yaml
+kubectl apply -f deploy/production/studio-ingress.yaml
+kubectl apply -f deploy/production/studio-proxy.yaml
+kubectl apply -f deploy/production/legacy-hub-redirect.yaml
+roll_stage "${RELEASE_TAG}-bridge" "$PREVIOUS_TAGGED_IMAGE"
+roll_stage "$RELEASE_TAG" "ghcr.io/acedatacloud/studio-frontend:${RELEASE_TAG}-bridge"
+
+if ! python3 deploy/verify-html-assets.py "https://studio.acedata.cloud/"; then
+  rollback "ghcr.io/acedatacloud/studio-frontend:${RELEASE_TAG}-bridge"
+  exit 1
+fi
+kubectl annotate deployment "$DEPLOYMENT" -n "$NAMESPACE" \
+  "acedata.cloud/last-successful-revision=$GITHUB_SHA" \
+  "acedata.cloud/release-id=$RELEASE_TAG" \
+  "acedata.cloud/release-phase=final" --overwrite

--- a/deploy/verify-cutover.sh
+++ b/deploy/verify-cutover.sh
@@ -89,6 +89,13 @@ if ! python3 deploy/verify-html-assets.py "https://studio.acedata.cloud/"; then
   rollback "ghcr.io/acedatacloud/studio-frontend:${RELEASE_TAG}-bridge"
   exit 1
 fi
+for legacy_url in \
+  'https://hub.acedata.cloud/retired-check?keep=1' \
+  'https://retired-check.hub.acedata.cloud/retired-check?keep=1'; do
+  location=$(curl -fsSI "$legacy_url" | tr -d '\r' | awk 'tolower($1)=="location:" {print $2; exit}')
+  test "$location" = "https://studio.acedata.cloud/retired-check?keep=1"
+done
+
 kubectl annotate deployment "$DEPLOYMENT" -n "$NAMESPACE" \
   "acedata.cloud/last-successful-revision=$GITHUB_SHA" \
   "acedata.cloud/release-id=$RELEASE_TAG" \

--- a/deploy/verify-html-assets.py
+++ b/deploy/verify-html-assets.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+from html.parser import HTMLParser
+import sys
+from urllib.parse import urljoin, urlparse
+from urllib.request import Request, urlopen
+
+class Assets(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.paths = set()
+    def handle_starttag(self, tag, attrs):
+        values = dict(attrs)
+        value = values.get("src") if tag == "script" else values.get("href") if tag == "link" and values.get("rel") == "stylesheet" else None
+        if value and urlparse(value).path.startswith("/assets/"):
+            self.paths.add(value)
+
+base = sys.argv[1]
+request = Request(base, headers={"Cache-Control": "no-cache", "User-Agent": "release-cutover-verifier"})
+with urlopen(request, timeout=30) as response:
+    html = response.read().decode("utf-8")
+    if response.status != 200:
+        raise SystemExit(f"HTML returned {response.status}")
+    cache = response.headers.get("Cache-Control", "")
+    if "no-store" not in cache and "no-cache" not in cache:
+        raise SystemExit(f"HTML is cacheable: {cache}")
+parser = Assets()
+parser.feed(html)
+if not parser.paths:
+    raise SystemExit("HTML contains no hashed entry assets")
+for path in sorted(parser.paths):
+    with urlopen(Request(urljoin(base, path), headers={"User-Agent": "release-cutover-verifier"}), timeout=30) as response:
+        content_type = response.headers.get("Content-Type", "")
+        if response.status != 200 or ("javascript" not in content_type and "css" not in content_type):
+            raise SystemExit(f"bad asset {path}: {response.status} {content_type}")
+print(f"verified {len(parser.paths)} entry assets from {base}")

--- a/deploy/verify-release-unchanged.sh
+++ b/deploy/verify-release-unchanged.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${EXPECTED_IMAGE:?EXPECTED_IMAGE is required}"
+: "${EXPECTED_TAGGED_IMAGE:?EXPECTED_TAGGED_IMAGE is required}"
+: "${DEPLOYMENT:?DEPLOYMENT is required}"
+: "${SERVICE:?SERVICE is required}"
+: "${IMAGE_REPOSITORY:?IMAGE_REPOSITORY is required}"
+
+tmp_env=$(mktemp)
+cleanup() { rm -f "$tmp_env"; }
+trap cleanup EXIT
+GITHUB_ENV="$tmp_env" OUTPUT_PREFIX=CURRENT bash deploy/preflight-release.sh
+# shellcheck disable=SC1090
+source "$tmp_env"
+if [ "$CURRENT_IMAGE" != "$EXPECTED_IMAGE" ] || [ "$CURRENT_TAGGED_IMAGE" != "$EXPECTED_TAGGED_IMAGE" ]; then
+  echo "$DEPLOYMENT changed while release images were building" >&2
+  echo "expected: $EXPECTED_TAGGED_IMAGE ($EXPECTED_IMAGE)" >&2
+  echo "current:  $CURRENT_TAGGED_IMAGE ($CURRENT_IMAGE)" >&2
+  exit 1
+fi

--- a/scripts/check_studio_deployment.py
+++ b/scripts/check_studio_deployment.py
@@ -17,4 +17,20 @@ assert [rule['http']['paths'][0]['backend']['service']['name'] for rule in redir
 assert 'delete deployment hub-frontend' not in workflow
 assert 'delete service hub-frontend' not in workflow
 assert 'ghcr.io/acedatacloud/hub-frontend' not in workflow
+
+container = studio['spec']['template']['spec']['containers'][0]
+assert studio['spec']['strategy']['type'] == 'RollingUpdate'
+assert studio['spec']['strategy']['rollingUpdate'] == {'maxSurge': 1, 'maxUnavailable': 0}
+assert studio['spec']['minReadySeconds'] == 10
+assert container['readinessProbe']['httpGet']['path'] == '/index.html'
+cutover = (ROOT / 'deploy/verify-cutover.sh').read_text()
+dockerfile = (ROOT / 'Dockerfile').read_text()
+bridge = cutover.index('roll_stage "${RELEASE_TAG}-bridge"')
+final = cutover.index('roll_stage "$RELEASE_TAG"')
+verify = cutover.index('verify-html-assets.py')
+annotate = cutover.index('last-successful-revision')
+assert bridge < final < verify < annotate
+assert 'FROM ${PREVIOUS_IMAGE} AS bridge' in dockerfile
+assert 'FROM runtime-base AS final' in dockerfile
+assert workflow.index('preflight-release.sh') < workflow.index('--target bridge') < workflow.index('verify-cutover.sh')
 print('Studio deployment contract OK')

--- a/scripts/check_studio_deployment.py
+++ b/scripts/check_studio_deployment.py
@@ -32,5 +32,5 @@ annotate = cutover.index('last-successful-revision')
 assert bridge < final < verify < annotate
 assert 'FROM ${PREVIOUS_IMAGE} AS bridge' in dockerfile
 assert 'FROM runtime-base AS final' in dockerfile
-assert workflow.index('preflight-release.sh') < workflow.index('--target bridge') < workflow.index('verify-cutover.sh')
+assert workflow.index('preflight-release.sh') < workflow.index('--target bridge') < workflow.index('verify-release-unchanged.sh') < workflow.index('verify-cutover.sh')
 print('Studio deployment contract OK')

--- a/scripts/check_studio_deployment.py
+++ b/scripts/check_studio_deployment.py
@@ -34,3 +34,5 @@ assert 'FROM ${PREVIOUS_IMAGE} AS bridge' in dockerfile
 assert 'FROM runtime-base AS final' in dockerfile
 assert workflow.index('preflight-release.sh') < workflow.index('--target bridge') < workflow.index('verify-release-unchanged.sh') < workflow.index('verify-cutover.sh')
 print('Studio deployment contract OK')
+ci = (ROOT / '.github/workflows/check-pr.yaml').read_text()
+assert 'test-compatible-images.sh studio-frontend' in ci

--- a/scripts/test_release_assets.py
+++ b/scripts/test_release_assets.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HELPER = ROOT / "deploy/release_assets.py"
+
+
+class ReleaseAssetsTest(unittest.TestCase):
+    def run_helper(self, *args: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["python3", str(HELPER), *(str(arg) for arg in args)],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def test_manifest_and_validate_happy_path(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp) / "assets"
+            root.mkdir()
+            (root / "a.js").write_text("a")
+            (root / "nested").mkdir()
+            (root / "nested/b.css").write_text("bb")
+            manifest = Path(temp) / "manifest"
+            self.assertEqual(self.run_helper("manifest", root, manifest).returncode, 0)
+            result = self.run_helper("validate", root, manifest, 2, 3)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("release_files=2", result.stdout)
+
+    def test_rejects_unsafe_and_noncanonical_manifests(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            manifest = Path(temp) / "manifest"
+            for text in ("../secret\n", "-T\n", "b.js\na.js\n", "a.js\na.js\n"):
+                manifest.write_text(text)
+                result = self.run_helper("check-list", manifest, 10)
+                self.assertNotEqual(result.returncode, 0, text)
+
+    def test_rejects_symlinks_and_size_overflow(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp) / "assets"
+            root.mkdir()
+            target = root / "target.js"
+            target.write_text("large")
+            (root / "link.js").symlink_to(target)
+            manifest = Path(temp) / "manifest"
+            manifest.write_text("link.js\ntarget.js\n")
+            self.assertNotEqual(self.run_helper("validate", root, manifest, 2, 100).returncode, 0)
+            (root / "link.js").unlink()
+            manifest.write_text("target.js\n")
+            self.assertNotEqual(self.run_helper("validate", root, manifest, 1, 4).returncode, 0)
+
+    def test_merge_rejects_conflicts_and_accepts_identical_files(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            source = Path(temp) / "source"
+            destination = Path(temp) / "destination"
+            source.mkdir()
+            destination.mkdir()
+            (source / "same.js").write_text("new")
+            (destination / "same.js").write_text("old")
+            manifest = Path(temp) / "manifest"
+            manifest.write_text("same.js\n")
+            conflict = self.run_helper("merge", source, manifest, destination, 1, 100)
+            self.assertNotEqual(conflict.returncode, 0)
+            (destination / "same.js").write_text("new")
+            identical = self.run_helper("merge", source, manifest, destination, 1, 100)
+            self.assertEqual(identical.returncode, 0, identical.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add bridge/final Docker targets so mixed Studio Pods can serve both release asset sets
- roll one existing Deployment through bridge then final with endpoint convergence gates
- preserve the existing Service, Ingress, Caddy tenant path, and Hub redirect topology
- publish Docker Hub latest only after the verified final production rollout
- add checksummed legacy migration and Docker target integration coverage

## Why
Studio 2064→2065 mixed old/new Pods for about nine minutes after a CNI delay. HTML and chunks randomly landed on incompatible Pods, producing the observed JS/CSS 404 white screen.

## Verification
- 238/238 Vitest files passed, 1749/1749 tests
- production web build passed
- Beachball/release/deployment contracts passed
- legacy production extraction: 1170 files, 18,010,189 bytes
- Docker bridge/final target smoke test added to PR CI

No automatic merge requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)