### PR TITLE
fix(tasks): reconcile pending scenario cards

### DIFF
--- a/change/task-polling-reconciliation.json
+++ b/change/task-polling-reconciliation.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Keep pending task cards synchronized efficiently across all active generation scenarios.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/pages/digitalhuman/Index.vue
+++ b/src/pages/digitalhuman/Index.vue
@@ -29,6 +29,7 @@ import {
   type X402WalletContext,
   resolveX402WalletContext
 } from '@/operators/x402';
+import { taskPollingMixin } from '@/utils/taskPollingMixin';
 
 interface IData {
   job: number;
@@ -44,7 +45,7 @@ export default defineComponent({
     Layout,
     RecentPanel
   },
-  mixins: [uploadTrackerProviderMixin],
+  mixins: [uploadTrackerProviderMixin, taskPollingMixin('digitalhuman', false)],
   inject: ['initialized'],
   data(): IData {
     return {
@@ -79,7 +80,7 @@ export default defineComponent({
       async handler(value: boolean, oldValue: boolean | undefined) {
         if (oldValue === undefined || value === oldValue) return;
         this.$store.commit('digitalhuman/setTasks', undefined);
-        if (value && !this.job) this.job = window.setInterval(this.onGetTasks, 5000);
+        if (value && !this.job) this.job = window.setInterval(this.onPollTasks, 5000);
         if (!value && !this.credential?.token) {
           window.clearInterval(this.job);
           this.job = 0;
@@ -96,7 +97,7 @@ export default defineComponent({
         if (newValue) {
           await this.onGetTasks();
           await this.onScrollDown();
-          if (!this.job) this.job = window.setInterval(this.onGetTasks, 5000);
+          if (!this.job) this.job = window.setInterval(this.onPollTasks, 5000);
         }
       },
       immediate: true

--- a/src/pages/fish/Tts.vue
+++ b/src/pages/fish/Tts.vue
@@ -34,6 +34,7 @@ import { FISH_DEFAULT_TTS_MODEL } from '@/constants';
 import { loadPreviousPage } from '@/utils/pagination';
 import { uploadTrackerProviderMixin, ensureNoPendingUpload, ensureLoggedIn } from '@/utils';
 import { showcaseRecreateMixin } from '@/utils/showcaseRecreateMixin';
+import { taskPollingMixin } from '@/utils/taskPollingMixin';
 
 interface IData {
   task: IFishTask | undefined;
@@ -51,7 +52,7 @@ export default defineComponent({
     ShowcaseResultTabs,
     TabSwitcher
   },
-  mixins: [uploadTrackerProviderMixin, showcaseRecreateMixin('fish')],
+  mixins: [uploadTrackerProviderMixin, showcaseRecreateMixin('fish'), taskPollingMixin('fish')],
   inject: ['initialized'],
   data(): IData {
     return {
@@ -88,7 +89,7 @@ export default defineComponent({
           await this.onGetTasks();
           await this.onScrollDown();
           this.job = window.setInterval(() => {
-            this.onGetTasks();
+            void this.onPollTasks();
           }, 5000);
         }
       },

--- a/src/pages/flux/Index.vue
+++ b/src/pages/flux/Index.vue
@@ -31,6 +31,7 @@ import {
   type X402WalletContext,
   resolveX402WalletContext
 } from '@/operators/x402';
+import { taskPollingMixin } from '@/utils/taskPollingMixin';
 
 interface IData {
   task: IFluxTask | undefined;
@@ -47,7 +48,7 @@ export default defineComponent({
     Layout,
     RecentPanel
   },
-  mixins: [uploadTrackerProviderMixin],
+  mixins: [uploadTrackerProviderMixin, taskPollingMixin('flux')],
   inject: ['initialized'],
   data(): IData {
     return {
@@ -107,7 +108,7 @@ export default defineComponent({
           await this.onGetTasks();
           await this.onScrollDown();
           this.job = window.setInterval(() => {
-            this.onGetTasks();
+            void this.onPollTasks();
           }, 5000);
         }
       },

--- a/src/pages/grokvideo/Index.vue
+++ b/src/pages/grokvideo/Index.vue
@@ -35,6 +35,7 @@ import {
   type X402WalletContext,
   resolveX402WalletContext
 } from '@/operators/x402';
+import { taskPollingMixin } from '@/utils/taskPollingMixin';
 
 interface IData {
   task: IGrokVideoTask | undefined;
@@ -52,7 +53,7 @@ export default defineComponent({
     RecentPanel,
     ShowcaseResultTabs
   },
-  mixins: [uploadTrackerProviderMixin, showcaseRecreateMixin('grokvideo')],
+  mixins: [uploadTrackerProviderMixin, showcaseRecreateMixin('grokvideo'), taskPollingMixin('grokvideo')],
   inject: ['initialized'],
   data(): IData {
     return {
@@ -88,7 +89,7 @@ export default defineComponent({
       async handler(value: boolean, oldValue: boolean | undefined) {
         if (oldValue === undefined || value === oldValue) return;
         this.$store.commit('grokvideo/setTasks', undefined);
-        if (value && !this.job) this.job = window.setInterval(this.onGetTasks, 5000);
+        if (value && !this.job) this.job = window.setInterval(this.onPollTasks, 5000);
         if (!value && !this.credential?.token) {
           window.clearInterval(this.job);
           this.job = 0;
@@ -104,7 +105,7 @@ export default defineComponent({
         if (newValue) {
           await this.onGetTasks();
           await this.onScrollDown();
-          if (!this.job) this.job = window.setInterval(this.onGetTasks, 5000);
+          if (!this.job) this.job = window.setInterval(this.onPollTasks, 5000);
         }
       },
       immediate: true

--- a/src/pages/hailuo/Index.vue
+++ b/src/pages/hailuo/Index.vue
@@ -31,6 +31,7 @@ import {
   resolveX402WalletContext
 } from '@/operators/x402';
 import { getGenerationInputError } from '@/utils/generationInput';
+import { taskPollingMixin } from '@/utils/taskPollingMixin';
 
 interface IData {
   task: IHailuoTask | undefined;
@@ -47,7 +48,7 @@ export default defineComponent({
     Layout,
     RecentPanel
   },
-  mixins: [uploadTrackerProviderMixin],
+  mixins: [uploadTrackerProviderMixin, taskPollingMixin('hailuo')],
   inject: ['initialized'],
   data(): IData {
     return {
@@ -88,7 +89,7 @@ export default defineComponent({
       async handler(value: boolean, oldValue: boolean | undefined) {
         if (oldValue === undefined || value === oldValue) return;
         this.$store.commit('hailuo/setTasks', undefined);
-        if (value && !this.job) this.job = window.setInterval(this.onGetTasks, 5000);
+        if (value && !this.job) this.job = window.setInterval(this.onPollTasks, 5000);
         if (!value && !this.credential?.token) {
           window.clearInterval(this.job);
           this.job = 0;
@@ -115,7 +116,7 @@ export default defineComponent({
           console.debug('layout initialized');
           await this.onGetTasks();
           await this.onScrollDown();
-          if (!this.job) this.job = window.setInterval(this.onGetTasks, 5000);
+          if (!this.job) this.job = window.setInterval(this.onPollTasks, 5000);
         }
       },
       immediate: true

--- a/src/pages/kling/Index.vue
+++ b/src/pages/kling/Index.vue
@@ -48,6 +48,7 @@ import {
   resolveX402WalletContext
 } from '@/operators/x402';
 import { getGenerationInputError } from '@/utils/generationInput';
+import { taskPollingMixin } from '@/utils/taskPollingMixin';
 
 interface IData {
   task: IKlingTask | undefined;
@@ -68,7 +69,7 @@ export default defineComponent({
     RecentPanel,
     ShowcaseResultTabs
   },
-  mixins: [uploadTrackerProviderMixin, showcaseRecreateMixin('kling')],
+  mixins: [uploadTrackerProviderMixin, showcaseRecreateMixin('kling'), taskPollingMixin('kling')],
   inject: ['initialized'],
   data(): IData {
     return {
@@ -119,7 +120,7 @@ export default defineComponent({
       async handler(value: boolean, oldValue: boolean | undefined) {
         if (oldValue === undefined || value === oldValue) return;
         this.$store.commit('kling/setTasks', undefined);
-        if (value && !this.job) this.job = window.setInterval(this.onGetTasks, 5000);
+        if (value && !this.job) this.job = window.setInterval(this.onPollTasks, 5000);
         if (!value && !this.credential?.token) {
           window.clearInterval(this.job);
           this.job = 0;
@@ -146,7 +147,7 @@ export default defineComponent({
           console.debug('layout initialized');
           await this.onGetTasks();
           await this.onScrollDown();
-          if (!this.job) this.job = window.setInterval(this.onGetTasks, 5000);
+          if (!this.job) this.job = window.setInterval(this.onPollTasks, 5000);
         }
       },
       immediate: true

--- a/src/pages/luma/Index.vue
+++ b/src/pages/luma/Index.vue
@@ -30,6 +30,7 @@ import {
   type X402WalletContext,
   resolveX402WalletContext
 } from '@/operators/x402';
+import { taskPollingMixin } from '@/utils/taskPollingMixin';
 
 interface IData {
   task: ILumaTask | undefined;
@@ -46,7 +47,7 @@ export default defineComponent({
     Layout,
     RecentPanel
   },
-  mixins: [uploadTrackerProviderMixin],
+  mixins: [uploadTrackerProviderMixin, taskPollingMixin('luma')],
   inject: ['initialized'],
   emits: ['extend'],
   data(): IData {
@@ -86,7 +87,7 @@ export default defineComponent({
       async handler(value: boolean, oldValue: boolean | undefined) {
         if (oldValue === undefined || value === oldValue) return;
         this.$store.commit('luma/setTasks', undefined);
-        if (value && !this.job) this.job = window.setInterval(this.onGetTasks, 5000);
+        if (value && !this.job) this.job = window.setInterval(this.onPollTasks, 5000);
         if (!value && !this.credential?.token) {
           window.clearInterval(this.job);
           this.job = 0;
@@ -113,7 +114,7 @@ export default defineComponent({
           console.debug('layout initialized');
           await this.onGetTasks();
           await this.onScrollDown();
-          if (!this.job) this.job = window.setInterval(this.onGetTasks, 5000);
+          if (!this.job) this.job = window.setInterval(this.onPollTasks, 5000);
         }
       },
       immediate: true

--- a/src/pages/maestro/Index.vue
+++ b/src/pages/maestro/Index.vue
@@ -36,6 +36,7 @@ import {
   resolveX402WalletContext
 } from '@/operators/x402';
 import { getGenerationInputError } from '@/utils/generationInput';
+import { taskPollingMixin } from '@/utils/taskPollingMixin';
 
 interface IData {
   job: number;
@@ -52,7 +53,7 @@ export default defineComponent({
     RecentPanel,
     ShowcaseResultTabs
   },
-  mixins: [showcaseRecreateMixin('maestro')],
+  mixins: [showcaseRecreateMixin('maestro'), taskPollingMixin('maestro', false)],
   inject: ['initialized'],
   data(): IData {
     return {
@@ -87,7 +88,7 @@ export default defineComponent({
       async handler(value: boolean, oldValue: boolean | undefined) {
         if (oldValue === undefined || value === oldValue) return;
         this.$store.commit('maestro/setTasks', undefined);
-        if (value && !this.job) this.job = window.setInterval(this.onGetTasks, 5000);
+        if (value && !this.job) this.job = window.setInterval(this.onPollTasks, 5000);
         if (!value && !this.credential?.token) {
           window.clearInterval(this.job);
           this.job = 0;
@@ -103,7 +104,7 @@ export default defineComponent({
         if (newValue) {
           await this.onGetTasks();
           await this.onScrollDown();
-          if (!this.job) this.job = window.setInterval(this.onGetTasks, 5000);
+          if (!this.job) this.job = window.setInterval(this.onPollTasks, 5000);
         }
       },
       immediate: true

--- a/src/pages/midjourney/Index.vue
+++ b/src/pages/midjourney/Index.vue
@@ -43,6 +43,7 @@ import {
   type X402WalletContext,
   resolveX402WalletContext
 } from '@/operators/x402';
+import { taskPollingMixin } from '@/utils/taskPollingMixin';
 
 interface IData {
   operating: boolean;
@@ -59,7 +60,7 @@ export default defineComponent({
     TaskList,
     Layout
   },
-  mixins: [uploadTrackerProviderMixin],
+  mixins: [uploadTrackerProviderMixin, taskPollingMixin('midjourney')],
   inject: ['initialized'],
   data(): IData {
     return {
@@ -98,7 +99,7 @@ export default defineComponent({
       async handler(value: boolean, oldValue: boolean | undefined) {
         if (oldValue === undefined || value === oldValue) return;
         this.$store.commit('midjourney/setTasks', undefined);
-        if (value && !this.job) this.job = window.setInterval(this.onGetTasks, 5000);
+        if (value && !this.job) this.job = window.setInterval(this.onPollTasks, 5000);
         if (!value && !this.credential?.token) {
           window.clearInterval(this.job);
           this.job = 0;
@@ -125,7 +126,7 @@ export default defineComponent({
           console.debug('layout initialized');
           await this.onGetTasks();
           await this.onScrollDown();
-          if (!this.job) this.job = window.setInterval(this.onGetTasks, 5000);
+          if (!this.job) this.job = window.setInterval(this.onPollTasks, 5000);
         }
       },
       immediate: true

--- a/src/pages/minimax/Index.vue
+++ b/src/pages/minimax/Index.vue
@@ -30,6 +30,7 @@ import {
   type X402WalletContext,
   resolveX402WalletContext
 } from '@/operators/x402';
+import { taskPollingMixin } from '@/utils/taskPollingMixin';
 
 interface IData {
   task: IMinimaxTask | undefined;
@@ -46,7 +47,7 @@ export default defineComponent({
     Layout,
     RecentPanel
   },
-  mixins: [uploadTrackerProviderMixin],
+  mixins: [uploadTrackerProviderMixin, taskPollingMixin('minimax')],
   inject: ['initialized'],
   data(): IData {
     return {
@@ -87,7 +88,7 @@ export default defineComponent({
       async handler(value: boolean, oldValue: boolean | undefined) {
         if (oldValue === undefined || value === oldValue) return;
         this.$store.commit('minimax/setTasks', undefined);
-        if (value && !this.job) this.job = window.setInterval(this.onGetTasks, 5000);
+        if (value && !this.job) this.job = window.setInterval(this.onPollTasks, 5000);
         if (!value && !this.credential?.token) {
           window.clearInterval(this.job);
           this.job = 0;
@@ -114,7 +115,7 @@ export default defineComponent({
           console.debug('layout initialized');
           await this.onGetTasks();
           await this.onScrollDown();
-          if (!this.job) this.job = window.setInterval(this.onGetTasks, 5000);
+          if (!this.job) this.job = window.setInterval(this.onPollTasks, 5000);
         }
       },
       immediate: true

--- a/src/pages/nanobanana/Index.vue
+++ b/src/pages/nanobanana/Index.vue
@@ -37,6 +37,7 @@ import {
 } from '@/operators/x402';
 import { buildNanobananaRequest } from '@/utils/x402/imageRequests';
 import { showcaseRecreateMixin } from '@/utils/showcaseRecreateMixin';
+import { taskPollingMixin } from '@/utils/taskPollingMixin';
 
 interface IData {
   task: INanobananaTask | undefined;
@@ -53,7 +54,7 @@ export default defineComponent({
     RecentPanel,
     ShowcaseResultTabs
   },
-  mixins: [uploadTrackerProviderMixin, showcaseRecreateMixin('nanobanana')],
+  mixins: [uploadTrackerProviderMixin, showcaseRecreateMixin('nanobanana'), taskPollingMixin('nanobanana')],
   inject: ['initialized'],
   data(): IData {
     return {
@@ -110,7 +111,7 @@ export default defineComponent({
           await this.onGetTasks();
           await this.onScrollDown();
           this.job = window.setInterval(() => {
-            this.onGetTasks();
+            void this.onPollTasks();
           }, 5000);
         }
       },

--- a/src/pages/omni/Index.vue
+++ b/src/pages/omni/Index.vue
@@ -29,6 +29,7 @@ import {
   type X402WalletContext,
   resolveX402WalletContext
 } from '@/operators/x402';
+import { taskPollingMixin } from '@/utils/taskPollingMixin';
 
 interface IData {
   task: IOmniTask | undefined;
@@ -45,7 +46,7 @@ export default defineComponent({
     Layout,
     RecentPanel
   },
-  mixins: [uploadTrackerProviderMixin],
+  mixins: [uploadTrackerProviderMixin, taskPollingMixin('omni')],
   inject: ['initialized'],
   data(): IData {
     return {
@@ -81,7 +82,7 @@ export default defineComponent({
       async handler(value: boolean, oldValue: boolean | undefined) {
         if (oldValue === undefined || value === oldValue) return;
         this.$store.commit('omni/setTasks', undefined);
-        if (value && !this.job) this.job = window.setInterval(this.onGetTasks, 5000);
+        if (value && !this.job) this.job = window.setInterval(this.onPollTasks, 5000);
         if (!value && !this.credential?.token) {
           window.clearInterval(this.job);
           this.job = 0;
@@ -97,7 +98,7 @@ export default defineComponent({
         if (newValue) {
           await this.onGetTasks();
           await this.onScrollDown();
-          if (!this.job) this.job = window.setInterval(this.onGetTasks, 5000);
+          if (!this.job) this.job = window.setInterval(this.onPollTasks, 5000);
         }
       },
       immediate: true

--- a/src/pages/openaiimage/Index.vue
+++ b/src/pages/openaiimage/Index.vue
@@ -37,6 +37,7 @@ import {
 } from '@/operators/x402';
 import { buildOpenAIImageGenerateRequest } from '@/utils/x402/imageRequests';
 import { showcaseRecreateMixin } from '@/utils/showcaseRecreateMixin';
+import { taskPollingMixin } from '@/utils/taskPollingMixin';
 
 interface IData {
   task: IOpenAIImageTask | undefined;
@@ -53,7 +54,7 @@ export default defineComponent({
     RecentPanel,
     ShowcaseResultTabs
   },
-  mixins: [uploadTrackerProviderMixin, showcaseRecreateMixin('openaiimage')],
+  mixins: [uploadTrackerProviderMixin, showcaseRecreateMixin('openaiimage'), taskPollingMixin('openaiimage')],
   inject: ['initialized'],
   data(): IData {
     return {
@@ -118,7 +119,7 @@ export default defineComponent({
           await this.onGetTasks();
           await this.onScrollDown();
           this.job = window.setInterval(() => {
-            this.onGetTasks();
+            void this.onPollTasks();
           }, 5000);
         }
       },

--- a/src/pages/pika/Index.vue
+++ b/src/pages/pika/Index.vue
@@ -32,6 +32,7 @@ import {
   resolveX402WalletContext
 } from '@/operators/x402';
 import { getGenerationInputError } from '@/utils/generationInput';
+import { taskPollingMixin } from '@/utils/taskPollingMixin';
 
 interface IData {
   task: IPikaTask | undefined;
@@ -48,7 +49,7 @@ export default defineComponent({
     Layout,
     RecentPanel
   },
-  mixins: [uploadTrackerProviderMixin],
+  mixins: [uploadTrackerProviderMixin, taskPollingMixin('pika')],
   inject: ['initialized'],
   data(): IData {
     return {
@@ -99,7 +100,7 @@ export default defineComponent({
       async handler(value: boolean, oldValue: boolean | undefined) {
         if (oldValue === undefined || value === oldValue) return;
         this.$store.commit('pika/setTasks', undefined);
-        if (value && !this.job) this.job = window.setInterval(this.onGetTasks, 5000);
+        if (value && !this.job) this.job = window.setInterval(this.onPollTasks, 5000);
         if (!value && !this.credential?.token) {
           window.clearInterval(this.job);
           this.job = 0;
@@ -126,7 +127,7 @@ export default defineComponent({
           console.debug('layout initialized');
           await this.onGetTasks();
           await this.onScrollDown();
-          if (!this.job) this.job = window.setInterval(this.onGetTasks, 5000);
+          if (!this.job) this.job = window.setInterval(this.onPollTasks, 5000);
         }
       },
       immediate: true

--- a/src/pages/pixverse/Index.vue
+++ b/src/pages/pixverse/Index.vue
@@ -31,6 +31,7 @@ import {
   resolveX402WalletContext
 } from '@/operators/x402';
 import { getGenerationInputError } from '@/utils/generationInput';
+import { taskPollingMixin } from '@/utils/taskPollingMixin';
 
 interface IData {
   task: IPixverseTask | undefined;
@@ -47,7 +48,7 @@ export default defineComponent({
     Layout,
     RecentPanel
   },
-  mixins: [uploadTrackerProviderMixin],
+  mixins: [uploadTrackerProviderMixin, taskPollingMixin('pixverse')],
   inject: ['initialized'],
   data(): IData {
     return {
@@ -83,7 +84,7 @@ export default defineComponent({
       async handler(value: boolean, oldValue: boolean | undefined) {
         if (oldValue === undefined || value === oldValue) return;
         this.$store.commit('pixverse/setTasks', undefined);
-        if (value && !this.job) this.job = window.setInterval(this.onGetTasks, 5000);
+        if (value && !this.job) this.job = window.setInterval(this.onPollTasks, 5000);
         if (!value && !this.credential?.token) {
           window.clearInterval(this.job);
           this.job = 0;
@@ -110,7 +111,7 @@ export default defineComponent({
           console.debug('layout initialized');
           await this.onGetTasks();
           await this.onScrollDown();
-          if (!this.job) this.job = window.setInterval(this.onGetTasks, 5000);
+          if (!this.job) this.job = window.setInterval(this.onPollTasks, 5000);
         }
       },
       immediate: true

--- a/src/pages/producer/Index.vue
+++ b/src/pages/producer/Index.vue
@@ -43,6 +43,7 @@ import {
   resolveX402WalletContext
 } from '@/operators/x402';
 import { getGenerationInputError } from '@/utils/generationInput';
+import { taskPollingMixin } from '@/utils/taskPollingMixin';
 
 interface IData {
   task: IProducerTask | undefined;
@@ -60,7 +61,7 @@ export default defineComponent({
     RecentPanel,
     PreviewPanel
   },
-  mixins: [uploadTrackerProviderMixin, showcaseRecreateMixin('producer')],
+  mixins: [uploadTrackerProviderMixin, showcaseRecreateMixin('producer'), taskPollingMixin('producer')],
   inject: ['initialized'],
   data(): IData {
     return {
@@ -111,7 +112,7 @@ export default defineComponent({
       async handler(value: boolean, oldValue: boolean | undefined) {
         if (oldValue === undefined || value === oldValue) return;
         this.$store.commit('producer/setTasks', undefined);
-        if (value && !this.job) this.job = window.setInterval(this.onGetTasks, 5000);
+        if (value && !this.job) this.job = window.setInterval(this.onPollTasks, 5000);
         if (!value && !this.credential?.token) {
           window.clearInterval(this.job);
           this.job = 0;
@@ -136,7 +137,7 @@ export default defineComponent({
           console.debug('layout initialized');
           await this.onGetTasks();
           await this.onScrollDown();
-          if (!this.job) this.job = window.setInterval(this.onGetTasks, 5000);
+          if (!this.job) this.job = window.setInterval(this.onPollTasks, 5000);
         }
       },
       immediate: true

--- a/src/pages/qrart/Index.vue
+++ b/src/pages/qrart/Index.vue
@@ -43,6 +43,7 @@ import {
   resolveX402WalletContext
 } from '@/operators/x402';
 import { getGenerationInputError } from '@/utils/generationInput';
+import { taskPollingMixin } from '@/utils/taskPollingMixin';
 
 interface IData {
   task: IQrartTask | undefined;
@@ -60,7 +61,7 @@ export default defineComponent({
     ApplicationStatus,
     RecentPanel
   },
-  mixins: [uploadTrackerProviderMixin],
+  mixins: [uploadTrackerProviderMixin, taskPollingMixin('qrart')],
   inject: ['initialized'],
   data(): IData {
     return {
@@ -132,7 +133,7 @@ export default defineComponent({
           await this.onGetTasks();
           await this.onScrollDown();
           this.job = window.setInterval(() => {
-            this.onGetTasks();
+            void this.onPollTasks();
           }, 5000);
         }
       },

--- a/src/pages/qwenimage/Index.vue
+++ b/src/pages/qwenimage/Index.vue
@@ -31,6 +31,7 @@ import { uploadTrackerProviderMixin, ensureNoPendingUpload, ensureLoggedIn } fro
 import { IQwenImageTask } from '@/models';
 import { showcaseRecreateMixin } from '@/utils/showcaseRecreateMixin';
 import { getGenerationInputError } from '@/utils/generationInput';
+import { taskPollingMixin } from '@/utils/taskPollingMixin';
 
 interface IData {
   task: IQwenImageTask | undefined;
@@ -46,7 +47,7 @@ export default defineComponent({
     RecentPanel,
     ShowcaseResultTabs
   },
-  mixins: [uploadTrackerProviderMixin, showcaseRecreateMixin('qwenimage')],
+  mixins: [uploadTrackerProviderMixin, showcaseRecreateMixin('qwenimage'), taskPollingMixin('qwenimage')],
   inject: ['initialized'],
   data(): IData {
     return {
@@ -91,7 +92,7 @@ export default defineComponent({
           await this.onGetTasks();
           await this.onScrollDown();
           this.job = window.setInterval(() => {
-            this.onGetTasks();
+            void this.onPollTasks();
           }, 5000);
         }
       },

--- a/src/pages/seedance/Index.vue
+++ b/src/pages/seedance/Index.vue
@@ -36,6 +36,7 @@ import {
   type X402WalletContext,
   resolveX402WalletContext
 } from '@/operators/x402';
+import { taskPollingMixin } from '@/utils/taskPollingMixin';
 
 interface IData {
   task: ISeedanceTask | undefined;
@@ -53,7 +54,7 @@ export default defineComponent({
     RecentPanel,
     ShowcaseResultTabs
   },
-  mixins: [uploadTrackerProviderMixin, showcaseRecreateMixin('seedance')],
+  mixins: [uploadTrackerProviderMixin, showcaseRecreateMixin('seedance'), taskPollingMixin('seedance')],
   inject: ['initialized'],
   data(): IData {
     return {
@@ -89,7 +90,7 @@ export default defineComponent({
       async handler(value: boolean, oldValue: boolean | undefined) {
         if (oldValue === undefined || value === oldValue) return;
         this.$store.commit('seedance/setTasks', undefined);
-        if (value && !this.job) this.job = window.setInterval(this.onGetTasks, 5000);
+        if (value && !this.job) this.job = window.setInterval(this.onPollTasks, 5000);
         if (!value && !this.credential?.token) {
           window.clearInterval(this.job);
           this.job = 0;
@@ -105,7 +106,7 @@ export default defineComponent({
         if (newValue) {
           await this.onGetTasks();
           await this.onScrollDown();
-          if (!this.job) this.job = window.setInterval(this.onGetTasks, 5000);
+          if (!this.job) this.job = window.setInterval(this.onPollTasks, 5000);
         }
       },
       immediate: true

--- a/src/pages/seedream/Index.vue
+++ b/src/pages/seedream/Index.vue
@@ -32,6 +32,7 @@ import { uploadTrackerProviderMixin, ensureNoPendingUpload, ensureLoggedIn } fro
 import { ISeedreamTask } from '@/models';
 import { showcaseRecreateMixin } from '@/utils/showcaseRecreateMixin';
 import { getGenerationInputError } from '@/utils/generationInput';
+import { taskPollingMixin } from '@/utils/taskPollingMixin';
 
 interface IData {
   task: ISeedreamTask | undefined;
@@ -47,7 +48,7 @@ export default defineComponent({
     RecentPanel,
     ShowcaseResultTabs
   },
-  mixins: [uploadTrackerProviderMixin, showcaseRecreateMixin('seedream')],
+  mixins: [uploadTrackerProviderMixin, showcaseRecreateMixin('seedream'), taskPollingMixin('seedream')],
   inject: ['initialized'],
   data(): IData {
     return {
@@ -92,7 +93,7 @@ export default defineComponent({
           await this.onGetTasks();
           await this.onScrollDown();
           this.job = window.setInterval(() => {
-            this.onGetTasks();
+            void this.onPollTasks();
           }, 5000);
         }
       },

--- a/src/pages/suno/Index.vue
+++ b/src/pages/suno/Index.vue
@@ -48,6 +48,7 @@ import {
   type X402WalletContext,
   resolveX402WalletContext
 } from '@/operators/x402';
+import { taskPollingMixin } from '@/utils/taskPollingMixin';
 
 interface IData {
   task: ISunoTask | undefined;
@@ -67,7 +68,7 @@ export default defineComponent({
     ShowcaseResultTabs,
     PreviewPanel
   },
-  mixins: [uploadTrackerProviderMixin, showcaseRecreateMixin('suno')],
+  mixins: [uploadTrackerProviderMixin, showcaseRecreateMixin('suno'), taskPollingMixin('suno')],
   inject: ['initialized'],
   data(): IData {
     return {
@@ -119,7 +120,7 @@ export default defineComponent({
       async handler(value: boolean, oldValue: boolean | undefined) {
         if (oldValue === undefined || value === oldValue) return;
         this.$store.commit('suno/setTasks', undefined);
-        if (value && !this.job) this.job = window.setInterval(this.onGetTasks, 5000);
+        if (value && !this.job) this.job = window.setInterval(this.onPollTasks, 5000);
         if (!value && !this.credential?.token) {
           window.clearInterval(this.job);
           this.job = 0;
@@ -144,7 +145,7 @@ export default defineComponent({
         if (newValue) {
           await this.onGetTasks();
           await this.onScrollDown();
-          if (!this.job) this.job = window.setInterval(this.onGetTasks, 5000);
+          if (!this.job) this.job = window.setInterval(this.onPollTasks, 5000);
         }
       },
       immediate: true

--- a/src/pages/veo/Index.vue
+++ b/src/pages/veo/Index.vue
@@ -37,6 +37,7 @@ import {
   resolveX402WalletContext
 } from '@/operators/x402';
 import { getGenerationInputError } from '@/utils/generationInput';
+import { taskPollingMixin } from '@/utils/taskPollingMixin';
 
 interface IData {
   task: IVeoTask | undefined;
@@ -54,7 +55,7 @@ export default defineComponent({
     RecentPanel,
     ShowcaseResultTabs
   },
-  mixins: [uploadTrackerProviderMixin, showcaseRecreateMixin('veo')],
+  mixins: [uploadTrackerProviderMixin, showcaseRecreateMixin('veo'), taskPollingMixin('veo')],
   inject: ['initialized'],
   data(): IData {
     return {
@@ -90,7 +91,7 @@ export default defineComponent({
       async handler(value: boolean, oldValue: boolean | undefined) {
         if (oldValue === undefined || value === oldValue) return;
         this.$store.commit('veo/setTasks', undefined);
-        if (value && !this.job) this.job = window.setInterval(this.onGetTasks, 5000);
+        if (value && !this.job) this.job = window.setInterval(this.onPollTasks, 5000);
         if (!value && !this.credential?.token) {
           window.clearInterval(this.job);
           this.job = 0;
@@ -117,7 +118,7 @@ export default defineComponent({
           console.debug('layout initialized');
           await this.onGetTasks();
           await this.onScrollDown();
-          if (!this.job) this.job = window.setInterval(this.onGetTasks, 5000);
+          if (!this.job) this.job = window.setInterval(this.onPollTasks, 5000);
         }
       },
       immediate: true

--- a/src/pages/wan/Index.vue
+++ b/src/pages/wan/Index.vue
@@ -31,6 +31,7 @@ import {
   resolveX402WalletContext
 } from '@/operators/x402';
 import { getGenerationInputError } from '@/utils/generationInput';
+import { taskPollingMixin } from '@/utils/taskPollingMixin';
 
 interface IData {
   task: IWanTask | undefined;
@@ -47,7 +48,7 @@ export default defineComponent({
     Layout,
     RecentPanel
   },
-  mixins: [uploadTrackerProviderMixin],
+  mixins: [uploadTrackerProviderMixin, taskPollingMixin('wan')],
   inject: ['initialized'],
   data(): IData {
     return {
@@ -88,7 +89,7 @@ export default defineComponent({
       async handler(value: boolean, oldValue: boolean | undefined) {
         if (oldValue === undefined || value === oldValue) return;
         this.$store.commit('wan/setTasks', undefined);
-        if (value && !this.job) this.job = window.setInterval(this.onGetTasks, 5000);
+        if (value && !this.job) this.job = window.setInterval(this.onPollTasks, 5000);
         if (!value && !this.credential?.token) {
           window.clearInterval(this.job);
           this.job = 0;
@@ -114,7 +115,7 @@ export default defineComponent({
           console.debug('layout initialized');
           await this.onGetTasks();
           await this.onScrollDown();
-          if (!this.job) this.job = window.setInterval(this.onGetTasks, 5000);
+          if (!this.job) this.job = window.setInterval(this.onPollTasks, 5000);
         }
       },
       immediate: true

--- a/src/store/factories/createTaskActions.test.ts
+++ b/src/store/factories/createTaskActions.test.ts
@@ -102,6 +102,42 @@ describe('createTaskActions/deleteTask', () => {
   });
 });
 
+describe('createTaskActions/getTasks concurrency', () => {
+  it('coalesces identical requests but keeps different filters independent', async () => {
+    const tasks = vi.fn().mockResolvedValue({ data: { items: [] } });
+    const actions: any = makeActions({ tasks });
+    const state = { credential: { token: 'tok' }, tasks: undefined, status: { getTasks: 'None' } };
+    const context = { state, rootState: { user: { id: 'u' } }, commits: [] as Array<[string, unknown]> };
+
+    await Promise.all([
+      invoke(actions.getTasks, context, { limit: 20 }),
+      invoke(actions.getTasks, context, { limit: 20 }),
+      invoke(actions.getTasks, context, { limit: 20, createdAtMax: 10 })
+    ]);
+
+    expect(tasks).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not coalesce requests whose root-state filter changed', async () => {
+    const tasks = vi.fn().mockResolvedValue({ data: { items: [] } });
+    const actions: any = createTaskActions<unknown, { id: string }, { type?: string }>({
+      serviceId: 'svc-1',
+      operator: { tasks },
+      buildFilter: (rootState: any) => ({ type: rootState.taskType })
+    });
+    const state = { credential: { token: 'tok' }, tasks: undefined, status: { getTasks: 'None' } };
+    const rootState: any = { taskType: 'videos' };
+    const context = { state, rootState, commits: [] as Array<[string, unknown]> };
+
+    const first = invoke(actions.getTasks, context);
+    rootState.taskType = 'motion';
+    const second = invoke(actions.getTasks, context);
+    await Promise.all([first, second]);
+
+    expect(tasks).toHaveBeenCalledTimes(2);
+  });
+});
+
 describe('createTaskActions/getTasks payment mode', () => {
   it('queries known task IDs without a Credential in x402 mode', async () => {
     const tasks = vi.fn().mockResolvedValue({ data: { items: [{ id: 'wallet-task' }], count: 1 } });

--- a/src/store/factories/createTaskActions.ts
+++ b/src/store/factories/createTaskActions.ts
@@ -5,6 +5,7 @@ import { applicationOperator, credentialOperator, serviceOperator } from '@/oper
 import { mergeAndSortLists } from '@/utils/merge';
 import { IRootState } from '../common/models';
 import type { OperatorRequestOptions, PaymentMode } from '@/operators/x402';
+import { refreshPendingTaskItems } from './taskPolling';
 
 /**
  * Generic state shape every per-service Vuex module conforms to.
@@ -72,7 +73,7 @@ export interface IGetTasksArgs {
  * from `rootState.kling.taskType`) can pass `opts.buildFilter` to take
  * over completely.
  */
-export function createTaskActions<TConfig, TTask, TFilter>(opts: {
+export function createTaskActions<TConfig, TTask extends { id?: string }, TFilter>(opts: {
   serviceId: string;
   operator: ITaskOperator<TFilter, TTask>;
   /** Pass through `offset` / `limit` from the dispatch arg. */
@@ -81,8 +82,11 @@ export function createTaskActions<TConfig, TTask, TFilter>(opts: {
   type?: string;
   /** Fully custom filter — when provided, `paginated` and `type` are ignored. */
   buildFilter?: (rootState: IRootState, args: IGetTasksArgs) => TFilter;
+  isPending?: (task: TTask) => boolean;
 }): ActionTree<ITaskServiceState<TConfig, TTask>, IRootState> {
   type S = ITaskServiceState<TConfig, TTask>;
+  const taskRequests = new Map<string, Promise<TTask[]>>();
+  let pendingRequest: Promise<TTask[]> | undefined;
   const buildFilter =
     opts.buildFilter ??
     ((rootState: IRootState, args: IGetTasksArgs): TFilter =>
@@ -186,17 +190,17 @@ export function createTaskActions<TConfig, TTask, TFilter>(opts: {
     }
   };
 
-  const getTasks = async (
+  const getTasks = (
     { commit, state, rootState }: ActionContext<S, IRootState>,
     args: IGetTasksArgs = {}
   ): Promise<TTask[]> => {
     const token = state.credential?.token;
     const mode = args.mode || 'credits';
-    if (mode === 'credits' && !token) throw new Error('no token');
+    if (mode === 'credits' && !token) return Promise.reject(new Error('no token'));
     if (mode === 'x402' && !args.ids?.length) {
       commit('setTasksItems', []);
       commit('setTasksTotal', 0);
-      return [];
+      return Promise.resolve([]);
     }
     const filter =
       mode === 'x402'
@@ -205,19 +209,60 @@ export function createTaskActions<TConfig, TTask, TFilter>(opts: {
             offset: args.offset,
             limit: args.limit,
             createdAtMin: args.createdAtMin,
-            createdAtMax: args.createdAtMax
+            createdAtMax: args.createdAtMax,
+            ...(opts.type ? { type: opts.type } : {})
           } as unknown as TFilter)
         : buildFilter(rootState, args);
-    const response = await opts.operator.tasks(filter, { token, mode });
-    const existingItems = state?.tasks?.items || [];
-    const newItems = response.data.items || [];
-    const mergedItems = mergeAndSortLists(existingItems, newItems);
-    commit('setTasksItems', mergedItems);
-    const total = response.data.count ?? response.data.total;
-    if (total !== undefined) {
-      commit('setTasksTotal', total);
-    }
-    return response.data.items;
+    const requestKey = JSON.stringify([mode, token || '', filter]);
+    const activeRequest = taskRequests.get(requestKey);
+    if (activeRequest) return activeRequest;
+    const request = (async () => {
+      if (state.status) state.status.getTasks = Status.Request;
+      try {
+        const requestOptions: OperatorRequestOptions = mode === 'x402' ? { mode: 'x402' } : { token };
+        const response = await opts.operator.tasks(filter, requestOptions);
+        const existingItems = state?.tasks?.items || [];
+        const newItems = response.data.items || [];
+        commit('setTasksItems', mergeAndSortLists(existingItems, newItems));
+        const total = response.data.count ?? response.data.total;
+        if (total !== undefined) commit('setTasksTotal', total);
+        if (state.status) state.status.getTasks = Status.Success;
+        return newItems;
+      } catch (error) {
+        if (state.status) state.status.getTasks = Status.Error;
+        throw error;
+      }
+    })().finally(() => {
+      taskRequests.delete(requestKey);
+    });
+    taskRequests.set(requestKey, request);
+    return request;
+  };
+
+  const refreshPendingTasks = (
+    { commit, state }: ActionContext<S, IRootState>,
+    args: Pick<IGetTasksArgs, 'mode'> = {}
+  ): Promise<TTask[]> => {
+    if (!opts.isPending || pendingRequest) return pendingRequest || Promise.resolve([]);
+    const token = state.credential?.token;
+    const mode = args.mode || 'credits';
+    if (mode === 'credits' && !token) return Promise.reject(new Error('no token'));
+    const requestOptions: OperatorRequestOptions = mode === 'x402' ? { mode: 'x402' } : { token };
+    pendingRequest = refreshPendingTaskItems({
+      getItems: () => state.tasks?.items || [],
+      isPending: opts.isPending,
+      fetch: async (ids) => {
+        const response = await opts.operator.tasks(
+          { ids, ...(opts.type ? { type: opts.type } : {}) } as unknown as TFilter,
+          requestOptions
+        );
+        return response.data.items || [];
+      },
+      commit: (items) => commit('setTasksItems', items)
+    }).finally(() => {
+      pendingRequest = undefined;
+    });
+    return pendingRequest!;
   };
 
   // Hard-delete one of the caller's own tasks and drop it from the list.
@@ -292,6 +337,7 @@ export function createTaskActions<TConfig, TTask, TFilter>(opts: {
     setTasksTotal,
     setTasksActive,
     getTasks,
+    refreshPendingTasks,
     deleteTask
   };
 }

--- a/src/store/factories/taskPolling.test.ts
+++ b/src/store/factories/taskPolling.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  pendingByResponseState,
+  pendingByTopLevelStatus,
+  pendingUntilResponse,
+  pendingUntilResponseOrTerminalStatus,
+  pendingUntilSuccessfulMedia,
+  refreshPendingTaskItems
+} from './taskPolling';
+
+type TestTask = { id?: string; response?: { success?: boolean } };
+
+describe('task polling predicates', () => {
+  it('recognizes wrapper, nested, media, and top-level terminal states', () => {
+    expect(pendingUntilResponse({})).toBe(true);
+    expect(pendingUntilResponse({ response: { success: true } })).toBe(false);
+    expect(pendingByResponseState({ response: { data: { status: 'running' } } })).toBe(true);
+    expect(pendingByResponseState({ response: { data: { status: 'succeeded' } } })).toBe(false);
+    expect(pendingUntilSuccessfulMedia({ response: { video_url: 'https://example.com/video.mp4' } })).toBe(false);
+    expect(pendingUntilSuccessfulMedia({ response: { success: true } })).toBe(false);
+    expect(pendingByTopLevelStatus({ status: 'running' })).toBe(true);
+    expect(pendingUntilResponseOrTerminalStatus({ status: 'failed' })).toBe(false);
+    expect(pendingUntilResponseOrTerminalStatus({ state: 'finished' })).toBe(false);
+  });
+
+  it('does not commit unchanged pending snapshots', async () => {
+    const commit = vi.fn();
+    await refreshPendingTaskItems<TestTask>({
+      getItems: () => [{ id: 'a' }],
+      isPending: pendingUntilResponse,
+      fetch: async () => [{ id: 'a' }],
+      commit
+    });
+    expect(commit).not.toHaveBeenCalled();
+  });
+
+  it('applies terminal updates to the latest task list', async () => {
+    const commit = vi.fn();
+    let current: TestTask[] = [{ id: 'a' }];
+    let release!: (items: TestTask[]) => void;
+    const fetch = () => new Promise<TestTask[]>((resolve) => (release = resolve));
+    const request = refreshPendingTaskItems({
+      getItems: () => current,
+      isPending: pendingUntilResponse,
+      fetch,
+      commit
+    });
+    current = [{ id: 'new', response: { success: true } }, { id: 'a' }];
+    release([{ id: 'a', response: { success: true } }]);
+    await request;
+    expect(commit).toHaveBeenCalledWith([
+      { id: 'new', response: { success: true } },
+      { id: 'a', response: { success: true } }
+    ]);
+  });
+
+  it('replaces a pending item in place when it reaches terminal state', async () => {
+    const commit = vi.fn();
+    const done = { id: 'a', response: { success: true } };
+    await refreshPendingTaskItems<TestTask>({
+      getItems: () => [{ id: 'before', response: { success: true } }, { id: 'a' }],
+      isPending: pendingUntilResponse,
+      fetch: async () => [done],
+      commit
+    });
+    expect(commit).toHaveBeenCalledWith([{ id: 'before', response: { success: true } }, done]);
+  });
+});

--- a/src/store/factories/taskPolling.ts
+++ b/src/store/factories/taskPolling.ts
@@ -1,0 +1,74 @@
+type TaskLike = {
+  response?: { success?: boolean; error?: unknown; state?: string; video_url?: string; data?: unknown };
+  status?: string;
+  state?: string;
+};
+
+const RUNNING = new Set(['queued', 'pending', 'processing', 'running']);
+const TERMINAL = new Set([
+  'success',
+  'succeed',
+  'succeeded',
+  'completed',
+  'finished',
+  'failure',
+  'failed',
+  'cancelled',
+  'dead'
+]);
+const value = (input: unknown) => String(input || '').toLowerCase();
+
+export const pendingUntilResponse = (task: TaskLike) => !task.response;
+
+export const pendingByResponseState = (task: TaskLike) => {
+  if (!task.response) return true;
+  const data = Array.isArray(task.response.data) ? task.response.data[0] : task.response.data;
+  return RUNNING.has(
+    value(
+      (data as { state?: string; status?: string } | undefined)?.state ||
+        (data as { state?: string; status?: string } | undefined)?.status ||
+        task.response.state
+    )
+  );
+};
+
+export const pendingUntilSuccessfulMedia = (task: TaskLike) =>
+  !task.response || (!task.response.error && task.response.success !== true && !task.response.video_url);
+
+export const pendingByTopLevelStatus = (task: TaskLike) => RUNNING.has(value(task.status || task.state));
+export const pendingUntilResponseOrTerminalStatus = (task: TaskLike) =>
+  !task.response && !TERMINAL.has(value(task.status || task.state));
+
+type PendingRefreshOptions<T> = {
+  getItems: () => T[];
+  isPending: (task: T) => boolean;
+  fetch: (ids: string[]) => Promise<T[]>;
+  commit: (items: T[]) => void;
+};
+
+export async function refreshPendingTaskItems<T extends { id?: string }>({
+  getItems,
+  isPending,
+  fetch,
+  commit
+}: PendingRefreshOptions<T>): Promise<T[]> {
+  const ids = getItems()
+    .filter(isPending)
+    .slice(-20)
+    .map((task) => task.id)
+    .filter((id): id is string => Boolean(id));
+  if (!ids.length) return [];
+  const result = await fetch(ids);
+  const updates = new Map(result.map((task) => [task.id, task]));
+  let changed = false;
+  const next = getItems().map((task) => {
+    const update = updates.get(task.id);
+    if (update && isPending(task) && !isPending(update)) {
+      changed = true;
+      return update;
+    }
+    return task;
+  });
+  if (changed) commit(next);
+  return result;
+}

--- a/src/store/fish/actions.ts
+++ b/src/store/fish/actions.ts
@@ -6,10 +6,12 @@ import { createTaskActions } from '@/store/factories/createTaskActions';
 import { IFishTaskFilter } from '@/operators/fish';
 import { IRootState } from '@/store/common/models';
 import { IFishState } from './models';
+import { pendingUntilResponse } from '@/store/factories/taskPolling';
 
 const baseActions = createTaskActions<IFishTtsConfig, IFishTask, IFishTaskFilter>({
   serviceId: FISH_SERVICE_ID,
   operator: fishOperator,
+  isPending: pendingUntilResponse,
   // Default page (`/fish/tts`) lists fish_tts jobs. The /fish/model page
   // overrides via dispatching with a custom filter or — once added in
   // PR #2 — its own dedicated filter shape.

--- a/src/store/flux/actions.ts
+++ b/src/store/flux/actions.ts
@@ -2,10 +2,12 @@ import { fluxOperator } from '@/operators';
 import { IFluxConfig, IFluxTask } from '@/models';
 import { FLUX_SERVICE_ID } from '@/constants';
 import { createTaskActions } from '@/store/factories/createTaskActions';
+import { pendingUntilResponse } from '@/store/factories/taskPolling';
 
 const actions = createTaskActions<IFluxConfig, IFluxTask, Record<string, unknown>>({
   serviceId: FLUX_SERVICE_ID,
   operator: fluxOperator,
+  isPending: pendingUntilResponse,
   type: 'images'
 });
 

--- a/src/store/grokvideo/actions.ts
+++ b/src/store/grokvideo/actions.ts
@@ -2,10 +2,12 @@ import { grokvideoOperator } from '@/operators';
 import { IGrokVideoConfig, IGrokVideoTask } from '@/models';
 import { GROKVIDEO_SERVICE_ID } from '@/constants';
 import { createTaskActions } from '@/store/factories/createTaskActions';
+import { pendingByResponseState } from '@/store/factories/taskPolling';
 
 const actions = createTaskActions<IGrokVideoConfig, IGrokVideoTask, Record<string, unknown>>({
   serviceId: GROKVIDEO_SERVICE_ID,
   operator: grokvideoOperator,
+  isPending: pendingByResponseState,
   paginated: true,
   type: 'videos'
 });

--- a/src/store/hailuo/actions.ts
+++ b/src/store/hailuo/actions.ts
@@ -2,10 +2,12 @@ import { hailuoOperator } from '@/operators';
 import { IHailuoConfig, IHailuoTask } from '@/models';
 import { HAILUO_SERVICE_ID } from '@/constants';
 import { createTaskActions } from '@/store/factories/createTaskActions';
+import { pendingByResponseState } from '@/store/factories/taskPolling';
 
 const actions = createTaskActions<IHailuoConfig, IHailuoTask, Record<string, unknown>>({
   serviceId: HAILUO_SERVICE_ID,
   operator: hailuoOperator,
+  isPending: pendingByResponseState,
   type: 'videos'
 });
 

--- a/src/store/kling/actions.ts
+++ b/src/store/kling/actions.ts
@@ -6,12 +6,14 @@ import { ITaskListFilter } from '@/operators/baseTaskOperator';
 import { ActionContext } from 'vuex';
 import { IRootState } from '../common/models';
 import { IKlingState } from './models';
+import { pendingUntilSuccessfulMedia } from '@/store/factories/taskPolling';
 
 type KlingTasksFilter = ITaskListFilter & { type?: IKlingTaskType };
 
 const baseActions = createTaskActions<IKlingConfig, IKlingTask, KlingTasksFilter>({
   serviceId: KLING_SERVICE_ID,
   operator: klingOperator,
+  isPending: pendingUntilSuccessfulMedia,
   buildFilter: (rootState, args: IGetTasksArgs): KlingTasksFilter => ({
     userId: rootState?.user?.id,
     createdAtMin: args.createdAtMin,

--- a/src/store/luma/actions.ts
+++ b/src/store/luma/actions.ts
@@ -2,10 +2,12 @@ import { lumaOperator } from '@/operators';
 import { ILumaConfig, ILumaTask } from '@/models';
 import { LUMA_SERVICE_ID } from '@/constants';
 import { createTaskActions } from '@/store/factories/createTaskActions';
+import { pendingByResponseState } from '@/store/factories/taskPolling';
 
 const actions = createTaskActions<ILumaConfig, ILumaTask, Record<string, unknown>>({
   serviceId: LUMA_SERVICE_ID,
-  operator: lumaOperator
+  operator: lumaOperator,
+  isPending: pendingByResponseState
 });
 
 export default actions;

--- a/src/store/midjourney/actions.ts
+++ b/src/store/midjourney/actions.ts
@@ -6,6 +6,7 @@ import { IApplication, ICredential, IMidjourneyConfig, IMidjourneyTask, IService
 import { Status } from '@/models/common';
 import { MIDJOURNEY_SERVICE_ID } from '@/constants';
 import { mergeAndSortLists } from '@/utils/merge';
+import { pendingUntilResponseOrTerminalStatus, refreshPendingTaskItems } from '@/store/factories/taskPolling';
 
 export const resetAll = ({ commit }: ActionContext<IMidjourneyState, IRootState>): void => {
   commit('resetAll');
@@ -187,7 +188,24 @@ export const getTasks = async (
   });
 };
 
+export const refreshPendingTasks = async (
+  { commit, state }: ActionContext<IMidjourneyState, IRootState>,
+  args: { mode?: 'credits' | 'x402' } = {}
+): Promise<IMidjourneyTask[]> => {
+  const token = state.credential?.token;
+  const mode = args.mode || 'credits';
+  if (mode === 'credits' && !token) throw new Error('no token');
+  const requestOptions = mode === 'x402' ? { mode: 'x402' as const } : { token };
+  return refreshPendingTaskItems({
+    getItems: () => state.tasks?.items || [],
+    isPending: pendingUntilResponseOrTerminalStatus,
+    fetch: async (ids) => (await midjourneyOperator.tasks({ ids }, requestOptions)).data.items || [],
+    commit: (items) => commit('setTasksItems', items)
+  });
+};
+
 export default {
+  refreshPendingTasks,
   setService,
   getService,
   resetAll,

--- a/src/store/minimax/actions.ts
+++ b/src/store/minimax/actions.ts
@@ -2,10 +2,12 @@ import { minimaxOperator } from '@/operators';
 import { IMinimaxConfig, IMinimaxVideoTask } from '@/models';
 import { MINIMAX_SERVICE_ID } from '@/constants';
 import { createTaskActions } from '@/store/factories/createTaskActions';
+import { pendingByTopLevelStatus } from '@/store/factories/taskPolling';
 
 const actions = createTaskActions<IMinimaxConfig, IMinimaxVideoTask, Record<string, unknown>>({
   serviceId: MINIMAX_SERVICE_ID,
   operator: minimaxOperator,
+  isPending: pendingByTopLevelStatus,
   type: 'videos'
 });
 

--- a/src/store/nanobanana/actions.ts
+++ b/src/store/nanobanana/actions.ts
@@ -2,10 +2,12 @@ import { nanobananaOperator } from '@/operators';
 import { INanobananaConfig, INanobananaTask } from '@/models';
 import { NANOBANANA_SERVICE_ID } from '@/constants';
 import { createTaskActions } from '@/store/factories/createTaskActions';
+import { pendingUntilResponse } from '@/store/factories/taskPolling';
 
 const actions = createTaskActions<INanobananaConfig, INanobananaTask, Record<string, unknown>>({
   serviceId: NANOBANANA_SERVICE_ID,
   operator: nanobananaOperator,
+  isPending: pendingUntilResponse,
   paginated: true,
   type: 'images'
 });

--- a/src/store/omni/actions.ts
+++ b/src/store/omni/actions.ts
@@ -2,10 +2,12 @@ import { omniOperator } from '@/operators';
 import { IOmniConfig, IOmniTask } from '@/models';
 import { OMNI_SERVICE_ID } from '@/constants';
 import { createTaskActions } from '@/store/factories/createTaskActions';
+import { pendingByResponseState } from '@/store/factories/taskPolling';
 
 const actions = createTaskActions<IOmniConfig, IOmniTask, Record<string, unknown>>({
   serviceId: OMNI_SERVICE_ID,
   operator: omniOperator,
+  isPending: pendingByResponseState,
   paginated: true,
   type: 'videos'
 });

--- a/src/store/openaiimage/actions.ts
+++ b/src/store/openaiimage/actions.ts
@@ -2,10 +2,12 @@ import { openaiimageOperator } from '@/operators';
 import { IOpenAIImageConfig, IOpenAIImageTask } from '@/models';
 import { OPENAIIMAGE_SERVICE_ID } from '@/constants';
 import { createTaskActions } from '@/store/factories/createTaskActions';
+import { pendingUntilResponse } from '@/store/factories/taskPolling';
 
 const actions = createTaskActions<IOpenAIImageConfig, IOpenAIImageTask, Record<string, unknown>>({
   serviceId: OPENAIIMAGE_SERVICE_ID,
   operator: openaiimageOperator,
+  isPending: pendingUntilResponse,
   paginated: true
 });
 

--- a/src/store/pika/actions.ts
+++ b/src/store/pika/actions.ts
@@ -2,10 +2,12 @@ import { pikaOperator } from '@/operators';
 import { IPikaConfig, IPikaTask } from '@/models';
 import { PIKA_SERVICE_ID } from '@/constants';
 import { createTaskActions } from '@/store/factories/createTaskActions';
+import { pendingByResponseState } from '@/store/factories/taskPolling';
 
 const actions = createTaskActions<IPikaConfig, IPikaTask, Record<string, unknown>>({
   serviceId: PIKA_SERVICE_ID,
   operator: pikaOperator,
+  isPending: pendingByResponseState,
   type: 'videos'
 });
 

--- a/src/store/pixverse/actions.ts
+++ b/src/store/pixverse/actions.ts
@@ -2,10 +2,12 @@ import { pixverseOperator } from '@/operators';
 import { IPixverseConfig, IPixverseTask } from '@/models';
 import { PIXVERSE_SERVICE_ID } from '@/constants';
 import { createTaskActions } from '@/store/factories/createTaskActions';
+import { pendingByResponseState } from '@/store/factories/taskPolling';
 
 const actions = createTaskActions<IPixverseConfig, IPixverseTask, Record<string, unknown>>({
   serviceId: PIXVERSE_SERVICE_ID,
   operator: pixverseOperator,
+  isPending: pendingByResponseState,
   type: 'videos'
 });
 

--- a/src/store/producer/actions.ts
+++ b/src/store/producer/actions.ts
@@ -6,6 +6,7 @@ import { IApplication, ICredential, IProducerConfig, IProducerTask, IService } f
 import { Status } from '@/models/common';
 import { PRODUCER_SERVICE_ID } from '@/constants';
 import { mergeAndSortLists } from '@/utils/merge';
+import { pendingUntilResponse, refreshPendingTaskItems } from '@/store/factories/taskPolling';
 
 export const resetAll = ({ commit }: ActionContext<IProducerState, IRootState>): void => {
   commit('resetAll');
@@ -190,7 +191,24 @@ export const getTasks = async (
   });
 };
 
+export const refreshPendingTasks = async (
+  { commit, state }: ActionContext<IProducerState, IRootState>,
+  args: { mode?: 'credits' | 'x402' } = {}
+): Promise<IProducerTask[]> => {
+  const token = state.credential?.token;
+  const mode = args.mode || 'credits';
+  if (mode === 'credits' && !token) throw new Error('no token');
+  const requestOptions = mode === 'x402' ? { mode: 'x402' as const } : { token };
+  return refreshPendingTaskItems({
+    getItems: () => state.tasks?.items || [],
+    isPending: pendingUntilResponse,
+    fetch: async (ids) => (await producerOperator.tasks({ ids, type: 'audios' }, requestOptions)).data.items || [],
+    commit: (items) => commit('setTasksItems', items)
+  });
+};
+
 export default {
+  refreshPendingTasks,
   setService,
   getService,
   resetAll,

--- a/src/store/qrart/actions.ts
+++ b/src/store/qrart/actions.ts
@@ -2,10 +2,12 @@ import { qrartOperator } from '@/operators';
 import { IQrartConfig, IQrartTask } from '@/models';
 import { QRART_SERVICE_ID } from '@/constants';
 import { createTaskActions } from '@/store/factories/createTaskActions';
+import { pendingUntilResponse } from '@/store/factories/taskPolling';
 
 const actions = createTaskActions<IQrartConfig, IQrartTask, Record<string, unknown>>({
   serviceId: QRART_SERVICE_ID,
-  operator: qrartOperator
+  operator: qrartOperator,
+  isPending: pendingUntilResponse
 });
 
 export default actions;

--- a/src/store/qwenimage/actions.ts
+++ b/src/store/qwenimage/actions.ts
@@ -6,6 +6,7 @@ import { IApplication, ICredential, IQwenImageConfig, IQwenImageTask, IService }
 import { Status } from '@/models/common';
 import { QWEN_IMAGE_SERVICE_ID } from '@/constants';
 import { mergeAndSortLists } from '@/utils/merge';
+import { pendingUntilResponse, refreshPendingTaskItems } from '@/store/factories/taskPolling';
 
 export const resetAll = ({ commit }: ActionContext<IQwenImageState, IRootState>): void => {
   commit('resetAll');
@@ -182,7 +183,23 @@ export const getTasks = async (
   });
 };
 
+export const refreshPendingTasks = async ({
+  commit,
+  state
+}: ActionContext<IQwenImageState, IRootState>): Promise<IQwenImageTask[]> => {
+  const token = state.credential?.token;
+  if (!token) throw new Error('no token');
+  const requestOptions = { token };
+  return refreshPendingTaskItems({
+    getItems: () => state.tasks?.items || [],
+    isPending: pendingUntilResponse,
+    fetch: async (ids) => (await qwenimageOperator.tasks({ ids, type: 'images' }, requestOptions)).data.items || [],
+    commit: (items) => commit('setTasksItems', items)
+  });
+};
+
 export default {
+  refreshPendingTasks,
   createCredential,
   setService,
   getService,

--- a/src/store/seedance/actions.ts
+++ b/src/store/seedance/actions.ts
@@ -2,10 +2,12 @@ import { seedanceOperator } from '@/operators';
 import { ISeedanceConfig, ISeedanceTask } from '@/models';
 import { SEEDANCE_SERVICE_ID } from '@/constants';
 import { createTaskActions } from '@/store/factories/createTaskActions';
+import { pendingByResponseState } from '@/store/factories/taskPolling';
 
 const actions = createTaskActions<ISeedanceConfig, ISeedanceTask, Record<string, unknown>>({
   serviceId: SEEDANCE_SERVICE_ID,
   operator: seedanceOperator,
+  isPending: pendingByResponseState,
   paginated: true,
   type: 'videos'
 });

--- a/src/store/seedream/actions.ts
+++ b/src/store/seedream/actions.ts
@@ -6,6 +6,7 @@ import { IApplication, ICredential, ISeedreamConfig, ISeedreamTask, IService } f
 import { Status } from '@/models/common';
 import { SEEDREAM_SERVICE_ID } from '@/constants';
 import { mergeAndSortLists } from '@/utils/merge';
+import { pendingUntilResponse, refreshPendingTaskItems } from '@/store/factories/taskPolling';
 
 export const resetAll = ({ commit }: ActionContext<ISeedreamState, IRootState>): void => {
   commit('resetAll');
@@ -182,7 +183,23 @@ export const getTasks = async (
   });
 };
 
+export const refreshPendingTasks = async ({
+  commit,
+  state
+}: ActionContext<ISeedreamState, IRootState>): Promise<ISeedreamTask[]> => {
+  const token = state.credential?.token;
+  if (!token) throw new Error('no token');
+  const requestOptions = { token };
+  return refreshPendingTaskItems({
+    getItems: () => state.tasks?.items || [],
+    isPending: pendingUntilResponse,
+    fetch: async (ids) => (await seedreamOperator.tasks({ ids, type: 'images' }, requestOptions)).data.items || [],
+    commit: (items) => commit('setTasksItems', items)
+  });
+};
+
 export default {
+  refreshPendingTasks,
   createCredential,
   setService,
   getService,

--- a/src/store/suno/actions.ts
+++ b/src/store/suno/actions.ts
@@ -6,6 +6,7 @@ import { IApplication, ICredential, ISunoConfig, ISunoPersona, ISunoTask, IServi
 import { Status } from '@/models/common';
 import { SUNO_SERVICE_ID } from '@/constants';
 import { mergeAndSortLists } from '@/utils/merge';
+import { pendingUntilResponse, refreshPendingTaskItems } from '@/store/factories/taskPolling';
 
 export const resetAll = ({ commit }: ActionContext<ISunoState, IRootState>): void => {
   commit('resetAll');
@@ -235,7 +236,24 @@ export const deletePersona = async (
   }
 };
 
+export const refreshPendingTasks = async (
+  { commit, state }: ActionContext<ISunoState, IRootState>,
+  args: { mode?: 'credits' | 'x402' } = {}
+): Promise<ISunoTask[]> => {
+  const token = state.credential?.token;
+  const mode = args.mode || 'credits';
+  if (mode === 'credits' && !token) throw new Error('no token');
+  const requestOptions = mode === 'x402' ? { mode: 'x402' as const } : { token };
+  return refreshPendingTaskItems({
+    getItems: () => state.tasks?.items || [],
+    isPending: pendingUntilResponse,
+    fetch: async (ids) => (await sunoOperator.tasks({ ids, type: 'audios' }, requestOptions)).data.items || [],
+    commit: (items) => commit('setTasksItems', items)
+  });
+};
+
 export default {
+  refreshPendingTasks,
   setService,
   getService,
   resetAll,

--- a/src/store/veo/actions.ts
+++ b/src/store/veo/actions.ts
@@ -2,11 +2,13 @@ import { veoOperator } from '@/operators';
 import { IVeoConfig, IVeoTask } from '@/models';
 import { VEO_SERVICE_ID } from '@/constants';
 import { createTaskActions } from '@/store/factories/createTaskActions';
+import { pendingByResponseState } from '@/store/factories/taskPolling';
 
 // No `type` filter: /veo/tasks returns the user's generated videos.
 const actions = createTaskActions<IVeoConfig, IVeoTask, Record<string, unknown>>({
   serviceId: VEO_SERVICE_ID,
-  operator: veoOperator
+  operator: veoOperator,
+  isPending: pendingByResponseState
 });
 
 export default actions;

--- a/src/store/wan/actions.ts
+++ b/src/store/wan/actions.ts
@@ -2,10 +2,12 @@ import { wanOperator } from '@/operators';
 import { IWanConfig, IWanTask } from '@/models';
 import { WAN_SERVICE_ID } from '@/constants';
 import { createTaskActions } from '@/store/factories/createTaskActions';
+import { pendingByResponseState } from '@/store/factories/taskPolling';
 
 const actions = createTaskActions<IWanConfig, IWanTask, Record<string, unknown>>({
   serviceId: WAN_SERVICE_ID,
   operator: wanOperator,
+  isPending: pendingByResponseState,
   type: 'videos'
 });
 

--- a/src/utils/taskPollingMixin.test.ts
+++ b/src/utils/taskPollingMixin.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from 'vitest';
+import { taskPollingMixin } from './taskPollingMixin';
+
+const methods = (module = 'demo') => taskPollingMixin(module).methods as { onPollTasks: () => Promise<void> };
+
+describe('taskPollingMixin', () => {
+  it('isolates overlapping poll locks per component instance', async () => {
+    let release!: () => void;
+    const pending = new Promise<void>((resolve) => (release = resolve));
+    const dispatch = vi.fn().mockReturnValueOnce(pending).mockResolvedValueOnce(undefined);
+    const poll = methods().onPollTasks;
+    const first: any = { taskPollRunning: false, taskHistoryPolledAt: Date.now(), $store: { dispatch } };
+    const second: any = { taskPollRunning: false, taskHistoryPolledAt: Date.now(), $store: { dispatch } };
+
+    const firstPoll = poll.call(first);
+    await poll.call(second);
+    expect(dispatch).toHaveBeenCalledTimes(2);
+    release();
+    await firstPoll;
+  });
+
+  it('runs due history independently when pending reconciliation fails', async () => {
+    const dispatch = vi.fn().mockRejectedValue(new Error('pending failed'));
+    const onGetTasks = vi.fn().mockResolvedValue(undefined);
+    const state: any = { taskPollRunning: false, taskHistoryPolledAt: 0, $store: { dispatch }, onGetTasks };
+
+    await methods().onPollTasks.call(state);
+
+    expect(onGetTasks).toHaveBeenCalledOnce();
+    expect(state.taskPollRunning).toBe(false);
+  });
+});

--- a/src/utils/taskPollingMixin.ts
+++ b/src/utils/taskPollingMixin.ts
@@ -1,0 +1,36 @@
+import { defineComponent } from 'vue';
+
+const HISTORY_INTERVAL_MS = 60000;
+
+export function taskPollingMixin(storeModule: string, targeted = true) {
+  return defineComponent({
+    data() {
+      return { taskPollRunning: false, taskHistoryPolledAt: Date.now() };
+    },
+    methods: {
+      async onPollTasks() {
+        if (this.taskPollRunning) return;
+        this.taskPollRunning = true;
+        try {
+          const self = this as any;
+          const walletMode = Boolean(self.walletMode && !self.credential?.token);
+          const now = Date.now();
+          const requests: Promise<unknown>[] = [];
+          if (targeted && !walletMode) {
+            requests.push(self.$store.dispatch(`${storeModule}/refreshPendingTasks`, { mode: 'credits' }));
+          }
+          if (now - this.taskHistoryPolledAt >= HISTORY_INTERVAL_MS) {
+            this.taskHistoryPolledAt = now;
+            requests.push(self.onGetTasks());
+          }
+          const results = await Promise.allSettled(requests);
+          results.forEach((result) => {
+            if (result.status === 'rejected') console.warn(`${storeModule} task poll failed`, result.reason);
+          });
+        } finally {
+          this.taskPollRunning = false;
+        }
+      }
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- replace 5-second full-history polling with targeted pending-ID reconciliation across all 23 active generation scenarios
- refresh authoritative history at most once per 60 seconds, including failure backoff, while preserving immediate initial/pagination/post-generation refreshes
- centralize scenario-specific pending predicates and page polling behavior with coverage gates
- preserve Credits/x402 wire contracts and custom Suno/Producer/Midjourney/Seedream/Qwen actions
- keep task state monotonic and identity-safe under overlapping responses, mode switches, credential changes, and deletion races

## Active scenario coverage
- 21 scenarios use targeted pending-ID reconciliation.
- Digital Human and Maestro reduce full-history polling to once per 60 seconds because their batch endpoints do not accept ID lists.
- Sora remains excluded because its API and Kong routes were intentionally retired.

## Production evidence
- affected OpenAI Image account had 14,233 task rows and repeated 30-second history timeouts on a 5-second timer
- production read-only contract audit found 22/23 active endpoints ignored `ids` when gateway identity was present
- OpenAI production benchmark: 20 serial ID reads ~22.8ms; one indexed `$in` query ~1.4ms

## Verification
- 27 focused scheduler/predicate/mixin/x402 tests passed
- all 23 active scenario coverage checks passed
- `vue-tsc -b` passed
- ESLint: 0 errors (2 pre-existing warnings in `dropUploadMixin.test.ts`)
- Vite production build passed
- Beachball check passed

## Merge dependency

## Review notes
The original concurrency/state implementation reached Codex CLEAN before this all-scenario expansion. Subsequent Codex attempts were blocked by repeated external review-service timeouts. Manual adversarial review found and fixed: history retry storms, page guards blocking lightweight reconciliation, stale/contradictory status predicates, Credits/x402 wire drift, retired Sora assumptions, real known-ID task lookup compatibility across active scenario endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Backend scope correction
No PlatformService change is required. Production already supports exact `retrieve_batch(ids)` lookup for known persisted task IDs; the earlier backend investigation used synthetic missing IDs and misread empty-hit fallback behavior. PlatformService PR https://github.com/AceDataCloud/PlatformService/pull/2215 was closed without merge.

## 🤖 对抗评审 (reviewer: codex)
- The first implementation was rejected as over-designed and rewritten from scratch.
- Removed identity generations, deletion queues, tombstones, total revisions, and legacy-store migrations.
- Fixed stale task-list commits, request coalescing by effective filter, instance-shared polling state, and Midjourney `finished` terminal handling.
- Final verdict: APPROVE — no remaining RISK or material over-design.


## Simplification
The all-scenario implementation was reduced from +1,264/-401 to +522/-80. Most touched files contain only 2-7 lines of scenario wiring; shared production logic is limited to the keyed request guard, pending reconciliation helper, predicates, and instance-owned polling mixin.
