### PR TITLE
fix: make Studio rollouts asset-compatible

### DIFF
--- a/.github/workflows/check-pr.yaml
+++ b/.github/workflows/check-pr.yaml
@@ -76,3 +76,11 @@ jobs:
 
       - name: Build
         run: npm run build
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build compatible Docker targets
+        env:
+          IMAGE_NAME: studio-frontend
+        run: bash deploy/test-compatible-images.sh

--- a/.github/workflows/check-pr.yaml
+++ b/.github/workflows/check-pr.yaml
@@ -57,6 +57,9 @@ jobs:
       - name: Studio deployment contract
         run: python3 scripts/check_studio_deployment.py
 
+      - name: Release asset manifest tests
+        run: python3 -m unittest scripts/test_release_assets.py
+
       - name: Set up Python
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/deploy-web.yaml
+++ b/.github/workflows/deploy-web.yaml
@@ -77,6 +77,10 @@ jobs:
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
 
+      - name: Set release tag
+        if: steps.changes.outputs.deploy == 'true'
+        run: echo "RELEASE_TAG=${BUILD_NUMBER}-${GITHUB_RUN_ATTEMPT}" >> "$GITHUB_ENV"
+
       - name: Compute Docker Hub version tag
         if: steps.changes.outputs.deploy == 'true'
         id: docker_tag
@@ -101,38 +105,48 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build & push image (GHCR + Docker Hub)
+      - name: Lock current production release
         if: steps.changes.outputs.deploy == 'true'
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          push: true
-          tags: |
-            ghcr.io/acedatacloud/studio-frontend:${{ env.BUILD_NUMBER }}
-            acedatacloud/nexior:${{ steps.docker_tag.outputs.version }}
-            acedatacloud/nexior:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+        env:
+          DEPLOYMENT: studio-frontend
+          SERVICE: studio-frontend
+          IMAGE_REPOSITORY: ghcr.io/acedatacloud/studio-frontend
+        run: bash deploy/preflight-release.sh
 
-      - name: Apply manifests
+      - name: Prepare previous release assets
         if: steps.changes.outputs.deploy == 'true'
-        run: sh ./deploy/run.sh
+        env:
+          MAX_RELEASE_FILES: '4000'
+          MAX_RELEASE_BYTES: '268435456'
+        run: bash deploy/prepare-previous-assets.sh
 
-      - name: Verify rollouts and images
+      - name: Build and push bridge and final images
         if: steps.changes.outputs.deploy == 'true'
         run: |
-          kubectl -n acedatacloud rollout status deployment/studio-frontend --timeout=10m
-          expected="ghcr.io/acedatacloud/studio-frontend:$BUILD_NUMBER"
-          test "$(kubectl -n acedatacloud get deployment studio-frontend -o jsonpath='{.spec.template.spec.containers[0].image}')" = "$expected"
-          test "$(kubectl -n acedatacloud get ingress hub-frontend -o jsonpath='{.spec.rules[0].http.paths[0].backend.service.name}')" = "studio-frontend"
-          test "$(kubectl -n acedatacloud get ingress hub-frontend -o jsonpath='{.spec.rules[1].http.paths[0].backend.service.name}')" = "studio-frontend"
-          test "$(curl -fsS -o /dev/null -w '%{http_code}' https://studio.acedata.cloud/health)" = "200" || \
-            test "$(curl -fsS -o /dev/null -w '%{http_code}' https://studio.acedata.cloud/)" = "200"
-          location=$(curl -fsSI 'https://hub.acedata.cloud/retired-check?keep=1' | tr -d '\r' | awk 'tolower($1)=="location:" {print $2; exit}')
-          test "$location" = "https://studio.acedata.cloud/retired-check?keep=1"
+          docker buildx build --target bridge --build-arg "PREVIOUS_IMAGE=$PREVIOUS_IMAGE" \
+            --tag "ghcr.io/acedatacloud/studio-frontend:${RELEASE_TAG}-bridge" --push \
+            --cache-from type=gha --cache-to type=gha,mode=max .
+          docker buildx build --target final --build-arg "PREVIOUS_IMAGE=$PREVIOUS_IMAGE" \
+            --tag "ghcr.io/acedatacloud/studio-frontend:${RELEASE_TAG}" --push \
+            --cache-from type=gha .
 
-      - name: Record successful revision
+      - name: Apply and verify compatible rollout
+        if: steps.changes.outputs.deploy == 'true'
+        run: bash deploy/verify-cutover.sh
+
+      - name: Verify legacy Hub redirects
         if: steps.changes.outputs.deploy == 'true'
         run: |
-          kubectl -n acedatacloud annotate deployment studio-frontend \
-            "acedata.cloud/last-successful-revision=$GITHUB_SHA" --overwrite
+          for legacy_url in \
+            'https://hub.acedata.cloud/retired-check?keep=1' \
+            'https://retired-check.hub.acedata.cloud/retired-check?keep=1'; do
+            location=$(curl -fsSI "$legacy_url" | tr -d '\r' | awk 'tolower($1)=="location:" {print $2; exit}')
+            test "$location" = "https://studio.acedata.cloud/retired-check?keep=1"
+          done
+
+      - name: Publish verified final image to Docker Hub
+        if: steps.changes.outputs.deploy == 'true'
+        run: |
+          docker buildx build --target final --build-arg "PREVIOUS_IMAGE=$PREVIOUS_IMAGE" \
+            --tag "acedatacloud/nexior:${{ steps.docker_tag.outputs.version }}" \
+            --tag acedatacloud/nexior:latest --push --cache-from type=gha .

