### PR TITLE
fix: align wallet payment error card

### DIFF
--- a/change/scenario-payment-error-card.json
+++ b/change/scenario-payment-error-card.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Align wallet payment failures with Studio's compact status-card hierarchy across generation scenarios.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/common/ScenarioPaymentMode.test.ts
+++ b/src/components/common/ScenarioPaymentMode.test.ts
@@ -6,7 +6,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const gate = vi.hoisted(() => ({
   enabled: false,
-  states: {} as Record<string, { mode: 'credits' | 'wallet'; quoteUsdc?: string; quoteLoading: boolean }>
+  states: {} as Record<string, { mode: 'credits' | 'wallet'; quoteUsdc?: string; quoteLoading: boolean }>,
+  errors: {} as Record<string, Record<string, unknown> | undefined>
 }));
 
 vi.mock('@/utils/x402/scenarioPayment', () => ({
@@ -15,6 +16,14 @@ vi.mock('@/utils/x402/scenarioPayment', () => ({
     if (!gate.states[scenario]) gate.states[scenario] = reactive({ mode: 'credits', quoteLoading: false });
     return gate.states[scenario];
   }
+}));
+
+vi.mock('@/utils/x402/paymentErrorState', () => ({
+  scenarioPaymentError: (scenario: string) => gate.errors[scenario]
+}));
+
+vi.mock('@acedatacloud/core/x402', () => ({
+  resolveX402PaymentError: (error: Record<string, unknown>) => error
 }));
 
 import ScenarioPaymentMode from './ScenarioPaymentMode.vue';
@@ -30,6 +39,7 @@ describe('ScenarioPaymentMode', () => {
   beforeEach(() => {
     gate.enabled = false;
     gate.states = {};
+    gate.errors = {};
   });
 
   it('renders nothing while x402 or wallet mode is disabled', () => {
@@ -47,6 +57,43 @@ describe('ScenarioPaymentMode', () => {
 
     expect(wrapper.text()).toContain('0.095215 USDC');
     expect(wrapper.find('button').exists()).toBe(false);
+  });
+
+  it('renders a compact semantic payment error with all recovery details', async () => {
+    gate.enabled = true;
+    const wrapper = mountComponent();
+    gate.states.nanobanana.mode = 'wallet';
+    gate.states.nanobanana.quoteUsdc = '0.012263';
+    gate.errors.nanobanana = {
+      title: 'Payment incomplete',
+      description: 'The payment could not be completed.',
+      safety: 'Verification failed; no charge was initiated.',
+      nextStep: 'Check the wallet and network, then retry.',
+      technicalCode: 'Technical code: payment_failed',
+      severity: 'error'
+    };
+    await wrapper.vm.$nextTick();
+
+    const alert = wrapper.get('[role="alert"]');
+    expect(alert.classes()).toContain('scenario-payment-error');
+    expect(alert.classes()).toContain('is-error');
+    expect(alert.get('.scenario-error-title').text()).toBe('Payment incomplete');
+    expect(alert.get('.scenario-error-description').text()).toBe('The payment could not be completed.');
+    expect(alert.get('.scenario-error-safety').text()).toContain('no charge was initiated');
+    expect(alert.get('.scenario-error-next-step').text()).toContain('then retry');
+    expect(alert.get('.scenario-error-code').text()).toBe('Technical code: payment_failed');
+    expect(alert.findComponent({ name: 'ErrorIcon' }).exists()).toBe(true);
+  });
+
+  it('does not render an empty error card when payment has no error', async () => {
+    gate.enabled = true;
+    const wrapper = mountComponent();
+    gate.states.nanobanana.mode = 'wallet';
+    gate.states.nanobanana.quoteUsdc = '0.012263';
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.find('[role="alert"]').exists()).toBe(false);
+    expect(wrapper.text()).toContain('0.012263 USDC');
   });
 
   it('reads quote state for its own scenario only', async () => {

--- a/src/components/common/ScenarioPaymentMode.vue
+++ b/src/components/common/ScenarioPaymentMode.vue
@@ -1,37 +1,39 @@
 <template>
   <div v-if="enabled && walletMode" class="scenario-wallet-price">
-    <span v-if="state.quoteLoading">…</span>
-    <span v-else-if="state.quoteUsdc" class="font-medium">{{ state.quoteUsdc }} USDC</span>
-    <span v-else>{{ $t('common.x402Scenario.quoteBeforeSigning') }}</span>
-    <el-alert
-      v-if="paymentError"
-      :type="paymentError.severity"
-      :title="paymentError.title"
-      :closable="false"
-      show-icon
-      role="alert"
-      class="scenario-payment-error"
-    >
-      <template #default>
-        <p>{{ paymentError.description }}</p>
-        <p v-if="paymentError.safety" class="scenario-error-safety">{{ paymentError.safety }}</p>
-        <p>{{ paymentError.nextStep }}</p>
-        <code>{{ paymentError.technicalCode }}</code>
-      </template>
-    </el-alert>
+    <div class="scenario-wallet-quote">
+      <span v-if="state.quoteLoading">…</span>
+      <span v-else-if="state.quoteUsdc" class="font-medium">{{ state.quoteUsdc }} USDC</span>
+      <span v-else>{{ $t('common.x402Scenario.quoteBeforeSigning') }}</span>
+    </div>
+    <section v-if="paymentError" :class="['scenario-payment-error', `is-${paymentError.severity}`]" role="alert">
+      <div class="scenario-error-icon" aria-hidden="true">
+        <warning-icon v-if="paymentError.severity === 'warning'" :size="'1em' as any" focusable="false" />
+        <error-icon v-else :size="'1em' as any" focusable="false" />
+      </div>
+      <div class="scenario-error-content">
+        <h3 class="scenario-error-title">{{ paymentError.title }}</h3>
+        <p class="scenario-error-description">{{ paymentError.description }}</p>
+        <div v-if="paymentError.safety" class="scenario-error-safety">
+          <success-icon :size="'1em' as any" aria-hidden="true" focusable="false" />
+          <span>{{ paymentError.safety }}</span>
+        </div>
+        <p class="scenario-error-next-step">{{ paymentError.nextStep }}</p>
+        <code class="scenario-error-code">{{ paymentError.technicalCode }}</code>
+      </div>
+    </section>
   </div>
 </template>
 
 <script lang="ts">
+import { ErrorIcon, SuccessIcon, WarningIcon } from '@acedatacloud/core/icons/components';
 import { defineComponent } from 'vue';
-import { ElAlert } from 'element-plus';
 import { isScenarioX402Enabled, scenarioPaymentState } from '@/utils/x402/scenarioPayment';
 import { resolveX402PaymentError, type X402ErrorPresentation } from '@acedatacloud/core/x402';
 import { scenarioPaymentError } from '@/utils/x402/paymentErrorState';
 
 export default defineComponent({
   name: 'ScenarioPaymentMode',
-  components: { ElAlert },
+  components: { ErrorIcon, SuccessIcon, WarningIcon },
   props: {
     scenario: { type: String, required: true }
   },
@@ -56,7 +58,11 @@ export default defineComponent({
 
 <style scoped>
 .scenario-wallet-price {
-  margin-bottom: 4px;
+  width: 100%;
+  margin-bottom: 8px;
+}
+
+.scenario-wallet-quote {
   color: var(--el-text-color-secondary);
   font-size: 12px;
   line-height: 1.4;
@@ -64,21 +70,116 @@ export default defineComponent({
 }
 
 .scenario-payment-error {
-  margin-top: 8px;
+  display: grid;
+  grid-template-columns: 22px minmax(0, 1fr);
+  gap: 10px;
+  width: 100%;
+  box-sizing: border-box;
+  margin-top: 10px;
+  padding: 13px 14px 12px 12px;
+  border: 1px solid var(--el-color-danger-light-7);
+  border-left: 3px solid var(--el-color-danger);
+  border-radius: 12px;
+  background: var(--el-color-danger-light-9);
+  color: var(--el-text-color-regular);
   text-align: left;
 }
 
-.scenario-payment-error p {
-  margin: 0 0 6px;
+.scenario-payment-error.is-warning {
+  border-color: var(--el-color-warning-light-7);
+  border-left-color: var(--el-color-warning);
+  background: var(--el-color-warning-light-9);
+}
+
+.scenario-error-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  margin-top: 1px;
+  border-radius: 50%;
+  background: var(--el-color-danger);
+  color: var(--el-color-white);
+  font-size: 13px;
+}
+
+.is-warning .scenario-error-icon {
+  background: var(--el-color-warning);
+}
+
+.scenario-error-content {
+  min-width: 0;
+}
+
+.scenario-error-title {
+  margin: 0;
+  color: var(--el-color-danger);
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 1.35;
+}
+
+.is-warning .scenario-error-title {
+  color: var(--el-color-warning-dark-2);
+}
+
+.scenario-error-description,
+.scenario-error-next-step {
+  margin: 5px 0 0;
+  color: var(--el-text-color-regular);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.scenario-error-next-step {
+  font-weight: 500;
 }
 
 .scenario-error-safety {
-  color: var(--el-color-success);
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  max-width: 100%;
+  margin-top: 8px;
+  padding: 3px 8px;
+  border: 1px solid var(--el-color-success-light-7);
+  border-radius: 999px;
+  background: var(--el-color-success-light-9);
+  color: var(--el-color-success-dark-2);
+  font-size: 12px;
   font-weight: 600;
+  line-height: 1.35;
 }
 
-.scenario-payment-error code {
+.scenario-error-code {
+  display: block;
+  margin-top: 9px;
+  padding-top: 8px;
+  border-top: 1px solid var(--el-border-color-lighter);
+  background: transparent;
   color: var(--el-text-color-secondary);
+  font-family: var(--el-font-family);
   font-size: 11px;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+@media (max-width: 480px) {
+  .scenario-payment-error {
+    grid-template-columns: 20px minmax(0, 1fr);
+    gap: 9px;
+    padding: 12px 12px 11px 10px;
+  }
+
+  .scenario-error-icon {
+    width: 20px;
+    height: 20px;
+    font-size: 12px;
+  }
+
+  .scenario-error-title {
+    font-size: 15px;
+  }
 }
 </style>


### PR DESCRIPTION
## Problem

The persistent wallet-payment failure shown above generation CTAs used Element Plus's default `el-alert` layout inside a narrow 400–500px config column. Its large default title/icon, red body copy, stacked paragraphs, green safety paragraph, and raw code label produced an oversized red block that did not align with Studio task cards or the full-width generate button.

Because `ScenarioPaymentMode` is shared by 20+ generation scenarios, this fixes the shared presentation rather than adding Nano Banana-only overrides.

## Fix

- replace default alert internals with a semantic compact `role=alert` status card
- separate quote typography from error-card typography
- use top-aligned status icon, 16px title, neutral body copy, compact no-charge success badge, primary next step, and muted technical metadata footer
- align card width with the generation CTA and use Studio/Element Plus theme tokens for light/dark themes
- add narrow-screen sizing and `overflow-wrap:anywhere` for diagnostic codes
- preserve the existing error protocol, translations, severity, safety copy, next step, and technical code

## Validation

- `ScenarioPaymentMode.test.ts` + `x402ScenarioContract.test.ts`: 14 passed
- ESLint: passed
- `vue-tsc -b`: passed with clean lockfile dependencies (`@acedatacloud/core` 0.22.0)
- production web build: passed
- Beachball gate: passed
- visual fixture using the component's exact CSS:
  - desktop light/dark: card 378px wide, button 378px wide, card height 182px
  - 390px viewport light/dark: card 300px wide, button 300px wide, card height 198px
  - no horizontal overflow in all four renders

## Scope

No payment behavior, copy, translation, classification, or billing changes. The transient top toast is unchanged; this PR only aligns the persistent shared error card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
