### PR TITLE
fix: close Showcase dialog after recreate

### DIFF
--- a/change/close-showcase-dialog.json
+++ b/change/close-showcase-dialog.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Close Showcase details after Create similar fills the generation form.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/showcase/ShowcaseDetailDialog.test.ts
+++ b/src/components/showcase/ShowcaseDetailDialog.test.ts
@@ -4,6 +4,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ResolvedShowcase } from '@/models';
 import ShowcaseDetailDialog from './ShowcaseDetailDialog.vue';
 
+const mocks = vi.hoisted(() => ({ push: vi.fn() }));
+
+vi.mock('vue-router', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('vue-router')>()),
+  useRouter: () => ({ push: mocks.push })
+}));
 vi.mock('@/components/common/VideoPlayer.vue', () => ({
   default: { props: ['src'], template: '<div class="video-player" />' }
 }));
@@ -58,10 +64,6 @@ function mountDialog(item: ResolvedShowcase) {
           emits: ['close', 'closed', 'update:modelValue'],
           template: '<div v-if="modelValue" class="dialog-stub" :id="id"><slot /></div>'
         },
-        RouterLink: {
-          props: ['to'],
-          template: '<a class="router-link"><slot /></a>'
-        },
         VideoPlayer: { props: ['src'], template: '<div class="video-player" />' },
         ShowcaseAudioPlayer: { props: ['src', 'cover', 'title'], template: '<div class="audio-player" />' }
       },
@@ -71,9 +73,13 @@ function mountDialog(item: ResolvedShowcase) {
 }
 
 describe('ShowcaseDetailDialog', () => {
-  beforeEach(() => vi.stubGlobal('ResizeObserver', ResizeObserverStub));
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.push.mockResolvedValue(undefined);
+    vi.stubGlobal('ResizeObserver', ResizeObserverStub);
+  });
 
-  it('shows the image brief, layout, safe parameters, and create-similar destination', () => {
+  it('shows the image brief, layout, and safe parameters', () => {
     const wrapper = mountDialog(baseItem);
 
     expect(wrapper.get('.detail-layout').classes()).toContain('layout-portrait');
@@ -82,10 +88,18 @@ describe('ShowcaseDetailDialog', () => {
     expect(wrapper.get('.service-copy').find('.service-name').text()).toBe(baseItem.name);
     expect(wrapper.get('.service-copy').find('.model').text()).toBe(baseItem.model);
     expect(wrapper.findAll('.parameters dt').map((node) => node.text())).toEqual(['Aspect ratio', 'Seed']);
-    expect((wrapper.getComponent('.router-link') as any).props('to')).toEqual({
+  });
+
+  it('navigates to recreate the item and closes the detail Dialog', async () => {
+    const wrapper = mountDialog(baseItem);
+
+    await wrapper.get('.create-similar').trigger('click');
+
+    expect(mocks.push).toHaveBeenCalledWith({
       name: 'nanobanana-index',
       query: { showcase: baseItem.id }
     });
+    expect(wrapper.emitted('close')).toHaveLength(1);
   });
 
   it('uses a lightweight custom close button while preserving the Dialog close event', async () => {

--- a/src/components/showcase/ShowcaseDetailDialog.vue
+++ b/src/components/showcase/ShowcaseDetailDialog.vue
@@ -71,9 +71,9 @@
             </dl>
           </section>
         </div>
-        <router-link :to="{ name: item.routeName, query: { showcase: item.id } }" class="create-similar">
+        <button type="button" class="create-similar" @click="createSimilar">
           {{ $t('intro.home.showcase.createSimilar') }} <span aria-hidden="true">→</span>
-        </router-link>
+        </button>
       </aside>
     </div>
   </el-dialog>
@@ -93,6 +93,7 @@
 
 <script setup lang="ts">
 import { computed, nextTick, onBeforeUnmount, ref, watch } from 'vue';
+import { useRouter } from 'vue-router';
 import { ElDialog } from 'element-plus';
 import { CloseIcon } from '@acedatacloud/core/icons/components';
 import type { ResolvedShowcase } from '@/models';
@@ -101,6 +102,7 @@ import ShowcaseAudioPlayer from './ShowcaseAudioPlayer.vue';
 
 const props = defineProps<{ item?: ResolvedShowcase }>();
 const emit = defineEmits<{ close: [] }>();
+const router = useRouter();
 const promptElement = ref<HTMLElement>();
 const promptToggle = ref<HTMLButtonElement>();
 const promptDialogVisible = ref(false);
@@ -146,6 +148,13 @@ onBeforeUnmount(() => resizeObserver?.disconnect());
 
 function restorePromptFocus(): void {
   promptToggle.value?.focus();
+}
+
+async function createSimilar(): Promise<void> {
+  const item = props.item;
+  if (!item) return;
+  await router.push({ name: item.routeName, query: { showcase: item.id } });
+  emit('close');
 }
 
 function parameterLabel(key: string): string {
@@ -417,9 +426,12 @@ function parameterLabel(key: string): string {
   justify-content: center;
   flex: none;
   margin: 0 28px 26px;
+  border: 0;
   border-radius: 999px;
   color: #fff;
   background: var(--el-color-primary);
+  cursor: pointer;
+  font: inherit;
   font-weight: 800;
 
   &:focus-visible {


### PR DESCRIPTION
## Summary
- close the Showcase detail dialog after Create similar navigation succeeds
- preserve the existing showcase replay route and form-fill behavior
- add component coverage for navigation plus dialog dismissal

## Verification
- `npm run test:run -- src/components/showcase/ShowcaseDetailDialog.test.ts` (8 passed)
- ESLint on changed Vue/test files
- `git diff --check`
- `npx beachball check --branch origin/main`
- Full `vue-tsc -b` was attempted but the reused local `node_modules` has an older `@acedatacloud/core` missing exports already required by current `main`; CI will install the lockfile dependencies cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)