--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,8 @@ launch.json
 temp
 
 .pr_body.md
+# Generated from the running production image during deploy
+.previous-assets/
+.previous-release-assets
+
+__pycache__/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,57 @@
-# build stage
-FROM node:26 as build-stage
+ARG PREVIOUS_IMAGE=nginx:stable-alpine
+
+FROM node:26 AS build-stage
 WORKDIR /app
 COPY package.json package-lock.json .npmrc ./
 RUN npm ci
 COPY . .
-# Pre-render the flag-allowlisted routes, then derive a plain SPA shell from
-# each. nginx serves the shell by default and the SSG page only when the runtime
-# `features=ssr` flag is set (URL/cookie) — prod behaviour unchanged until opt-in.
-RUN npm run build:ssg && node scripts/ssg-shell.mjs
+RUN npm run build:ssg && node scripts/ssg-shell.mjs && \
+    mkdir /app/current-assets && cp -a /app/dist/assets/. /app/current-assets/ && \
+    (cd /app/current-assets && find . -type f -printf '%P\n' | LC_ALL=C sort) > /app/release-assets && \
+    test "$(wc -l < /app/release-assets)" -le 4000 && \
+    test "$(du -sb /app/current-assets | cut -f1)" -le 268435456
 
-# production stage
-FROM nginx:stable-alpine as production-stage
-COPY --from=build-stage /app/dist /usr/share/nginx/html
+FROM nginx:stable-alpine AS runtime-base
 COPY nginx.conf /etc/nginx/conf.d/default.conf
-# Included by nginx.conf from every location that sets its own add_header.
 COPY security-headers.conf /etc/nginx/security-headers.conf
+
+FROM runtime-base AS production-stage
+COPY --from=build-stage /app/dist /usr/share/nginx/html
+COPY --from=build-stage /app/release-assets /opt/acedata/release-assets
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]
+
+FROM ${PREVIOUS_IMAGE} AS bridge
+RUN rm -rf /usr/share/nginx/html/assets && mkdir -p /usr/share/nginx/html/assets
+COPY .previous-assets/ /usr/share/nginx/html/assets/
+COPY --from=build-stage /app/current-assets/ /tmp/current-assets/
+RUN set -eu; \
+    cd /tmp/current-assets; \
+    find . -type f -print | while IFS= read -r asset; do \
+      destination="/usr/share/nginx/html/assets/${asset#./}"; \
+      if [ -f "$destination" ]; then cmp -s "$asset" "$destination" || { echo "conflicting immutable asset: ${asset#./}" >&2; exit 1; }; \
+      else mkdir -p "$(dirname "$destination")"; cp "$asset" "$destination"; fi; \
+    done; \
+    rm -rf /tmp/current-assets; \
+    test "$(find /usr/share/nginx/html/assets -type f | wc -l)" -le 8000; \
+    test "$(du -sb /usr/share/nginx/html/assets | cut -f1)" -le 536870912
+COPY .previous-release-assets /opt/acedata/release-assets
+
+FROM runtime-base AS final
+COPY .previous-assets/ /tmp/previous-assets/
+COPY --from=build-stage /app/dist /usr/share/nginx/html
+RUN set -eu; \
+    cd /tmp/previous-assets; \
+    find . -type f -print | while IFS= read -r asset; do \
+      destination="/usr/share/nginx/html/assets/${asset#./}"; \
+      if [ -f "$destination" ]; then cmp -s "$asset" "$destination" || { echo "conflicting immutable asset: ${asset#./}" >&2; exit 1; }; \
+      else mkdir -p "$(dirname "$destination")"; cp "$asset" "$destination"; fi; \
+    done; \
+    rm -rf /tmp/previous-assets; \
+    test "$(find /usr/share/nginx/html/assets -type f | wc -l)" -le 8000; \
+    test "$(du -sb /usr/share/nginx/html/assets | cut -f1)" -le 536870912
+COPY --from=build-stage /app/release-assets /opt/acedata/release-assets
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]
+
+FROM production-stage AS default-stage

--- a/change/rolling-assets.json
+++ b/change/rolling-assets.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Make web rollouts preserve compatible hashed assets across mixed Pods.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "none"
+}

