### PR TITLE
fix(tasks): refresh task history every five seconds

### DIFF
--- a/change/submitted-task-discovery.json
+++ b/change/submitted-task-discovery.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Refresh generation task history every five seconds so new tasks appear promptly.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/utils/taskPollingMixin.test.ts
+++ b/src/utils/taskPollingMixin.test.ts
@@ -19,6 +19,24 @@ describe('taskPollingMixin', () => {
     await firstPoll;
   });
 
+  it('refreshes task history every five seconds', async () => {
+    const dispatch = vi.fn().mockResolvedValue(undefined);
+    const onGetTasks = vi.fn().mockResolvedValue(undefined);
+    const now = Date.now();
+    const state: any = { taskPollRunning: false, taskHistoryPolledAt: now, $store: { dispatch }, onGetTasks };
+    const nowSpy = vi.spyOn(Date, 'now');
+
+    nowSpy.mockReturnValue(now + 4999);
+    await methods().onPollTasks.call(state);
+    expect(onGetTasks).not.toHaveBeenCalled();
+
+    nowSpy.mockReturnValue(now + 5000);
+    await methods().onPollTasks.call(state);
+    expect(onGetTasks).toHaveBeenCalledOnce();
+
+    nowSpy.mockRestore();
+  });
+
   it('runs due history independently when pending reconciliation fails', async () => {
     const dispatch = vi.fn().mockRejectedValue(new Error('pending failed'));
     const onGetTasks = vi.fn().mockResolvedValue(undefined);

--- a/src/utils/taskPollingMixin.ts
+++ b/src/utils/taskPollingMixin.ts
@@ -1,6 +1,6 @@
 import { defineComponent } from 'vue';
 
-const HISTORY_INTERVAL_MS = 60000;
+const HISTORY_INTERVAL_MS = 5000;
 
 export function taskPollingMixin(storeModule: string, targeted = true) {
   return defineComponent({


### PR DESCRIPTION
## Bug

New generation tasks sometimes did not appear in the right-side task list until the user refreshed the page.

## Root cause

The task-history refresh interval was changed from 5 seconds to 60 seconds. Pending-ID reconciliation updates tasks already present in the list, but it cannot discover a newly created task that the initial post-submit fetch missed.

## Fix

Change `HISTORY_INTERVAL_MS` from 60 seconds back to 5 seconds.

## Verification

- focused polling tests: **3/3 passed**
- full test suite with one worker: **258 files / 1,984 tests passed**
- TypeScript check passed
- ESLint passed with 0 errors
- production web build passed
- Beachball check passed

The default parallel full-suite run exposed an unrelated existing Electron shell test timeout under load; that file passed 24/24 alone, and the complete suite passed with `--maxWorkers=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)