### PR TITLE
fix(layout): tighten service result spacing

### DIFF
--- a/change/kling-content-spacing.json
+++ b/change/kling-content-spacing.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Tighten workspace spacing around service task results.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/layouts/DigitalHuman.vue
+++ b/src/layouts/DigitalHuman.vue
@@ -5,7 +5,7 @@
     >
       <slot name="config" />
     </div>
-    <div class="result h-full p-6 flex-1 flex flex-col min-w-0 overflow-x-hidden bg-[var(--app-content-bg)]">
+    <div class="result h-full p-4 flex-1 flex flex-col min-w-0 overflow-x-hidden bg-[var(--app-content-bg)]">
       <slot name="result" />
     </div>
     <el-button

--- a/src/layouts/Flux.vue
+++ b/src/layouts/Flux.vue
@@ -5,7 +5,7 @@
     >
       <slot name="config" />
     </div>
-    <div class="result h-full p-6 flex-1 flex flex-col min-w-0 overflow-x-hidden bg-[var(--app-content-bg)]">
+    <div class="result h-full p-4 flex-1 flex flex-col min-w-0 overflow-x-hidden bg-[var(--app-content-bg)]">
       <slot name="result" />
     </div>
     <el-button

--- a/src/layouts/GrokVideo.vue
+++ b/src/layouts/GrokVideo.vue
@@ -5,7 +5,7 @@
     >
       <slot name="config" />
     </div>
-    <div class="result h-full p-6 flex-1 flex flex-col min-w-0 overflow-x-hidden bg-[var(--app-content-bg)]">
+    <div class="result h-full p-4 flex-1 flex flex-col min-w-0 overflow-x-hidden bg-[var(--app-content-bg)]">
       <slot name="result" />
     </div>
     <el-button

--- a/src/layouts/Hailuo.vue
+++ b/src/layouts/Hailuo.vue
@@ -5,7 +5,7 @@
     >
       <slot name="config" />
     </div>
-    <div class="result h-full p-6 flex-1 flex flex-col min-w-0 overflow-x-hidden bg-[var(--app-content-bg)]">
+    <div class="result h-full p-4 flex-1 flex flex-col min-w-0 overflow-x-hidden bg-[var(--app-content-bg)]">
       <slot name="result" />
     </div>
     <el-button

--- a/src/layouts/Kling.vue
+++ b/src/layouts/Kling.vue
@@ -5,7 +5,7 @@
     >
       <slot name="config" />
     </div>
-    <div class="result h-full p-6 flex-1 flex flex-col min-w-0 overflow-x-hidden bg-[var(--app-content-bg)]">
+    <div class="result h-full p-4 flex-1 flex flex-col min-w-0 overflow-x-hidden bg-[var(--app-content-bg)]">
       <slot name="result" />
     </div>
     <el-button

--- a/src/layouts/Luma.vue
+++ b/src/layouts/Luma.vue
@@ -5,7 +5,7 @@
     >
       <slot name="config" />
     </div>
-    <div class="result h-full p-6 flex-1 flex flex-col min-w-0 overflow-x-hidden bg-[var(--app-content-bg)]">
+    <div class="result h-full p-4 flex-1 flex flex-col min-w-0 overflow-x-hidden bg-[var(--app-content-bg)]">
       <slot name="result" />
     </div>
     <el-button

--- a/src/layouts/Maestro.vue
+++ b/src/layouts/Maestro.vue
@@ -5,7 +5,7 @@
     >
       <slot name="config" />
     </div>
-    <div class="result h-full p-6 flex-1 flex flex-col min-w-0 overflow-x-hidden bg-[var(--app-content-bg)]">
+    <div class="result h-full p-4 flex-1 flex flex-col min-w-0 overflow-x-hidden bg-[var(--app-content-bg)]">
       <slot name="result" />
     </div>
     <el-button

--- a/src/layouts/Nanobanana.vue
+++ b/src/layouts/Nanobanana.vue
@@ -5,7 +5,7 @@
     >
       <slot name="config" />
     </div>
-    <div class="result h-full p-6 flex-1 flex flex-col min-w-0 overflow-x-hidden bg-[var(--app-content-bg)]">
+    <div class="result h-full p-4 flex-1 flex flex-col min-w-0 overflow-x-hidden bg-[var(--app-content-bg)]">
       <slot name="result" />
     </div>
     <el-button

--- a/src/layouts/Omni.vue
+++ b/src/layouts/Omni.vue
@@ -5,7 +5,7 @@
     >
       <slot name="config" />
     </div>
-    <div class="result h-full p-6 flex-1 flex flex-col min-w-0 overflow-x-hidden bg-[var(--app-content-bg)]">
+    <div class="result h-full p-4 flex-1 flex flex-col min-w-0 overflow-x-hidden bg-[var(--app-content-bg)]">
       <slot name="result" />
     </div>
     <el-button

--- a/src/layouts/OpenAIImage.vue
+++ b/src/layouts/OpenAIImage.vue
@@ -5,7 +5,7 @@
     >
       <slot name="config" />
     </div>