--- a/deploy/preflight-release.sh
+++ b/deploy/preflight-release.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${DEPLOYMENT:?DEPLOYMENT is required}"
+: "${SERVICE:?SERVICE is required}"
+: "${IMAGE_REPOSITORY:?IMAGE_REPOSITORY is required}"
+NAMESPACE=${NAMESPACE:-acedatacloud}
+ENV_FILE=${GITHUB_ENV:-/dev/stdout}
+OUTPUT_PREFIX=${OUTPUT_PREFIX:-PREVIOUS}
+
+desired=$(kubectl get deployment "$DEPLOYMENT" -n "$NAMESPACE" -o jsonpath='{.spec.replicas}')
+generation=$(kubectl get deployment "$DEPLOYMENT" -n "$NAMESPACE" -o jsonpath='{.metadata.generation}')
+observed=$(kubectl get deployment "$DEPLOYMENT" -n "$NAMESPACE" -o jsonpath='{.status.observedGeneration}')
+updated=$(kubectl get deployment "$DEPLOYMENT" -n "$NAMESPACE" -o jsonpath='{.status.updatedReplicas}')
+ready=$(kubectl get deployment "$DEPLOYMENT" -n "$NAMESPACE" -o jsonpath='{.status.readyReplicas}')
+available=$(kubectl get deployment "$DEPLOYMENT" -n "$NAMESPACE" -o jsonpath='{.status.availableReplicas}')
+unavailable=$(kubectl get deployment "$DEPLOYMENT" -n "$NAMESPACE" -o jsonpath='{.status.unavailableReplicas}')
+
+if [ "$observed" != "$generation" ] || [ "$updated" != "$desired" ] || \
+   [ "$ready" != "$desired" ] || [ "$available" != "$desired" ] || \
+   { [ -n "$unavailable" ] && [ "$unavailable" != 0 ]; }; then
+  echo "$DEPLOYMENT is not fully converged" >&2
+  exit 1
+fi
+
+pods=$(kubectl get endpoints "$SERVICE" -n "$NAMESPACE" \
+  -o jsonpath='{range .subsets[*].addresses[*]}{.targetRef.name}{"\n"}{end}')
+if [ "$(printf '%s\n' "$pods" | grep -c . || true)" != "$desired" ]; then
+  echo "$SERVICE endpoint count does not match $DEPLOYMENT replicas" >&2
+  exit 1
+fi
+
+spec_image=
+image_id=
+for pod in $pods; do
+  pod_image=$(kubectl get pod "$pod" -n "$NAMESPACE" -o jsonpath='{.spec.containers[0].image}')
+  pod_image_id=$(kubectl get pod "$pod" -n "$NAMESPACE" -o jsonpath='{.status.containerStatuses[0].imageID}')
+  case "$pod_image" in "$IMAGE_REPOSITORY":*|"$IMAGE_REPOSITORY"@sha256:*) ;; *) echo "Unexpected image: $pod_image" >&2; exit 1 ;; esac
+  case "$pod_image_id" in "$IMAGE_REPOSITORY"@sha256:*) ;; *) echo "Unexpected image ID: $pod_image_id" >&2; exit 1 ;; esac
+  if [ -n "$spec_image" ] && { [ "$pod_image" != "$spec_image" ] || [ "$pod_image_id" != "$image_id" ]; }; then
+    echo "$SERVICE endpoints run mixed images" >&2
+    exit 1
+  fi
+  spec_image=$pod_image
+  image_id=$pod_image_id
+done
+
+first_pod=$(printf '%s\n' "$pods" | sed -n '1p')
+printf '%s_IMAGE=%s\n' "$OUTPUT_PREFIX" "$image_id" >> "$ENV_FILE"
+printf '%s_POD=%s\n' "$OUTPUT_PREFIX" "$first_pod" >> "$ENV_FILE"
+printf '%s_TAGGED_IMAGE=%s\n' "$OUTPUT_PREFIX" "$spec_image" >> "$ENV_FILE"
+printf 'previous_image=%s\n' "$image_id"

--- a/deploy/prepare-previous-assets.sh
+++ b/deploy/prepare-previous-assets.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+: "${PREVIOUS_POD:?PREVIOUS_POD is required}"
+: "${MAX_RELEASE_FILES:?MAX_RELEASE_FILES is required}"
+: "${MAX_RELEASE_BYTES:?MAX_RELEASE_BYTES is required}"
+output_dir=${OUTPUT_DIR:-.previous-assets}
+manifest_file=${MANIFEST_FILE:-.previous-release-assets}
+tmp_dir=$(mktemp -d)
+cleanup() { rm -rf "$tmp_dir"; }
+trap cleanup EXIT
+rm -rf "$output_dir"
+mkdir -p "$output_dir"
+token="${GITHUB_RUN_ID:-local}-$$"
+fetch_manifest=
+if kubectl exec -n acedatacloud "$PREVIOUS_POD" -- test -f /opt/acedata/release-assets 2>/dev/null; then
+  kubectl exec -n acedatacloud "$PREVIOUS_POD" -- cat /opt/acedata/release-assets > "$manifest_file"
+  python3 deploy/release_assets.py check-list "$manifest_file" "$MAX_RELEASE_FILES"
+  fetch_manifest=--manifest
+else
+  echo "Previous image has no release manifest; synthesizing one legacy release"
+fi
+python3 deploy/release_assets.py fetch "$PREVIOUS_POD" /usr/share/nginx/html/assets "$tmp_dir/assets.tar" "$token" ${fetch_manifest:-}
+tar -xf "$tmp_dir/assets.tar" -C "$output_dir"
+if [ ! -f "$manifest_file" ]; then python3 deploy/release_assets.py manifest "$output_dir" "$manifest_file"; fi
+python3 deploy/release_assets.py validate "$output_dir" "$manifest_file" "$MAX_RELEASE_FILES" "$MAX_RELEASE_BYTES"

