### PR TITLE
feat(seedream): add 5.0 Pro production controls

### DIFF
--- a/change/seedream-5-official-parity.json
+++ b/change/seedream-5-official-parity.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Align Seedream 5.0 Pro and Lite controls, layer results, and request contracts with the official API.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/seedream/ConfigPanel.test.ts
+++ b/src/components/seedream/ConfigPanel.test.ts
@@ -64,3 +64,9 @@ describe('seedream/ConfigPanel', () => {
     expect(getConsumptionMock.mock.lastCall?.[0]).toMatchObject({ action: 'edit', input_image_count: 1 });
   });
 });
+
+it('allows promptless Pro decomposition with one image', () => {
+  const { wrapper } = mountPanel(['one.png'], 'doubao-seedream-5-0-pro-260628');
+  Object.assign((wrapper.vm as any).config, { prompt: '', layer_decomposition: true });
+  expect((wrapper.vm as any).canGenerate).toBe(true);
+});

--- a/src/components/seedream/ConfigPanel.vue
+++ b/src/components/seedream/ConfigPanel.vue
@@ -5,6 +5,7 @@
       <size-selector class="mb-4" />
       <max-images-selector class="mb-4" />
       <output-format-selector class="mb-4" />
+      <advanced-options class="mb-4" />
       <seed-input class="mb-4" />
       <guidance-scale-input class="mb-4" />
       <prompt-input class="mb-4" />
@@ -32,6 +33,7 @@ import ModelSelector from './config/ModelSelector.vue';
 import SizeSelector from './config/SizeSelector.vue';
 import MaxImagesSelector from './config/MaxImagesSelector.vue';
 import OutputFormatSelector from './config/OutputFormatSelector.vue';
+import AdvancedOptions from './config/AdvancedOptions.vue';
 import SeedInput from './config/SeedInput.vue';
 import GuidanceScaleInput from './config/GuidanceScaleInput.vue';
 import { getSeedreamShortModel } from '@/constants';
