### PR TITLE
fix: initialize Studio cutover image safely

### DIFF
--- a/change/studio-cutover-local-init.json
+++ b/change/studio-cutover-local-init.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix Studio web cutover so strict Bash mode initializes the expected image after the release tag.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/deploy/verify-cutover.sh
+++ b/deploy/verify-cutover.sh
@@ -70,7 +70,8 @@ rollback() {
 }
 
 roll_stage() {
-  local tag=$1 fallback=$2 expected="$IMAGE_REPOSITORY:$tag"
+  local tag=$1 fallback=$2
+  local expected="$IMAGE_REPOSITORY:$tag"
   apply_stage "$tag"
   if ! wait_converged "$DEPLOYMENT" "$SERVICE" "$expected"; then
     rollback "$fallback"

--- a/scripts/check_studio_deployment.py
+++ b/scripts/check_studio_deployment.py
@@ -30,6 +30,8 @@ final = cutover.index('roll_stage "$RELEASE_TAG"')
 verify = cutover.index('verify-html-assets.py')
 annotate = cutover.index('last-successful-revision')
 assert bridge < final < verify < annotate
+assert 'local tag=$1 fallback=$2 expected=' not in cutover
+assert 'local tag=$1 fallback=$2\n  local expected="$IMAGE_REPOSITORY:$tag"' in cutover
 assert 'FROM ${PREVIOUS_IMAGE} AS bridge' in dockerfile
 assert 'FROM runtime-base AS final' in dockerfile
 assert workflow.index('preflight-release.sh') < workflow.index('--target bridge') < workflow.index('verify-release-unchanged.sh') < workflow.index('verify-cutover.sh')


### PR DESCRIPTION
## Production failure

Web deploy run https://github.com/AceDataCloud/Nexior/actions/runs/32815692374 successfully prepared legacy assets and built images, then failed before mutating `studio-frontend`:

```text
deploy/verify-cutover.sh: line 73: tag: unbound variable
```

With `set -u`, Bash expands `expected="$IMAGE_REPOSITORY:$tag"` before `tag` assigned in the same `local` statement.

Production remained unchanged at `studio-frontend:2068`, 2/2 Ready.

## Fix

- split `tag`/`fallback` assignment from the dependent `expected` assignment
- add a permanent deployment contract rejecting the unsafe combined declaration
- include a Beachball patch record

## Validation

- `bash -n deploy/verify-cutover.sh`
- exact `roll_stage` function executed under `bash -euo pipefail` with mocked rollout helpers
- `python3 scripts/check_studio_deployment.py`
- continuous-payment regression: 15 passed
- local full web build was blocked by the existing host `node_modules` containing `@acedatacloud/core` 0.20.1 while lockfile requires 0.21.1; PR CI uses clean `npm ci` and Docker Build

## Rollout

Merge after CI, then rerun `Deploy · Web` for main. The previous failed run did not update the Studio Deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
