### PR TITLE
perf(openai): avoid exact task history counts

### DIFF
--- a/change/openai-task-pagination.json
+++ b/change/openai-task-pagination.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Use bounded OpenAI task pagination without expensive exact history counts.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/operators/baseTaskOperator.ts
+++ b/src/operators/baseTaskOperator.ts
@@ -18,7 +18,7 @@ export interface ITaskListFilter {
   offset?: number;
   createdAtMax?: number;
   createdAtMin?: number;
-  countMode?: 'exact' | 'bounded' | 'none';
+  countMode?: 'exact' | 'none';
   /**
    * Service-specific filter keys may be passed via this index.
    * Camel-case keys are auto-converted to snake_case in the request body.

--- a/src/operators/baseTaskOperator.ts
+++ b/src/operators/baseTaskOperator.ts
@@ -18,6 +18,7 @@ export interface ITaskListFilter {
   offset?: number;
   createdAtMax?: number;
   createdAtMin?: number;
+  countMode?: 'exact' | 'bounded' | 'none';
   /**
    * Service-specific filter keys may be passed via this index.
    * Camel-case keys are auto-converted to snake_case in the request body.

--- a/src/store/factories/createTaskActions.test.ts
+++ b/src/store/factories/createTaskActions.test.ts
@@ -182,3 +182,23 @@ describe('createTaskActions/getTasks payment mode', () => {
     ]);
   });
 });
+
+describe('createTaskActions/getTasks pagination metadata', () => {
+  it('persists has_more only when the module opts in', async () => {
+    const tasks = vi.fn().mockResolvedValue({ data: { items: [{ id: 'a' }], has_more: false } });
+    const actions: any = createTaskActions<unknown, { id: string }, Record<string, unknown>>({
+      serviceId: 'svc-1',
+      operator: { tasks },
+      paginationMetadata: true
+    });
+    const commits: Array<[string, unknown]> = [];
+
+    await invoke(actions.getTasks, {
+      state: { credential: { token: 'tok' }, tasks: undefined, status: { getTasks: 'None' } },
+      rootState: {},
+      commits
+    });
+
+    expect(commits).toContainEqual(['setTasksHasMore', false]);
+  });
+});

--- a/src/store/factories/createTaskActions.ts
+++ b/src/store/factories/createTaskActions.ts
@@ -39,7 +39,9 @@ export interface ITaskOperator<TFilter, TTask> {
   tasks(
     filter: TFilter,
     options: OperatorRequestOptions
-  ): Promise<{ data: { items: TTask[]; count?: number; total?: number } }>;
+  ): Promise<{
+    data: { items: TTask[]; count?: number; total?: number; has_more?: boolean; count_is_exact?: boolean };
+  }>;
   delete?(
     id: string,
     options: { token: string; userId?: string; applicationId?: string }
@@ -80,6 +82,8 @@ export function createTaskActions<TConfig, TTask extends { id?: string }, TFilte
   paginated?: boolean;
   /** Static upstream `type` discriminator, e.g. `'images'` / `'videos'`. */
   type?: string;
+  /** Skip expensive exact history counts when pagination can use `has_more`. */
+  countMode?: 'exact' | 'bounded' | 'none';
   /** Fully custom filter — when provided, `paginated` and `type` are ignored. */
   buildFilter?: (rootState: IRootState, args: IGetTasksArgs) => TFilter;
   isPending?: (task: TTask) => boolean;
@@ -95,7 +99,8 @@ export function createTaskActions<TConfig, TTask extends { id?: string }, TFilte
         ...(opts.paginated ? { offset: args.offset, limit: args.limit } : {}),
         createdAtMin: args.createdAtMin,
         createdAtMax: args.createdAtMax,
-        ...(opts.type ? { type: opts.type } : {})
+        ...(opts.type ? { type: opts.type } : {}),
+        ...(opts.countMode ? { countMode: opts.countMode } : {})
       }) as unknown as TFilter);
 
   const setApplication = async (
@@ -225,7 +230,7 @@ export function createTaskActions<TConfig, TTask extends { id?: string }, TFilte
         const newItems = response.data.items || [];
         commit('setTasksItems', mergeAndSortLists(existingItems, newItems));
         const total = response.data.count ?? response.data.total;
-        if (total !== undefined) commit('setTasksTotal', total);
+        if (total !== undefined && response.data.count_is_exact !== false) commit('setTasksTotal', total);
         if (state.status) state.status.getTasks = Status.Success;
         return newItems;
       } catch (error) {

--- a/src/store/factories/createTaskActions.ts
+++ b/src/store/factories/createTaskActions.ts
@@ -83,7 +83,9 @@ export function createTaskActions<TConfig, TTask extends { id?: string }, TFilte
   /** Static upstream `type` discriminator, e.g. `'images'` / `'videos'`. */
   type?: string;
   /** Skip expensive exact history counts when pagination can use `has_more`. */
-  countMode?: 'exact' | 'bounded' | 'none';
+  countMode?: 'exact' | 'none';
+  /** Persist `has_more` in modules that expose pagination metadata. */
+  paginationMetadata?: boolean;
   /** Fully custom filter — when provided, `paginated` and `type` are ignored. */
   buildFilter?: (rootState: IRootState, args: IGetTasksArgs) => TFilter;
   isPending?: (task: TTask) => boolean;
@@ -231,6 +233,9 @@ export function createTaskActions<TConfig, TTask extends { id?: string }, TFilte
         commit('setTasksItems', mergeAndSortLists(existingItems, newItems));
         const total = response.data.count ?? response.data.total;
         if (total !== undefined && response.data.count_is_exact !== false) commit('setTasksTotal', total);
+        if (opts.paginationMetadata && response.data.has_more !== undefined) {
+          commit('setTasksHasMore', response.data.has_more);
+        }
         if (state.status) state.status.getTasks = Status.Success;
         return newItems;
       } catch (error) {

--- a/src/store/openaiimage/actions.ts
+++ b/src/store/openaiimage/actions.ts
@@ -8,7 +8,8 @@ const actions = createTaskActions<IOpenAIImageConfig, IOpenAIImageTask, Record<s
   serviceId: OPENAIIMAGE_SERVICE_ID,
   operator: openaiimageOperator,
   isPending: pendingUntilResponse,
-  paginated: true
+  paginated: true,
+  countMode: 'none'
 });
 
 export default actions;

