### PR TITLE
fix: enforce authentication at request boundaries

### DIFF
--- a/change/clear-signed-out-balance.json
+++ b/change/clear-signed-out-balance.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Hide cached credit balances after sign-out and clear persisted account-owned application state.",
+  "comment": "Clear persisted account state after sign-out and require login before protected guest operations such as uploads.",
   "packageName": "@acedatacloud/nexior",
   "email": "dev@acedata.cloud",
   "dependentChangeType": "patch"

--- a/change/clear-signed-out-balance.json
+++ b/change/clear-signed-out-balance.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Hide cached credit balances after sign-out and clear persisted account-owned application state.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/change/clear-signed-out-balance.json
+++ b/change/clear-signed-out-balance.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Clear persisted account state after sign-out and require login before protected guest operations such as uploads.",
+  "comment": "Keep signed-out account state consistent and enforce authentication at protected request boundaries.",
   "packageName": "@acedatacloud/nexior",
   "email": "dev@acedata.cloud",
   "dependentChangeType": "patch"

--- a/src/App.vue
+++ b/src/App.vue
@@ -32,7 +32,8 @@ import { Browser } from '@capacitor/browser';
 import { ElMessage } from 'element-plus';
 import { isNative, isDesktop } from '@/utils/surface';
 import { desktopBridge } from '@/utils/desktop';
-import { currentSiteOrigin } from '@/utils';
+import { currentSiteOrigin, ensureLoggedIn } from '@/utils';
+import { installUploadAuthGuard } from '@/utils/uploadAuthGuard';
 import { parseInviterFromDeepLink, writeInviterCookie } from '@/utils/attribution';
 import { exchangeSsoCode } from '@/utils/auth/exchangeSsoCode';
 import { canTopUpQuota, closeQuotaExhausted, getQuotaPurchaseRoute, quotaExhaustedState } from '@/utils/quotaExhausted';
