### PR TITLE
feat(x402): track Studio wallet connections

### DIFF
--- a/change/x402-wallet-telemetry.json
+++ b/change/x402-wallet-telemetry.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Record successful x402 wallet connections across Studio payment entry points.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/application/Status.vue
+++ b/src/components/application/Status.vue
@@ -130,6 +130,7 @@ import QrCode from 'vue-qrcode';
 import { ElButton, ElDialog, ElMessage, ElRadioButton, ElRadioGroup, ElTabPane, ElTabs, ElTag } from 'element-plus';
 import { IApplicationType, IApplication, IService } from '@/models';
 import { ROUTE_CONSOLE_USAGE_LIST } from '@/router';
+import { trackWalletConnected } from '@/plugins/telemetry';
 import ApplicationInfo from './Info.vue';
 import ContinuousPaymentCard from './ContinuousPaymentCard.vue';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
@@ -326,6 +327,7 @@ export default defineComponent({
         }
         setActiveWalletRail('base');
         this.evmWalletPickerVisible = false;
+        trackWalletConnected('base', 'scenario_status');
       } catch (error) {
         console.warn('Base wallet connect failed', error);
         ElMessage.error(String(this.$t('coin.message.connectError')));
@@ -350,6 +352,7 @@ export default defineComponent({
         await walletApi.connect();
         setActiveWalletRail('solana');
         this.walletPickerVisible = false;
+        trackWalletConnected('solana', 'scenario_status');
       } catch (error) {
         console.warn('wallet connect failed', error);
         ElMessage.error(String(this.$t('coin.message.connectError')));

--- a/src/components/order/X402Pay.vue
+++ b/src/components/order/X402Pay.vue
@@ -203,6 +203,7 @@ import {
 import SolanaWalletPickerDialog from '@/components/common/SolanaWalletPickerDialog.vue';
 import { IOrder } from '@/models';
 import { httpClient, orderOperator } from '@/operators';
+import { trackWalletConnected } from '@/plugins/telemetry';
 import { isMobile } from '@/utils';
 import { buildSolanaX402Header, executeSolanaPayment, SolanaPaymentRequirements } from '@/utils/x402/solana';
 import { discoverEvmWallets, type EvmWalletInfo } from '@/utils/x402/evmWallet';
@@ -545,6 +546,7 @@ export default defineComponent({
       try {
         await this.connectSolanaWalletWithRetry(wallet.adapter.name);
         this.solanaWalletModalVisible = false;
+        trackWalletConnected('solana', 'order_checkout');
       } catch (error) {
         console.warn('wallet connect failed', error);
         ElMessage.error(String(this.$t?.('coin.message.connectError') || 'Wallet connect failed'));
@@ -581,6 +583,7 @@ export default defineComponent({
         this.evmAddress = address;
         await this.refreshChainId();
         await this.ensureNetwork();
+        trackWalletConnected('base', 'order_checkout');
       } catch (error) {
         console.warn('EVM wallet connect failed', error);
         ElMessage.error(String(this.$t?.('coin.message.connectError') || 'Wallet connect failed'));

--- a/src/main.ts
+++ b/src/main.ts
@@ -148,7 +148,7 @@ export const createApp = ViteSSG(App, { routes, base: import.meta.env.BASE_URL }
   void runLiveUpdate();
   initializeSiteAnalytics(store.state.site || undefined);
 
-  void initTelemetry({
+  await initTelemetry({
     uin: store.getters.user?.id,
     // __APP_VERSION__ is injected by vite.config `define` for all surfaces.
     // (Previously this read import.meta.env.VITE_APP_VERSION, which was never

--- a/src/plugins/telemetry.ts
+++ b/src/plugins/telemetry.ts
@@ -25,6 +25,13 @@ export const captureError = telemetry.captureError;
 export const trackApiFailure = telemetry.trackApiFailure;
 export const isInitialized = telemetry.isInitialized;
 
+export type X402WalletRail = 'base' | 'solana';
+export type X402WalletEntrypoint = 'scenario_status' | 'order_checkout';
+
+export function trackWalletConnected(rail: X402WalletRail, entrypoint: X402WalletEntrypoint): void {
+  track('x402_wallet_connected', { provider: rail, id: entrypoint });
+}
+
 /**
  * Wrap a generation request with `generation_submit` / `generation_success` /
  * `generation_failed` events. Preserves the underlying promise's value and


### PR DESCRIPTION
## Summary

- record one `x402_wallet_connected` RUM event after a wallet connection succeeds
- cover Base and Solana in the shared scenario/Spending Guardrails entry point and x402 order checkout
- distinguish only the payment rail and entry point; no wallet address, signature, URI, transaction data, or raw error is sent
- await the existing telemetry initialization so an early connection is not silently dropped

## Measurement

- connection actions: count `msg=x402_wallet_connected`
- rail: Aegis `ext1` (`base` or `solana`)
- entry point: Aegis `ext2` (`scenario_status` or `order_checkout`)
- unique authenticated users/devices: deduplicate by the existing Aegis `uin` / `aid`
- successful transactions and unique payer wallets remain sourced from settled `ApiUsage.metadata`

## Verification

- `npm run lint:check` (0 errors; 2 pre-existing warnings)
- `npm run build`
- `npm run test:run -- --maxWorkers=4` (253 files, 1,949 tests passed)
- `npx beachball check --branch origin/main`

## 🤖 对抗评审 (reviewer: codex, 2 rounds)

- RISK: telemetry 初始化完成前的早期连接事件会被静默丢弃 → 已修：应用启动等待现有 `initTelemetry()` 完成。
- RISK: disconnect connector 与 connect connector 维度不一致 → 已修：按实际需求删除非必要的 disconnect 事件及 connector 维度。
- 复杂度收缩：从 16 文件 / +390 行缩减为 5 文件 / +21 行，只保留成功连接事件、rail 与 entrypoint。
- Round 2: `VERDICT: CLEAN`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)