@@ -51,19 +53,23 @@ export default defineComponent({
     SizeSelector,
     MaxImagesSelector,
     OutputFormatSelector,
+    AdvancedOptions,
     SeedInput,
     GuidanceScaleInput
   },
   emits: ['generate'],
   computed: {
     action(): 'generate' | 'edit' {
-      return getSeedreamAction(this.config?.model, this.config?.image);
+      const image = this.config?.image;
+      return getSeedreamAction(this.config?.model, typeof image === 'string' ? [image] : image);
     },
     capabilities() {
       return getSeedreamCapabilities(this.config?.model);
     },
     canGenerate(): boolean {
-      return canSubmitGeneration('seedream', buildSeedreamRequest(this.config));
+      const request = buildSeedreamRequest(this.config);
+      if (request.layer_decomposition) return request.image?.length === 1;
+      return canSubmitGeneration('seedream', request);
     },
     config() {
       return this.$store.state.seedream?.config;
@@ -77,13 +83,27 @@ export default defineComponent({
         request.sequential_image_generation === 'auto'
           ? Math.max(1, Math.floor(request.sequential_image_generation_options?.max_images || 1))
           : 1;
+      const pixels =
+        typeof request.size === 'string' && /^\d+x\d+$/i.test(request.size)
+          ? request.size
+              .split('x')
+              .map(Number)
+              .reduce((width, height) => width * height)
+          : request.size === '2K'
+            ? 4_194_304
+            : 1_000_000;
+      const pro = request.model === 'doubao-seedream-5-0-pro-260628';
       return getConsumption(
         {
           ...request,
           action: this.action,
           model: getSeedreamShortModel(request.model),
-          input_image_count: request.image?.length || 0,
-          count: requestedCount
+          input_image_count: Array.isArray(request.image) ? request.image.length : request.image ? 1 : 0,
+          count: requestedCount,
+          layer_decomposition: request.layer_decomposition === true,
+          layer_low_count: request.layer_decomposition ? 1 : 0,
+          regular_low_count: pro && !request.layer_decomposition && pixels <= 2_610_000 ? 1 : 0,
+          regular_high_count: pro && !request.layer_decomposition && pixels > 2_610_000 ? 1 : 0
         },
         this.service?.cost
       );

--- a/src/components/seedream/config/AdvancedOptions.test.ts
+++ b/src/components/seedream/config/AdvancedOptions.test.ts
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+import { shallowMount } from '@vue/test-utils';
+import { describe, expect, it, vi } from 'vitest';
+import AdvancedOptions from './AdvancedOptions.vue';
+
+const mountOptions = (config: Record<string, any>) => {
+  const commit = vi.fn();
+  const wrapper = shallowMount(AdvancedOptions, {
+    global: {
+      mocks: {
+        $t: (key: string) => key,
+        $store: { state: { seedream: { config } }, commit }
+      }
+    }
+  });
+  return { commit, wrapper };
+};
+
+describe('Seedream advanced options', () => {
+  it('switches Pro to decomposition and clears incompatible settings', () => {
+    const { commit, wrapper } = mountOptions({
+      model: 'doubao-seedream-5-0-pro-260628',
+      image: ['one.png', 'two.png'],
+      size: '2K',
+      background: 'transparent',
+      sequential_image_generation: 'auto',
+      tools: [{ type: 'web_search' }]
+    });
+
+    (wrapper.vm as any).mode = 'layers';
+
+    expect(commit).toHaveBeenCalledWith(
+      'seedream/setConfig',
+      expect.objectContaining({ layer_decomposition: true, image: ['one.png'], size: 'auto' })
+    );
+    const next = commit.mock.calls[0][1];
+    expect(next).not.toHaveProperty('background');
+    expect(next).not.toHaveProperty('sequential_image_generation');
+    expect(next).not.toHaveProperty('tools');
+  });
+
+  it('forces PNG when transparent background is selected', () => {
+    const { commit, wrapper } = mountOptions({ model: 'doubao-seedream-5-0-pro-260628', image: ['one.png'] });
+    (wrapper.vm as any).background = 'transparent';
+    expect(commit).toHaveBeenCalledWith(
+      'seedream/setConfig',
+      expect.objectContaining({ background: 'transparent', output_format: 'png' })
+    );
+  });
+});

--- a/src/components/seedream/config/AdvancedOptions.vue
+++ b/src/components/seedream/config/AdvancedOptions.vue
@@ -1,0 +1,135 @@
+<template>
+  <div class="advanced-options">
+    <div v-if="capabilities.layerDecomposition" class="field">
+      <div class="label">
+        <h2 class="title font-bold">{{ $t('seedream.name.mode') }}</h2>
+      </div>
+      <el-select v-model="mode" class="value">
+        <el-option :label="$t('seedream.mode.image')" value="image" />
+        <el-option :label="$t('seedream.mode.layers')" value="layers" />
+      </el-select>
+    </div>
+    <div v-if="capabilities.transparentBackground && mode === 'image' && hasSingleImage" class="field">
+      <div class="label">
+        <h2 class="title font-bold">{{ $t('seedream.name.background') }}</h2>
+      </div>
+      <el-select v-model="background" class="value" clearable>
+        <el-option :label="$t('seedream.background.opaque')" value="opaque" />
+        <el-option :label="$t('seedream.background.transparent')" value="transparent" />
+      </el-select>
+    </div>
+    <div v-if="capabilities.promptOptimization.length" class="field">
+      <div class="label">
+        <h2 class="title font-bold">{{ $t('seedream.name.promptOptimization') }}</h2>
+      </div>
+      <el-select v-model="promptOptimization" class="value" clearable>
+        <el-option v-for="option in capabilities.promptOptimization" :key="option" :label="option" :value="option" />
+      </el-select>
+    </div>
+    <div v-if="capabilities.webSearch && mode === 'image'" class="field">
+      <div class="label">
+        <h2 class="title font-bold">{{ $t('seedream.name.webSearch') }}</h2>
+      </div>
+      <el-switch v-model="webSearch" />
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElOption, ElSelect, ElSwitch } from 'element-plus';
+import { getSeedreamCapabilities } from '@/utils/seedream/capabilities';
+
+export default defineComponent({
+  name: 'SeedreamAdvancedOptions',
+  components: { ElOption, ElSelect, ElSwitch },
+  computed: {
+    config(): any {
+      return this.$store.state.seedream?.config || {};
+    },
+    capabilities() {
+      return getSeedreamCapabilities(this.config.model);
+    },
+    hasSingleImage(): boolean {
+      return Array.isArray(this.config.image) && this.config.image.length === 1;
+    },
+    mode: {
+      get(): 'image' | 'layers' {
+        return this.config.layer_decomposition ? 'layers' : 'image';
+      },
+      set(value: 'image' | 'layers') {
+        const config = { ...this.config };
+        if (value === 'layers') {
+          config.layer_decomposition = true;
+          config.image = (config.image || []).slice(0, 1);
+          config.size = 'auto';
+          delete config.background;
+          delete config.sequential_image_generation;
+          delete config.sequential_image_generation_options;
+          delete config.tools;
+        } else {
+          delete config.layer_decomposition;
+          if (config.size === 'auto') delete config.size;
+        }
+        this.$store.commit('seedream/setConfig', config);
+      }
+    },
+    background: {
+      get(): 'transparent' | 'opaque' | undefined {
+        return this.config.background;
+      },
+      set(value: 'transparent' | 'opaque' | undefined) {
+        const config = { ...this.config, background: value };
+        if (value === 'transparent') config.output_format = 'png';
+        if (!value) delete config.background;
+        this.$store.commit('seedream/setConfig', config);
+      }
+    },
+    promptOptimization: {
+      get(): 'standard' | 'fast' | undefined {
+        return this.config.optimize_prompt_options?.mode;
+      },
+      set(value: 'standard' | 'fast' | undefined) {
+        const config = { ...this.config };
+        if (value) config.optimize_prompt_options = { mode: value };
+        else delete config.optimize_prompt_options;
+        this.$store.commit('seedream/setConfig', config);
+      }
+    },
+    webSearch: {
+      get(): boolean {
+        return this.config.tools?.some((tool: any) => tool?.type === 'web_search') === true;
+      },
+      set(value: boolean) {
+        const config = { ...this.config };
+        if (value) config.tools = [{ type: 'web_search' }];
+        else delete config.tools;
+        this.$store.commit('seedream/setConfig', config);
+      }
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.advanced-options {
+  display: grid;
+  gap: 1rem;
+}
+.field {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+.label {
+  min-width: 30%;
+}
+.title {
+  margin: 0;
+  font-size: 14px;
+}
+.value {
+  width: min(200px, 65%);
+}
+</style>

--- a/src/components/seedream/config/ImageInput.vue
+++ b/src/components/seedream/config/ImageInput.vue
@@ -13,8 +13,8 @@
           v-model:file-list="fileList"
           accept=".png,.jpg,.jpeg,.gif,.bmp,.webp"
           name="file"
-          :limit="14"
-          :multiple="true"
+          :limit="limit"
+          :multiple="limit > 1"
           :show-file-list="false"
           :before-upload="beforeUploadSizeGuard"
           :action="uploadUrl"
@@ -100,13 +100,19 @@ export default defineComponent({
       );
     },
     value(): string[] | undefined {
-      return this.$store.state.seedream?.config?.image;
+      const image = this.$store.state.seedream?.config?.image;
+      if (typeof image === 'string') return [image];
+      return Array.isArray(image) ? image : undefined;
     },
     model(): string | undefined {
       return this.$store.state.seedream?.config?.model;
     },
     supported(): boolean {
       return getSeedreamCapabilities(this.model).image;
+    },
+    limit(): number {
+      const config = this.$store.state.seedream?.config || {};
+      return config.layer_decomposition ? 1 : getSeedreamCapabilities(this.model).maxInputImages;
     }
   },
   watch: {
@@ -168,7 +174,7 @@ export default defineComponent({
       this.onSetImages();
     },
     onExceed() {
-      ElMessage.warning(this.$t('seedream.message.uploadImageExceed'));
+      ElMessage.warning(this.$t('seedream.message.uploadImageExceed', { count: this.limit }));
     },
     onError() {
       ElMessage.error(this.$t('seedream.message.uploadImageError'));

--- a/src/components/seedream/config/ModelSelector.test.ts
+++ b/src/components/seedream/config/ModelSelector.test.ts
@@ -39,7 +39,7 @@ describe('seedream/ModelSelector', () => {
 
     expect(commit).toHaveBeenCalledWith(
       'seedream/setConfig',
-      expect.objectContaining({ model: 'doubao-seedream-4-5-251128' })
+      expect.objectContaining({ model: 'doubao-seedream-5-0-260128' })
     );
     const migrated = commit.mock.calls[0][1];
     expect(migrated).not.toHaveProperty('size');

--- a/src/components/seedream/config/SizeSelector.test.ts
+++ b/src/components/seedream/config/SizeSelector.test.ts
@@ -1,0 +1,28 @@
+// @vitest-environment jsdom
+import { shallowMount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import SizeSelector from './SizeSelector.vue';
+
+const mount = (model: string) =>
+  shallowMount(SizeSelector, {
+    global: {
+      mocks: {
+        $t: (key: string) => key,
+        $store: { state: { seedream: { config: { model } } }, commit: () => undefined }
+      }
+    }
+  });
+
+describe('Seedream size options', () => {
+  it('does not offer sub-2K pixel presets to Lite', () => {
+    const wrapper = mount('doubao-seedream-5-0-260128');
+    const values = (wrapper.vm as any).pixelOptions.map((item: any) => item.value);
+    expect(values).not.toContain('1024x1024');
+    expect(values).toContain('2048x2048');
+  });
+
+  it('keeps 1K pixel presets for Pro', () => {
+    const wrapper = mount('doubao-seedream-5-0-pro-260628');
+    expect((wrapper.vm as any).pixelOptions.map((item: any) => item.value)).toContain('1024x1024');
+  });
+});

--- a/src/components/seedream/config/SizeSelector.vue
+++ b/src/components/seedream/config/SizeSelector.vue
@@ -47,7 +47,7 @@ export default defineComponent({
   },
   data() {
     return {
-      pixelOptions: SEEDREAM_PIXEL_PRESETS
+      allPixelOptions: SEEDREAM_PIXEL_PRESETS
     };
   },
   computed: {
@@ -56,6 +56,16 @@ export default defineComponent({
     },
     capabilities(): ISeedreamCapability {
       return getSeedreamCapabilities(this.model);
+    },
+    pixelOptions(): Array<{ value: string; ratio: string }> {
+      const minimumPixels =
+        this.model === 'doubao-seedream-5-0-260128' || this.model === 'doubao-seedream-4-5-251128'
+          ? 3_686_400
+          : 921_600;
+      return this.allPixelOptions.filter((item) => {
+        const [width, height] = item.value.split('x').map(Number);
+        return width * height >= minimumPixels;
+      });
     },
     layerDecomposition(): boolean {
       return this.$store.state.seedream?.config?.layer_decomposition === true;

--- a/src/components/seedream/config/SizeSelector.vue
+++ b/src/components/seedream/config/SizeSelector.vue
@@ -16,13 +16,7 @@
     >
       <el-option-group v-if="capabilities.sizeTiers.length" :label="$t('seedream.size.group.tier')">
         <el-option v-for="item in capabilities.sizeTiers" :key="item" :label="item" :value="item" />
-      </el-option-group>
-      <el-option-group v-if="capabilities.sizeAdaptive" :label="$t('seedream.size.group.adaptive')">
-        <el-option
-          :key="SEEDREAM_SIZE_ADAPTIVE"
-          :label="$t('seedream.size.adaptive')"
-          :value="SEEDREAM_SIZE_ADAPTIVE"
-        />
+        <el-option v-if="layerDecomposition" label="AUTO" value="auto" />
       </el-option-group>
       <el-option-group :label="$t('seedream.size.group.pixel')">
         <el-option
@@ -40,7 +34,7 @@
 import { defineComponent } from 'vue';
 import { ElSelect, ElOption, ElOptionGroup } from 'element-plus';
 import InfoIcon from '@/components/common/InfoIcon.vue';
-import { SEEDREAM_DEFAULT_SIZE, SEEDREAM_PIXEL_PRESETS, SEEDREAM_SIZE_ADAPTIVE } from '@/constants';
+import { SEEDREAM_DEFAULT_SIZE, SEEDREAM_PIXEL_PRESETS } from '@/constants';
 import { getSeedreamCapabilities, ISeedreamCapability } from '@/utils/seedream/capabilities';
 
 export default defineComponent({
@@ -53,7 +47,6 @@ export default defineComponent({
   },
   data() {
     return {
-      SEEDREAM_SIZE_ADAPTIVE,
       pixelOptions: SEEDREAM_PIXEL_PRESETS
     };
   },
@@ -63,6 +56,9 @@ export default defineComponent({
     },
     capabilities(): ISeedreamCapability {
       return getSeedreamCapabilities(this.model);
+    },
+    layerDecomposition(): boolean {
+      return this.$store.state.seedream?.config?.layer_decomposition === true;
     },
     value: {
       get(): string | undefined {

--- a/src/components/seedream/task/Preview.test.ts
+++ b/src/components/seedream/task/Preview.test.ts
@@ -56,3 +56,33 @@ describe('seedream/task/Preview', () => {
     expect(mountFailure('A lighthouse').find('.content').classes()).toEqual(['content']);
   });
 });
+
+it('sorts and labels layer decomposition results', () => {
+  const wrapper = shallowMount(Preview, {
+    props: {
+      modelValue: {
+        id: 'layer-task',
+        request: { layer_decomposition: true, image: ['input.png'] },
+        response: {
+          success: true,
+          task_id: 'layer-task',
+          data: [
+            { image_url: 'top.png', z_index: 2, name: 'Title', bounding_box: { absolute: [10, 20, 100, 200] } },
+            { image_url: 'base.jpg', z_index: 0, output_format: 'jpeg' }
+          ]
+        }
+      }
+    },
+    global: {
+      mocks: {
+        $t: (key: string) => key,
+        $dayjs: { format: () => '2026-09-05' },
+        $store: { state: { seedream: { config: {} } }, commit: () => undefined }
+      }
+    }
+  });
+  expect((wrapper.vm as any).images.map((image: any) => image.z_index)).toEqual([0, 2]);
+  expect(wrapper.text()).toContain('seedream.name.baseLayer');
+  expect(wrapper.text()).toContain('Title');
+  expect(wrapper.text()).toContain('10, 20, 100, 200');
+});

--- a/src/components/seedream/task/Preview.vue
+++ b/src/components/seedream/task/Preview.vue
@@ -22,12 +22,9 @@
         </el-tooltip>
       </div>
       <div class="info">
-        <div
-          v-if="Array.isArray(modelValue?.request?.image) && modelValue?.request?.image.length > 0"
-          class="flex justify-start items-center gap-2 mt-2 w-full overflow-x-auto"
-        >
+        <div v-if="requestImages.length > 0" class="flex justify-start items-center gap-2 mt-2 w-full overflow-x-auto">
           <image-preview
-            v-for="(url, idx) in modelValue?.request?.image"
+            v-for="(url, idx) in requestImages"
             :key="idx"
             :url="url"
             :name="`image-${idx + 1}`"
@@ -54,13 +51,17 @@
         </el-alert>
       </div>
       <div v-else-if="modelValue?.response?.success === true" :class="{ content: true, failed: true }">
-        <div class="flex justify-start items-center gap-4 w-full overflow-x-auto">
-          <image-wrapper
-            v-for="(image, imageIndex) in images"
-            :key="imageIndex"
-            :src="image?.image_url!"
-            :raw-src="image?.image_url!"
-          />
+        <div class="layer-grid">
+          <article v-for="(image, imageIndex) in images" :key="imageIndex" class="layer-card">
+            <image-wrapper v-if="image?.image_url" :src="image.image_url" :raw-src="image.image_url" />
+            <div v-if="isLayerResult || image.error" class="layer-meta">
+              <strong>{{ layerTitle(image, imageIndex) }}</strong>
+              <span v-if="image.size">{{ image.size }} · {{ image.output_format?.toUpperCase() }}</span>
+              <span v-if="image.description">{{ image.description }}</span>
+              <code v-if="image.bounding_box?.absolute">{{ image.bounding_box.absolute.join(', ') }}</code>
+              <span v-if="image.error" class="layer-error">{{ image.error.message || image.error.code }}</span>
+            </div>
+          </article>
         </div>
         <div :class="{ operations: true, 'mt-2': true, 'mb-2': true }">
           <el-tooltip class="box-item" effect="dark" :content="$t('common.button.edit')" placement="top-start">
@@ -232,18 +233,26 @@ export default defineComponent({
     apiRequest() {
       return buildSeedreamRequest(this.modelValue?.request);
     },
+    requestImages(): string[] {
+      const image = this.modelValue?.request?.image;
+      if (typeof image === 'string') return [image];
+      return Array.isArray(image) ? image : [];
+    },
     isEdit(): boolean {
       return Array.isArray(this.modelValue?.request?.image) && (this.modelValue?.request?.image?.length || 0) > 0;
     },
     images(): ISeedreamImage[] {
-      const result: ISeedreamImage[] = [];
-      // @ts-ignore
-      if (Array.isArray(this.modelValue?.response?.data)) {
-        this.modelValue?.response?.data?.forEach((item: any) => {
-          result.push(item as ISeedreamImage);
-        });
-      }
-      return result;
+      const data = this.modelValue?.response?.data;
+      if (!Array.isArray(data)) return [];
+      return [...data].sort(
+        (left, right) => (left.z_index ?? Number.MAX_SAFE_INTEGER) - (right.z_index ?? Number.MAX_SAFE_INTEGER)
+      );
+    },
+    isLayerResult(): boolean {
+      return (
+        this.modelValue?.request?.layer_decomposition === true ||
+        this.images.some((image) => image.z_index !== undefined)
+      );
     }
   },
   methods: {
@@ -269,6 +278,11 @@ export default defineComponent({
     },
     shortModel(model?: string) {
       return getSeedreamShortModel(model) || model;
+    },
+    layerTitle(image: ISeedreamImage, index: number): string {
+      if (image.error) return this.$t('seedream.name.failedLayer', { index: index + 1 });
+      if (image.z_index === 0) return this.$t('seedream.name.baseLayer');
+      return image.name || this.$t('seedream.name.layer', { index: image.z_index ?? index + 1 });
     },
     onEdit(imageUrl?: string) {
       if (!imageUrl) return;
@@ -385,6 +399,33 @@ $left-width: 70px;
       }
     }
 
+    .layer-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(min(180px, 100%), 1fr));
+      gap: 12px;
+      width: 100%;
+    }
+    .layer-card {
+      min-width: 0;
+      overflow: hidden;
+      border: 1px solid var(--el-border-color-light);
+      border-radius: 10px;
+      background: var(--el-bg-color);
+    }
+    .layer-meta {
+      display: grid;
+      gap: 4px;
+      padding: 10px;
+      font-size: 12px;
+      color: var(--el-text-color-secondary);
+      code {
+        overflow-x: auto;
+        white-space: nowrap;
+      }
+    }
+    .layer-error {
+      color: var(--el-color-danger);
+    }
     .operations {
       display: flex;
       justify-content: left;

--- a/src/constants/seedream.ts
+++ b/src/constants/seedream.ts
@@ -10,17 +10,15 @@ export const SEEDREAM_MODEL_5_0_PRO = 'doubao-seedream-5-0-pro-260628';
 export const SEEDREAM_DEFAULT_MODEL = SEEDREAM_MODEL_4_5;
 
 export const SEEDREAM_SIZE_1K = '1K';
+export const SEEDREAM_SIZE_1_5K = '1.5K';
 export const SEEDREAM_SIZE_2K = '2K';
 export const SEEDREAM_SIZE_3K = '3K';
 export const SEEDREAM_SIZE_4K = '4K';
-export const SEEDREAM_SIZE_ADAPTIVE = 'adaptive';
 
 export const SEEDREAM_DEFAULT_SIZE = SEEDREAM_SIZE_2K;
 
 // Common explicit width×height presets (aspect ratio + pixel dimensions).
-// The Volcengine LAS API accepts any `<width>x<height>` string in addition to
-// the 1K-4K tier presets and `adaptive`. These cover the most useful aspect
-// ratios at 1K (~1MP) and 2K (~4MP).
+// Explicit dimensions remain available when they satisfy the selected model limits.
 export const SEEDREAM_PIXEL_PRESETS: { value: string; ratio: string }[] = [
   { value: '1024x1024', ratio: '1:1' },
   { value: '1280x720', ratio: '16:9' },

--- a/src/constants/seedream.ts
+++ b/src/constants/seedream.ts
@@ -7,7 +7,7 @@ export const SEEDREAM_MODEL_4_5 = 'doubao-seedream-4-5-251128';
 export const SEEDREAM_MODEL_5_0 = 'doubao-seedream-5-0-260128';
 export const SEEDREAM_MODEL_5_0_PRO = 'doubao-seedream-5-0-pro-260628';
 
-export const SEEDREAM_DEFAULT_MODEL = SEEDREAM_MODEL_4_5;
+export const SEEDREAM_DEFAULT_MODEL = SEEDREAM_MODEL_5_0;
 
 export const SEEDREAM_SIZE_1K = '1K';
 export const SEEDREAM_SIZE_1_5K = '1.5K';

--- a/src/i18n/ar/seedream.json
+++ b/src/i18n/ar/seedream.json
@@ -215,16 +215,56 @@
     "message": "مستوى الدقة",
     "description": "مجموعة مستويات الدقة في قائمة الأحجام المنسدلة (1K-4K)"
   },
-  "size.group.adaptive": {
-    "message": "تلقائي",
-    "description": "مجموعة adaptive في قائمة الأحجام المنسدلة"
-  },
   "size.group.pixel": {
     "message": "أبعاد بكسل محددة",
     "description": "مجموعة أبعاد البكسل في قائمة الأحجام المنسدلة"
   },
-  "size.adaptive": {
-    "message": "تلقائي (مطابق للصورة المرجعية)",
-    "description": "تسمية خيار adaptive"
+  "name.mode": {
+    "message": "الوضع",
+    "description": "الوضع العادي للصور أو وضع تفكيك الطبقات"
+  },
+  "mode.image": {
+    "message": "توليد / تحرير الصور",
+    "description": "الوضع العادي للصور"
+  },
+  "mode.layers": {
+    "message": "تفكيك الطبقات",
+    "description": "وضع تفكيك الطبقات"
+  },
+  "name.background": {
+    "message": "وضع الخلفية",
+    "description": "خلفية شفافة أو غير شفافة"
+  },
+  "background.opaque": {
+    "message": "غير شفاف",
+    "description": "خلفية غير شفافة عادية"
+  },
+  "background.transparent": {
+    "message": "خلفية شفافة",
+    "description": "وضع الخلفية الشفافة"
+  },
+  "name.promptOptimization": {
+    "message": "تحسين النصوص",
+    "description": "وضع تحسين النصوص"
+  },
+  "name.webSearch": {
+    "message": "بحث عبر الإنترنت",
+    "description": "ما إذا كان يجب تمكين البحث عبر الإنترنت"
+  },
+  "name.baseLayer": {
+    "message": "الطبقة الأساسية",
+    "description": "الطبقة الأساسية في وضع تفكيك الطبقات"
+  },
+  "name.layer": {
+    "message": "الطبقة {index}",
+    "description": "اسم الطبقة الاحتياطي"
+  },
+  "name.failedLayer": {
+    "message": "العنصر الفاشل {index}",
+    "description": "اسم الطبقة الفاشلة"
+  },
+  "name.layerDecomposition": {
+    "message": "تفكيك الطبقات",
+    "description": "علامة القدرة على تفكيك الطبقات"
   }
 }

--- a/src/i18n/de/seedream.json
+++ b/src/i18n/de/seedream.json
@@ -33,7 +33,7 @@
   },
   "name.status": {
     "message": "Status",
-    "description": "Status der Aufgabe"
+    "description": "Aufgabenstatus"
   },
   "name.traceId": {
     "message": "Verfolgungs-ID",
@@ -215,16 +215,56 @@
     "message": "Auflösungsstufen",
     "description": "Gruppe für die Auflösungsstufen im Größen-Dropdown (1K-4K)"
   },
-  "size.group.adaptive": {
-    "message": "Anpassungsfähig",
-    "description": "Gruppe für die adaptive Auswahl im Größen-Dropdown"
-  },
   "size.group.pixel": {
     "message": "Spezifische Pixelgröße",
     "description": "Gruppe für die Pixelgrößen im Größen-Dropdown"
   },
-  "size.adaptive": {
-    "message": "Anpassungsfähig (entspricht Referenzbild)",
-    "description": "Label für die adaptive Option"
+  "name.mode": {
+    "message": "Modus",
+    "description": "Normaler Bildmodus oder Ebenenaufteilungsmodus"
+  },
+  "mode.image": {
+    "message": "Bild generieren / bearbeiten",
+    "description": "Normaler Bildmodus"
+  },
+  "mode.layers": {
+    "message": "Ebenenaufteilung",
+    "description": "Ebenenaufteilungsmodus"
+  },
+  "name.background": {
+    "message": "Hintergrundmodus",
+    "description": "Transparenter oder undurchsichtiger Hintergrund"
+  },
+  "background.opaque": {
+    "message": "Undurchsichtig",
+    "description": "Normale undurchsichtige Hintergrund"
+  },
+  "background.transparent": {
+    "message": "Transparenter Hintergrund",
+    "description": "Transparenter Hintergrundmodus"
+  },
+  "name.promptOptimization": {
+    "message": "Eingabeaufforderung Optimierung",
+    "description": "Modus zur Optimierung der Eingabeaufforderung"
+  },
+  "name.webSearch": {
+    "message": "Online-Suche",
+    "description": "Ob die Online-Suche aktiviert ist"
+  },
+  "name.baseLayer": {
+    "message": "Basisebene",
+    "description": "Basisebene der Ebenenaufteilung"
+  },
+  "name.layer": {
+    "message": "Ebene {index}",
+    "description": "Rückfallname der Ebene"
+  },
+  "name.failedLayer": {
+    "message": "Fehlerhaftes Element {index}",
+    "description": "Name der fehlerhaften Ebene"
+  },
+  "name.layerDecomposition": {
+    "message": "Ebenenaufteilung",
+    "description": "Label für die Fähigkeit zur Ebenenaufteilung"
   }
 }

--- a/src/i18n/en/seedream.json
+++ b/src/i18n/en/seedream.json
@@ -68,7 +68,7 @@
     "description": "Description of the model parameter"
   },
   "description.size": {
-    "message": "Image size. Allowed tier presets vary by model: 5.0 supports 2K/3K/4K, 4.5/4.0 support 1K/2K/4K, and 3.0-t2i / seededit-3.0-i2i only accept explicit `<width>x<height>` pixel values (e.g. 1024x1024, 1280x720). On preset-supporting models you can also pick `adaptive` (match the reference image) or type any `<width>x<height>` directly into the dropdown.",
+    "message": "Sizes vary by model: 5.0 Pro supports 1K/1.5K/2K and auto for layers; 5.0 Lite supports 2K/3K/4K. Valid <width>x<height> values are also accepted.",
     "description": "Description of the size parameter (per-model)"
   },
   "description.watermark": {
@@ -76,7 +76,7 @@
     "description": "Description of the watermark parameter"
   },
   "description.imageUrls": {
-    "message": "Upload 1-14 reference images to enable image editing.",
+    "message": "Upload references: Pro accepts up to 10, layer decomposition exactly 1, and other current models up to 14.",
     "description": "Description of the image parameter"
   },
   "status.pending": {
@@ -128,7 +128,7 @@
     "description": "Exhausted credits message"
   },
   "message.uploadImageExceed": {
-    "message": "You can upload a maximum of 14 images",
+    "message": "You can upload at most {count} images",
     "description": "Image count exceeds limit"
   },
   "message.uploadImageError": {
@@ -208,23 +208,63 @@
     "description": "output_format parameter label"
   },
   "description.outputFormat": {
-    "message": "File format of the generated image, jpeg or png. Default is jpeg. Only supported by doubao-seedream-5.0.",
+    "message": "Image format is jpeg or png on Seedream 5.0 Pro/Lite. Decomposed layers are always PNG.",
     "description": "Description of the output_format parameter"
   },
   "size.group.tier": {
     "message": "Resolution tier",
     "description": "Group label for the 1K-4K presets in the size dropdown"
   },
-  "size.group.adaptive": {
-    "message": "Adaptive",
-    "description": "Group label for the adaptive option in the size dropdown"
-  },
   "size.group.pixel": {
     "message": "Explicit dimensions",
     "description": "Group label for the pixel presets in the size dropdown"
   },
-  "size.adaptive": {
-    "message": "Adaptive (match reference)",
-    "description": "Label for the adaptive option"
+  "name.mode": {
+    "message": "Creation mode",
+    "description": "Image or layer decomposition mode"
+  },
+  "mode.image": {
+    "message": "Generate / edit image",
+    "description": "Regular image mode"
+  },
+  "mode.layers": {
+    "message": "Layer decomposition",
+    "description": "Layer decomposition mode"
+  },
+  "name.background": {
+    "message": "Background",
+    "description": "Transparent or opaque background"
+  },
+  "background.opaque": {
+    "message": "Solid background",
+    "description": "Regular opaque background"
+  },
+  "background.transparent": {
+    "message": "Transparent",
+    "description": "Transparent background mode"
+  },
+  "name.promptOptimization": {
+    "message": "Prompt optimization",
+    "description": "Prompt optimization mode"
+  },
+  "name.webSearch": {
+    "message": "Web search",
+    "description": "Enable web search"
+  },
+  "name.baseLayer": {
+    "message": "Base image",
+    "description": "Base image in layer decomposition"
+  },
+  "name.layer": {
+    "message": "Layer {index}",
+    "description": "Fallback layer name"
+  },
+  "name.failedLayer": {
+    "message": "Failed item {index}",
+    "description": "Failed layer item name"
+  },
+  "name.layerDecomposition": {
+    "message": "Layer decomposition",
+    "description": "Layer decomposition capability label"
   }
 }

--- a/src/i18n/es/seedream.json
+++ b/src/i18n/es/seedream.json
@@ -215,16 +215,56 @@
     "message": "Resolución",
     "description": "Grupo de niveles de resolución en el desplegable (1K-4K)"
   },
-  "size.group.adaptive": {
-    "message": "Adaptativo",
-    "description": "Grupo de tamaño adaptativo en el desplegable"
-  },
   "size.group.pixel": {
     "message": "Tamaño en píxeles",
     "description": "Grupo de tamaño por píxeles en el desplegable"
   },
-  "size.adaptive": {
-    "message": "Adaptativo (igual que la imagen de referencia)",
-    "description": "Etiqueta de opción adaptive"
+  "name.mode": {
+    "message": "Modo",
+    "description": "Modo de imagen normal o modo de descomposición de capas"
+  },
+  "mode.image": {
+    "message": "Generación / Edición de imágenes",
+    "description": "Modo de imagen normal"
+  },
+  "mode.layers": {
+    "message": "Descomposición de capas",
+    "description": "Modo de descomposición de capas"
+  },
+  "name.background": {
+    "message": "Modo de fondo",
+    "description": "Fondo transparente u opaco"
+  },
+  "background.opaque": {
+    "message": "Opaco",
+    "description": "Fondo opaco normal"
+  },
+  "background.transparent": {
+    "message": "Fondo transparente",
+    "description": "Modo de fondo transparente"
+  },
+  "name.promptOptimization": {
+    "message": "Optimización de indicaciones",
+    "description": "Modo de optimización de indicaciones"
+  },
+  "name.webSearch": {
+    "message": "Búsqueda en línea",
+    "description": "Si se habilita la búsqueda en línea"
+  },
+  "name.baseLayer": {
+    "message": "Capa base",
+    "description": "Capa base en la descomposición de capas"
+  },
+  "name.layer": {
+    "message": "Capa {index}",
+    "description": "Nombre de la capa de retroceso"
+  },
+  "name.failedLayer": {
+    "message": "Elemento fallido {index}",
+    "description": "Nombre de la capa fallida"
+  },
+  "name.layerDecomposition": {
+    "message": "Descomposición de capas",
+    "description": "Etiqueta de capacidad de descomposición de capas"
   }
 }

--- a/src/i18n/fr/seedream.json
+++ b/src/i18n/fr/seedream.json
@@ -1,7 +1,7 @@
 {
   "name.action": {
     "message": "Action",
-    "description": "Générer ou éditer un sélecteur d'action"
+    "description": "Générer ou éditer un sélecteur d'actions"
   },
   "name.taskId": {
     "message": "ID de tâche",
@@ -215,16 +215,56 @@
     "message": "Niveau de résolution",
     "description": "Groupe de niveaux de résolution dans le menu déroulant (1K-4K)"
   },
-  "size.group.adaptive": {
-    "message": "Adaptatif",
-    "description": "Groupe adaptatif dans le menu déroulant de tailles"
-  },
   "size.group.pixel": {
     "message": "Taille en pixels",
     "description": "Groupe de tailles en pixels dans le menu déroulant"
   },
-  "size.adaptive": {
-    "message": "Adaptatif (comme l'image de référence)",
-    "description": "Étiquette de l'option adaptive"
+  "name.mode": {
+    "message": "Mode",
+    "description": "Mode d'image normale ou de séparation de calques"
+  },
+  "mode.image": {
+    "message": "Génération / Édition d'image",
+    "description": "Mode d'image ordinaire"
+  },
+  "mode.layers": {
+    "message": "Décomposition des couches",
+    "description": "Mode de décomposition des couches"
+  },
+  "name.background": {
+    "message": "Mode de fond",
+    "description": "Fond transparent ou opaque"
+  },
+  "background.opaque": {
+    "message": "Opaque",
+    "description": "Fond opaque normal"
+  },
+  "background.transparent": {
+    "message": "Fond transparent",
+    "description": "Mode de fond transparent"
+  },
+  "name.promptOptimization": {
+    "message": "Optimisation des invites",
+    "description": "Mode d'optimisation des invites"
+  },
+  "name.webSearch": {
+    "message": "Recherche en ligne",
+    "description": "Indique si la recherche en ligne est activée"
+  },
+  "name.baseLayer": {
+    "message": "Couche de base",
+    "description": "Couche de base pour la décomposition des couches"
+  },
+  "name.layer": {
+    "message": "Couche {index}",
+    "description": "Nom de la couche de repli"
+  },
+  "name.failedLayer": {
+    "message": "Échec {index}",
+    "description": "Nom de la couche échouée"
+  },
+  "name.layerDecomposition": {
+    "message": "Décomposition des couches",
+    "description": "Étiquette de capacité de décomposition des couches"
   }
 }

--- a/src/i18n/it/seedream.json
+++ b/src/i18n/it/seedream.json
@@ -215,16 +215,56 @@
     "message": "Livello di risoluzione",
     "description": "Gruppo di livelli nel menu a discesa delle dimensioni (1K-4K)"
   },
-  "size.group.adaptive": {
-    "message": "Adattivo",
-    "description": "Gruppo adattivo nel menu a discesa delle dimensioni"
-  },
   "size.group.pixel": {
     "message": "Dimensioni pixel specifiche",
     "description": "Gruppo di dimensioni pixel nel menu a discesa delle dimensioni"
   },
-  "size.adaptive": {
-    "message": "Adattivo (coerente con l'immagine di riferimento)",
-    "description": "Etichetta dell'opzione adattiva"
+  "name.mode": {
+    "message": "Modalità",
+    "description": "Modalità immagine normale o modalità di separazione dei livelli"
+  },
+  "mode.image": {
+    "message": "Generazione / Modifica immagine",
+    "description": "Modalità immagine normale"
+  },
+  "mode.layers": {
+    "message": "Separazione dei livelli",
+    "description": "Modalità di separazione dei livelli"
+  },
+  "name.background": {
+    "message": "Modalità sfondo",
+    "description": "Sfondo trasparente o opaco"
+  },
+  "background.opaque": {
+    "message": "Opaco",
+    "description": "Sfondo opaco normale"
+  },
+  "background.transparent": {
+    "message": "Sfondo trasparente",
+    "description": "Modalità sfondo trasparente"
+  },
+  "name.promptOptimization": {
+    "message": "Ottimizzazione del prompt",
+    "description": "Modalità di ottimizzazione del prompt"
+  },
+  "name.webSearch": {
+    "message": "Ricerca online",
+    "description": "Se abilitare la ricerca online"
+  },
+  "name.baseLayer": {
+    "message": "Livello di base",
+    "description": "Livello di base per la separazione dei livelli"
+  },
+  "name.layer": {
+    "message": "Livello {index}",
+    "description": "Nome di fallback del livello"
+  },
+  "name.failedLayer": {
+    "message": "Elemento fallito {index}",
+    "description": "Nome del livello fallito"
+  },
+  "name.layerDecomposition": {
+    "message": "Separazione dei livelli",
+    "description": "Etichetta della capacità di separazione dei livelli"
   }
 }

--- a/src/i18n/ja/seedream.json
+++ b/src/i18n/ja/seedream.json
@@ -215,16 +215,56 @@
     "message": "解像度階層",
     "description": "サイズドロップダウンの階層グループ（1K-4K）"
   },
-  "size.group.adaptive": {
-    "message": "自適応",
-    "description": "サイズドロップダウンの自適応グループ"
-  },
   "size.group.pixel": {
     "message": "具体的なピクセルサイズ",
     "description": "サイズドロップダウンのピクセルサイズグループ"
   },
-  "size.adaptive": {
-    "message": "自適応（参照画像に一致）",
-    "description": "adaptive オプションのラベル"
+  "name.mode": {
+    "message": "モード",
+    "description": "通常の画像モードまたはレイヤー分解モード"
+  },
+  "mode.image": {
+    "message": "画像生成 / 編集",
+    "description": "通常の画像モード"
+  },
+  "mode.layers": {
+    "message": "レイヤー分解",
+    "description": "レイヤー分解モード"
+  },
+  "name.background": {
+    "message": "背景モード",
+    "description": "透明または不透明な背景"
+  },
+  "background.opaque": {
+    "message": "不透明",
+    "description": "通常の不透明な背景"
+  },
+  "background.transparent": {
+    "message": "透明背景",
+    "description": "透明な背景モード"
+  },
+  "name.promptOptimization": {
+    "message": "プロンプト最適化",
+    "description": "プロンプト最適化モード"
+  },
+  "name.webSearch": {
+    "message": "ウェブ検索",
+    "description": "ウェブ検索を有効にするかどうか"
+  },
+  "name.baseLayer": {
+    "message": "ベースレイヤー",
+    "description": "レイヤー分解のベースレイヤー"
+  },
+  "name.layer": {
+    "message": "レイヤー {index}",
+    "description": "レイヤー名のフォールバック"
+  },
+  "name.failedLayer": {
+    "message": "失敗項目 {index}",
+    "description": "失敗したレイヤーの名前"
+  },
+  "name.layerDecomposition": {
+    "message": "レイヤー分解",
+    "description": "レイヤー分解機能のラベル"
   }
 }

--- a/src/i18n/ko/seedream.json
+++ b/src/i18n/ko/seedream.json
@@ -215,16 +215,56 @@
     "message": "해상도 단계",
     "description": "크기 드롭다운의 단계 그룹 (1K-4K)"
   },
-  "size.group.adaptive": {
-    "message": "자동 맞춤",
-    "description": "크기 드롭다운의 자동 맞춤 그룹"
-  },
   "size.group.pixel": {
     "message": "정확한 픽셀 크기",
     "description": "크기 드롭다운의 픽셀 크기 그룹"
   },
-  "size.adaptive": {
-    "message": "자동 맞춤 (참조 이미지와 동일)",
-    "description": "adaptive 옵션 라벨"
+  "name.mode": {
+    "message": "모드",
+    "description": "일반 이미지 또는 레이어 분해 모드"
+  },
+  "mode.image": {
+    "message": "이미지 생성 / 편집",
+    "description": "일반 이미지 모드"
+  },
+  "mode.layers": {
+    "message": "레이어 분해",
+    "description": "레이어 분해 모드"
+  },
+  "name.background": {
+    "message": "배경 모드",
+    "description": "투명 또는 불투명 배경"
+  },
+  "background.opaque": {
+    "message": "불투명",
+    "description": "일반 불투명 배경"
+  },
+  "background.transparent": {
+    "message": "투명 배경",
+    "description": "투명 배경 모드"
+  },
+  "name.promptOptimization": {
+    "message": "프롬프트 최적화",
+    "description": "프롬프트 최적화 모드"
+  },
+  "name.webSearch": {
+    "message": "연결 검색",
+    "description": "연결 검색 사용 여부"
+  },
+  "name.baseLayer": {
+    "message": "기본 이미지",
+    "description": "레이어 분해의 기본 이미지"
+  },
+  "name.layer": {
+    "message": "레이어 {index}",
+    "description": "레이어 이름 회귀"
+  },
+  "name.failedLayer": {
+    "message": "실패 항목 {index}",
+    "description": "실패한 레이어 이름"
+  },
+  "name.layerDecomposition": {
+    "message": "레이어 분해",
+    "description": "레이어 분해 기능 태그"
   }
 }

--- a/src/i18n/pt/seedream.json
+++ b/src/i18n/pt/seedream.json
@@ -33,7 +33,7 @@
   },
   "name.status": {
     "message": "Status",
-    "description": "Estado da tarefa"
+    "description": "Status da tarefa"
   },
   "name.traceId": {
     "message": "ID de Rastreamento",
@@ -215,16 +215,56 @@
     "message": "Níveis de resolução",
     "description": "Grupo de níveis (1K-4K) no dropdown de tamanho"
   },
-  "size.group.adaptive": {
-    "message": "Adaptativo",
-    "description": "Grupo adaptativo no dropdown de tamanho"
-  },
   "size.group.pixel": {
     "message": "Tamanho em pixels específico",
     "description": "Grupo de tamanhos em pixels no dropdown de tamanho"
   },
-  "size.adaptive": {
-    "message": "Adaptativo (igual à imagem de referência)",
-    "description": "Etiqueta da opção adaptive"
+  "name.mode": {
+    "message": "Modo",
+    "description": "Modo de imagem comum ou modo de desagregação de camadas"
+  },
+  "mode.image": {
+    "message": "Geração / Edição de Imagem",
+    "description": "Modo de imagem comum"
+  },
+  "mode.layers": {
+    "message": "Desagregação de Camadas",
+    "description": "Modo de desagregação de camadas"
+  },
+  "name.background": {
+    "message": "Modo de Fundo",
+    "description": "Fundo transparente ou opaco"
+  },
+  "background.opaque": {
+    "message": "Opaco",
+    "description": "Fundo opaco comum"
+  },
+  "background.transparent": {
+    "message": "Fundo transparente",
+    "description": "Modo de fundo transparente"
+  },
+  "name.promptOptimization": {
+    "message": "Otimização de Prompt",
+    "description": "Modo de otimização de prompt"
+  },
+  "name.webSearch": {
+    "message": "Pesquisa na Web",
+    "description": "Se a pesquisa na web está habilitada"
+  },
+  "name.baseLayer": {
+    "message": "Camada Base",
+    "description": "Camada base da desagregação de camadas"
+  },
+  "name.layer": {
+    "message": "Camada {index}",
+    "description": "Nome da camada de fallback"
+  },
+  "name.failedLayer": {
+    "message": "Item Falhado {index}",
+    "description": "Nome da camada falhada"
+  },
+  "name.layerDecomposition": {
+    "message": "Desagregação de Camadas",
+    "description": "Etiqueta de capacidade de desagregação de camadas"
   }
 }

--- a/src/i18n/ru/seedream.json
+++ b/src/i18n/ru/seedream.json
@@ -215,16 +215,56 @@
     "message": "Уровни разрешения",
     "description": "Группа уровней разрешения в выпадающем списке (1K-4K)"
   },
-  "size.group.adaptive": {
-    "message": "Адаптивно",
-    "description": "Группа адаптивных размеров в выпадающем списке"
-  },
   "size.group.pixel": {
     "message": "Конкретные пиксельные размеры",
     "description": "Группа пиксельных размеров в выпадающем списке"
   },
-  "size.adaptive": {
-    "message": "Адаптивно (соответствует образцу)",
-    "description": "Метка опции adaptive"
+  "name.mode": {
+    "message": "Режим",
+    "description": "Обычный режим изображений или режим разделения слоев"
+  },
+  "mode.image": {
+    "message": "Генерация / Редактирование изображений",
+    "description": "Обычный режим изображений"
+  },
+  "mode.layers": {
+    "message": "Разделение слоев",
+    "description": "Режим разделения слоев"
+  },
+  "name.background": {
+    "message": "Режим фона",
+    "description": "Прозрачный или непрозрачный фон"
+  },
+  "background.opaque": {
+    "message": "Непрозрачный",
+    "description": "Обычный непрозрачный фон"
+  },
+  "background.transparent": {
+    "message": "Прозрачный фон",
+    "description": "Режим прозрачного фона"
+  },
+  "name.promptOptimization": {
+    "message": "Оптимизация подсказок",
+    "description": "Режим оптимизации подсказок"
+  },
+  "name.webSearch": {
+    "message": "Поиск в интернете",
+    "description": "Включение или отключение поиска в интернете"
+  },
+  "name.baseLayer": {
+    "message": "Базовый слой",
+    "description": "Базовый слой для разделения слоев"
+  },
+  "name.layer": {
+    "message": "Слой {index}",
+    "description": "Имя слоя для возврата"
+  },
+  "name.failedLayer": {
+    "message": "Неудачный элемент {index}",
+    "description": "Название неудачного слоя"
+  },
+  "name.layerDecomposition": {
+    "message": "Разделение слоев",
+    "description": "Метка возможности разделения слоев"
   }
 }

--- a/src/i18n/zh-CN/seedream.json
+++ b/src/i18n/zh-CN/seedream.json
@@ -68,7 +68,7 @@
     "description": "model 参数说明"
   },
   "description.size": {
-    "message": "图片尺寸。不同模型支持的预设不同：5.0 仅支持 2K/3K/4K，4.5/4.0 支持 1K/2K/4K，3.0-t2i 与 seededit-3.0-i2i 仅支持 `<宽>x<高>` 像素值（如 1024x1024、1280x720）。预设模型还可选择「自适应」（与参考图保持一致比例），也可在下拉框中直接输入任意 `<宽>x<高>`。",
+    "message": "不同模型支持的尺寸不同：5.0 Pro 支持 1K/1.5K/2K，图层拆分还支持 auto；5.0 Lite 支持 2K/3K/4K；也可输入符合模型限制的 <宽>x<高>。",
     "description": "size 参数说明（按模型）"
   },
   "description.watermark": {
@@ -76,7 +76,7 @@
     "description": "watermark 参数说明"
   },
   "description.imageUrls": {
-    "message": "上传 1-14 张参考图片以启用图片编辑。",
+    "message": "上传参考图片；5.0 Pro 最多 10 张，图层拆分限 1 张，其他当前模型最多 14 张。",
     "description": "image 参数说明"
   },
   "status.pending": {
@@ -128,7 +128,7 @@
     "description": "已用完提示"
   },
   "message.uploadImageExceed": {
-    "message": "最多可上传 14 张图片",
+    "message": "最多可上传 {count} 张图片",
     "description": "图片数量超过限制"
   },
   "message.uploadImageError": {
@@ -208,23 +208,63 @@
     "description": "output_format 参数标签"
   },
   "description.outputFormat": {
-    "message": "生成图片的文件格式，jpeg 或 png，默认 jpeg。仅 doubao-seedream-5.0 支持。",
+    "message": "图片格式为 jpeg 或 png。Seedream 5.0 Pro/Lite 支持；拆分图层固定为 PNG。",
     "description": "output_format 参数说明"
   },
   "size.group.tier": {
     "message": "分辨率档位",
     "description": "尺寸下拉的档位分组（1K-4K）"
   },
-  "size.group.adaptive": {
-    "message": "自适应",
-    "description": "尺寸下拉的自适应分组"
-  },
   "size.group.pixel": {
     "message": "具体像素尺寸",
     "description": "尺寸下拉的像素尺寸分组"
   },
-  "size.adaptive": {
-    "message": "自适应（与参考图一致）",
-    "description": "adaptive 选项标签"
+  "name.mode": {
+    "message": "创作模式",
+    "description": "普通图片或图层拆分模式"
+  },
+  "mode.image": {
+    "message": "图片生成 / 编辑",
+    "description": "普通图片模式"
+  },
+  "mode.layers": {
+    "message": "图层拆分",
+    "description": "图层拆分模式"
+  },
+  "name.background": {
+    "message": "背景模式",
+    "description": "透明或不透明背景"
+  },
+  "background.opaque": {
+    "message": "实体背景",
+    "description": "普通不透明背景"
+  },
+  "background.transparent": {
+    "message": "透明背景",
+    "description": "透明背景模式"
+  },
+  "name.promptOptimization": {
+    "message": "提示词优化",
+    "description": "提示词优化模式"
+  },
+  "name.webSearch": {
+    "message": "联网搜索",
+    "description": "是否启用联网搜索"
+  },
+  "name.baseLayer": {
+    "message": "底图",
+    "description": "图层拆分的底图"
+  },
+  "name.layer": {
+    "message": "图层 {index}",
+    "description": "图层名称回退"
+  },
+  "name.failedLayer": {
+    "message": "失败项 {index}",
+    "description": "失败图层名称"
+  },
+  "name.layerDecomposition": {
+    "message": "图层拆分",
+    "description": "图层拆分能力标签"
   }
 }

--- a/src/i18n/zh-TW/seedream.json
+++ b/src/i18n/zh-TW/seedream.json
@@ -215,16 +215,56 @@
     "message": "解析度檔位",
     "description": "尺寸下拉的檔位分組（1K-4K）"
   },
-  "size.group.adaptive": {
-    "message": "自適應",
-    "description": "尺寸下拉的自適應分組"
-  },
   "size.group.pixel": {
     "message": "具體畫素尺寸",
     "description": "尺寸下拉的畫素尺寸分組"
   },
-  "size.adaptive": {
-    "message": "自適應（與參考圖一致）",
-    "description": "adaptive 選項標籤"
+  "name.mode": {
+    "message": "模式",
+    "description": "普通圖片或圖層拆分模式"
+  },
+  "mode.image": {
+    "message": "圖片生成 / 編輯",
+    "description": "普通圖片模式"
+  },
+  "mode.layers": {
+    "message": "圖層拆分",
+    "description": "圖層拆分模式"
+  },
+  "name.background": {
+    "message": "背景模式",
+    "description": "透明或不透明背景"
+  },
+  "background.opaque": {
+    "message": "不透明",
+    "description": "普通不透明背景"
+  },
+  "background.transparent": {
+    "message": "透明背景",
+    "description": "透明背景模式"
+  },
+  "name.promptOptimization": {
+    "message": "提示詞優化",
+    "description": "提示詞優化模式"
+  },
+  "name.webSearch": {
+    "message": "聯網搜索",
+    "description": "是否啟用聯網搜索"
+  },
+  "name.baseLayer": {
+    "message": "底圖",
+    "description": "圖層拆分的底圖"
+  },
+  "name.layer": {
+    "message": "圖層 {index}",
+    "description": "圖層名稱回退"
+  },
+  "name.failedLayer": {
+    "message": "失敗項 {index}",
+    "description": "失敗圖層名稱"
+  },
+  "name.layerDecomposition": {
+    "message": "圖層拆分",
+    "description": "圖層拆分能力標籤"
   }
 }

--- a/src/models/seedream.ts
+++ b/src/models/seedream.ts
@@ -6,7 +6,11 @@ export interface ISeedreamConfig {
   action?: 'generate' | 'edit';
   model?: string;
   prompt?: string;
-  image?: string[];
+  image?: string | string[];
+  layer_decomposition?: boolean;
+  background?: 'transparent' | 'opaque';
+  optimize_prompt_options?: { mode: 'standard' | 'fast' };
+  tools?: Array<{ type: 'web_search' }>;
   size?: string;
   seed?: number;
   sequential_image_generation?: 'auto' | 'disabled';
@@ -23,7 +27,11 @@ export interface ISeedreamConfig {
 export interface ISeedreamGenerateRequest {
   model?: string;
   prompt?: string;
-  image?: string[];
+  image?: string | string[];
+  layer_decomposition?: boolean;
+  background?: 'transparent' | 'opaque';
+  optimize_prompt_options?: { mode: 'standard' | 'fast' };
+  tools?: Array<{ type: 'web_search' }>;
   size?: string;
   seed?: number;
   sequential_image_generation?: 'auto' | 'disabled';
@@ -41,6 +49,16 @@ export interface ISeedreamImage {
   prompt?: string;
   size?: string;
   image_url?: string;
+  b64_json?: string;
+  output_format?: 'jpeg' | 'png';
+  z_index?: number;
+  name?: string;
+  description?: string;
+  bounding_box?: {
+    absolute?: [number, number, number, number];
+    normalized?: [number, number, number, number];
+  };
+  error?: { code?: string; message?: string };
 }
 
 export interface ISeedreamGenerateResponse {
@@ -48,6 +66,8 @@ export interface ISeedreamGenerateResponse {
   task_id: string;
   trace_id?: string;
   data?: ISeedreamImage[];
+  usage?: Record<string, unknown>;
+  tools?: Array<{ type: string }>;
   error?: {
     code?: string;
     message?: string;

--- a/src/utils/seedream/capabilities.test.ts
+++ b/src/utils/seedream/capabilities.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { getSeedreamCapabilities } from './capabilities';
+
+describe('Seedream official capability matrix', () => {
+  it('models Pro-only production features', () => {
+    const capabilities = getSeedreamCapabilities('doubao-seedream-5-0-pro-260628');
+    expect(capabilities.sizeTiers).toEqual(['1K', '1.5K', '2K']);
+    expect(capabilities.layerDecomposition).toBe(true);
+    expect(capabilities.transparentBackground).toBe(true);
+    expect(capabilities.promptOptimization).toEqual(['standard', 'fast']);
+    expect(capabilities.groupGeneration).toBe(false);
+    expect(capabilities.webSearch).toBe(false);
+  });
+
+  it('models Lite group and web capabilities', () => {
+    const capabilities = getSeedreamCapabilities('doubao-seedream-5-0-260128');
+    expect(capabilities.sizeTiers).toEqual(['2K', '3K', '4K']);
+    expect(capabilities.groupGeneration).toBe(true);
+    expect(capabilities.webSearch).toBe(true);
+    expect(capabilities.layerDecomposition).toBe(false);
+    expect(capabilities.promptOptimization).toEqual(['standard']);
+  });
+});

--- a/src/utils/seedream/capabilities.ts
+++ b/src/utils/seedream/capabilities.ts
@@ -1,20 +1,9 @@
-// Capability matrix for Seedream / SeedEdit image models.
-//
-// Single source of truth derived from the Volcengine Ark image-generation docs:
-// https://www.volcengine.com/docs/82379/1541523
-//
-// Mirrors the pattern used by `utils/kling/capabilities.ts`. Used by the
-// Seedream config UI to:
-//   - decide which selectors are visible for the current model
-//   - filter the set of valid `size` presets
-//   - prompt the user before silently dropping config that is no longer
-//     supported (image upload, custom seed, group generation, etc.)
-
 import {
   SEEDREAM_MODEL_4_0,
   SEEDREAM_MODEL_4_5,
   SEEDREAM_MODEL_5_0,
   SEEDREAM_MODEL_5_0_PRO,
+  SEEDREAM_SIZE_1_5K,
   SEEDREAM_SIZE_1K,
   SEEDREAM_SIZE_2K,
   SEEDREAM_SIZE_3K,
@@ -22,109 +11,115 @@ import {
 } from '@/constants';
 
 export interface ISeedreamCapability {
-  /** Accepts the `image` request parameter (reference / edit images). */
   image: boolean;
-  /** `image` is *required* (image-to-image only). */
   imageRequired: boolean;
-  /** Allowed tier presets. Empty array means the model only accepts an
-   *  explicit `<W>x<H>` value. */
+  maxInputImages: number;
   sizeTiers: string[];
-  /** Accepts the `adaptive` size value (matches the reference image ratio). */
-  sizeAdaptive: boolean;
-  /** Accepts `<W>x<H>` pixel-value sizes. (Always true at the moment, kept
-   *  for symmetry with the other flags.) */
   sizePixel: boolean;
-  /** Default `<W>x<H>` to seed when the model rejects every preset. */
+  sizeAdaptive: boolean;
   sizePixelDefault?: string;
-  /** Supports `sequential_image_generation=auto` group generation. */
   groupGeneration: boolean;
-  /** Supports the `seed` parameter. */
   seed: boolean;
-  /** Supports the `guidance_scale` parameter. */
   guidanceScale: boolean;
-  /** Default `guidance_scale` value, when supported. */
   guidanceScaleDefault?: number;
-  /** Supports the `output_format` parameter (jpeg / png). */
   outputFormat: boolean;
-  /** Supports the `tools=[{type:"web_search"}]` parameter. */
-  tools: boolean;
+  webSearch: boolean;
+  promptOptimization: Array<'standard' | 'fast'>;
+  layerDecomposition: boolean;
+  transparentBackground: boolean;
 }
 
 const FALLBACK: ISeedreamCapability = {
   image: true,
   imageRequired: false,
-  sizeTiers: [SEEDREAM_SIZE_1K, SEEDREAM_SIZE_2K, SEEDREAM_SIZE_3K, SEEDREAM_SIZE_4K],
-  sizeAdaptive: true,
+  maxInputImages: 14,
+  sizeTiers: [SEEDREAM_SIZE_1K, SEEDREAM_SIZE_2K, SEEDREAM_SIZE_4K],
   sizePixel: true,
+  sizeAdaptive: false,
   sizePixelDefault: undefined,
   groupGeneration: false,
   seed: false,
   guidanceScale: false,
   outputFormat: false,
-  tools: false
+  webSearch: false,
+  promptOptimization: [],
+  layerDecomposition: false,
+  transparentBackground: false
 };
 
-/** Return the support matrix for a given model. */
 export function getSeedreamCapabilities(model?: string): ISeedreamCapability {
   switch (model) {
     case SEEDREAM_MODEL_5_0_PRO:
-      // 5.0 Pro: flagship single-image. Size presets 1K/2K only. No group
-      // generation / stream / web_search tools. Supports output_format.
       return {
         image: true,
         imageRequired: false,
-        sizeTiers: [SEEDREAM_SIZE_1K, SEEDREAM_SIZE_2K],
-        sizeAdaptive: true,
+        maxInputImages: 10,
+        sizeTiers: [SEEDREAM_SIZE_1K, SEEDREAM_SIZE_1_5K, SEEDREAM_SIZE_2K],
         sizePixel: true,
+        sizeAdaptive: false,
+        sizePixelDefault: undefined,
         groupGeneration: false,
         seed: false,
         guidanceScale: false,
         outputFormat: true,
-        tools: false
+        webSearch: false,
+        promptOptimization: ['standard', 'fast'],
+        layerDecomposition: true,
+        transparentBackground: true
       };
     case SEEDREAM_MODEL_5_0:
-      // 5.0-lite: tier presets 2K/3K/4K (no 1K — min ~3.7M pixels).
       return {
         image: true,
         imageRequired: false,
+        maxInputImages: 14,
         sizeTiers: [SEEDREAM_SIZE_2K, SEEDREAM_SIZE_3K, SEEDREAM_SIZE_4K],
-        sizeAdaptive: true,
         sizePixel: true,
+        sizeAdaptive: false,
+        sizePixelDefault: undefined,
         groupGeneration: true,
         seed: false,
         guidanceScale: false,
         outputFormat: true,
-        tools: true
+        webSearch: true,
+        promptOptimization: ['standard'],
+        layerDecomposition: false,
+        transparentBackground: false
       };
     case SEEDREAM_MODEL_4_5:
-      // 4.5: tier presets 2K/4K (no 1K, no 3K). Verified live —
-      // 4.5 + 1K returns "the specified size is not supported for model
-      // doubao-seedream-4-5". Pixel min is 3,686,400 (≈2K), same as 5.0.
       return {
         image: true,
         imageRequired: false,
+        maxInputImages: 14,
         sizeTiers: [SEEDREAM_SIZE_2K, SEEDREAM_SIZE_4K],
-        sizeAdaptive: true,
         sizePixel: true,
+        sizeAdaptive: false,
+        sizePixelDefault: undefined,
         groupGeneration: true,
         seed: false,
         guidanceScale: false,
         outputFormat: false,
-        tools: false
+        webSearch: false,
+        promptOptimization: ['standard'],
+        layerDecomposition: false,
+        transparentBackground: false
       };
     case SEEDREAM_MODEL_4_0:
-      // 4.0: tier presets 1K/2K/4K (no 3K). Pixel min is 921,600 (≈1K).
       return {
         image: true,
         imageRequired: false,
+        maxInputImages: 14,
         sizeTiers: [SEEDREAM_SIZE_1K, SEEDREAM_SIZE_2K, SEEDREAM_SIZE_4K],
-        sizeAdaptive: true,
         sizePixel: true,
+        sizeAdaptive: false,
+        sizePixelDefault: undefined,
         groupGeneration: true,
         seed: false,
         guidanceScale: false,
         outputFormat: false,
-        tools: false
+        webSearch: false,
+        promptOptimization: ['standard', 'fast'],
+        layerDecomposition: false,
+        transparentBackground: false
       };
     default:
       return FALLBACK;
@@ -133,18 +128,13 @@ export function getSeedreamCapabilities(model?: string): ISeedreamCapability {
 
 export function getCompatibleSeedreamAction(
   action: 'generate' | 'edit' | undefined,
-  model?: string
+  _model?: string
 ): 'generate' | 'edit' {
-  const capabilities = getSeedreamCapabilities(model);
-  if (capabilities.imageRequired) return 'edit';
-  if (!capabilities.image) return 'generate';
   return action === 'edit' ? 'edit' : 'generate';
 }
 
-export function getSeedreamAction(model?: string, image?: string[]): 'generate' | 'edit' {
-  const capabilities = getSeedreamCapabilities(model);
-  if (capabilities.imageRequired) return 'edit';
-  return capabilities.image && image?.length ? 'edit' : 'generate';
+export function getSeedreamAction(_model?: string, image?: string[]): 'generate' | 'edit' {
+  return image?.length ? 'edit' : 'generate';
 }
 
 export type SeedreamConflictField =
@@ -154,113 +144,87 @@ export type SeedreamConflictField =
   | 'seed'
   | 'guidance_scale'
   | 'output_format'
-  | 'tools';
+  | 'tools'
+  | 'optimize_prompt_options'
+  | 'layer_decomposition'
+  | 'background';
 
 export interface ISeedreamConflict {
   field: SeedreamConflictField;
-  /** i18n key for the user-facing label of the field. */
   i18nLabel: string;
 }
 
-const TIER_PRESETS = [SEEDREAM_SIZE_1K, SEEDREAM_SIZE_2K, SEEDREAM_SIZE_3K, SEEDREAM_SIZE_4K];
+const TIER_PRESETS = [SEEDREAM_SIZE_1K, SEEDREAM_SIZE_1_5K, SEEDREAM_SIZE_2K, SEEDREAM_SIZE_3K, SEEDREAM_SIZE_4K];
 
-/**
- * Compute which currently-set config fields will be unsupported under the
- * proposed `next` change (typically a model switch).
- */
 export function findSeedreamConflicts(
   config: Record<string, any> | undefined,
   next: { model?: string }
 ): ISeedreamConflict[] {
   if (!config) return [];
-  const model = next.model ?? config.model;
-  if (!model) return [];
-
-  const caps = getSeedreamCapabilities(model);
+  const capabilities = getSeedreamCapabilities(next.model ?? config.model);
   const conflicts: ISeedreamConflict[] = [];
+  const size = typeof config.size === 'string' ? config.size : undefined;
 
-  if (Array.isArray(config.image) && config.image.length > 0 && !caps.image) {
+  if (Array.isArray(config.image) && config.image.length > capabilities.maxInputImages) {
     conflicts.push({ field: 'image', i18nLabel: 'seedream.name.imageUrls' });
   }
-
-  // Size: flag tier presets the new model rejects, and `adaptive` when the
-  // new model is pixel-only. Free-form `<W>x<H>` is always accepted.
-  const size = typeof config.size === 'string' ? config.size : undefined;
-  if (size) {
-    const upper = size.toUpperCase();
-    if (TIER_PRESETS.includes(upper) && !caps.sizeTiers.includes(upper)) {
-      conflicts.push({ field: 'size', i18nLabel: 'seedream.name.size' });
-    } else if (size === 'adaptive' && !caps.sizeAdaptive) {
-      conflicts.push({ field: 'size', i18nLabel: 'seedream.name.size' });
-    }
+  if (size && (size === 'adaptive' || (TIER_PRESETS.includes(size) && !capabilities.sizeTiers.includes(size)))) {
+    conflicts.push({ field: 'size', i18nLabel: 'seedream.name.size' });
   }
-
-  if (config.sequential_image_generation === 'auto' && !caps.groupGeneration) {
+  if (config.sequential_image_generation === 'auto' && !capabilities.groupGeneration) {
     conflicts.push({ field: 'sequential_image_generation', i18nLabel: 'seedream.name.maxImages' });
   }
-
-  if (config.seed !== undefined && config.seed !== null && !caps.seed) {
+  if (config.seed !== undefined) {
     conflicts.push({ field: 'seed', i18nLabel: 'seedream.name.seed' });
   }
-
-  if (config.guidance_scale !== undefined && config.guidance_scale !== null && !caps.guidanceScale) {
+  if (config.guidance_scale !== undefined) {
     conflicts.push({ field: 'guidance_scale', i18nLabel: 'seedream.name.guidanceScale' });
   }
-
-  if (config.output_format && !caps.outputFormat) {
+  if (config.output_format && !capabilities.outputFormat) {
     conflicts.push({ field: 'output_format', i18nLabel: 'seedream.name.outputFormat' });
   }
-
-  if (Array.isArray(config.tools) && config.tools.length > 0 && !caps.tools) {
-    conflicts.push({ field: 'tools', i18nLabel: 'seedream.name.tools' });
+  if (config.tools?.length && !capabilities.webSearch) {
+    conflicts.push({ field: 'tools', i18nLabel: 'seedream.name.webSearch' });
   }
-
+  const optimizeMode = config.optimize_prompt_options?.mode;
+  if (optimizeMode && !capabilities.promptOptimization.includes(optimizeMode)) {
+    conflicts.push({ field: 'optimize_prompt_options', i18nLabel: 'seedream.name.promptOptimization' });
+  }
+  if (config.layer_decomposition && !capabilities.layerDecomposition) {
+    conflicts.push({ field: 'layer_decomposition', i18nLabel: 'seedream.name.layerDecomposition' });
+  }
+  if (config.background && !capabilities.transparentBackground) {
+    conflicts.push({ field: 'background', i18nLabel: 'seedream.name.background' });
+  }
   return conflicts;
 }
 
-/**
- * Apply conflict resolutions to a config object. Returns a new object with the
- * offending fields cleared (or, for `size` on pixel-only models, replaced with
- * the model's pixel default).
- */
 export function clearSeedreamConflicts(
   config: Record<string, any>,
   conflicts: ISeedreamConflict[],
-  next: { model?: string }
+  _next: { model?: string }
 ): Record<string, any> {
   const result = { ...config };
-  const targetModel = next.model ?? config.model;
-  const caps = getSeedreamCapabilities(targetModel);
-
-  for (const c of conflicts) {
-    switch (c.field) {
+  for (const conflict of conflicts) {
+    switch (conflict.field) {
       case 'image':
-        delete result.image;
+        result.image = (result.image || []).slice(0, getSeedreamCapabilities(result.model).maxInputImages);
         break;
       case 'size':
-        // Replace with the model's pixel default if it has no tier presets,
-        // otherwise drop the field and let SizeSelector seed a tier default.
-        if (caps.sizePixelDefault) {
-          result.size = caps.sizePixelDefault;
-        } else {
-          delete result.size;
-        }
+        delete result.size;
         break;
       case 'sequential_image_generation':
         result.sequential_image_generation = 'disabled';
         delete result.sequential_image_generation_options;
         break;
       case 'seed':
-        delete result.seed;
-        break;
       case 'guidance_scale':
-        delete result.guidance_scale;
-        break;
       case 'output_format':
-        delete result.output_format;
-        break;
       case 'tools':
-        delete result.tools;
+      case 'optimize_prompt_options':
+      case 'layer_decomposition':
+      case 'background':
+        delete result[conflict.field];
         break;
     }
   }

--- a/src/utils/seedream/request.test.ts
+++ b/src/utils/seedream/request.test.ts
@@ -25,10 +25,16 @@ describe('buildSeedreamRequest', () => {
   it('removes group options when group generation is inactive', () => {
     expect(
       buildSeedreamRequest({
+        model: 'doubao-seedream-5-0-260128',
         sequential_image_generation: 'disabled',
         sequential_image_generation_options: { max_images: 4 }
       })
-    ).toEqual({ sequential_image_generation: 'disabled', watermark: false, async: true });
+    ).toEqual({
+      model: 'doubao-seedream-5-0-260128',
+      sequential_image_generation: 'disabled',
+      watermark: false,
+      async: true
+    });
   });
 
   it('disables watermarks for persisted legacy configurations', () => {
@@ -46,4 +52,58 @@ it('trims prompts without mutating config', () => {
   const config = { prompt: '  image prompt  ' };
   expect(buildSeedreamRequest(config).prompt).toBe('image prompt');
   expect(config.prompt).toBe('  image prompt  ');
+});
+
+it('builds a Pro decomposition request without a prompt', () => {
+  expect(
+    buildSeedreamRequest({
+      model: 'doubao-seedream-5-0-pro-260628',
+      prompt: '   ',
+      image: ['one.png', 'two.png'],
+      size: '1.5K',
+      layer_decomposition: true,
+      background: 'transparent',
+      stream: true
+    })
+  ).toEqual({
+    model: 'doubao-seedream-5-0-pro-260628',
+    image: ['one.png'],
+    size: '1.5K',
+    layer_decomposition: true,
+    watermark: false,
+    async: true
+  });
+});
+
+it('keeps transparent Pro edits in PNG', () => {
+  expect(
+    buildSeedreamRequest({
+      model: 'doubao-seedream-5-0-pro-260628',
+      prompt: 'replace the object',
+      image: ['layer.png'],
+      background: 'transparent',
+      output_format: 'jpeg'
+    })
+  ).toMatchObject({ background: 'transparent', output_format: 'png' });
+});
+
+it('keeps Lite groups and web search but drops Pro-only fields', () => {
+  const request = buildSeedreamRequest({
+    model: 'doubao-seedream-5-0-260128',
+    prompt: 'current city skyline',
+    sequential_image_generation: 'auto',
+    sequential_image_generation_options: { max_images: 3 },
+    tools: [{ type: 'web_search' }],
+    optimize_prompt_options: { mode: 'standard' },
+    layer_decomposition: true,
+    background: 'transparent'
+  });
+  expect(request).toMatchObject({
+    sequential_image_generation: 'auto',
+    sequential_image_generation_options: { max_images: 3 },
+    tools: [{ type: 'web_search' }],
+    optimize_prompt_options: { mode: 'standard' }
+  });
+  expect(request).not.toHaveProperty('layer_decomposition');
+  expect(request).not.toHaveProperty('background');
 });

--- a/src/utils/seedream/request.ts
+++ b/src/utils/seedream/request.ts
@@ -1,22 +1,42 @@
 import type { ISeedreamConfig, ISeedreamGenerateRequest } from '@/models';
-import { getSeedreamAction } from './capabilities';
+import { SEEDREAM_MODEL_5_0_PRO } from '@/constants';
+import { getSeedreamCapabilities } from './capabilities';
 
 export const buildSeedreamRequest = (config?: ISeedreamConfig): ISeedreamGenerateRequest => {
   const request = { ...(config || {}) };
   if (typeof request.prompt === 'string') request.prompt = request.prompt.trim();
-  const action = getSeedreamAction(request.model, request.image);
   delete request.action;
+  delete request.stream;
+  delete request.seed;
+  delete request.guidance_scale;
   request.watermark = false;
 
-  if (action !== 'edit' || !request.image?.length) {
-    delete request.image;
-  }
-  if (!request.size) {
-    delete request.size;
-  }
-  if (request.sequential_image_generation !== 'auto') {
+  const capabilities = getSeedreamCapabilities(request.model);
+  const decomposing = request.model === SEEDREAM_MODEL_5_0_PRO && request.layer_decomposition === true;
+  if (!request.image?.length) delete request.image;
+  if (!request.size) delete request.size;
+  if (decomposing) {
+    request.image = request.image?.slice(0, 1);
+    request.size = request.size || 'auto';
+    if (!request.prompt) delete request.prompt;
+    delete request.background;
+    delete request.sequential_image_generation;
     delete request.sequential_image_generation_options;
+    delete request.tools;
+  } else {
+    delete request.layer_decomposition;
+    if (!capabilities.transparentBackground) delete request.background;
+    if (request.background === 'transparent') request.output_format = 'png';
+    if (!capabilities.groupGeneration || request.sequential_image_generation !== 'auto') {
+      if (!capabilities.groupGeneration) delete request.sequential_image_generation;
+      delete request.sequential_image_generation_options;
+    }
+    if (!capabilities.webSearch) delete request.tools;
   }
-
+  if (!capabilities.outputFormat) delete request.output_format;
+  const optimizeMode = request.optimize_prompt_options?.mode;
+  if (!optimizeMode || !capabilities.promptOptimization.includes(optimizeMode)) {
+    delete request.optimize_prompt_options;
+  }
   return { ...request, async: true };
 };


### PR DESCRIPTION
## Dependency node

5. Studio UI. Depends on https://github.com/AceDataCloud/PlatformService/pull/2256 and https://github.com/AceDataCloud/PlatformBackend/pull/1692.

## Contract

- Adds model-aware Pro layer decomposition, transparent background, prompt optimization, and Lite web-search controls.
- Corrects Pro 1K/1.5K/2K, Lite 2K/3K/4K, removes adaptive sizing, and enforces model-specific input limits.
- Cleans incompatible fields when switching models or modes and supports promptless automatic decomposition.
- Displays layer results ordered by z-index with names, descriptions, formats, sizes, bounding boxes, and per-item errors.
- Aligns Studio price previews with the regular/layer low/high billing counters.
- Does not expose streaming because Studio submits async tasks; REST/CLI are the streaming surfaces.

## Tests

- 260 test files / 1,993 tests passed
- ESLint: 0 errors (2 pre-existing warnings)
- `vue-tsc -b` passed
- production web build passed
- beachball check passed
- i18n: 11 locales × 50 namespaces, no missing or English-placeholder keys
- `git diff --check`

## Rollout / rollback

Deploy only after runtime and backend contract PRs. Rollback hides the controls while existing task history remains renderable.

## Out of scope

The UI presents individual editable layers and coordinates; a full raster editor is not introduced.

## Review

Capability switching, request normalization, billing preview, and layer rendering have dedicated tests; no separate adversarial review was requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)