--- a/deploy/prepare-previous-assets.sh
+++ b/deploy/prepare-previous-assets.sh
@@ -15,7 +15,7 @@ fetch_manifest=
 if kubectl exec -n acedatacloud "$PREVIOUS_POD" -- test -f /opt/acedata/release-assets 2>/dev/null; then
   kubectl exec -n acedatacloud "$PREVIOUS_POD" -- cat /opt/acedata/release-assets > "$manifest_file"
   python3 deploy/release_assets.py check-list "$manifest_file" "$MAX_RELEASE_FILES"
-  fetch_manifest=--manifest
+  fetch_manifest="--manifest-path /opt/acedata/release-assets"
 else
   echo "Previous image has no release manifest; synthesizing one legacy release"
 fi

--- a/deploy/production/studio-deployment.yaml
+++ b/deploy/production/studio-deployment.yaml
@@ -8,6 +8,13 @@ metadata:
 spec:
   replicas: 2
   revisionHistoryLimit: 5
+  minReadySeconds: 10
+  progressDeadlineSeconds: 1200
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   selector:
     matchLabels:
       app: studio-frontend
@@ -21,6 +28,14 @@ spec:
           name: studio-frontend
           ports:
             - containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /index.html
+              port: 80
+            initialDelaySeconds: 2
+            periodSeconds: 3
+            failureThreshold: 5
+            timeoutSeconds: 2
           livenessProbe:
             httpGet:
               path: /

