### PR TITLE
fix(android): remediate AI content policy

### DIFF
--- a/.github/workflows/release-android.yaml
+++ b/.github/workflows/release-android.yaml
@@ -349,7 +349,6 @@ jobs:
           releaseFiles: android/app/build/outputs/bundle/playRelease/app-play-release.aab
           tracks: ${{ needs.preflight.outputs.track }}
           status: completed
-          changesNotSentForReview: true
 
   promote:
     name: Promote to Production

--- a/.github/workflows/release-android.yaml
+++ b/.github/workflows/release-android.yaml
@@ -334,8 +334,14 @@ jobs:
           files: nexior-${{ needs.preflight.outputs.version-name }}.apk
           fail_on_unmatched_files: true
 
+      - name: Block direct production upload during policy remediation
+        if: (inputs.upload_to_play || startsWith(github.ref, 'refs/tags/android-v')) && needs.preflight.outputs.track == 'production'
+        run: |
+          echo '::error::Direct production upload is disabled during Google Play policy remediation. Upload to internal or beta, then submit manually.'
+          exit 1
+
       - name: Upload to Play Store
-        if: inputs.upload_to_play || startsWith(github.ref, 'refs/tags/android-v')
+        if: (inputs.upload_to_play || startsWith(github.ref, 'refs/tags/android-v')) && needs.preflight.outputs.track != 'production'
         uses: r0adkll/upload-google-play@v1
         with:
           serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
@@ -343,6 +349,7 @@ jobs:
           releaseFiles: android/app/build/outputs/bundle/playRelease/app-play-release.aab
           tracks: ${{ needs.preflight.outputs.track }}
           status: completed
+          changesNotSentForReview: true
 
   promote:
     name: Promote to Production
@@ -355,6 +362,7 @@ jobs:
       && needs.preflight.result == 'success'
       && (needs.build.result == 'success' || needs.build.result == 'skipped')
       && needs.preflight.outputs.track != 'production'
+      && vars.ANDROID_POLICY_HOLD == 'cleared'
       && (inputs.promote_to_production || startsWith(github.ref, 'refs/tags/android-v'))
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release-android.yaml
+++ b/.github/workflows/release-android.yaml
@@ -249,6 +249,7 @@ jobs:
         env:
           VITE_STRIPE_PUBLISHABLE_KEY: ${{ secrets.VITE_STRIPE_PUBLISHABLE_KEY }}
           VITE_COMPUTER_USE: 'false'
+          VITE_PLAY_BUILD: 'true'
         run: npm run build:android
 
       - name: Stage play-flavor web assets

--- a/.github/workflows/release-mobile-production.yaml
+++ b/.github/workflows/release-mobile-production.yaml
@@ -290,7 +290,8 @@ jobs:
     name: Android · Play production
     needs: gate
     if: >-
-      needs.gate.outputs.android-ok == 'true'
+      vars.ANDROID_POLICY_HOLD == 'cleared'
+      && needs.gate.outputs.android-ok == 'true'
       && (github.event_name != 'workflow_dispatch' || !inputs.dry_run)
       && (github.event_name == 'schedule' || inputs.platforms == 'both' || inputs.platforms == 'android')
     uses: ./.github/workflows/release-android.yaml

--- a/change/play-ai-content-policy.json
+++ b/change/play-ai-content-policy.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Hide blocked AI image results, expose complete in-app reporting, and hold automatic Play promotion during policy remediation.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/change/play-ai-content-policy.json
+++ b/change/play-ai-content-policy.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Hide blocked AI image results, expose complete in-app reporting, and hold automatic Play promotion during policy remediation.",
+  "comment": "Hide Nano Banana from the Google Play build until its provider safety contract is deterministic, while improving AI content reporting and blocked-result rendering.",
   "packageName": "@acedatacloud/nexior",
   "email": "dev@acedata.cloud",
   "dependentChangeType": "patch"

--- a/docs/android-release.md
+++ b/docs/android-release.md
@@ -15,6 +15,8 @@ the pipeline end-to-end on **2026-05-23 (run [26324168813][run-3351])**.
 
 Automatic Play production promotion is currently fail-closed while the AI-generated content policy remediation is under review. Remediation builds may be uploaded only to an internal or testing track and are left unsent for review. Set the repository variable `ANDROID_POLICY_HOLD=cleared` only after the Play Console policy case is cleared for the new version code; production submission remains a deliberate manual action.
 