-    <div class="result h-full p-6 flex-1 flex flex-col min-w-0 overflow-x-hidden bg-[var(--app-content-bg)]">
+    <div class="result h-full p-4 flex-1 flex flex-col min-w-0 overflow-x-hidden bg-[var(--app-content-bg)]">
       <slot name="result" />
     </div>
     <el-button

--- a/src/layouts/Pika.vue
+++ b/src/layouts/Pika.vue
@@ -5,7 +5,7 @@
     >
       <slot name="config" />
     </div>
-    <div class="result h-full p-6 flex-1 flex flex-col min-w-0 overflow-x-hidden bg-[var(--app-content-bg)]">
+    <div class="result h-full p-4 flex-1 flex flex-col min-w-0 overflow-x-hidden bg-[var(--app-content-bg)]">
       <slot name="result" />
     </div>
     <el-button

--- a/src/layouts/Pixverse.vue
+++ b/src/layouts/Pixverse.vue
@@ -5,7 +5,7 @@
     >
       <slot name="config" />
     </div>
-    <div class="result h-full p-6 flex-1 flex flex-col min-w-0 overflow-x-hidden bg-[var(--app-content-bg)]">
+    <div class="result h-full p-4 flex-1 flex flex-col min-w-0 overflow-x-hidden bg-[var(--app-content-bg)]">
       <slot name="result" />
     </div>
     <el-button

--- a/src/layouts/Qrart.vue
+++ b/src/layouts/Qrart.vue
@@ -5,7 +5,7 @@
     >
       <slot name="config" />
     </div>
-    <div class="result h-full p-6 flex-1 flex flex-col min-w-0 overflow-x-hidden bg-[var(--app-content-bg)]">
+    <div class="result h-full p-4 flex-1 flex flex-col min-w-0 overflow-x-hidden bg-[var(--app-content-bg)]">
       <slot name="result" />
     </div>
     <el-button

--- a/src/layouts/QwenImage.vue
+++ b/src/layouts/QwenImage.vue
@@ -5,7 +5,7 @@
     >
       <slot name="config" />
     </div>
-    <div class="result h-full p-6 flex-1 flex flex-col min-w-0 overflow-x-hidden bg-[var(--app-content-bg)]">
+    <div class="result h-full p-4 flex-1 flex flex-col min-w-0 overflow-x-hidden bg-[var(--app-content-bg)]">
       <slot name="result" />
     </div>
     <el-button

--- a/src/layouts/Seedance.vue
+++ b/src/layouts/Seedance.vue
@@ -5,7 +5,7 @@
     >
       <slot name="config" />
     </div>
-    <div class="result h-full p-6 flex-1 flex flex-col min-w-0 overflow-x-hidden bg-[var(--app-content-bg)]">
+    <div class="result h-full p-4 flex-1 flex flex-col min-w-0 overflow-x-hidden bg-[var(--app-content-bg)]">
       <slot name="result" />
     </div>
     <el-button

--- a/src/layouts/Seedream.vue
+++ b/src/layouts/Seedream.vue
@@ -5,7 +5,7 @@
     >
       <slot name="config" />
     </div>
-    <div class="result h-full p-6 flex-1 flex flex-col min-w-0 overflow-x-hidden bg-[var(--app-content-bg)]">
+    <div class="result h-full p-4 flex-1 flex flex-col min-w-0 overflow-x-hidden bg-[var(--app-content-bg)]">
       <slot name="result" />
     </div>
     <el-button

--- a/src/layouts/Sora.vue
+++ b/src/layouts/Sora.vue
@@ -5,7 +5,7 @@
     >
       <slot name="config" />
     </div>
-    <div class="result h-full p-6 flex-1 flex flex-col min-w-0 overflow-x-hidden bg-[var(--app-content-bg)]">
+    <div class="result h-full p-4 flex-1 flex flex-col min-w-0 overflow-x-hidden bg-[var(--app-content-bg)]">
       <slot name="result" />
     </div>
     <el-button

--- a/src/layouts/Veo.vue
+++ b/src/layouts/Veo.vue
@@ -5,7 +5,7 @@
     >
       <slot name="config" />
     </div>
-    <div class="result h-full p-6 flex-1 flex flex-col min-w-0 overflow-x-hidden bg-[var(--app-content-bg)]">
+    <div class="result h-full p-4 flex-1 flex flex-col min-w-0 overflow-x-hidden bg-[var(--app-content-bg)]">
       <slot name="result" />
     </div>
     <el-button

--- a/src/layouts/Wan.vue
+++ b/src/layouts/Wan.vue
@@ -5,7 +5,7 @@
     >
       <slot name="config" />
     </div>
-    <div class="result h-full p-6 flex-1 flex flex-col min-w-0 overflow-x-hidden bg-[var(--app-content-bg)]">
+    <div class="result h-full p-4 flex-1 flex flex-col min-w-0 overflow-x-hidden bg-[var(--app-content-bg)]">
       <slot name="result" />
     </div>
     <el-button


### PR DESCRIPTION
## Summary

- reduce result workspace padding from 24px to 16px across all matching service generator layouts
- move task tabs and result content slightly left and upward consistently
- preserve layouts that already use tighter or zero result padding
- update the required Beachball patch entry

## Verification

- ESLint passed for all 19 updated layout components
- `beachball check`
- `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)