--- a/deploy/release_assets.py
+++ b/deploy/release_assets.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import base64
+import gzip
+import hashlib
+from pathlib import Path, PurePosixPath
+import re
+import shlex
+import shutil
+import subprocess
+
+TOKEN_PATTERN = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+def safe_path(value: str) -> PurePosixPath:
+    path = PurePosixPath(value)
+    if (
+        not value
+        or path.is_absolute()
+        or value.startswith(("./", "-"))
+        or ".." in path.parts
+        or "\\" in value
+        or any(ord(char) < 32 for char in value)
+    ):
+        raise ValueError(f"unsafe release asset path: {value!r}")
+    return path
+
+
+def load_manifest(path: Path, max_files: int) -> list[str]:
+    items = path.read_text().splitlines()
+    if not items or len(items) > max_files:
+        raise ValueError(f"release has {len(items)} files (limit {max_files})")
+    if items != sorted(set(items)):
+        raise ValueError("release manifest must be sorted and unique")
+    for item in items:
+        safe_path(item)
+    return items
+
+
+def kubectl(*args: str, text: bool = False) -> subprocess.CompletedProcess:
+    return subprocess.run(["kubectl", *args], check=True, capture_output=True, text=text)
+
+
+def command_fetch(args: argparse.Namespace) -> None:
+    if not TOKEN_PATTERN.fullmatch(args.token):
+        raise ValueError("unsafe transfer token")
+    remote = f"/tmp/acedata-assets-{args.token}"
+    directory = shlex.quote(args.directory)
+    tar_args = "-T /opt/acedata/release-assets" if args.manifest else "."
+    setup = (
+        f"set -eu; rm -rf {remote}; mkdir -p {remote}; "
+        f"cd {directory}; tar -cf - {tar_args} | gzip -c > {remote}/archive.tgz; "
+        f"split -b 262144 -a 4 {remote}/archive.tgz {remote}/part-; "
+        f"sha256sum {remote}/archive.tgz | cut -d' ' -f1 > {remote}/sha256; "
+        f"find {remote} -name 'part-*' -type f | sort > {remote}/parts"
+    )
+    kubectl("exec", "-n", args.namespace, args.pod, "--", "sh", "-lc", setup)
+    try:
+        parts_output = kubectl("exec", "-n", args.namespace, args.pod, "--", "cat", f"{remote}/parts", text=True).stdout
+        parts = [part for part in parts_output.splitlines() if part]
+        if not parts or any(not part.startswith(f"{remote}/part-") for part in parts):
+            raise ValueError(f"invalid archive parts: {parts!r}")
+        expected = kubectl("exec", "-n", args.namespace, args.pod, "--", "cat", f"{remote}/sha256", text=True).stdout.strip()
+        compressed = bytearray()
+        for part in parts:
+            encoded = kubectl("exec", "-n", args.namespace, args.pod, "--", "base64", part).stdout
+            compressed.extend(base64.b64decode(encoded))
+        actual = hashlib.sha256(compressed).hexdigest()
+        if actual != expected:
+            raise ValueError(f"archive checksum mismatch: expected {expected}, got {actual}")
+        Path(args.output).write_bytes(gzip.decompress(compressed))
+        print(f"archive_parts={len(parts)}")
+        print(f"archive_sha256={actual}")
+    finally:
+        subprocess.run(["kubectl", "exec", "-n", args.namespace, args.pod, "--", "rm", "-rf", remote], check=False)
+
+
+def command_manifest(args: argparse.Namespace) -> None:
+    root = Path(args.root)
+    items = sorted(path.relative_to(root).as_posix() for path in root.rglob("*") if path.is_file())
+    Path(args.output).write_text("".join(f"{item}\n" for item in items))
+
+
+def command_check_list(args: argparse.Namespace) -> None:
+    load_manifest(Path(args.manifest), args.max_files)
+
+
+def validate_tree(root: Path, manifest: Path, max_files: int, max_bytes: int) -> tuple[list[str], int]:
+    items = load_manifest(manifest, max_files)
+    size = 0
+    actual = []
+    for path in root.rglob("*"):
+        if path.is_symlink():
+            raise ValueError(f"release asset may not be a symlink: {path.relative_to(root)}")
+        if path.is_file():
+            actual.append(path.relative_to(root).as_posix())
+    actual.sort()
+    if actual != items:
+        missing = sorted(set(items) - set(actual))
+        surplus = sorted(set(actual) - set(items))
+        raise ValueError(f"asset tree differs from manifest; missing={missing[:3]} surplus={surplus[:3]}")
+    for item in items:
+        path = root / item
+        if not path.is_file():
+            raise ValueError(f"missing release asset: {item}")
+        size += path.stat().st_size
+    if size > max_bytes:
+        raise ValueError(f"release has {size} bytes (limit {max_bytes})")
+    return items, size
+
+
+def command_validate(args: argparse.Namespace) -> None:
+    items, size = validate_tree(Path(args.root), Path(args.manifest), args.max_files, args.max_bytes)
+    digest = hashlib.sha256(Path(args.manifest).read_bytes()).hexdigest()
+    print(f"release_files={len(items)}")
+    print(f"release_bytes={size}")
+    print(f"release_manifest_sha256={digest}")
+
+
+def command_merge(args: argparse.Namespace) -> None:
+    source = Path(args.source)
+    destination = Path(args.destination)
+    items, size = validate_tree(source, Path(args.manifest), args.max_files, args.max_bytes)
+    destination.mkdir(parents=True, exist_ok=True)
+    for item in items:
+        src = source / item
+        dst = destination / item
+        if dst.exists():
+            if not dst.is_file() or hashlib.sha256(dst.read_bytes()).digest() != hashlib.sha256(src.read_bytes()).digest():
+                raise ValueError(f"conflicting immutable asset: {item}")
+            continue
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, dst)
+    print(f"merged_release_files={len(items)}")
+    print(f"merged_release_bytes={size}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    fetch = subparsers.add_parser("fetch")
+    fetch.add_argument("pod")
+    fetch.add_argument("directory")
+    fetch.add_argument("output")
+    fetch.add_argument("token")
+    fetch.add_argument("--manifest", action="store_true")
+    fetch.add_argument("--namespace", default="acedatacloud")
+    fetch.set_defaults(func=command_fetch)
+    manifest = subparsers.add_parser("manifest")
+    manifest.add_argument("root")
+    manifest.add_argument("output")
+    manifest.set_defaults(func=command_manifest)
+    check = subparsers.add_parser("check-list")
+    check.add_argument("manifest")
+    check.add_argument("max_files", type=int)
+    check.set_defaults(func=command_check_list)
+    validate = subparsers.add_parser("validate")
+    validate.add_argument("root")
+    validate.add_argument("manifest")
+    validate.add_argument("max_files", type=int)
+    validate.add_argument("max_bytes", type=int)
+    validate.set_defaults(func=command_validate)
+    merge = subparsers.add_parser("merge")
+    merge.add_argument("source")
+    merge.add_argument("manifest")
+    merge.add_argument("destination")
+    merge.add_argument("max_files", type=int)
+    merge.add_argument("max_bytes", type=int)
+    merge.set_defaults(func=command_merge)
+    args = parser.parse_args()
+    try:
+        args.func(args)
+    except (OSError, ValueError, subprocess.CalledProcessError) as error:
+        raise SystemExit(str(error)) from error
+
+
+if __name__ == "__main__":
+    main()

--- a/deploy/release_assets.py
+++ b/deploy/release_assets.py
@@ -48,7 +48,7 @@ def command_fetch(args: argparse.Namespace) -> None:
         raise ValueError("unsafe transfer token")
     remote = f"/tmp/acedata-assets-{args.token}"
     directory = shlex.quote(args.directory)
-    tar_args = "-T /opt/acedata/release-assets" if args.manifest else "."
+    tar_args = f"-T {shlex.quote(args.manifest_path)}" if args.manifest_path else "."
     setup = (
         f"set -eu; rm -rf {remote}; mkdir -p {remote}; "
         f"cd {directory}; tar -cf - {tar_args} | gzip -c > {remote}/archive.tgz; "
@@ -145,7 +145,10 @@ def main() -> None:
     fetch.add_argument("directory")
     fetch.add_argument("output")
     fetch.add_argument("token")
-    fetch.add_argument("--manifest", action="store_true")
+    fetch.add_argument(
+        "--manifest-path",
+        choices=("/opt/acedata/release-assets", "/opt/acedata/ssr-client-release-assets"),
+    )
     fetch.add_argument("--namespace", default="acedatacloud")
     fetch.set_defaults(func=command_fetch)
     manifest = subparsers.add_parser("manifest")

--- a/deploy/test-compatible-images.sh
+++ b/deploy/test-compatible-images.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${IMAGE_NAME:?IMAGE_NAME is required}"
+previous_image="$IMAGE_NAME:ci-previous"
+bridge_image="$IMAGE_NAME:ci-bridge"
+final_image="$IMAGE_NAME:ci-final"
+current_image="$IMAGE_NAME:ci-current"
+
+[ ! -e .previous-assets ] || { echo '.previous-assets already exists' >&2; exit 1; }
+[ ! -e .previous-release-assets ] || { echo '.previous-release-assets already exists' >&2; exit 1; }
+cleanup() { rm -rf .previous-assets .previous-release-assets "$tmp_dir"; }
+tmp_dir=$(mktemp -d)
+trap cleanup EXIT
+
+mkdir .previous-assets
+printf 'previous release fixture\n' > .previous-assets/old-ci.js
+printf 'old-ci.js\n' > .previous-release-assets
+
+docker build --target production-stage -t "$current_image" .
+cat > "$tmp_dir/Dockerfile" <<'DOCKERFILE'
+ARG CURRENT_IMAGE
+FROM ${CURRENT_IMAGE}
+COPY old-ci.js /usr/share/nginx/html/assets/old-ci.js
+COPY release-assets /opt/acedata/release-assets
+DOCKERFILE
+cp .previous-assets/old-ci.js "$tmp_dir/old-ci.js"
+cp .previous-release-assets "$tmp_dir/release-assets"
+docker build --build-arg "CURRENT_IMAGE=$current_image" -t "$previous_image" "$tmp_dir"
+docker build --target bridge --build-arg "PREVIOUS_IMAGE=$previous_image" -t "$bridge_image" .
+docker build --target final --build-arg "PREVIOUS_IMAGE=$previous_image" -t "$final_image" .
+
+previous_index=$(docker run --rm --entrypoint sha256sum "$previous_image" /usr/share/nginx/html/index.html | cut -d' ' -f1)
+bridge_index=$(docker run --rm --entrypoint sha256sum "$bridge_image" /usr/share/nginx/html/index.html | cut -d' ' -f1)
+[ "$previous_index" = "$bridge_index" ]
+for image in "$bridge_image" "$final_image"; do
+  docker run --rm --entrypoint sh "$image" -lc '
+    test -f /usr/share/nginx/html/assets/old-ci.js
+    test -s /opt/acedata/release-assets
+    release_asset=$(sed -n "1p" /opt/acedata/release-assets)
+    test -f "/usr/share/nginx/html/assets/$release_asset"
+  '
+done

--- a/deploy/verify-cutover.sh
+++ b/deploy/verify-cutover.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${RELEASE_TAG:?RELEASE_TAG is required}"
+: "${PREVIOUS_IMAGE:?PREVIOUS_IMAGE is required}"
+: "${PREVIOUS_TAGGED_IMAGE:?PREVIOUS_TAGGED_IMAGE is required}"
+: "${GITHUB_SHA:?GITHUB_SHA is required}"
+NAMESPACE=acedatacloud
+DEPLOYMENT=studio-frontend
+CONTAINER=studio-frontend
+SERVICE=studio-frontend
+MANIFEST=deploy/production/studio-deployment.yaml
+IMAGE_REPOSITORY=ghcr.io/acedatacloud/studio-frontend
+
+wait_converged() {
+  local deployment=$1 service=$2 expected_image=$3 expected_repository
+  expected_repository=${expected_image%@*}
+  if [ "$expected_repository" = "$expected_image" ]; then expected_repository=${expected_image%:*}; fi
+  kubectl rollout status "deployment/$deployment" -n "$NAMESPACE" --timeout=20m
+  local deadline=$(( $(date +%s) + 300 ))
+  while :; do
+    local desired observed generation updated ready available unavailable endpoints pod image image_id expected_image_id all_ready
+    desired=$(kubectl get deployment "$deployment" -n "$NAMESPACE" -o jsonpath='{.spec.replicas}')
+    generation=$(kubectl get deployment "$deployment" -n "$NAMESPACE" -o jsonpath='{.metadata.generation}')
+    observed=$(kubectl get deployment "$deployment" -n "$NAMESPACE" -o jsonpath='{.status.observedGeneration}')
+    updated=$(kubectl get deployment "$deployment" -n "$NAMESPACE" -o jsonpath='{.status.updatedReplicas}')
+    ready=$(kubectl get deployment "$deployment" -n "$NAMESPACE" -o jsonpath='{.status.readyReplicas}')
+    available=$(kubectl get deployment "$deployment" -n "$NAMESPACE" -o jsonpath='{.status.availableReplicas}')
+    unavailable=$(kubectl get deployment "$deployment" -n "$NAMESPACE" -o jsonpath='{.status.unavailableReplicas}')
+    endpoints=$(kubectl get endpoints "$service" -n "$NAMESPACE" -o jsonpath='{range .subsets[*].addresses[*]}{.targetRef.name}{"\n"}{end}' 2>/dev/null || true)
+    all_ready=true
+    [ "$observed" = "$generation" ] || all_ready=false
+    [ "$updated" = "$desired" ] || all_ready=false
+    [ "$ready" = "$desired" ] || all_ready=false
+    [ "$available" = "$desired" ] || all_ready=false
+    [ -z "$unavailable" ] || [ "$unavailable" = 0 ] || all_ready=false
+    [ "$(printf '%s\n' "$endpoints" | grep -c . || true)" = "$desired" ] || all_ready=false
+    for pod in $endpoints; do
+      image=$(kubectl get pod "$pod" -n "$NAMESPACE" -o jsonpath='{.spec.containers[0].image}' 2>/dev/null || true)
+      image_id=$(kubectl get pod "$pod" -n "$NAMESPACE" -o jsonpath='{.status.containerStatuses[0].imageID}' 2>/dev/null || true)
+      [ "$image" = "$expected_image" ] || all_ready=false
+      case "$image_id" in "$expected_repository"@sha256:*) ;; *) all_ready=false ;; esac
+      if [ -n "${expected_image_id:-}" ] && [ "$image_id" != "$expected_image_id" ]; then all_ready=false; fi
+      expected_image_id=$image_id
+    done
+    if [ "$all_ready" = true ]; then
+      return 0
+    fi
+    if [ "$(date +%s)" -ge "$deadline" ]; then
+      echo "$deployment/$service did not converge to $expected_image" >&2
+      kubectl get deployment "$deployment" -n "$NAMESPACE" -o wide || true
+      kubectl get pods -n "$NAMESPACE" -l "app=$deployment" -o wide || true
+      kubectl get endpoints "$service" -n "$NAMESPACE" -o wide || true
+      return 1
+    fi
+    sleep 2
+  done
+}
+
+apply_stage() {
+  local tag=$1
+  sed "s|\${TAG}|$tag|g" "$MANIFEST" | kubectl apply -f -
+}
+
+rollback() {
+  local image=$1
+  echo "Rolling $DEPLOYMENT back to $image" >&2
+  kubectl set image "deployment/$DEPLOYMENT" "$CONTAINER=$image" -n "$NAMESPACE"
+  wait_converged "$DEPLOYMENT" "$SERVICE" "$image" || true
+}
+
+roll_stage() {
+  local tag=$1 fallback=$2 expected="$IMAGE_REPOSITORY:$tag"
+  apply_stage "$tag"
+  if ! wait_converged "$DEPLOYMENT" "$SERVICE" "$expected"; then
+    rollback "$fallback"
+    return 1
+  fi
+}
+
+kubectl apply -f deploy/production/studio-service.yaml
+kubectl apply -f deploy/production/studio-ingress.yaml
+kubectl apply -f deploy/production/studio-proxy.yaml
+kubectl apply -f deploy/production/legacy-hub-redirect.yaml
+roll_stage "${RELEASE_TAG}-bridge" "$PREVIOUS_TAGGED_IMAGE"
+roll_stage "$RELEASE_TAG" "ghcr.io/acedatacloud/studio-frontend:${RELEASE_TAG}-bridge"
+
+if ! python3 deploy/verify-html-assets.py "https://studio.acedata.cloud/"; then
+  rollback "ghcr.io/acedatacloud/studio-frontend:${RELEASE_TAG}-bridge"
+  exit 1
+fi
+kubectl annotate deployment "$DEPLOYMENT" -n "$NAMESPACE" \
+  "acedata.cloud/last-successful-revision=$GITHUB_SHA" \
+  "acedata.cloud/release-id=$RELEASE_TAG" \
+  "acedata.cloud/release-phase=final" --overwrite