@@ -75,7 +76,8 @@ export default defineComponent({
       offAuthCb: null as null | (() => void),
       offAuthExpired: null as null | (() => void),
       offSiteWatch: null as null | (() => void),
-      offCredentialWatch: null as null | (() => void)
+      offCredentialWatch: null as null | (() => void),
+      offUploadAuthGuard: null as null | (() => void)
     };
   },
   computed: {
@@ -104,6 +106,8 @@ export default defineComponent({
     }
   },
   mounted() {
+    this.offUploadAuthGuard = installUploadAuthGuard(document, ensureLoggedIn);
+
     // Listen for deep link callbacks from the native (Capacitor) OAuth flow.
     if (isNative()) {
       CapApp.addListener('appUrlOpen', async ({ url }) => {
@@ -189,6 +193,7 @@ export default defineComponent({
     this.offAuthExpired?.();
     this.offSiteWatch?.();
     this.offCredentialWatch?.();
+    this.offUploadAuthGuard?.();
   },
   methods: {
     onQuotaVisibility(visible: boolean) {

--- a/src/components/common/ApiCodeDialog.vue
+++ b/src/components/common/ApiCodeDialog.vue
@@ -103,6 +103,7 @@
 </template>
 
 <script lang="ts">
+import { requireServiceToken } from '@/utils/requestAuth';
 import {
   CodeIcon,
   DocsIcon,
@@ -306,7 +307,7 @@ export default defineComponent({
         const res = await fetch(this.url, {
           method: (this.method || 'POST').toUpperCase(),
           headers: {
-            authorization: `Bearer ${this.token}`,
+            authorization: `Bearer ${requireServiceToken(this.token)}`,
             'content-type': 'application/json'
           },
           body: JSON.stringify(this.body || {})

--- a/src/components/fish/model/Recorder.vue
+++ b/src/components/fish/model/Recorder.vue
@@ -75,6 +75,7 @@
 </template>
 
 <script lang="ts">
+import { ensureUploadAuthenticated } from '@/utils/uploadAuthGuard';
 import {
   ConfirmIcon,
   DocsIcon,
@@ -245,6 +246,7 @@ export default defineComponent({
         ElMessage.warning(this.$t('fish.message.recordingTooShort'));
         return;
       }
+      if (!ensureUploadAuthenticated()) return;
       this.uploading = true;
       try {
         const token = this.$store.state.token?.access;

--- a/src/components/fish/model/Recorder.vue
+++ b/src/components/fish/model/Recorder.vue
@@ -76,6 +76,7 @@
 
 <script lang="ts">
 import { ensureUploadAuthenticated } from '@/utils/uploadAuthGuard';
+import { requireAccountToken } from '@/utils/requestAuth';
 import {
   ConfirmIcon,
   DocsIcon,
@@ -249,7 +250,7 @@ export default defineComponent({
       if (!ensureUploadAuthenticated()) return;
       this.uploading = true;
       try {
-        const token = this.$store.state.token?.access;
+        const token = requireAccountToken();
         const ext = this.extensionForMime(this.recordedBlob.type || '');
         const file = new File([this.recordedBlob], `recording-${Date.now()}.${ext}`, {
           type: this.recordedBlob.type || 'audio/webm'

--- a/src/components/recordedUploadAuthContract.test.ts
+++ b/src/components/recordedUploadAuthContract.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+const source = (path: string) => readFileSync(new URL(path, import.meta.url), 'utf8');
+
+describe('recorded audio upload auth', () => {
+  it.each(['./fish/model/Recorder.vue', './suno/config/UploadAudio.vue'])(
+    'checks deferred auth before sending %s',
+    (path) => {
+      const component = source(path);
+      const guard = component.indexOf('if (!ensureUploadAuthenticated()) return;');
+      const network = Math.min(
+        ...['axios.post(', 'fetch(this.uploadUrl'].map((needle) => {
+          const index = component.indexOf(needle);
+          return index < 0 ? Number.POSITIVE_INFINITY : index;
+        })
+      );
+      expect(guard).toBeGreaterThan(-1);
+      expect(network).toBeGreaterThan(guard);
+    }
+  );
+});

--- a/src/components/suno/config/UploadAudio.vue
+++ b/src/components/suno/config/UploadAudio.vue
@@ -102,6 +102,7 @@
 
 <script lang="ts">
 import { ensureUploadAuthenticated } from '@/utils/uploadAuthGuard';
+import { requireAccountToken } from '@/utils/requestAuth';
 import { MicrophoneIcon, StopIcon, SuccessIcon, UndoIcon, UploadIcon } from '@acedatacloud/core/icons/components';
 import { defineComponent } from 'vue';
 import {
@@ -333,7 +334,7 @@ export default defineComponent({
         const resp = await fetch(this.uploadUrl, {
           method: 'POST',
           headers: {
-            Authorization: `Bearer ${this.$store.state.token.access}`
+            Authorization: `Bearer ${requireAccountToken()}`
           },
           body: formData
         });

--- a/src/components/suno/config/UploadAudio.vue
+++ b/src/components/suno/config/UploadAudio.vue
@@ -101,6 +101,7 @@
 </template>
 
 <script lang="ts">
+import { ensureUploadAuthenticated } from '@/utils/uploadAuthGuard';
 import { MicrophoneIcon, StopIcon, SuccessIcon, UndoIcon, UploadIcon } from '@acedatacloud/core/icons/components';
 import { defineComponent } from 'vue';
 import {
@@ -323,6 +324,7 @@ export default defineComponent({
     },
     async uploadRecording() {
       if (!this.recordedBlob) return;
+      if (!ensureUploadAuthenticated()) return;
       this.uploadingRecord = true;
       try {
         const formData = new FormData();

--- a/src/layouts/Main.home.test.ts
+++ b/src/layouts/Main.home.test.ts
@@ -3,7 +3,17 @@ import { shallowMount } from '@vue/test-utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import Main from './Main.vue';
 
-const mountMain = (appName?: string) => {
+const scenario = vi.hoisted(() => ({ mode: 'credits' as 'credits' | 'wallet', walletAvailable: true }));
+
+vi.mock('@/utils/x402/scenarioPayment', () => ({
+  isScenarioX402Supported: () => true,
+  scenarioPaymentState: () => scenario
+}));
+
+const mountMain = (
+  appName?: string,
+  options: { access?: string; application?: { id: string; remaining_amount: number } } = {}
+) => {
   const dispatch = vi.fn();
   const wrapper = shallowMount(Main, {
     global: {
@@ -17,9 +27,17 @@ const mountMain = (appName?: string) => {
         $route: { meta: appName ? { appName } : {} },
         $store: {
           state: {
-            token: {},
+            token: { access: options.access },
             applications: [],
-            ...(appName ? { [appName]: { applications: [], status: {} } } : {})
+            ...(appName
+              ? {
+                  [appName]: {
+                    application: options.application,
+                    applications: options.application ? [options.application] : [],
+                    status: {}
+                  }
+                }
+              : {})
           },
           getters: { user: {} },
           dispatch,
@@ -35,6 +53,8 @@ const mountMain = (appName?: string) => {
 describe('Main layout shell-only home', () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    scenario.mode = 'credits';
+    scenario.walletAvailable = true;
   });
 
   it('renders routed content and Navigator without application controls', async () => {
@@ -65,5 +85,34 @@ describe('Main layout shell-only home', () => {
     expect((wrapper.vm as any).hasApplicationContext).toBe(true);
     expect(dispatch).not.toHaveBeenCalledWith('undefined/getApplications');
     expect((wrapper.vm as any).balanceTimer).not.toBe(0);
+  });
+
+  it('does not show persisted credit balance to a signed-out visitor', async () => {
+    const { wrapper } = mountMain('nanobanana', {
+      application: { id: 'stale-app', remaining_amount: 44.79 }
+    });
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.findComponent({ name: 'ApplicationStatus' }).exists()).toBe(false);
+  });
+
+  it('shows the current credit balance to an authenticated user', async () => {
+    const { wrapper } = mountMain('nanobanana', {
+      access: 'valid-access-token',
+      application: { id: 'current-app', remaining_amount: 44.79 }
+    });
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.findComponent({ name: 'ApplicationStatus' }).exists()).toBe(true);
+  });
+
+  it('keeps the guest wallet entry available in wallet mode', async () => {
+    scenario.mode = 'wallet';
+    const { wrapper } = mountMain('nanobanana', {
+      application: { id: 'stale-app', remaining_amount: 44.79 }
+    });
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.findComponent({ name: 'ApplicationStatus' }).exists()).toBe(true);
   });
 });

--- a/src/layouts/Main.vue
+++ b/src/layouts/Main.vue
@@ -3,7 +3,7 @@
     <router-view class="main" />
     <navigator class="navigator" :direction="mobile ? 'row' : 'column'" />
     <application-status
-      v-if="hasApplicationContext && (application || x402Scenario)"
+      v-if="showApplicationStatus"
       class="status-floating fixed right-2 z-[200]"
       :application="application"
       :applications="applications"
@@ -67,6 +67,11 @@ export default defineComponent({
     x402Scenario(): string | undefined {
       if (!isScenarioX402Supported(this.appName)) return undefined;
       return scenarioPaymentState(this.appName).walletAvailable ? this.appName : undefined;
+    },
+    showApplicationStatus(): boolean {
+      if (!this.hasApplicationContext) return false;
+      if (this.$store.state.token?.access) return Boolean(this.application || this.x402Scenario);
+      return Boolean(this.x402Scenario && scenarioPaymentState(this.x402Scenario).mode === 'wallet');
     },
     application() {
       if (!this.appName) return undefined;

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,6 +26,8 @@ import { syncFeaturesFromUrl } from '@/utils/featureFlag';
 import { initializeSiteAnalytics } from '@/utils/siteAnalytics';
 import { runVersionGate } from '@/utils/versionGate';
 import { runLiveUpdate } from '@/utils/liveUpdate';
+import { configureRequestAuth, installServiceRequestAuthGuard, isAuthTransitionError } from '@/utils/requestAuth';
+import { ensureLoggedIn } from '@/utils/login';
 import { initializeLocalizedBootstrap } from '@/utils/localizedBootstrap';
 import {
   initializeCookies,
@@ -81,6 +83,14 @@ export const createApp = ViteSSG(App, { routes, base: import.meta.env.BASE_URL }
   }
 
   // ---- client-only bootstrap (formerly module top-level + main()) ----
+  configureRequestAuth({
+    getAccountToken: () => store.state.token?.access,
+    isAuthenticated: () => store.getters.authenticated,
+    triggerLogin: () => {
+      ensureLoggedIn();
+    }
+  });
+  installServiceRequestAuthGuard();
   syncFeaturesFromUrl();
   initializeChunkLoadErrorHandler();
 
@@ -155,6 +165,7 @@ export const createApp = ViteSSG(App, { routes, base: import.meta.env.BASE_URL }
   initializeFavicon();
 
   window.addEventListener('unhandledrejection', (event) => {
+    if (isAuthTransitionError(event.reason)) return;
     captureError(event.reason, { source: 'unhandledrejection' });
   });
 

--- a/src/operators/api.ts
+++ b/src/operators/api.ts
@@ -1,6 +1,6 @@
 import { AxiosResponse } from 'axios';
 import { BaseOperator } from '@acedatacloud/core/operators';
-import { httpClient } from './common';
+import { httpClient, optionalHttpClient } from './common';
 import { IApi, IApiDetailResponse, IApiListResponse } from '@/models';
 
 export interface IApiQuery {
@@ -14,8 +14,16 @@ class ApiOperator extends BaseOperator<IApi, IApiListResponse, IApiDetailRespons
     super(httpClient, 'apis');
   }
 
+  override async getAll(query?: IApiQuery): Promise<AxiosResponse<IApiListResponse>> {
+    return await optionalHttpClient.get(this.listUrl(), { params: query });
+  }
+
+  override async get(id: string): Promise<AxiosResponse<IApiDetailResponse>> {
+    return await optionalHttpClient.get(this.detailUrl(id));
+  }
+
   async getAllForService(serviceId: string, query?: IApiQuery): Promise<AxiosResponse<IApiListResponse>> {
-    return await httpClient.get(`/services/${serviceId}/${this.key}/`, {
+    return await optionalHttpClient.get(`/services/${serviceId}/${this.key}/`, {
       params: query
     });
   }

--- a/src/operators/appVersion.ts
+++ b/src/operators/appVersion.ts
@@ -1,5 +1,5 @@
 import { AxiosResponse } from 'axios';
-import { httpClient } from './common';
+import { anonymousHttpClient } from './common';
 
 export interface IAppVersionResponse {
   app: string;
@@ -12,7 +12,7 @@ export interface IAppVersionResponse {
 
 class AppVersionOperator {
   async get(app: string, platform: string): Promise<AxiosResponse<IAppVersionResponse>> {
-    return httpClient.get('/app-version/', {
+    return anonymousHttpClient.get('/app-version/', {
       params: { app, platform },
       timeout: 5000
     });

--- a/src/operators/artifacts.ts
+++ b/src/operators/artifacts.ts
@@ -1,11 +1,12 @@
 import axios from 'axios';
 import { BASE_URL_API } from '@/constants';
 import { currentSiteOrigin } from '@/utils';
+import { serviceAuthHeaders } from '@/utils/requestAuth';
 
 function headers(token: string) {
   const origin = currentSiteOrigin();
   return {
-    Authorization: `Bearer ${token}`,
+    ...serviceAuthHeaders(token),
     'Content-Type': 'application/json',
     ...(origin ? { 'x-site-origin': origin } : {})
   };

--- a/src/operators/attribution.ts
+++ b/src/operators/attribution.ts
@@ -1,5 +1,5 @@
 import { AxiosResponse } from 'axios';
-import { httpClient } from './common';
+import { anonymousHttpClient } from './common';
 
 export interface IAttributionResolveRequest {
   // Token round-tripped via Play Install Referrer (Android) or clipboard (iOS).
@@ -14,12 +14,12 @@ export interface IAttributionResolveResponse {
 
 class AttributionOperator {
   /**
-   * First-launch deferred-deep-link resolution. The shared httpClient already
+   * First-launch deferred-deep-link resolution. The shared anonymousHttpClient already
    * attaches `x-fingerprint`, so the backend can fall back to a probabilistic
    * IP/UA match when no `click_id` is available (iOS without clipboard token).
    */
   async resolve(payload: IAttributionResolveRequest): Promise<AxiosResponse<IAttributionResolveResponse>> {
-    return httpClient.post('/attribution/resolve/', payload);
+    return anonymousHttpClient.post('/attribution/resolve/', payload);
   }
 }
 

--- a/src/operators/auth.ts
+++ b/src/operators/auth.ts
@@ -1,11 +1,11 @@
 import { AxiosResponse } from 'axios';
-import { httpClient } from './common';
+import { anonymousHttpClient, httpClient } from './common';
 import { IAuthCodeResponse, ITokenResponse, IToken, IOAuthTokenRequest, IOAuthTokenResponse } from '@/models';
 import { getBaseUrlAuth } from '@/utils';
 
 class AuthOperator {
   async refreshToken(payload: IToken): Promise<AxiosResponse<ITokenResponse>> {
-    return httpClient.post('/auth/refresh/', payload);
+    return anonymousHttpClient.post('/auth/refresh/', payload);
   }
 
   async getCode(): Promise<AxiosResponse<IAuthCodeResponse>> {
@@ -15,7 +15,7 @@ class AuthOperator {
 
 class SSOOperator {
   async token(payload: IOAuthTokenRequest): Promise<AxiosResponse<IOAuthTokenResponse>> {
-    return httpClient.post('/token', payload, {
+    return anonymousHttpClient.post('/token', payload, {
       baseURL: `${getBaseUrlAuth()}/sso/v1`
     });
   }

--- a/src/operators/chat.ts
+++ b/src/operators/chat.ts
@@ -12,6 +12,7 @@ import {
 } from '@/models';
 import { BASE_URL_API, BASE_URL_X402, ERROR_CODE_API_ERROR, ERROR_CODE_CONTENT_TOO_LARGE } from '@/constants';
 import { currentSiteOrigin } from '@/utils';
+import { requireServiceToken } from '@/utils/requestAuth';
 import { isBrowserToolExecutionState, sanitizeBrowserOrigin } from '@/utils/browserToolExecution';
 import { scenarioPaymentState } from '@/utils/x402/scenarioPayment';
 import {
@@ -52,10 +53,11 @@ class ChatOperator {
         }
         const continuous = walletMode && continuousPaymentActive();
         if (walletMode && !continuous) throw new BaseError(402, 'payment_authorization_required', '');
+        const token = continuous ? options.token : requireServiceToken(options.token);
         const response = await fetch(`${continuous ? BASE_URL_X402 : BASE_URL_API}/aichat2/conversations`, {
           method: 'POST',
           headers: {
-            authorization: `Bearer ${options.token}`,
+            authorization: `Bearer ${token}`,
             ...(continuous ? continuousPaymentHeaders(options.token) : {}),
             'Content-Type': 'application/json',
             Accept: 'text/event-stream',

--- a/src/operators/common.test.ts
+++ b/src/operators/common.test.ts
@@ -1,0 +1,120 @@
+import { AxiosError, type AxiosAdapter, type AxiosRequestConfig } from 'axios';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const state = vi.hoisted(() => ({
+  token: undefined as string | undefined,
+  login: vi.fn(),
+  logout: vi.fn()
+}));
+
+vi.mock('@/store', () => ({
+  default: {
+    get getters() {
+      return {
+        token: { access: state.token },
+        authenticated: !!state.token,
+        user: {},
+        fingerprint: undefined
+      };
+    },
+    get state() {
+      return { token: { access: state.token } };
+    },
+    dispatch: (action: string) => (action === 'logout' ? state.logout() : state.login())
+  }
+}));
+
+vi.mock('@/utils/login', () => ({
+  ensureLoggedIn: () => {
+    state.login();
+    return false;
+  }
+}));
+vi.mock('@/utils/baseUrl', () => ({ getBaseUrlPlatform: () => 'https://platform.acedata.cloud' }));
+vi.mock('@/plugins/telemetry', () => ({ trackApiFailure: vi.fn() }));
+vi.mock('typescript-cookie', () => ({ getCookie: vi.fn() }));
+
+import { anonymousHttpClient, httpClient, optionalHttpClient } from './common';
+import { AuthRequiredError, configureRequestAuth } from '@/utils/requestAuth';
+
+const adapter =
+  (send: (config: unknown) => void): AxiosAdapter =>
+  async (config) => {
+    send(config);
+    return { data: {}, status: 200, statusText: 'OK', headers: {}, config };
+  };
+
+const unauthorizedAdapter: AxiosAdapter = async (config) => {
+  throw new AxiosError('unauthorized', 'ERR_BAD_REQUEST', config, undefined, {
+    data: {},
+    status: 401,
+    statusText: 'Unauthorized',
+    headers: {},
+    config
+  });
+};
+
+const run = (client: typeof httpClient, config: AxiosRequestConfig = {}) => {
+  const send = vi.fn();
+  client.defaults.adapter = adapter(send);
+  return { promise: client.get('/resource', config), send };
+};
+
+beforeEach(() => {
+  state.token = undefined;
+  state.login.mockClear();
+  state.logout.mockClear();
+  configureRequestAuth({
+    getAccountToken: () => state.token,
+    isAuthenticated: () => !!state.token,
+    triggerLogin: state.login
+  });
+});
+
+describe('Platform HTTP auth modes', () => {
+  it('blocks required requests before the adapter and starts login', async () => {
+    const { promise, send } = run(httpClient);
+    await expect(promise).rejects.toBeInstanceOf(AuthRequiredError);
+    expect(send).not.toHaveBeenCalled();
+    expect(state.login).toHaveBeenCalledOnce();
+  });
+
+  it('allows optional guest requests without Authorization', async () => {
+    const { promise, send } = run(optionalHttpClient);
+    await expect(promise).resolves.toMatchObject({ status: 200 });
+    expect(send.mock.calls[0][0].headers.get('Authorization')).toBeUndefined();
+    expect(state.login).not.toHaveBeenCalled();
+  });
+
+  it('adds the account token to optional requests when signed in', async () => {
+    state.token = 'account-token';
+    const { promise, send } = run(optionalHttpClient);
+    await promise;
+    expect(send.mock.calls[0][0].headers.get('Authorization')).toBe('Bearer account-token');
+  });
+
+  it('never adds the account token to anonymous requests', async () => {
+    state.token = 'account-token';
+    const { promise, send } = run(anonymousHttpClient);
+    await promise;
+    expect(send.mock.calls[0][0].headers.get('Authorization')).toBeUndefined();
+  });
+
+  it('logs out an authenticated required request on 401', async () => {
+    state.token = 'expired-token';
+    httpClient.defaults.adapter = unauthorizedAdapter;
+    await expect(httpClient.get('/protected')).rejects.toMatchObject({ response: { status: 401 } });
+    expect(state.logout).toHaveBeenCalledOnce();
+    expect(state.login).not.toHaveBeenCalled();
+  });
+
+  it.each([optionalHttpClient, anonymousHttpClient])(
+    'keeps non-required 401 responses non-interactive',
+    async (client) => {
+      client.defaults.adapter = unauthorizedAdapter;
+      await expect(client.get('/public')).rejects.toMatchObject({ response: { status: 401 } });
+      expect(state.login).not.toHaveBeenCalled();
+      expect(state.logout).not.toHaveBeenCalled();
+    }
+  );
+});

--- a/src/operators/common.ts
+++ b/src/operators/common.ts
@@ -1,38 +1,42 @@
 import store from '@/store';
-import { getBaseUrlPlatform } from '@/utils';
+import { getBaseUrlPlatform } from '@/utils/baseUrl';
+import { ensureLoggedIn } from '@/utils/login';
+import { requireAccountToken } from '@/utils/requestAuth';
 import { trackApiFailure } from '@/plugins/telemetry';
 import { createHttpClient } from '@acedatacloud/core/http';
+import type { AxiosInstance } from 'axios';
 import qs from 'qs';
 import { getCookie } from 'typescript-cookie';
 import { v4 as uuidv4 } from 'uuid';
 
-// The axios instance + interceptor contract now lives in @acedatacloud/core;
-// this configures it with Nexior's token/fingerprint/user sources and 401
-// behavior. Header set (x-request-id / Authorization / accept-language /
-// x-fingerprint / x-user-id) and 4xx/5xx-to-RUM are handled inside the factory.
-const httpClient = createHttpClient({
-  baseURL: `${getBaseUrlPlatform()}/api/v1`,
-  // Without a timeout a stalled mobile connection leaves the promise pending
-  // forever (e.g. SSO code exchange / getUser after Apple login). Fail after
-  // 20s so the caller's catch runs and RUM captures it.
-  timeout: 20000,
-  getToken: () => store.getters.token?.access,
-  getUserId: () => store.getters.user?.id,
-  getFingerprint: () => store.getters.fingerprint,
-  getLocale: () => getCookie('LOCALE'),
-  paramsSerializer: (params) => qs.stringify(params, { arrayFormat: 'repeat' }),
-  generateRequestId: () => uuidv4(),
-  // Fire-and-forget (not awaited) to preserve the original timing: the caller's
-  // rejection runs without waiting for logout to complete.
-  onUnauthorized: () => {
-    // Guests (no token) may browse freely — a 401 on a guest request is
-    // expected (passive catalog/bootstrap calls) and must NOT bounce them to
-    // the login page. Only a logged-in user whose token expired gets logged out.
-    if (store.getters.authenticated) {
-      store.dispatch('logout');
-    }
-  },
-  onApiFailure: trackApiFailure
-});
+type AuthMode = 'required' | 'optional' | 'none';
 
-export { httpClient };
+const createClient = (mode: AuthMode): AxiosInstance => {
+  const client = createHttpClient({
+    baseURL: `${getBaseUrlPlatform()}/api/v1`,
+    timeout: 20000,
+    getToken: () => (mode === 'none' ? undefined : store.getters.token?.access),
+    getUserId: () => (mode === 'none' ? undefined : store.getters.user?.id),
+    getFingerprint: () => store.getters.fingerprint,
+    getLocale: () => getCookie('LOCALE'),
+    paramsSerializer: (params) => qs.stringify(params, { arrayFormat: 'repeat' }),
+    generateRequestId: () => uuidv4(),
+    onUnauthorized: () => {
+      if (mode !== 'required') return;
+      if (store.getters.authenticated) store.dispatch('logout');
+      else ensureLoggedIn();
+    },
+    onApiFailure: trackApiFailure
+  });
+  if (mode === 'required') {
+    client.interceptors.request.use((config) => {
+      requireAccountToken();
+      return config;
+    });
+  }
+  return client;
+};
+
+export const httpClient = createClient('required');
+export const optionalHttpClient = createClient('optional');
+export const anonymousHttpClient = createClient('none');

--- a/src/operators/config.ts
+++ b/src/operators/config.ts
@@ -1,12 +1,12 @@
 import { AxiosResponse } from 'axios';
-import { httpClient } from './common';
+import { anonymousHttpClient } from './common';
 import { IConfigResponse } from '@/models';
 
 class ConfigService {
   key = 'config';
 
   async get(): Promise<AxiosResponse<IConfigResponse>> {
-    return await httpClient.get(`/${this.key}/`);
+    return await anonymousHttpClient.get(`/${this.key}/`);
   }
 }
 

--- a/src/operators/exchange.ts
+++ b/src/operators/exchange.ts
@@ -1,10 +1,10 @@
 import { AxiosResponse } from 'axios';
-import { httpClient } from './common';
+import { anonymousHttpClient } from './common';
 import { IExchangeRateRequest, IExchangeRateResponse } from '@/models';
 
 class ExchangeOperator {
   async rate(payload: IExchangeRateRequest): Promise<AxiosResponse<IExchangeRateResponse>> {
-    return httpClient.post('/exchange-rate', payload);
+    return anonymousHttpClient.post('/exchange-rate', payload);
   }
 }
 

--- a/src/operators/memories.ts
+++ b/src/operators/memories.ts
@@ -2,11 +2,12 @@ import axios from 'axios';
 import { v4 as uuidv4 } from 'uuid';
 import { BASE_URL_API } from '@/constants';
 import { currentSiteOrigin } from '@/utils';
+import { serviceAuthHeaders } from '@/utils/requestAuth';
 
 function headers(token: string) {
   const origin = currentSiteOrigin();
   return {
-    Authorization: `Bearer ${token}`,
+    ...serviceAuthHeaders(token),
     'Content-Type': 'application/json',
     ...(origin ? { 'x-site-origin': origin } : {})
   };

--- a/src/operators/scheduledTasks.ts
+++ b/src/operators/scheduledTasks.ts
@@ -1,11 +1,12 @@
 import axios from 'axios';
 import { BASE_URL_API } from '@/constants';
 import { currentSiteOrigin } from '@/utils';
+import { serviceAuthHeaders } from '@/utils/requestAuth';
 
 function headers(token: string) {
   const origin = currentSiteOrigin();
   return {
-    Authorization: `Bearer ${token}`,
+    ...serviceAuthHeaders(token),
     'Content-Type': 'application/json',
     ...(origin ? { 'x-site-origin': origin } : {})
   };

--- a/src/operators/service.ts
+++ b/src/operators/service.ts
@@ -1,6 +1,7 @@
 import { BaseOperator } from '@acedatacloud/core/operators';
-import { httpClient } from './common';
+import { httpClient, optionalHttpClient } from './common';
 import { IService, IServiceDetailResponse, IServiceListResponse } from '@/models';
+import type { AxiosResponse } from 'axios';
 
 export interface IServiceQuery {
   limit?: number;
@@ -14,6 +15,14 @@ export interface IServiceQuery {
 class ServiceOperator extends BaseOperator<IService, IServiceListResponse, IServiceDetailResponse> {
   constructor() {
     super(httpClient, 'services');
+  }
+
+  override async getAll(query?: IServiceQuery): Promise<AxiosResponse<IServiceListResponse>> {
+    return await optionalHttpClient.get(this.listUrl(), { params: query });
+  }
+
+  override async get(id: string): Promise<AxiosResponse<IServiceDetailResponse>> {
+    return await optionalHttpClient.get(this.detailUrl(id));
   }
 }
 

--- a/src/operators/site.ts
+++ b/src/operators/site.ts
@@ -1,5 +1,5 @@
 import { AxiosResponse } from 'axios';
-import { httpClient } from './common';
+import { httpClient, optionalHttpClient } from './common';
 import { ISite, ISiteDetailResponse, ISiteListResponse } from '@/models';
 
 export interface ISiteQuery {
@@ -15,17 +15,17 @@ class SiteService {
   key = 'sites';
 
   async initialize(data: ISite): Promise<AxiosResponse<ISiteDetailResponse>> {
-    return await httpClient.post(`/${this.key}/initialize/`, data);
+    return await optionalHttpClient.post(`/${this.key}/initialize/`, data);
   }
 
   async getAll(query: ISiteQuery): Promise<AxiosResponse<ISiteListResponse>> {
-    return await httpClient.get(`/${this.key}/`, {
+    return await optionalHttpClient.get(`/${this.key}/`, {
       params: query
     });
   }
 
   async get(id: string): Promise<AxiosResponse<ISiteDetailResponse>> {
-    return await httpClient.get(`/${this.key}/${id}`);
+    return await optionalHttpClient.get(`/${this.key}/${id}`);
   }
 
   async create(data: ISite): Promise<AxiosResponse<ISiteDetailResponse>> {

--- a/src/operators/siteBanner.test.ts
+++ b/src/operators/siteBanner.test.ts
@@ -1,35 +1,42 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { httpClient } from './common';
-import { siteBannerOperator } from './siteBanner';
+
+const clients = vi.hoisted(() => ({
+  required: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
+  anonymous: { get: vi.fn() }
+}));
 
 vi.mock('./common', () => ({
-  httpClient: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() }
+  httpClient: clients.required,
+  anonymousHttpClient: clients.anonymous
 }));
+
+import { siteBannerOperator } from './siteBanner';
 
 describe('siteBannerOperator', () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it('scopes management and public reads', async () => {
-    vi.mocked(httpClient.get).mockResolvedValue({ data: [] });
+  it('scopes management and public reads to their auth clients', async () => {
+    clients.required.get.mockResolvedValue({ data: [] });
+    clients.anonymous.get.mockResolvedValue({ data: [] });
     await siteBannerOperator.getAll({ site: 'site-1', ordering: 'sort_order,created_at' });
     await siteBannerOperator.getPublic('tenant.studio.acedata.cloud');
-    expect(httpClient.get).toHaveBeenNthCalledWith(1, '/site-banners/', {
+    expect(clients.required.get).toHaveBeenCalledWith('/site-banners/', {
       params: { site: 'site-1', ordering: 'sort_order,created_at' }
     });
-    expect(httpClient.get).toHaveBeenNthCalledWith(2, '/site-banners/public/', {
+    expect(clients.anonymous.get).toHaveBeenCalledWith('/site-banners/public/', {
       params: { origin: 'tenant.studio.acedata.cloud' }
     });
   });
 
   it('uses the authenticated CRUD routes', async () => {
-    vi.mocked(httpClient.post).mockResolvedValue({ data: {} });
-    vi.mocked(httpClient.patch).mockResolvedValue({ data: {} });
-    vi.mocked(httpClient.delete).mockResolvedValue({ data: undefined });
+    clients.required.post.mockResolvedValue({ data: {} });
+    clients.required.patch.mockResolvedValue({ data: {} });
+    clients.required.delete.mockResolvedValue({ data: undefined });
     await siteBannerOperator.create({ site: 'site-1', visible: true });
     await siteBannerOperator.update('banner-1', { visible: false });
     await siteBannerOperator.delete('banner-1');
-    expect(httpClient.post).toHaveBeenCalledWith('/site-banners/', { site: 'site-1', visible: true });
-    expect(httpClient.patch).toHaveBeenCalledWith('/site-banners/banner-1/', { visible: false });
-    expect(httpClient.delete).toHaveBeenCalledWith('/site-banners/banner-1/');
+    expect(clients.required.post).toHaveBeenCalledWith('/site-banners/', { site: 'site-1', visible: true });
+    expect(clients.required.patch).toHaveBeenCalledWith('/site-banners/banner-1/', { visible: false });
+    expect(clients.required.delete).toHaveBeenCalledWith('/site-banners/banner-1/');
   });
 });

--- a/src/operators/siteBanner.ts
+++ b/src/operators/siteBanner.ts
@@ -1,5 +1,5 @@
 import type { AxiosResponse } from 'axios';
-import { httpClient } from './common';
+import { anonymousHttpClient, httpClient } from './common';
 import type {
   ISiteBanner,
   ISiteBannerCreateRequest,
@@ -24,7 +24,7 @@ class SiteBannerOperator {
   }
 
   async getPublic(origin: string): Promise<AxiosResponse<ISiteBanner[]>> {
-    return await httpClient.get(`/${this.key}/public/`, { params: { origin } });
+    return await anonymousHttpClient.get(`/${this.key}/public/`, { params: { origin } });
   }
 
   async create(data: ISiteBannerCreateRequest): Promise<AxiosResponse<ISiteBannerDetailResponse>> {

--- a/src/operators/skill.ts
+++ b/src/operators/skill.ts
@@ -1,5 +1,5 @@
 import { AxiosResponse } from 'axios';
-import { httpClient } from './common';
+import { httpClient, optionalHttpClient } from './common';
 import { getBaseUrlAuth } from '@/utils';
 
 /**
@@ -197,15 +197,15 @@ class SkillCatalogOperator {
   key = 'skills';
 
   async list(params: ISkillCatalogListParams = {}): Promise<AxiosResponse<ISkillCatalogPage>> {
-    return httpClient.get(`/${this.key}/`, { ...authApi(), params });
+    return optionalHttpClient.get(`/${this.key}/`, { ...authApi(), params });
   }
 
   async get(id: string): Promise<AxiosResponse<ISkillCatalogItem>> {
-    return httpClient.get(`/${this.key}/${id}/`, authApi());
+    return optionalHttpClient.get(`/${this.key}/${id}/`, authApi());
   }
 
   async categories(): Promise<AxiosResponse<{ namespaces: ISkillCatalogFacet[] }>> {
-    return httpClient.get(`/${this.key}/categories/`, authApi());
+    return optionalHttpClient.get(`/${this.key}/categories/`, authApi());
   }
 
   /**

--- a/src/pages/chat/Conversation.vue
+++ b/src/pages/chat/Conversation.vue
@@ -137,6 +137,7 @@ import { supportsClientTools, isDesktop, isWeb } from '@/utils/surface';
 import { openAuthorizeFlow } from '@/utils/connections/authorizeFlow';
 import { withAuthFrontendSession } from '@/utils/authHandoff';
 import { ensureLoggedIn } from '@/utils/login';
+import { requireAccountToken } from '@/utils/requestAuth';
 import { localExec, type LocalToolSpec } from '@/utils/desktop';
 import { getBaseUrlPlatform } from '@/utils';
 import {
@@ -1169,8 +1170,7 @@ export default defineComponent({
      */
     async _hostToolResultImage(image: string): Promise<string | null> {
       if (!image || !image.startsWith('data:')) return image || null;
-      const accessToken = this.$store.getters.token?.access;
-      if (!accessToken) return null;
+      const accessToken = requireAccountToken();
       try {
         const blob = await (await fetch(image)).blob();
         const ext = (blob.type.split('/')[1] || 'png').split(';')[0];

--- a/src/pages/console/usage/List.vue
+++ b/src/pages/console/usage/List.vue
@@ -594,6 +594,7 @@ import {
   ElMessage
 } from 'element-plus';
 import qs from 'qs';
+import { requireAccountToken } from '@/utils/requestAuth';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 import { getBaseUrlPlatform } from '@/utils';
 import { getX402CopyableTransaction, getX402UsagePayment, isX402Usage, omitX402Metadata } from '@/utils/usagePayment';
@@ -1422,7 +1423,7 @@ export default defineComponent({
 
       this.exporting = true;
       try {
-        const response = await fetch(url, { headers: { authorization: `Bearer ${token}` } });
+        const response = await fetch(url, { headers: { authorization: `Bearer ${requireAccountToken()}` } });
         if (!response.ok || !response.body) {
           throw new Error(`export failed: ${response.status}`);
         }

--- a/src/plugins/telemetry.ts
+++ b/src/plugins/telemetry.ts
@@ -11,6 +11,7 @@
  *   App:     Ace Data Cloud (应用ID 154475, business system rum-vK9sZMBo)
  */
 import { createTelemetry } from '@acedatacloud/core/telemetry';
+import { isAuthTransitionError } from '@/utils/requestAuth';
 
 const PROJECT_ID = 'LlKeKIj1mDzkYrY6na';
 const HOST_URL = 'https://rumt-zh.com';
@@ -38,6 +39,7 @@ export function instrumentGeneration<T>(service: string, promise: Promise<T>): P
       return data;
     },
     (error) => {
+      if (isAuthTransitionError(error)) throw error;
       const paymentError = error?.name === 'X402PaymentError' ? error?.paymentError : undefined;
       track(paymentError ? 'x402_payment_failed' : 'generation_failed', {
         service,

--- a/src/router/authPolicy.test.ts
+++ b/src/router/authPolicy.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { requiresLogin } from './authPolicy';
+
+describe('requiresLogin', () => {
+  it.each([
+    '/console',
+    '/console/connectors',
+    '/distribution',
+    '/settings/profile',
+    '/coding-bridge',
+    '/poivelle',
+    '/chatgpt/call',
+    '/chatgpt/scheduled',
+    '/chatgpt/artifacts'
+  ])('protects account-owned route %s', (path) => {
+    expect(requiresLogin(path)).toBe(true);
+  });
+
+  it.each([
+    '/',
+    '/chatgpt/conversations',
+    '/chatgpt/conversations/example',
+    '/nanobanana',
+    '/seedance',
+    '/openaiimage'
+  ])('keeps guest-browsable route %s public', (path) => {
+    expect(requiresLogin(path)).toBe(false);
+  });
+
+  it('does not match lookalike prefixes', () => {
+    expect(requiresLogin('/consolex')).toBe(false);
+    expect(requiresLogin('/chatgpt/callback')).toBe(false);
+  });
+});

--- a/src/router/authPolicy.ts
+++ b/src/router/authPolicy.ts
@@ -1,0 +1,13 @@
+const AUTH_REQUIRED_PREFIXES = [
+  '/console',
+  '/distribution',
+  '/settings',
+  '/coding-bridge',
+  '/poivelle',
+  '/chatgpt/call',
+  '/chatgpt/scheduled',
+  '/chatgpt/artifacts'
+];
+
+export const requiresLogin = (path: string): boolean =>
+  AUTH_REQUIRED_PREFIXES.some((prefix) => path === prefix || path.startsWith(`${prefix}/`));

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -90,17 +90,8 @@ import { evaluateUserIdGuard } from '@/utils/crossSiteUser';
 import { handleChunkLoadError } from '@/utils/chunkLoadError';
 import { loginRedirect } from '@/utils/login';
 import { isNative, isDesktop } from '@/utils/surface';
+import { requiresLogin } from './authPolicy';
 import { trackSitePageView } from '@/utils/siteAnalytics';
-
-// Sections that require a logged-in user — guests hitting these are sent to the
-// login flow (web: redirect preserving the target; native/desktop: in-app
-// popup). Everything else (AI service pages, home) is browsable as a guest;
-// login is deferred until they actually start an operation. Keep this list in
-// sync when adding account/billing-style routes.
-const AUTH_REQUIRED_PREFIXES = ['/console', '/distribution', '/settings', '/coding-bridge', '/poivelle'];
-
-const requiresLogin = (path: string): boolean =>
-  AUTH_REQUIRED_PREFIXES.some((prefix) => path === prefix || path.startsWith(`${prefix}/`));
 
 // SEO metadata per route path prefix
 const ROUTE_SEO: Record<string, { title: string; description: string; keywords: string[]; category: string }> = {

--- a/src/store/codingBridge/actions.ts
+++ b/src/store/codingBridge/actions.ts
@@ -674,7 +674,7 @@ export const connect = ({
   }
   socket?.close();
   commit('setConnection', 'connecting');
-  socket = new CodingBridgeSocket(token, {
+  socket = new CodingBridgeSocket({
     onOpen: () => {
       commit('setConnection', 'connected');
       // A dropped socket is the only way the relay can have restarted (it is

--- a/src/store/common/actions.test.ts
+++ b/src/store/common/actions.test.ts
@@ -8,7 +8,11 @@ vi.mock('@/operators', () => ({
   siteOperator: siteOperatorMock
 }));
 
-import { getSite } from './actions';
+vi.mock('@/store/lazy', () => ({
+  getRegisteredLazyModules: () => ['nanobanana', 'chat']
+}));
+
+import { getSite, resetAll } from './actions';
 
 describe('store/common getSite', () => {
   const commit = vi.fn();
@@ -31,5 +35,20 @@ describe('store/common getSite', () => {
 
     await expect(getSite({ state, commit } as never)).resolves.toBeUndefined();
     expect(commit).not.toHaveBeenCalled();
+  });
+});
+
+describe('store/common resetAll', () => {
+  it('clears account-owned state from the root and registered app modules', async () => {
+    const commit = vi.fn();
+    const dispatch = vi.fn().mockResolvedValue(undefined);
+
+    await resetAll({ commit, dispatch } as any);
+
+    expect(commit).toHaveBeenCalledWith('resetToken');
+    expect(commit).toHaveBeenCalledWith('resetUser');
+    expect(commit).toHaveBeenCalledWith('setApplications', undefined);
+    expect(dispatch).toHaveBeenCalledWith('nanobanana/resetAll');
+    expect(dispatch).toHaveBeenCalledWith('chat/resetAll');
   });
 });

--- a/src/store/common/actions.ts
+++ b/src/store/common/actions.ts
@@ -16,9 +16,15 @@ import { getBaseUrlAuth, getBaseUrlStudio, getInviterId, loginRedirect } from '@
 import { isIframeLoginEnabled } from '@/utils/loginMethod';
 import { isNative, isDesktop } from '@/utils/surface';
 
-export const resetAll = ({ commit }: ActionContext<IRootState, IRootState>) => {
+export const resetAll = async ({ commit, dispatch }: ActionContext<IRootState, IRootState>) => {
   commit('resetToken');
   commit('resetUser');
+  commit('setApplications', undefined);
+
+  const { getRegisteredLazyModules } = await import('@/store/lazy');
+  for (const name of getRegisteredLazyModules()) {
+    await dispatch(`${name}/resetAll`);
+  }
 };
 
 export const resetUser = ({ commit }: ActionContext<IRootState, IRootState>) => {
@@ -257,15 +263,6 @@ export const login = async (
 
 export const logout = async ({ dispatch, commit }: ActionContext<IRootState, IRootState>) => {
   await dispatch('resetAll');
-  // Per-app store modules are registered lazily (see `src/store/lazy.ts` and
-  // the router's `beforeEach` hook). Only fan out the reset to modules that
-  // are actually registered in the running session — there is nothing to
-  // reset for a module the user never opened, and dispatching to an
-  // unregistered module would emit a Vuex warning.
-  const { getRegisteredLazyModules } = await import('@/store/lazy');
-  for (const name of getRegisteredLazyModules()) {
-    await dispatch(`${name}/resetAll`);
-  }
   if (isNative() || isDesktop() || isIframeLoginEnabled()) {
     // On native AND desktop, show the in-app login popup instead of navigating
     // to an external auth URL (which on native opens Chrome → localhost, and on

--- a/src/store/common/actions.ts
+++ b/src/store/common/actions.ts
@@ -249,6 +249,7 @@ export const login = async (
   } else {
     commit('setAuth', {
       flow: 'redirect',
+      visible: true,
       redirect,
       action: 'login'
     });

--- a/src/utils/codingBridgeSocket.ts
+++ b/src/utils/codingBridgeSocket.ts
@@ -11,6 +11,7 @@ import {
   CB_RECONNECT_MIN_MS,
   CB_RECONNECT_MAX_MS
 } from '@/constants';
+import { requireAccountToken } from './requestAuth';
 import { ICodingBridgeNode } from '@/models';
 
 export interface ICodingBridgeSocketHandlers {
@@ -74,8 +75,8 @@ export class CodingBridgeSocket {
   private reconnectTimer: ReturnType<typeof setTimeout> | undefined;
   private closedByUser = false;
 
-  constructor(token: string, handlers: ICodingBridgeSocketHandlers) {
-    this.token = token;
+  constructor(handlers: ICodingBridgeSocketHandlers) {
+    this.token = requireAccountToken();
     this.handlers = handlers;
   }
 

--- a/src/utils/crossSiteUser.test.ts
+++ b/src/utils/crossSiteUser.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  dispatch: vi.fn(),
+  loginRedirect: vi.fn(),
+  iframeLogin: false
+}));
+
+vi.mock('@/store', () => ({
+  default: {
+    getters: { user: { id: 'current-user' } },
+    dispatch: mocks.dispatch
+  }
+}));
+
+vi.mock('./login', () => ({
+  loginRedirect: mocks.loginRedirect
+}));
+
+vi.mock('./loginMethod', () => ({
+  isIframeLoginEnabled: () => mocks.iframeLogin
+}));
+
+vi.mock('./is', () => ({
+  isMainOfficial: () => true
+}));
+
+import { evaluateUserIdGuard } from './crossSiteUser';
+
+describe('evaluateUserIdGuard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.iframeLogin = false;
+  });
+
+  it('clears all account-owned state before redirecting a mismatched user', () => {
+    const result = evaluateUserIdGuard({
+      path: '/nanobanana',
+      query: { user_id: 'expected-user', prompt: 'cat' }
+    } as any);
+
+    expect(result).toEqual({ kind: 'mismatch' });
+    expect(mocks.dispatch).toHaveBeenCalledWith('resetAll');
+    expect(mocks.dispatch).not.toHaveBeenCalledWith('resetToken');
+    expect(mocks.dispatch).not.toHaveBeenCalledWith('resetUser');
+    expect(mocks.loginRedirect).toHaveBeenCalledWith({ redirect: '/nanobanana?prompt=cat' });
+  });
+});

--- a/src/utils/crossSiteUser.ts
+++ b/src/utils/crossSiteUser.ts
@@ -138,8 +138,7 @@ export const evaluateUserIdGuard = (to: RouteLocationNormalized): UserIdGuardDec
 
   // Mismatch (or not logged in). Clear local session so the next render does
   // not flash the wrong identity, then bounce through the normal SSO flow.
-  store.dispatch('resetToken');
-  store.dispatch('resetUser');
+  store.dispatch('resetAll');
   const redirect = buildRedirectWithoutUserId(to);
   if (isIframeLoginEnabled()) {
     store.dispatch('login', { redirect });

--- a/src/utils/dropUploadMixin.test.ts
+++ b/src/utils/dropUploadMixin.test.ts
@@ -1,6 +1,10 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { defineComponent, nextTick } from 'vue';
+
+const auth = vi.hoisted(() => ({ allowed: true, ensure: vi.fn(() => auth.allowed) }));
+
+vi.mock('@/utils/login', () => ({ ensureLoggedIn: auth.ensure }));
 import { mount } from '@vue/test-utils';
 import { ElUpload } from 'element-plus';
 import { dropUploadMixin } from './dropUploadMixin';
@@ -30,6 +34,8 @@ const Host = defineComponent({
 });
 
 afterEach(() => {
+  auth.allowed = true;
+  auth.ensure.mockClear();
   isDraggingFiles.value = false;
   activeDropTargetId.value = null;
   document.body.innerHTML = '';
@@ -101,6 +107,29 @@ describe('dropUploadMixin (mounted)', () => {
     const passed = spy.mock.calls[0][0] as File;
     expect(passed.name.endsWith('.png')).toBe(true);
 
+    wrapper.unmount();
+  });
+
+  it('starts login instead of forwarding a dropped file when signed out', async () => {
+    auth.allowed = false;
+    const wrapper = mount(Host, { attachTo: document.body });
+    await nextTick();
+    const uploader: any = (wrapper.vm as any).$refs.uploader;
+    const spy = vi.spyOn(uploader, 'handleStart');
+    const file = makeFile();
+    const event = new Event('drop', { bubbles: true, cancelable: true }) as any;
+    event.dataTransfer = {
+      types: ['Files'],
+      files: [file],
+      items: [{ kind: 'file', getAsFile: () => file }]
+    };
+    Object.defineProperty(event, 'target', { value: wrapper.element });
+
+    document.dispatchEvent(event);
+    await nextTick();
+
+    expect(auth.ensure).toHaveBeenCalledOnce();
+    expect(spy).not.toHaveBeenCalled();
     wrapper.unmount();
   });
 

--- a/src/utils/dropUploadMixin.ts
+++ b/src/utils/dropUploadMixin.ts
@@ -21,6 +21,7 @@
 import type { ComponentPublicInstance } from 'vue';
 import { watch, type WatchStopHandle } from 'vue';
 import { forwardFileToUploader, renameForDedup } from '@/utils/uploadShared';
+import { ensureLoggedIn } from '@/utils/login';
 import { activeDropTargetId, isDraggingFiles, registerDropUploadTarget } from '@/utils/dropUpload';
 import i18n from '@/i18n';
 
@@ -137,7 +138,7 @@ export const dropUploadMixin = {
         isDisabled: () => Boolean(this.dropDisabled),
         getEl: () => (this.$el instanceof HTMLElement ? this.$el : null),
         handleFile: (file: File) => {
-          if (this.dropDisabled) return;
+          if (this.dropDisabled || !ensureLoggedIn()) return;
           forwardFileToUploader(this.$refs?.uploader, renameForDedup(file));
         }
       });

--- a/src/utils/login.test.ts
+++ b/src/utils/login.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const store = vi.hoisted(() => ({
+  getters: { authenticated: false },
+  state: { auth: { visible: false } },
+  dispatch: vi.fn()
+}));
+
+vi.mock('@/store', () => ({ default: store }));
+vi.mock('./baseUrl', () => ({
+  getBaseUrlAuth: () => 'https://auth.example.com',
+  getBaseUrlStudio: () => 'https://studio.example.com'
+}));
+vi.mock('typescript-cookie', () => ({ getCookie: vi.fn() }));
+
+import { ensureLoggedIn } from './login';
+
+describe('ensureLoggedIn', () => {
+  beforeEach(() => {
+    store.getters.authenticated = false;
+    store.state.auth.visible = false;
+    store.dispatch.mockClear();
+  });
+
+  it('allows authenticated operations', () => {
+    store.getters.authenticated = true;
+    expect(ensureLoggedIn()).toBe(true);
+    expect(store.dispatch).not.toHaveBeenCalled();
+  });
+
+  it('starts login for a guest', () => {
+    expect(ensureLoggedIn()).toBe(false);
+    expect(store.dispatch).toHaveBeenCalledOnce();
+    expect(store.dispatch).toHaveBeenCalledWith('login');
+  });
+
+  it('deduplicates concurrent login triggers', () => {
+    store.state.auth.visible = true;
+    expect(ensureLoggedIn()).toBe(false);
+    expect(store.dispatch).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/login.ts
+++ b/src/utils/login.ts
@@ -54,6 +54,8 @@ export const ensureLoggedIn = (): boolean => {
   if (store.getters.authenticated) {
     return true;
   }
-  store.dispatch('login');
+  if (!store.state.auth?.visible) {
+    store.dispatch('login');
+  }
   return false;
 };

--- a/src/utils/pasteUploadMixin.test.ts
+++ b/src/utils/pasteUploadMixin.test.ts
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent, nextTick } from 'vue';
+import { mount } from '@vue/test-utils';
+import { ElUpload } from 'element-plus';
+
+const auth = vi.hoisted(() => ({ allowed: true, ensure: vi.fn(() => auth.allowed) }));
+
+vi.mock('@/utils/login', () => ({ ensureLoggedIn: auth.ensure }));
+
+import { pasteUploadMixin } from './pasteUploadMixin';
+
+const Host = defineComponent({
+  name: 'PasteHost',
+  components: { ElUpload },
+  mixins: [pasteUploadMixin],
+  template: `<div><el-upload ref="uploader" accept=".png" :auto-upload="false" action="#"><button>u</button></el-upload></div>`
+});
+
+const pasteFile = (target: HTMLElement) => {
+  const file = new File([new Uint8Array([1])], 'pic.png', { type: 'image/png' });
+  const event = new Event('paste', { bubbles: true, cancelable: true }) as any;
+  event.clipboardData = { items: [{ kind: 'file', getAsFile: () => file }] };
+  Object.defineProperty(event, 'target', { value: target });
+  document.dispatchEvent(event);
+};
+
+afterEach(() => {
+  auth.allowed = true;
+  auth.ensure.mockClear();
+  document.body.innerHTML = '';
+});
+
+describe('pasteUploadMixin', () => {
+  it('forwards a pasted file while authenticated', async () => {
+    const wrapper = mount(Host, { attachTo: document.body });
+    await nextTick();
+    const spy = vi.spyOn((wrapper.vm as any).$refs.uploader, 'handleStart');
+
+    pasteFile(wrapper.element as HTMLElement);
+    await nextTick();
+
+    expect(auth.ensure).toHaveBeenCalledOnce();
+    expect(spy).toHaveBeenCalledOnce();
+    wrapper.unmount();
+  });
+
+  it('starts login instead of forwarding a pasted file when signed out', async () => {
+    auth.allowed = false;
+    const wrapper = mount(Host, { attachTo: document.body });
+    await nextTick();
+    const spy = vi.spyOn((wrapper.vm as any).$refs.uploader, 'handleStart');
+
+    pasteFile(wrapper.element as HTMLElement);
+    await nextTick();
+
+    expect(auth.ensure).toHaveBeenCalledOnce();
+    expect(spy).not.toHaveBeenCalled();
+    wrapper.unmount();
+  });
+});

--- a/src/utils/pasteUploadMixin.ts
+++ b/src/utils/pasteUploadMixin.ts
@@ -13,6 +13,7 @@
 import type { ComponentPublicInstance } from 'vue';
 import { registerPasteUploadTarget } from '@/utils/pasteUpload';
 import { forwardFileToUploader } from '@/utils/uploadShared';
+import { ensureLoggedIn } from '@/utils/login';
 
 interface IPasteMixinThis extends ComponentPublicInstance {
   pasteAccept?: string;
@@ -34,6 +35,7 @@ export const pasteUploadMixin = {
       accept: this.pasteAccept,
       el,
       handleFile: (file: File) => {
+        if (!ensureLoggedIn()) return;
         forwardFileToUploader(this.$refs?.uploader, file);
       }
     });

--- a/src/utils/realtimeClient.ts
+++ b/src/utils/realtimeClient.ts
@@ -1,4 +1,5 @@
 import { REALTIME_DEFAULT_VOICE, REALTIME_SAMPLE_RATE, WS_URL_REALTIME } from '@/constants';
+import { requireServiceToken } from './requestAuth';
 
 export type RealtimeStatus = 'connecting' | 'connected' | 'disconnected' | 'error';
 
@@ -84,7 +85,7 @@ export class RealtimeClient {
     // sanitizer drops the required session.type and GA nests voice under audio.output.
     const url =
       `${WS_URL_REALTIME}?model=${encodeURIComponent(this.model)}` + `&voice=${encodeURIComponent(this.voice)}`;
-    this.ws = new WebSocket(url, ['realtime', `acedata-token.${this.token}`]);
+    this.ws = new WebSocket(url, ['realtime', `acedata-token.${requireServiceToken(this.token)}`]);
 
     this.ws.onopen = () => {
       if (this.disposed) {

--- a/src/utils/requestAuth.test.ts
+++ b/src/utils/requestAuth.test.ts
@@ -1,0 +1,133 @@
+import axios, { type AxiosAdapter, type AxiosRequestConfig } from 'axios';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const auth = {
+  accountToken: undefined as string | undefined,
+  ensureLoggedIn: vi.fn()
+};
+
+import {
+  AuthRequiredError,
+  CredentialNotReadyError,
+  configureRequestAuth,
+  installServiceRequestAuthGuard,
+  requireAccountToken,
+  requireServiceToken
+} from './requestAuth';
+
+const adapter =
+  (send: (config: unknown) => void): AxiosAdapter =>
+  async (config) => {
+    send(config);
+    return { data: {}, status: 200, statusText: 'OK', headers: {}, config };
+  };
+
+const request = (config: AxiosRequestConfig, send = vi.fn()) => {
+  const client = axios.create();
+  installServiceRequestAuthGuard(client);
+  client.defaults.adapter = adapter(send);
+  return { promise: client.request(config), send };
+};
+
+beforeEach(() => {
+  auth.accountToken = undefined;
+  auth.ensureLoggedIn.mockClear();
+  configureRequestAuth({
+    getAccountToken: () => auth.accountToken,
+    isAuthenticated: () => !!auth.accountToken,
+    triggerLogin: auth.ensureLoggedIn
+  });
+});
+
+describe('request auth tokens', () => {
+  it('starts login when an account token is required for a guest', () => {
+    expect(() => requireAccountToken()).toThrow(AuthRequiredError);
+    expect(auth.ensureLoggedIn).toHaveBeenCalledOnce();
+  });
+
+  it('distinguishes signed-in credential provisioning from signed-out auth', () => {
+    auth.accountToken = 'account-token';
+    expect(() => requireServiceToken(undefined)).toThrow(CredentialNotReadyError);
+    expect(auth.ensureLoggedIn).not.toHaveBeenCalled();
+  });
+
+  it('returns a valid service credential unchanged', () => {
+    expect(requireServiceToken('service-token')).toBe('service-token');
+  });
+});
+
+describe('service API request guard', () => {
+  it('blocks a guest API request before the adapter and starts login', async () => {
+    const { promise, send } = request({
+      baseURL: 'https://api.acedata.cloud',
+      url: '/suno/audios',
+      method: 'post',
+      headers: { authorization: 'Bearer undefined' }
+    });
+
+    await expect(promise).rejects.toBeInstanceOf(AuthRequiredError);
+    expect(send).not.toHaveBeenCalled();
+    expect(auth.ensureLoggedIn).toHaveBeenCalledOnce();
+  });
+
+  it('blocks a signed-in request while its service credential is not ready', async () => {
+    auth.accountToken = 'account-token';
+    const { promise, send } = request({
+      baseURL: 'https://api.acedata.cloud',
+      url: '/suno/audios',
+      method: 'post',
+      headers: { authorization: 'Bearer null' }
+    });
+
+    await expect(promise).rejects.toBeInstanceOf(CredentialNotReadyError);
+    expect(send).not.toHaveBeenCalled();
+    expect(auth.ensureLoggedIn).not.toHaveBeenCalled();
+  });
+
+  it('allows an API request carrying a valid service credential', async () => {
+    const { promise, send } = request({
+      baseURL: 'https://api.acedata.cloud',
+      url: '/suno/audios',
+      method: 'post',
+      headers: { authorization: 'Bearer service-token' }
+    });
+
+    await expect(promise).resolves.toMatchObject({ status: 200 });
+    expect(send).toHaveBeenCalledOnce();
+  });
+
+  it.each(['https://x402.acedata.cloud', 'https://platform.acedata.cloud', 'https://example.com'])(
+    'does not apply service-token policy to %s',
+    async (baseURL) => {
+      const { promise, send } = request({ baseURL, url: '/resource', method: 'post' });
+      await expect(promise).resolves.toMatchObject({ status: 200 });
+      expect(send).toHaveBeenCalledOnce();
+      expect(auth.ensureLoggedIn).not.toHaveBeenCalled();
+    }
+  );
+});
+
+describe('default axios service operators', () => {
+  it('guards a real default-axios request after installation', async () => {
+    const send = vi.fn();
+    const off = installServiceRequestAuthGuard(axios);
+    const previousAdapter = axios.defaults.adapter;
+    axios.defaults.adapter = adapter(send);
+    try {
+      await expect(
+        axios.post(
+          '/flux/images',
+          {},
+          {
+            baseURL: 'https://api.acedata.cloud',
+            headers: { authorization: 'Bearer undefined' }
+          }
+        )
+      ).rejects.toBeInstanceOf(AuthRequiredError);
+      expect(send).not.toHaveBeenCalled();
+    } finally {
+      axios.defaults.adapter = previousAdapter;
+      off();
+    }
+  });
+});

--- a/src/utils/requestAuth.ts
+++ b/src/utils/requestAuth.ts
@@ -1,0 +1,85 @@
+import axios, { type AxiosInstance, type InternalAxiosRequestConfig } from 'axios';
+import { BASE_URL_API } from '@/constants';
+
+interface RequestAuthRuntime {
+  getAccountToken: () => string | undefined;
+  isAuthenticated: () => boolean;
+  triggerLogin: () => void;
+}
+
+let runtime: RequestAuthRuntime = {
+  getAccountToken: () => undefined,
+  isAuthenticated: () => false,
+  triggerLogin: () => undefined
+};
+
+export const configureRequestAuth = (next: RequestAuthRuntime): void => {
+  runtime = next;
+};
+
+export class AuthRequiredError extends Error {
+  readonly code = 'auth_required';
+
+  constructor() {
+    super('Authentication required');
+    this.name = 'AuthRequiredError';
+  }
+}
+
+export class CredentialNotReadyError extends Error {
+  readonly code = 'credential_not_ready';
+
+  constructor() {
+    super('Service credential is not ready');
+    this.name = 'CredentialNotReadyError';
+  }
+}
+
+export const isAuthTransitionError = (error: unknown): boolean =>
+  error instanceof AuthRequiredError || error instanceof CredentialNotReadyError;
+
+export const requireAccountToken = (): string => {
+  const token = runtime.getAccountToken();
+  if (typeof token === 'string' && token.trim()) return token;
+  runtime.triggerLogin();
+  throw new AuthRequiredError();
+};
+
+export const requireServiceToken = (token: string | undefined | null): string => {
+  if (typeof token === 'string' && token.trim()) return token;
+  if (!runtime.isAuthenticated()) {
+    runtime.triggerLogin();
+    throw new AuthRequiredError();
+  }
+  throw new CredentialNotReadyError();
+};
+
+export const serviceAuthHeaders = (token: string | undefined | null): Record<string, string> => ({
+  Authorization: `Bearer ${requireServiceToken(token)}`
+});
+
+const bearerToken = (config: InternalAxiosRequestConfig): string | undefined => {
+  const header = config.headers?.get?.('authorization') ?? config.headers?.get?.('Authorization');
+  if (typeof header !== 'string') return undefined;
+  const match = /^Bearer\s+(.+)$/i.exec(header.trim());
+  const token = match?.[1]?.trim();
+  if (!token || /^(undefined|null)$/i.test(token)) return undefined;
+  return token;
+};
+
+const requestOrigin = (config: InternalAxiosRequestConfig): string | undefined => {
+  try {
+    return new URL(config.url || '', config.baseURL || window.location.origin).origin;
+  } catch {
+    return undefined;
+  }
+};
+
+export const installServiceRequestAuthGuard = (client: AxiosInstance = axios): (() => void) => {
+  const interceptor = client.interceptors.request.use((config) => {
+    if (requestOrigin(config) !== new URL(BASE_URL_API).origin) return config;
+    requireServiceToken(bearerToken(config));
+    return config;
+  });
+  return () => client.interceptors.request.eject(interceptor);
+};

--- a/src/utils/requestAuthCoverage.test.ts
+++ b/src/utils/requestAuthCoverage.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const root = resolve(import.meta.dirname, '..');
+const source = (path: string) => readFileSync(resolve(root, path), 'utf8');
+
+const PROTECTED_RAW_REQUESTS: Record<string, string[]> = {
+  'operators/chat.ts': ['requireServiceToken(options.token)'],
+  'utils/speechRecognition.ts': ['requireServiceToken(token)'],
+  'utils/realtimeClient.ts': ['requireServiceToken(this.token)'],
+  'utils/codingBridgeSocket.ts': ['requireAccountToken()'],
+  'components/common/ApiCodeDialog.vue': ['requireServiceToken(this.token)'],
+  'pages/chat/Conversation.vue': ['requireAccountToken()'],
+  'pages/console/usage/List.vue': ['requireAccountToken()'],
+  'components/fish/model/Recorder.vue': ['requireAccountToken()'],
+  'components/suno/config/UploadAudio.vue': ['requireAccountToken()']
+};
+
+const EXPLICIT_ANONYMOUS_RAW_REQUESTS: Record<string, string[]> = {
+  'operators/chat.ts': [`fetch(\`${'${BASE_URL_API}'}/aichat2/shared\``],
+  'pages/chat/Conversation.vue': [`fetch(\`${'${BASE_URL_API}'}/aichat2/health\`)`]
+};
+
+describe('request auth coverage', () => {
+  it.each(Object.entries(PROTECTED_RAW_REQUESTS))('%s classifies protected raw requests', (path, markers) => {
+    const content = source(path);
+    for (const marker of markers) expect(content).toContain(marker);
+  });
+
+  it.each(Object.entries(EXPLICIT_ANONYMOUS_RAW_REQUESTS))(
+    '%s keeps reviewed anonymous requests explicit',
+    (path, markers) => {
+      const content = source(path);
+      for (const marker of markers) expect(content).toContain(marker);
+    }
+  );
+
+  it('keeps anonymous and optional mutations on the reviewed bootstrap allowlist', () => {
+    const operatorDir = resolve(root, 'operators');
+    const found = readdirSync(operatorDir)
+      .filter((name) => name.endsWith('.ts') && !name.endsWith('.test.ts'))
+      .flatMap((name) => {
+        const content = readFileSync(resolve(operatorDir, name), 'utf8');
+        return [
+          ...content.matchAll(/(anonymousHttpClient|optionalHttpClient)\.(post|put|patch|delete)\(([^\n]+)/g)
+        ].map((match) => `${name}:${match[1]}.${match[2]}:${match[3].trim()}`);
+      })
+      .sort();
+    expect(found).toEqual(
+      [
+        "attribution.ts:anonymousHttpClient.post:'/attribution/resolve/', payload);",
+        "auth.ts:anonymousHttpClient.post:'/auth/refresh/', payload);",
+        "auth.ts:anonymousHttpClient.post:'/token', payload, {",
+        "exchange.ts:anonymousHttpClient.post:'/exchange-rate', payload);",
+        'site.ts:optionalHttpClient.post:`/${this.key}/initialize/`, data);'
+      ].sort()
+    );
+  });
+
+  it('keeps every WebSocket constructor on the protected allowlist', () => {
+    const utilsDir = resolve(root, 'utils');
+    const found = readdirSync(utilsDir)
+      .filter((name) => name.endsWith('.ts') && !name.endsWith('.test.ts'))
+      .filter((name) => readFileSync(resolve(utilsDir, name), 'utf8').includes('new WebSocket'))
+      .sort();
+    expect(found).toEqual(['codingBridgeSocket.ts', 'realtimeClient.ts']);
+  });
+
+  it('installs the default Axios service guard before bootstrap requests', () => {
+    const main = source('main.ts');
+    expect(main.indexOf('configureRequestAuth({')).toBeGreaterThan(-1);
+    expect(main.indexOf('installServiceRequestAuthGuard();')).toBeGreaterThan(-1);
+    expect(main.indexOf('installServiceRequestAuthGuard();')).toBeLessThan(main.indexOf('resolveDeferredInviterId()'));
+  });
+});

--- a/src/utils/speechRecognition.ts
+++ b/src/utils/speechRecognition.ts
@@ -1,4 +1,5 @@
 import { BASE_URL_API } from '@/constants';
+import { requireServiceToken } from './requestAuth';
 
 export type SpeechRecognitionErrorCode =
   | 'permission-denied'
@@ -74,7 +75,7 @@ async function transcribeAudio(audio: Blob, fileName: string, language: string, 
 
   const response = await fetch(`${BASE_URL_API}/v1/audio/transcriptions`, {
     method: 'POST',
-    headers: { Authorization: `Bearer ${token}` },
+    headers: { Authorization: `Bearer ${requireServiceToken(token)}` },
     body: form
   });
   if (!response.ok) throw new Error(`transcription request failed (${response.status})`);

--- a/src/utils/uploadAuthGuard.test.ts
+++ b/src/utils/uploadAuthGuard.test.ts
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+const auth = vi.hoisted(() => ({ allowed: true, ensure: vi.fn(() => auth.allowed) }));
+
+vi.mock('./login', () => ({ ensureLoggedIn: auth.ensure }));
+
+import { ensureUploadAuthenticated, installUploadAuthGuard } from './uploadAuthGuard';
+
+const mountUpload = () => {
+  const upload = document.createElement('div');
+  upload.className = 'el-upload';
+  const button = document.createElement('button');
+  const input = document.createElement('input');
+  input.type = 'file';
+  upload.append(button, input);
+  document.body.appendChild(upload);
+  return { upload, button, input };
+};
+
+afterEach(() => {
+  auth.allowed = true;
+  auth.ensure.mockClear();
+  document.body.innerHTML = '';
+});
+
+describe('installUploadAuthGuard', () => {
+  it('blocks a signed-out upload click and starts login', () => {
+    const ensure = vi.fn(() => false);
+    const off = installUploadAuthGuard(document, ensure);
+    const { button } = mountUpload();
+    const downstream = vi.fn();
+    button.addEventListener('click', downstream);
+
+    const allowed = button.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+
+    expect(allowed).toBe(false);
+    expect(ensure).toHaveBeenCalledOnce();
+    expect(downstream).not.toHaveBeenCalled();
+    off();
+  });
+
+  it('allows authenticated upload clicks', () => {
+    const ensure = vi.fn(() => true);
+    const off = installUploadAuthGuard(document, ensure);
+    const { button } = mountUpload();
+    const downstream = vi.fn();
+    button.addEventListener('click', downstream);
+
+    const allowed = button.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+
+    expect(allowed).toBe(true);
+    expect(downstream).toHaveBeenCalledOnce();
+    off();
+  });
+
+  it('blocks a file change fallback and clears the selected value', () => {
+    const ensure = vi.fn(() => false);
+    const off = installUploadAuthGuard(document, ensure);
+    const { input } = mountUpload();
+    const downstream = vi.fn();
+    input.addEventListener('change', downstream);
+    Object.defineProperty(input, 'value', { value: 'selected.png', writable: true });
+
+    input.dispatchEvent(new Event('change', { bubbles: true, cancelable: true }));
+
+    expect(input.value).toBe('');
+    expect(downstream).not.toHaveBeenCalled();
+    off();
+  });
+
+  it('guards upload elements mounted after installation and stops after cleanup', () => {
+    const ensure = vi.fn(() => false);
+    const off = installUploadAuthGuard(document, ensure);
+    const { button } = mountUpload();
+
+    button.click();
+    expect(ensure).toHaveBeenCalledOnce();
+
+    off();
+    button.click();
+    expect(ensure).toHaveBeenCalledOnce();
+  });
+});
+
+describe('ensureUploadAuthenticated', () => {
+  it('delegates protected direct uploads to deferred auth', () => {
+    auth.allowed = false;
+    expect(ensureUploadAuthenticated()).toBe(false);
+    expect(auth.ensure).toHaveBeenCalledOnce();
+  });
+});

--- a/src/utils/uploadAuthGuard.ts
+++ b/src/utils/uploadAuthGuard.ts
@@ -1,0 +1,38 @@
+import { ensureLoggedIn } from './login';
+
+type EnsureLoggedIn = () => boolean;
+
+const uploadTarget = (target: EventTarget | null): Element | null => {
+  if (!(target instanceof Element)) return null;
+  if (target.matches('input[type="file"]')) return target;
+  return target.closest('.el-upload');
+};
+
+const blockUpload = (event: Event, ensureLoggedIn: EnsureLoggedIn): void => {
+  if (!uploadTarget(event.target) || ensureLoggedIn()) return;
+  event.preventDefault();
+  event.stopImmediatePropagation();
+  if (event.type === 'change' && event.target instanceof HTMLInputElement) {
+    event.target.value = '';
+  }
+};
+
+export const installUploadAuthGuard = (
+  target: Pick<Document, 'addEventListener' | 'removeEventListener'>,
+  ensureLoggedIn: EnsureLoggedIn
+): (() => void) => {
+  const onClick = (event: Event) => blockUpload(event, ensureLoggedIn);
+  const onChange = (event: Event) => blockUpload(event, ensureLoggedIn);
+  target.addEventListener('click', onClick, true);
+  target.addEventListener('change', onChange, true);
+
+  let active = true;
+  return () => {
+    if (!active) return;
+    active = false;
+    target.removeEventListener('click', onClick, true);
+    target.removeEventListener('change', onChange, true);
+  };
+};
+
+export const ensureUploadAuthenticated = (): boolean => ensureLoggedIn();


### PR DESCRIPTION
## Problem

Studio's deferred-auth model allowed visitors to browse, but authentication was enforced inconsistently at individual UI handlers. Consequences included:

- a signed-out menu alongside a persisted historical credits balance;
- uploads and other protected actions sending unauthenticated requests instead of starting login;
- direct service calls capable of constructing `Bearer undefined`;
- raw fetch/WebSocket paths bypassing the shared Platform client.

## Root cause

There was no request-layer authentication contract. Studio has two token domains — account access tokens for Platform/Auth and per-service credential tokens for `api.acedata.cloud` — plus intentional anonymous protocols such as x402, BYOK testing, public catalogs/share/health/bootstrap. Treating every 401 alike would be incorrect, while relying on buttons left transport-level holes.

## Fix

### Consistent signed-out state
- hide cached Credits state from guests while preserving x402 wallet mode
- clear global/per-service applications and credentials on logout, expiry, invalid startup state, and cross-site identity mismatch

### Early interaction UX
- intercept Element Plus upload clicks, file changes, paste and drag/drop before files leave the device
- guard direct Fish/Suno recorded uploads
- protect private ChatGPT call/scheduled/artifacts routes

### General request-boundary enforcement
- add typed `AuthRequiredError` and `CredentialNotReadyError`
- inject a cycle-free request-auth runtime during client bootstrap
- split Platform/Auth clients into required, optional, and anonymous policies
- make account-owned Platform requests required by default; explicitly classify Site/config/catalog/banner/SSO/attribution bootstrap reads
- install a default Axios preflight for `api.acedata.cloud`: missing/`Bearer undefined` service credentials are blocked before the adapter
- distinguish a guest (start one deduplicated login transition) from a signed-in user whose service credential is still provisioning (no logout, no network)
- apply the same invariant to chat streaming, transcription, realtime and Coding Bridge WebSockets, scheduled tasks, artifacts, memory, file hosting, API Run, and usage export
- keep x402, BYOK, public share/health/catalog and external media paths explicitly anonymous
- suppress expected auth-transition errors from failure telemetry

### Completeness gates
- CI tests fail on unreviewed anonymous/optional mutations
- WebSocket constructors are allowlisted and token-preflighted
- protected raw transports and reviewed anonymous raw requests are contract-tested
- service API requests are tested against a real Axios adapter to prove missing tokens never leave the browser

## Verification

- Node 22 complete suite with bounded workers: **253 files / 1947 tests passed**
- stable suite at default workers: **252 files / 1923 tests passed**
- Electron shell session separately: **24/24 passed** (the only default-full-suite local failure was its macOS 20s process timeout under peak parallel load)
- `npx vue-tsc -b`
- ESLint, Prettier, `git diff --check`, and `npm run verify`
- real local Chrome smoke:
  - signed-out home rendered normally without redirect;
  - signed-in + credential-not-ready returned `CredentialNotReadyError`, made **0** protected API requests, and did not log out;
  - signed-out protected operator call made **0** protected API requests and redirected to Auth;
  - upload intent made **0** file requests and started Auth with the correct return URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)