--- a/src/store/openaiimage/actions.ts
+++ b/src/store/openaiimage/actions.ts
@@ -9,7 +9,8 @@ const actions = createTaskActions<IOpenAIImageConfig, IOpenAIImageTask, Record<s
   operator: openaiimageOperator,
   isPending: pendingUntilResponse,
   paginated: true,
-  countMode: 'none'
+  countMode: 'none',
+  paginationMetadata: true
 });
 
 export default actions;

--- a/src/store/openaiimage/models.ts
+++ b/src/store/openaiimage/models.ts
@@ -12,6 +12,7 @@ export interface IOpenAIImageState {
         items: IOpenAIImageTask[] | undefined;
         total: number | undefined;
         active: IOpenAIImageTask | undefined;
+        hasMore?: boolean;
       }
     | undefined;
   status: {

--- a/src/store/openaiimage/mutations.ts
+++ b/src/store/openaiimage/mutations.ts
@@ -5,7 +5,8 @@ import { IOpenAIImageState } from './models';
 const defaultTasks = {
   items: undefined,
   total: undefined,
-  active: undefined
+  active: undefined,
+  hasMore: undefined
 };
 
 export const resetAll = (state: IOpenAIImageState): void => {
@@ -48,6 +49,13 @@ export const setTasksTotal = (state: IOpenAIImageState, payload: number): void =
   state.tasks = newPayload;
 };
 
+export const setTasksHasMore = (state: IOpenAIImageState, payload: boolean): void => {
+  state.tasks = {
+    ...(state.tasks || defaultTasks),
+    hasMore: payload
+  } as typeof state.tasks;
+};
+
 export const setTasksActive = (state: IOpenAIImageState, payload: IOpenAIImageTask): void => {
   const newPayload = {
     ...(state.tasks || defaultTasks),
@@ -70,5 +78,6 @@ export default {
   setTasksActive,
   setTasksItems,
   setTasksTotal,
+  setTasksHasMore,
   resetAll
 };

--- a/src/utils/pagination.test.ts
+++ b/src/utils/pagination.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it, vi } from 'vitest';
+import { loadPreviousPage } from './pagination';
+
+describe('loadPreviousPage', () => {
+  it('does not fetch after the server marks history exhausted', async () => {
+    const fetch = vi.fn();
+
+    await loadPreviousPage({
+      tasks: { items: [{ created_at: 1 }], hasMore: false },
+      loading: false,
+      setLoading: vi.fn(),
+      fetch
+    });
+
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/pagination.ts
+++ b/src/utils/pagination.ts
@@ -3,6 +3,7 @@ import { nextTick } from 'vue';
 type TasksLike = {
   items?: { created_at?: number }[];
   total?: number;
+  hasMore?: boolean;
 };
 
 export async function loadPreviousPage(options: {
@@ -40,7 +41,7 @@ export async function loadPreviousPage(options: {
 
   const total = currentTasks?.total;
   const currentLength = currentTasks?.items?.length || 0;
-  if (total !== undefined && total <= currentLength) {
+  if (currentTasks?.hasMore === false || (total !== undefined && total <= currentLength)) {
     return;
   }
 
@@ -64,7 +65,8 @@ export async function loadPreviousPage(options: {
     await nextTick();
     const latest = getTasks ? getTasks() : tasks;
     const newLength = latest?.items?.length || 0;
-    const hasMore = latest?.total !== undefined ? newLength < (latest.total || 0) : newLength > previousLength;
+    const hasMore =
+      latest?.hasMore ?? (latest?.total !== undefined ? newLength < (latest.total || 0) : newLength > previousLength);
     const scrollEl = getScrollElement?.();
     if (scrollEl) {
       // Preserve the user's visual position. These task lists are sorted


### PR DESCRIPTION
## Summary
- request no-count pagination for OpenAI image history
- preserve existing exact totals when a response explicitly marks count as exact
- use `has_more`-compatible task response typing

## Tests
- 9 task action tests passed
- ESLint passed with 2 existing warnings
- `vue-tsc -b` passed
- Beachball change validation passed

Depends on https://github.com/AceDataCloud/PlatformService/pull/2236

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 🤖 对抗评审 (reviewer: codex + claude-subagent, 2 rounds)
- RISK: has_more 被丢弃，终页重复请求 → 已修：仅 openaiimage opt-in 保存 Vuex hasMore，分页 helper 优先按该信号停止
- RISK: 全局 task polling 从 5s 改 60s → 未采纳，误报：该文件不在 GitHub PR diff 或 merge-base diff 中
- 第二轮 reviewer：APPROVE；11 项聚焦测试、lint、vue-tsc 通过

依赖 https://github.com/AceDataCloud/PlatformService/pull/2236 先部署。