--- a/deploy/verify-html-assets.py
+++ b/deploy/verify-html-assets.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+from html.parser import HTMLParser
+import sys
+from urllib.parse import urljoin, urlparse
+from urllib.request import Request, urlopen
+
+class Assets(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.paths = set()
+    def handle_starttag(self, tag, attrs):
+        values = dict(attrs)
+        value = values.get("src") if tag == "script" else values.get("href") if tag == "link" and values.get("rel") == "stylesheet" else None
+        if value and urlparse(value).path.startswith("/assets/"):
+            self.paths.add(value)
+
+base = sys.argv[1]
+request = Request(base, headers={"Cache-Control": "no-cache", "User-Agent": "release-cutover-verifier"})
+with urlopen(request, timeout=30) as response:
+    html = response.read().decode("utf-8")
+    if response.status != 200:
+        raise SystemExit(f"HTML returned {response.status}")
+    cache = response.headers.get("Cache-Control", "")
+    if "no-store" not in cache and "no-cache" not in cache:
+        raise SystemExit(f"HTML is cacheable: {cache}")
+parser = Assets()
+parser.feed(html)
+if not parser.paths:
+    raise SystemExit("HTML contains no hashed entry assets")
+for path in sorted(parser.paths):
+    with urlopen(Request(urljoin(base, path), headers={"User-Agent": "release-cutover-verifier"}), timeout=30) as response:
+        content_type = response.headers.get("Content-Type", "")
+        if response.status != 200 or ("javascript" not in content_type and "css" not in content_type):
+            raise SystemExit(f"bad asset {path}: {response.status} {content_type}")
+print(f"verified {len(parser.paths)} entry assets from {base}")

--- a/scripts/check_studio_deployment.py
+++ b/scripts/check_studio_deployment.py
@@ -17,4 +17,20 @@ assert [rule['http']['paths'][0]['backend']['service']['name'] for rule in redir
 assert 'delete deployment hub-frontend' not in workflow
 assert 'delete service hub-frontend' not in workflow
 assert 'ghcr.io/acedatacloud/hub-frontend' not in workflow
+
+container = studio['spec']['template']['spec']['containers'][0]
+assert studio['spec']['strategy']['type'] == 'RollingUpdate'
+assert studio['spec']['strategy']['rollingUpdate'] == {'maxSurge': 1, 'maxUnavailable': 0}
+assert studio['spec']['minReadySeconds'] == 10
+assert container['readinessProbe']['httpGet']['path'] == '/index.html'
+cutover = (ROOT / 'deploy/verify-cutover.sh').read_text()
+dockerfile = (ROOT / 'Dockerfile').read_text()
+bridge = cutover.index('roll_stage "${RELEASE_TAG}-bridge"')
+final = cutover.index('roll_stage "$RELEASE_TAG"')
+verify = cutover.index('verify-html-assets.py')
+annotate = cutover.index('last-successful-revision')
+assert bridge < final < verify < annotate
+assert 'FROM ${PREVIOUS_IMAGE} AS bridge' in dockerfile
+assert 'FROM runtime-base AS final' in dockerfile
+assert workflow.index('preflight-release.sh') < workflow.index('--target bridge') < workflow.index('verify-cutover.sh')
 print('Studio deployment contract OK')

--- a/scripts/check_studio_deployment.py
+++ b/scripts/check_studio_deployment.py
@@ -33,4 +33,5 @@ assert bridge < final < verify < annotate
 assert 'FROM ${PREVIOUS_IMAGE} AS bridge' in dockerfile
 assert 'FROM runtime-base AS final' in dockerfile
 assert workflow.index('preflight-release.sh') < workflow.index('--target bridge') < workflow.index('verify-cutover.sh')
+assert 'test-compatible-images.sh' in (ROOT / '.github/workflows/check-pr.yaml').read_text()
 print('Studio deployment contract OK')

--- a/scripts/test_release_assets.py
+++ b/scripts/test_release_assets.py
@@ -24,6 +24,13 @@ class ReleaseAssetsTest(unittest.TestCase):
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("unsafe transfer token", result.stderr)
 
+    def test_transfer_rejects_untrusted_manifest_path(self) -> None:
+        result = self.run_helper(
+            "fetch", "pod", "/assets", "archive.tar", "token", "--manifest-path", "/tmp/evil"
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("invalid choice", result.stderr)
+
     def test_manifest_and_validate_happy_path(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp) / "assets"

--- a/scripts/test_release_assets.py
+++ b/scripts/test_release_assets.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HELPER = ROOT / "deploy/release_assets.py"
+
+
+class ReleaseAssetsTest(unittest.TestCase):
+    def run_helper(self, *args: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["python3", str(HELPER), *(str(arg) for arg in args)],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def test_transfer_token_rejects_shell_metacharacters(self) -> None:
+        result = self.run_helper("fetch", "pod", "/assets", "archive.tar", "bad;token")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("unsafe transfer token", result.stderr)
+
+    def test_manifest_and_validate_happy_path(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp) / "assets"
+            root.mkdir()
+            (root / "a.js").write_text("a")
+            (root / "nested").mkdir()
+            (root / "nested/b.css").write_text("bb")
+            manifest = Path(temp) / "manifest"
+            self.assertEqual(self.run_helper("manifest", root, manifest).returncode, 0)
+            result = self.run_helper("validate", root, manifest, 2, 3)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("release_files=2", result.stdout)
+
+    def test_rejects_unsafe_and_noncanonical_manifests(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            manifest = Path(temp) / "manifest"
+            for text in ("../secret\n", "-T\n", "b.js\na.js\n", "a.js\na.js\n"):
+                manifest.write_text(text)
+                result = self.run_helper("check-list", manifest, 10)
+                self.assertNotEqual(result.returncode, 0, text)
+
+    def test_rejects_symlinks_and_size_overflow(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp) / "assets"
+            root.mkdir()
+            target = root / "target.js"
+            target.write_text("large")
+            (root / "link.js").symlink_to(target)
+            manifest = Path(temp) / "manifest"
+            manifest.write_text("link.js\ntarget.js\n")
+            self.assertNotEqual(self.run_helper("validate", root, manifest, 2, 100).returncode, 0)
+            (root / "link.js").unlink()
+            manifest.write_text("target.js\n")
+            self.assertNotEqual(self.run_helper("validate", root, manifest, 1, 4).returncode, 0)
+
+    def test_merge_rejects_conflicts_and_accepts_identical_files(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            source = Path(temp) / "source"
+            destination = Path(temp) / "destination"
+            source.mkdir()
+            destination.mkdir()
+            (source / "same.js").write_text("new")
+            (destination / "same.js").write_text("old")
+            manifest = Path(temp) / "manifest"
+            manifest.write_text("same.js\n")
+            conflict = self.run_helper("merge", source, manifest, destination, 1, 100)
+            self.assertNotEqual(conflict.returncode, 0)
+            (destination / "same.js").write_text("new")
+            identical = self.run_helper("merge", source, manifest, destination, 1, 100)
+            self.assertEqual(identical.returncode, 0, identical.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- publish bridge then final Docker images through the existing Studio Deployment, without blue-green workloads or a static host
- retain one manifest-owned previous asset generation so old/new HTML and dynamic chunks remain compatible during and after rollout
- add readiness, zero-unavailable rolling settings, endpoint convergence checks, bounded asset unions, and verified rollback to bridge
- publish Docker Hub aliases only after the GHCR final image passes production cutover

## Verification
- 238 test files / 1,746 tests passed
- `npm run build` passed
- Studio deployment, release workflow, Beachball, and release asset security contracts passed
- production read-only legacy extraction: 1,170 files / 18 MB, 21 transfer chunks with archive SHA-256 verification
- strict YAML, shell syntax, and diff checks passed
- local Docker daemon was unavailable; PR build/CI is required before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)