+The Google Play bundle compiles out Nano Banana navigation, routes, home cards, and showcases until its provider safety contract is deterministic. Web, iOS, desktop, and the full sideload Android APK remain unchanged.
+
 Before submitting a remediation build, verify that blocked AI results render no media, every visible generated result has an in-app Report action, and the content-report moderation queue is operational.
 
 ## Pipeline overview

--- a/docs/android-release.md
+++ b/docs/android-release.md
@@ -11,6 +11,12 @@ the pipeline end-to-end on **2026-05-23 (run [26324168813][run-3351])**.
 
 [run-3351]: https://github.com/AceDataCloud/Nexior/actions/runs/26324168813
 
+## Google Play policy hold
+
+Automatic Play production promotion is currently fail-closed while the AI-generated content policy remediation is under review. Remediation builds may be uploaded only to an internal or testing track and are left unsent for review. Set the repository variable `ANDROID_POLICY_HOLD=cleared` only after the Play Console policy case is cleared for the new version code; production submission remains a deliberate manual action.
+
+Before submitting a remediation build, verify that blocked AI results render no media, every visible generated result has an in-app Report action, and the content-report moderation queue is operational.
+
 ## Pipeline overview
 
 ```
@@ -94,11 +100,11 @@ This must be **strictly monotonically increasing** for the Play
 Store — that is the only constraint Google enforces.
 
 | package.json | versionName | versionCode |
-| --- | --- | --- |
-| `3.35.0` | `3.35.0` | `33500` |
-| `3.35.1` | `3.35.1` | `33501` |
-| `3.36.0` | `3.36.0` | `33600` |
-| `4.0.0`  | `4.0.0`  | `40000` |
+| ------------ | ----------- | ----------- |
+| `3.35.0`     | `3.35.0`    | `33500`     |
+| `3.35.1`     | `3.35.1`    | `33501`     |
+| `3.36.0`     | `3.36.0`    | `33600`     |
+| `4.0.0`      | `4.0.0`     | `40000`     |
 
 **Implication**: bumping the patch component gives you up to 99 builds
 before you have to bump the minor. If a code is consumed in any track
@@ -121,8 +127,7 @@ Console uploads).
 Capacitor 8 hard-codes `JavaVersion.VERSION_21` into the auto-generated
 `android/app/capacitor.build.gradle`. The CI workflow must therefore
 use Java 21 (`JAVA_VERSION: '21'` in `release-android.yaml`). If you see
-this error, check that `actions/setup-java@v5` is pinned to 21 — never
-17.
+this error, check that `actions/setup-java@v5` is pinned to 21 — never 17.
 
 ### 3. `Google Play Android Developer API has not been used in project … before or it is disabled`
 

--- a/scripts/check_release_workflows.py
+++ b/scripts/check_release_workflows.py
@@ -66,6 +66,7 @@ def main() -> None:
     require("workflow_call:" in android, "Android release must be reusable")
     require("workflow_call:" in ios, "iOS release must be reusable")
     require("changesNotSentForReview" not in android, "obsolete Google Play review parameter returned")
+    require("VITE_PLAY_BUILD: 'true'" in android, "Play web bundle must compile out unqualified AI surfaces")
     require("vars.ANDROID_POLICY_HOLD == 'cleared'" in android, "Play promotion must require explicit policy clearance")
     require("Block direct production upload during policy remediation" in android, "direct Play production upload must remain blocked")
     desktop = read("release-desktop.yaml")

--- a/scripts/check_release_workflows.py
+++ b/scripts/check_release_workflows.py
@@ -66,6 +66,8 @@ def main() -> None:
     require("workflow_call:" in android, "Android release must be reusable")
     require("workflow_call:" in ios, "iOS release must be reusable")
     require("changesNotSentForReview" not in android, "obsolete Google Play review parameter returned")
+    require("vars.ANDROID_POLICY_HOLD == 'cleared'" in android, "Play promotion must require explicit policy clearance")
+    require("Block direct production upload during policy remediation" in android, "direct Play production upload must remain blocked")
     desktop = read("release-desktop.yaml")
     require("ref: ${{ inputs.release_tag || github.sha }}" in android, "Android assets must checkout their release tag")
     require("ref: ${{ inputs.release_tag || github.sha }}" in desktop, "desktop assets must checkout their release tag")

--- a/src/components/common/Navigator.vue
+++ b/src/components/common/Navigator.vue
@@ -183,7 +183,7 @@ import {
 } from '@/constants';
 import Logo from './Logo.vue';
 import UserCenter from '@/components/user/Center.vue';
-import { isMacOS } from '@/utils/surface';
+import { isCapabilityAvailableOnBuild, isMacOS } from '@/utils/surface';
 import { desktopBridge } from '@/utils/desktop';
 import { CAPABILITY_ICONS, type CapabilityKey } from '@/constants/capabilities';
 import { resolveCapabilityPresentation } from '@/utils/capabilityPresentation';
@@ -344,7 +344,7 @@ export default defineComponent({
           category: 'image'
         });
       }
-      if (this.$store?.state?.site?.features?.nanobanana?.enabled) {
+      if (isCapabilityAvailableOnBuild('nanobanana') && this.$store?.state?.site?.features?.nanobanana?.enabled) {
         result.push({
           route: { name: ROUTE_NANOBANANA_INDEX },
           displayName: this.$t('common.nav.nanobanana'),

--- a/src/components/nanobanana/task/Preview.test.ts
+++ b/src/components/nanobanana/task/Preview.test.ts
@@ -72,4 +72,45 @@ describe('nanobanana/task/Preview', () => {
     expect(wrapper.text()).not.toContain('nanobanana.status.pending');
     expect(wrapper.findComponent({ name: 'WarningIcon' }).exists()).toBe(true);
   });
+  it.each([
+    {
+      success: true,
+      task_id: 'task-1',
+      data: [{ image_url: 'https://cdn.example.com/unsafe.png' }],
+      error: { code: 'forbidden', message: 'blocked by safety filter' }
+    },
+    {
+      task_id: 'task-1',
+      data: [{ image_url: 'https://cdn.example.com/unsafe.png' }],
+      error: { code: 'forbidden', message: 'blocked by safety filter' }
+    },
+    {
+      success: false,
+      task_id: 'task-1',
+      data: [{ image_url: 'https://cdn.example.com/unsafe.png' }]
+    }
+  ] as INanobananaTask['response'][])('never renders media when a response declares failure', (response) => {
+    const wrapper = mountPreview(response);
+    expect(wrapper.text()).toContain('nanobanana.name.failure');
+    expect(wrapper.findComponent({ name: 'ImageWrapper' }).exists()).toBe(false);
+  });
+
+  it('keeps image-only legacy successes visible and reports complete evidence', () => {
+    const wrapper = mountPreview({
+      task_id: 'task-1',
+      trace_id: 'trace-1',
+      data: [{ image_url: 'https://cdn.example.com/safe.png' }]
+    } as INanobananaTask['response']);
+
+    expect(wrapper.findComponent({ name: 'ImageWrapper' }).exists()).toBe(true);
+    const report = wrapper.findComponent({ name: 'ReportButton' });
+    expect(report.props('showLabel')).toBe(true);
+    expect(report.props('snapshot')).toMatchObject({
+      prompt: 'A lighthouse',
+      image_urls: ['https://cdn.example.com/safe.png'],
+      model: 'nano-banana-pro',
+      task_id: 'task-1',
+      trace_id: 'trace-1'
+    });
+  });
 });

--- a/src/components/nanobanana/task/Preview.vue
+++ b/src/components/nanobanana/task/Preview.vue
@@ -55,11 +55,7 @@
             </el-button>
           </el-tooltip>
           <api-code-button path="/nano-banana/images" :body="modelValue?.request" />
-          <report-button
-            service="nanobanana"
-            :target-id="modelValue?.id"
-            :snapshot="{ prompt: modelValue?.request?.prompt }"
-          />
+          <report-button service="nanobanana" :target-id="modelValue?.id" :snapshot="reportSnapshot" show-label />
         </div>
         <el-alert :closable="false" class="mt-2 success">
           <p v-if="modelValue?.request?.model" class="text-[var(--el-text-color-regular)] text-xs mb-2">
@@ -102,10 +98,7 @@
           </p>
         </el-alert>
       </div>
-      <div
-        v-else-if="modelValue?.response?.success === false || modelValue?.response?.error"
-        :class="{ content: true }"
-      >
+      <div v-else-if="isFailure" :class="{ content: true }">
         <el-alert :closable="false" class="failure">
           <template #template>
             <warning-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
@@ -266,11 +259,25 @@ export default defineComponent({
     hasImages(): boolean {
       return this.images.some((image) => !!image?.image_url);
     },
+    isFailure(): boolean {
+      const response = this.modelValue?.response;
+      return response?.success === false || !!response?.error;
+    },
     showResult(): boolean {
       const response = this.modelValue?.response;
-      if (!response) return false;
-      if (response.success === true) return true;
-      return this.hasImages && response.success !== false;
+      if (!response || this.isFailure) return false;
+      if (response.success === true) return this.hasImages;
+      return this.hasImages;
+    },
+    reportSnapshot(): Record<string, unknown> {
+      return {
+        prompt: this.modelValue?.request?.prompt,
+        image_urls: this.images.map((image) => image.image_url).filter(Boolean),
+        model: this.modelValue?.request?.model,
+        action: this.modelValue?.request?.action,
+        task_id: this.modelValue?.id,
+        trace_id: this.modelValue?.response?.trace_id
+      };
     }
   },
   methods: {

--- a/src/models/nanobanana.ts
+++ b/src/models/nanobanana.ts
@@ -27,7 +27,7 @@ export interface INanobananaImage {
 }
 
 export interface INanobananaGenerateResponse {
-  success: boolean;
+  success?: boolean;
   task_id: string;
   trace_id?: string;
   data?: INanobananaImage[];

--- a/src/pages/home/Index.vue
+++ b/src/pages/home/Index.vue
@@ -44,6 +44,7 @@ import { showcaseOperator, siteBannerOperator } from '@/operators';
 import { resolveCapabilityPresentation } from '@/utils/capabilityPresentation';
 import { resolveShowcase } from '@/utils/showcase';
 import { getSiteOrigin } from '@/utils/site';
+import { isCapabilityAvailableOnBuild } from '@/utils/surface';
 import { getHiddenDefaultBannerIds, resolveSiteBannerText } from '@/utils/siteBanner';
 import ShowcaseGrid from '@/components/common/ShowcaseGrid.vue';
 import ShowcaseDetailDialog from '@/components/showcase/ShowcaseDetailDialog.vue';
@@ -94,7 +95,7 @@ export default defineComponent({
     enabledKeys(): Set<CapabilityKey> {
       if (!this.siteLoaded) return new Set();
       const features = (this.site?.features ?? {}) as Record<string, { enabled?: boolean } | undefined>;
-      return new Set(CAPABILITY_KEYS.filter((key) => features[key]?.enabled));
+      return new Set(CAPABILITY_KEYS.filter((key) => features[key]?.enabled && isCapabilityAvailableOnBuild(key)));
     },
     banners(): ResolvedHomeBanner[] {
       const hiddenDefaults = getHiddenDefaultBannerIds(this.site);

--- a/src/pages/nanobanana/Index.test.ts
+++ b/src/pages/nanobanana/Index.test.ts
@@ -10,7 +10,8 @@ const mocks = vi.hoisted(() => ({
   ensureNoPendingUpload: vi.fn(() => true),
   instrument: vi.fn((_: string, operation: Promise<unknown>) => operation),
   resolveWallet: vi.fn(() => ({ address: 'wallet' })),
-  walletMode: false
+  walletMode: false,
+  android: false
 }));
 
 vi.mock('@/operators', () => ({ nanobananaOperator: { generate: mocks.generate } }));
@@ -18,6 +19,7 @@ vi.mock('@/plugins/telemetry', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@/plugins/telemetry')>()),
   instrumentGeneration: mocks.instrument
 }));
+vi.mock('@/utils/surface', () => ({ isAndroid: () => mocks.android }));
 vi.mock('@/utils/showcaseRecreateMixin', () => ({ showcaseRecreateMixin: () => ({}) }));
 vi.mock('@/utils/quotaExhausted', () => ({ showQuotaExhausted: vi.fn(() => false) }));
 vi.mock('@/utils/x402/scenarioPayment', () => ({
@@ -71,6 +73,7 @@ describe('Nano Banana prompt validation', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.walletMode = false;
+    mocks.android = false;
     mocks.ensureLoggedIn.mockReturnValue(true);
     mocks.ensureNoPendingUpload.mockReturnValue(true);
     mocks.resolveWallet.mockReturnValue({ address: 'wallet' });
@@ -145,5 +148,17 @@ describe('Nano Banana prompt validation', () => {
       }),
       expect.objectContaining({ mode: 'x402' })
     );
+  });
+  it('requires login before any Android generation flow', async () => {
+    mocks.android = true;
+    mocks.walletMode = true;
+    mocks.ensureLoggedIn.mockReturnValue(false);
+    const wrapper = mountPage('draw a safe landscape');
+
+    await (wrapper.vm as any).onGenerate();
+
+    expect(mocks.ensureLoggedIn).toHaveBeenCalledOnce();
+    expect(mocks.resolveWallet).not.toHaveBeenCalled();
+    expect(mocks.generate).not.toHaveBeenCalled();
   });
 });

--- a/src/pages/nanobanana/Index.vue
+++ b/src/pages/nanobanana/Index.vue
@@ -29,6 +29,7 @@ import { INanobananaTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
 import { uploadTrackerProviderMixin, ensureNoPendingUpload, ensureLoggedIn, hasMeaningfulText } from '@/utils';
 import { isScenarioX402Enabled, scenarioPaymentState } from '@/utils/x402/scenarioPayment';
+import { isAndroid } from '@/utils/surface';
 import {
   X402PaymentCancelledError,
   type X402PaymentQuote,
@@ -168,6 +169,7 @@ export default defineComponent({
       });
     },
     async onGenerate() {
+      if (isAndroid() && !ensureLoggedIn()) return;
       if (!hasMeaningfulText(this.config?.prompt)) {
         ElMessage.error(this.$t('common.message.promptRequired'));
         return;

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,3 +1,4 @@
+import { isCapabilityAvailableOnBuild } from '@/utils/surface';
 import { type Router } from 'vue-router';
 import store from '@/store';
 import auth from './auth';
@@ -333,7 +334,9 @@ const FEATURE_ROUTE_PRIORITY: Array<[string, string]> = [
   ['deepseek', ROUTE_DEEPSEEK_CONVERSATION_NEW],
   ['kimi', ROUTE_KIMI_CONVERSATION_NEW],
   ['midjourney', ROUTE_MIDJOURNEY_INDEX],
-  ['nanobanana', ROUTE_NANOBANANA_INDEX],
+  ...(isCapabilityAvailableOnBuild('nanobanana')
+    ? ([['nanobanana', ROUTE_NANOBANANA_INDEX]] as Array<[string, string]>)
+    : []),
   ['flux', ROUTE_FLUX_INDEX],
   ['seedream', ROUTE_SEEDREAM_INDEX],
   ['qwenimage', ROUTE_QWENIMAGE_INDEX],
@@ -403,7 +406,7 @@ export const routes = [
   minimax,
   suno,
   producer,
-  nanobanana,
+  ...(isCapabilityAvailableOnBuild('nanobanana') ? [nanobanana] : []),
   openaiimage,
   seedream,
   qwenimage,

--- a/src/router/playCapability.test.ts
+++ b/src/router/playCapability.test.ts
@@ -1,0 +1,23 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+async function routePaths(playBuild: boolean): Promise<string[]> {
+  vi.resetModules();
+  vi.stubEnv('VITE_PLAY_BUILD', playBuild ? 'true' : 'false');
+  const { routes } = await import('./index');
+  return routes.map((route) => String(route.path));
+}
+
+describe('Google Play capability boundary', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it('does not register the Nano Banana route in the Play bundle', async () => {
+    expect(await routePaths(true)).not.toContain('/nanobanana');
+  });
+
+  it('keeps the Nano Banana route in non-Play builds', async () => {
+    expect(await routePaths(false)).toContain('/nanobanana');
+  });
+});

--- a/src/utils/showcase.ts
+++ b/src/utils/showcase.ts
@@ -14,6 +14,7 @@ import {
   ROUTE_VEO_INDEX
 } from '@/router/constants';
 import { resolveCapabilityPresentation } from './capabilityPresentation';
+import { isCapabilityAvailableOnBuild } from './surface';
 
 export interface ShowcaseServiceDefinition {
   service: string;
@@ -200,7 +201,12 @@ function deriveMedia(
 
 export function resolveShowcase(item: IShowcase, site: ISite): ResolvedShowcase | undefined {
   const definition = SHOWCASE_SERVICES.get(item.service);
-  if (!definition || !site.features?.[definition.capability]?.enabled) return undefined;
+  if (
+    !definition ||
+    !isCapabilityAvailableOnBuild(definition.capability) ||
+    !site.features?.[definition.capability]?.enabled
+  )
+    return undefined;
   const request = objectValue(item.data.request);
   const response = objectValue(item.data.response);
   const result = firstResult(response);

--- a/src/utils/surface.test.ts
+++ b/src/utils/surface.test.ts
@@ -10,7 +10,9 @@ import {
   getPaymentSurface,
   getDesktopOS,
   isWindows,
-  isMacOS
+  isMacOS,
+  isPlayBuild,
+  isCapabilityAvailableOnBuild
 } from './surface';
 
 /**
@@ -117,6 +119,20 @@ describe('surface', () => {
       expect(getPaymentSurface()).toBe('ios');
       withSurface('android');
       expect(getPaymentSurface()).toBe('android');
+    });
+  });
+  describe('Play build capabilities', () => {
+    it('hides only Nano Banana from the Google Play bundle', () => {
+      vi.stubEnv('VITE_PLAY_BUILD', 'true');
+      expect(isPlayBuild()).toBe(true);
+      expect(isCapabilityAvailableOnBuild('nanobanana')).toBe(false);
+      expect(isCapabilityAvailableOnBuild('openaiimage')).toBe(true);
+    });
+
+    it('keeps Nano Banana on web, iOS, desktop, and sideload Android builds', () => {
+      vi.stubEnv('VITE_PLAY_BUILD', 'false');
+      expect(isPlayBuild()).toBe(false);
+      expect(isCapabilityAvailableOnBuild('nanobanana')).toBe(true);
     });
   });
 });

--- a/src/utils/surface.ts
+++ b/src/utils/surface.ts
@@ -95,3 +95,11 @@ export function getPaymentSurface(): 'pc' | 'wap' | 'ios' | 'android' {
   if (isDesktop()) return 'pc';
   return isMobile() ? 'wap' : 'pc';
 }
+
+export function isPlayBuild(): boolean {
+  return import.meta.env.VITE_PLAY_BUILD === 'true';
+}
+
+export function isCapabilityAvailableOnBuild(capability: string): boolean {
+  return !(isPlayBuild() && capability === 'nanobanana');
+}


### PR DESCRIPTION
## Summary
- compile Nano Banana routes, navigation, home cards, and showcases out of the Google Play bundle only
- keep Nano Banana available on web, iOS, desktop, and the full/sideload Android APK
- make error-bearing task responses authoritative so blocked media is never rendered
- expose a labeled in-app Report action with prompt, image, model, task, and trace evidence
- require login before Android generation flows that remain in the Play app
- keep automatic Play production promotion fail-closed until `ANDROID_POLICY_HOLD=cleared`

## Why Play removes Nano Banana
Production forensics proved a provider returned HTTP 200 plus an image for an explicit sexual prompt. Strict provider-native safety settings usually returned 451 in repeated tests, but one public production request still returned 200 and was charged. That contract is not deterministic enough for Google Play's requirement to prevent restricted AI content. The Play build therefore removes the feature instead of claiming unreliable prevention.

## Validation
- focused Vitest: 56 passed
- `vue-tsc -b`: passed
- ESLint: 0 errors (2 pre-existing warnings)
- Play web build: passed
- compiled Play route table contains no `/nanobanana` route or Nano page implementation
- non-Play route test confirms `/nanobanana` remains available
- release workflow contract: passed

## Rollout
Keep the Play production hold in place. Upload and review a new Play AAB after backend reporting and moderation-console changes are live. Restore Nano Banana to Play only after an upstream adapter proves deterministic, non-bypassable safety behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
