### PR TITLE
feat(suno): add custom music models

### DIFF
--- a/change/suno-custom-models.json
+++ b/change/suno-custom-models.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add Suno custom music model creation, management, and generation",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/suno/ConfigPanel.vue
+++ b/src/components/suno/ConfigPanel.vue
@@ -25,7 +25,8 @@
             <style-input class="mb-4" />
             <title-input class="mb-4" />
             <vocal-gender-selector v-if="!config?.instrumental && supportsVocalGender" class="mb-4" />
-            <persona-input v-if="supportsPersona" class="mb-4" />
+            <custom-model-input v-if="supportsCustomModels" class="mb-4" />
+            <persona-input v-if="supportsPersona && !config?.custom_model_id" class="mb-4" />
             <extend-from-input v-if="config?.action === 'extend'" class="mb-4" />
             <cover-from-input v-if="config?.action === 'cover'" class="mb-4" />
             <replace-section-input v-if="config?.action === 'replace_section'" class="mb-4" />
@@ -75,6 +76,7 @@ import UnderpaintingInput from './config/UnderpaintingInput.vue';
 import SamplesInput from './config/SamplesInput.vue';
 import AdjustSpeedInput from './config/AdjustSpeedInput.vue';
 import PersonaInput from './config/PersonaInput.vue';
+import CustomModelInput from './config/CustomModelInput.vue';
 import ServicePricingSummary from '../common/ServicePricingSummary.vue';
 import { getConsumption } from '@/utils';
 import ScenarioPaymentMode from '../common/ScenarioPaymentMode.vue';
@@ -102,6 +104,7 @@ export default defineComponent({
     SamplesInput,
     AdjustSpeedInput,
     PersonaInput,
+    CustomModelInput,
     ElButton,
     ElTabs,
     ElTabPane,
@@ -123,12 +126,14 @@ export default defineComponent({
       set(val: 'simple' | 'custom') {
         this.$store.commit('suno/setConfig', {
           ...this.$store.state.suno?.config,
-          custom: val === 'custom'
+          custom: val === 'custom',
+          custom_model_id: val === 'custom' ? this.$store.state.suno?.config?.custom_model_id : undefined
         });
       }
     },
     consumption() {
-      return getConsumption(this.config, this.service?.cost);
+      const pricingConfig = this.usesCustomModel ? { ...this.config, action: 'generate' } : this.config;
+      return getConsumption(pricingConfig, this.service?.cost);
     },
     service() {
       return this.$store.state.suno?.service;
@@ -143,6 +148,14 @@ export default defineComponent({
     supportsPersona() {
       const action = this.config?.action;
       return !action || action === 'generate' || action === 'artist_consistency' || action === 'artist_consistency_vox';
+    },
+    supportsCustomModels() {
+      const action = this.config?.action;
+      return !this.walletMode && (!action || action === 'generate');
+    },
+    usesCustomModel() {
+      const action = this.config?.action;
+      return !!this.config?.custom && !!this.config?.custom_model_id && (!action || action === 'generate');
     },
     generateButtonText() {
       const action = this.config?.action;

--- a/src/components/suno/config/CustomModelInput.vue
+++ b/src/components/suno/config/CustomModelInput.vue
@@ -1,0 +1,68 @@
+<template>
+  <div class="field">
+    <div class="flex items-center justify-between mb-2">
+      <div class="flex items-center">
+        <span class="text-sm font-bold">{{ $t('suno.customModel.name') }}</span>
+        <info-icon :content="$t('suno.customModel.description')" />
+      </div>
+      <el-button size="small" round @click="showManager = true">
+        <music-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
+        {{ $t('suno.customModel.manage') }}
+      </el-button>
+    </div>
+    <el-select
+      v-model="customModelId"
+      :placeholder="$t('suno.customModel.placeholder')"
+      clearable
+      filterable
+      class="w-full"
+    >
+      <el-option v-for="model in readyModels" :key="model.id" :value="model.id" :label="model.name" />
+    </el-select>
+    <el-drawer v-model="showManager" :title="$t('suno.customModel.title')" size="420px" direction="rtl">
+      <custom-model-manager @selected="showManager = false" />
+    </el-drawer>
+  </div>
+</template>
+
+<script lang="ts">
+import { MusicIcon } from '@acedatacloud/core/icons/components';
+import { defineComponent } from 'vue';
+import { ElButton, ElDrawer, ElOption, ElSelect } from 'element-plus';
+import InfoIcon from '@/components/common/InfoIcon.vue';
+import CustomModelManager from '@/components/suno/model/CustomModelManager.vue';
+import { ISunoCustomModel } from '@/models';
+
+export default defineComponent({
+  name: 'CustomModelInput',
+  components: { CustomModelManager, ElButton, ElDrawer, ElOption, ElSelect, InfoIcon, MusicIcon },
+  data() {
+    return { showManager: false };
+  },
+  computed: {
+    customModelId: {
+      get(): string {
+        return this.$store.state.suno?.config?.custom_model_id || '';
+      },
+      set(value: string) {
+        this.$store.commit('suno/setConfig', {
+          ...this.$store.state.suno?.config,
+          custom_model_id: value || undefined,
+          persona_id: value ? undefined : this.$store.state.suno?.config?.persona_id
+        });
+      }
+    },
+    readyModels(): ISunoCustomModel[] {
+      return (this.$store.state.suno?.customModels || []).filter((model: ISunoCustomModel) => model.status === 'ready');
+    }
+  },
+  watch: {
+    '$store.state.suno.credential': {
+      handler() {
+        if (this.$store.state.suno?.credential?.token) this.$store.dispatch('suno/getCustomModels');
+      },
+      immediate: true
+    }
+  }
+});
+</script>

--- a/src/components/suno/model/CustomModelCreateDialog.vue
+++ b/src/components/suno/model/CustomModelCreateDialog.vue
@@ -1,0 +1,105 @@
+<template>
+  <el-dialog
+    v-model="visible"
+    :title="$t('suno.customModel.createTitle')"
+    width="min(560px, 92vw)"
+    :close-on-click-modal="false"
+  >
+    <el-alert type="warning" :closable="false" class="mb-4" :title="$t('suno.customModel.rightsNotice')" />
+    <el-form label-position="top">
+      <el-form-item :label="$t('suno.customModel.modelName')">
+        <el-input v-model="name" maxlength="100" :placeholder="$t('suno.customModel.namePlaceholder')" />
+      </el-form-item>
+      <el-form-item :label="$t('suno.customModel.audioUrls')">
+        <el-input v-model="urlsText" type="textarea" :rows="9" :placeholder="$t('suno.customModel.urlsPlaceholder')" />
+        <div class="text-xs text-gray-400 mt-1">{{ $t('suno.customModel.urlCount', { count: urls.length }) }}</div>
+      </el-form-item>
+      <el-checkbox v-model="rightsConfirmed">{{ $t('suno.customModel.rightsConfirm') }}</el-checkbox>
+      <div class="text-sm mt-3">{{ $t('suno.customModel.createPrice') }}</div>
+    </el-form>
+    <template #footer>
+      <el-button @click="visible = false">{{ $t('common.button.cancel') }}</el-button>
+      <el-button type="primary" :loading="loading" :disabled="!canSubmit" @click="onSubmit">
+        {{ $t('suno.customModel.create') }}
+      </el-button>
+    </template>
+  </el-dialog>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElAlert, ElButton, ElCheckbox, ElDialog, ElForm, ElFormItem, ElInput, ElMessage } from 'element-plus';
+import { sunoOperator } from '@/operators/suno';
+
+export default defineComponent({
+  name: 'CustomModelCreateDialog',
+  components: { ElAlert, ElButton, ElCheckbox, ElDialog, ElForm, ElFormItem, ElInput },
+  props: { modelValue: { type: Boolean, default: false } },
+  emits: ['update:modelValue', 'created'],
+  data() {
+    return {
+      name: '',
+      urlsText: '',
+      rightsConfirmed: false,
+      loading: false,
+      submittedFingerprint: '',
+      idempotencyKey: ''
+    };
+  },
+  computed: {
+    visible: {
+      get(): boolean {
+        return this.modelValue;
+      },
+      set(value: boolean) {
+        this.$emit('update:modelValue', value);
+      }
+    },
+    urls(): string[] {
+      return this.urlsText
+        .split(/\r?\n/)
+        .map((value: string) => value.trim())
+        .filter(Boolean);
+    },
+    canSubmit(): boolean {
+      return (
+        !!this.name.trim() &&
+        this.urls.length >= 6 &&
+        this.urls.length <= 24 &&
+        new Set(this.urls).size === this.urls.length &&
+        this.urls.every((value: string) => value.startsWith('https://')) &&
+        this.rightsConfirmed &&
+        !!this.$store.state.suno?.credential?.token
+      );
+    }
+  },
+  methods: {
+    async onSubmit() {
+      const token = this.$store.state.suno?.credential?.token;
+      if (!token || !this.canSubmit) return;
+      this.loading = true;
+      try {
+        const payload = { action: 'create' as const, name: this.name.trim(), audio_urls: this.urls };
+        const fingerprint = JSON.stringify(payload);
+        if (fingerprint !== this.submittedFingerprint) {
+          this.submittedFingerprint = fingerprint;
+          this.idempotencyKey = crypto.randomUUID();
+        }
+        await sunoOperator.createCustomModel(payload, { token, idempotencyKey: this.idempotencyKey });
+        ElMessage.success(this.$t('suno.customModel.createAccepted'));
+        this.$emit('created');
+        this.visible = false;
+        this.name = '';
+        this.urlsText = '';
+        this.rightsConfirmed = false;
+        this.submittedFingerprint = '';
+        this.idempotencyKey = '';
+      } catch (error: any) {
+        ElMessage.error(error?.response?.data?.error?.message || this.$t('suno.customModel.createFailed'));
+      } finally {
+        this.loading = false;
+      }
+    }
+  }
+});
+</script>

--- a/src/components/suno/model/CustomModelManager.vue
+++ b/src/components/suno/model/CustomModelManager.vue
@@ -1,0 +1,119 @@
+<template>
+  <div>
+    <div class="flex items-center justify-between mb-3">
+      <span class="text-sm text-gray-500">{{ $t('suno.customModel.betaNotice') }}</span>
+      <div class="flex gap-2">
+        <el-button size="small" :loading="loading" @click="loadModels">{{ $t('common.button.refresh') }}</el-button>
+        <el-button type="primary" size="small" @click="showCreate = true">
+          <add-icon class="mr-1" :size="'1em' as any" aria-hidden="true" focusable="false" />
+          {{ $t('suno.customModel.create') }}
+        </el-button>
+      </div>
+    </div>
+    <el-empty v-if="!loading && models.length === 0" :description="$t('suno.customModel.empty')" />
+    <div v-else class="model-list">
+      <div v-for="model in models" :key="model.id" class="model-item">
+        <div class="flex-1 min-w-0">
+          <div class="font-medium text-sm truncate">{{ model.name }}</div>
+          <div class="text-xs text-gray-400 mt-1">
+            {{ $t(`suno.customModel.status.${model.status}`) }} · {{ model.source_count }}
+          </div>
+          <el-progress
+            v-if="model.status === 'uploading' && model.progress?.total"
+            class="mt-2"
+            :percentage="Math.round(((model.progress.uploaded || 0) / model.progress.total) * 100)"
+            :show-text="false"
+          />
+        </div>
+        <div class="flex gap-1 ml-2">
+          <el-button v-if="model.status === 'ready'" size="small" text type="primary" @click="select(model)">
+            {{ $t('suno.customModel.use') }}
+          </el-button>
+          <el-button size="small" text type="danger" :loading="archivingId === model.id" @click="archive(model)">
+            {{ $t('suno.customModel.archive') }}
+          </el-button>
+        </div>
+      </div>
+    </div>
+    <custom-model-create-dialog v-model="showCreate" @created="loadModels" />
+  </div>
+</template>
+
+<script lang="ts">
+import { AddIcon } from '@acedatacloud/core/icons/components';
+import { defineComponent } from 'vue';
+import { ElButton, ElEmpty, ElMessage, ElMessageBox, ElProgress } from 'element-plus';
+import { ISunoCustomModel } from '@/models';
+import CustomModelCreateDialog from './CustomModelCreateDialog.vue';
+
+export default defineComponent({
+  name: 'CustomModelManager',
+  components: { AddIcon, CustomModelCreateDialog, ElButton, ElEmpty, ElProgress },
+  emits: ['selected'],
+  data() {
+    return { loading: false, showCreate: false, archivingId: '' };
+  },
+  computed: {
+    models(): ISunoCustomModel[] {
+      return this.$store.state.suno?.customModels || [];
+    }
+  },
+  mounted() {
+    this.loadModels();
+  },
+  methods: {
+    async loadModels() {
+      this.loading = true;
+      try {
+        await this.$store.dispatch('suno/getCustomModels');
+      } finally {
+        this.loading = false;
+      }
+    },
+    select(model: ISunoCustomModel) {
+      this.$store.commit('suno/setConfig', {
+        ...this.$store.state.suno?.config,
+        custom_model_id: model.id,
+        persona_id: undefined,
+        custom: true
+      });
+      this.$emit('selected');
+    },
+    async archive(model: ISunoCustomModel) {
+      try {
+        await ElMessageBox.confirm(this.$t('suno.customModel.archiveConfirm'), this.$t('suno.customModel.archive'), {
+          type: 'warning'
+        });
+      } catch {
+        return;
+      }
+      this.archivingId = model.id;
+      const success = await this.$store.dispatch('suno/archiveCustomModel', model.id);
+      this.archivingId = '';
+      if (success) {
+        if (this.$store.state.suno?.config?.custom_model_id === model.id) {
+          this.$store.commit('suno/setConfig', { ...this.$store.state.suno.config, custom_model_id: undefined });
+        }
+        ElMessage.success(this.$t('suno.customModel.archiveSuccess'));
+      } else {
+        ElMessage.error(this.$t('suno.customModel.archiveFailed'));
+      }
+    }
+  }
+});
+</script>
+
+<style scoped>
+.model-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.model-item {
+  display: flex;
+  align-items: center;
+  padding: 10px;
+  border: 1px solid var(--el-border-color-lighter);
+  border-radius: 8px;
+}
+</style>

--- a/src/i18n/ar/suno.json
+++ b/src/i18n/ar/suno.json
@@ -942,5 +942,129 @@
   "name.lyricsMode": {
     "message": "وضع الكلمات",
     "description": "تسمية محدد وضع الكلمات (يدوي / تلقائي)"
+  },
+  "customModel.name": {
+    "message": "نموذج الموسيقى المخصص",
+    "description": "علامة اختيار نموذج الموسيقى المخصص"
+  },
+  "customModel.description": {
+    "message": "إنشاء نموذج موسيقى قابل لإعادة الاستخدام باستخدام 6 إلى 24 مقطع صوتي مرخص",
+    "description": "وصف نموذج الموسيقى المخصص"
+  },
+  "customModel.manage": {
+    "message": "إدارة النموذج",
+    "description": "زر إدارة نموذج الموسيقى المخصص"
+  },
+  "customModel.placeholder": {
+    "message": "اختر نموذج مخصص جاهز",
+    "description": "نموذج اختيار مخصص"
+  },
+  "customModel.title": {
+    "message": "نموذج الموسيقى المخصص الخاص بي",
+    "description": "عنوان إدارة النموذج المخصص"
+  },
+  "customModel.createTitle": {
+    "message": "إنشاء نموذج موسيقى مخصص",
+    "description": "عنوان نافذة إنشاء النموذج"
+  },
+  "customModel.modelName": {
+    "message": "اسم النموذج",
+    "description": "حقل اسم النموذج"
+  },
+  "customModel.namePlaceholder": {
+    "message": "على سبيل المثال: أسلوب ألبومي",
+    "description": "نموذج اسم الحقل"
+  },
+  "customModel.audioUrls": {
+    "message": "روابط الصوت المرخصة (واحد في كل سطر)",
+    "description": "حقل روابط الصوت للتدريب"
+  },
+  "customModel.urlsPlaceholder": {
+    "message": "أدخل 6 إلى 24 عنوان صوت HTTPS غير مكرر، واحد في كل سطر",
+    "description": "نموذج روابط الصوت للتدريب"
+  },
+  "customModel.urlCount": {
+    "message": "الحالي {count}، يسمح بـ 6 إلى 24",
+    "description": "عدد روابط الصوت للتدريب"
+  },
+  "customModel.rightsNotice": {
+    "message": "إنشاء نموذج هو مهمة مدفوعة. يرجى تقديم الصوتيات التي لديك حقوق استخدامها والموافقة على استخدامها لإنشاء النموذج.",
+    "description": "تنبيه حقوق النموذج"
+  },
+  "customModel.rightsConfirm": {
+    "message": "أؤكد أنني أملك حقوق إنشاء النموذج لهذه الصوتيات",
+    "description": "تأكيد حقوق الصوت"
+  },
+  "customModel.createPrice": {
+    "message": "تستهلك 5.6 اعتمادات عند نجاح إنشاء النموذج؛ لا يتم خصم أي شيء عند الفشل.",
+    "description": "تنبيه سعر إنشاء النموذج"
+  },
+  "customModel.create": {
+    "message": "إنشاء نموذج",
+    "description": "زر إنشاء النموذج"
+  },
+  "customModel.createAccepted": {
+    "message": "تم تقديم مهمة إنشاء النموذج",
+    "description": "تنبيه قبول إنشاء النموذج"
+  },
+  "customModel.createFailed": {
+    "message": "فشل إنشاء النموذج",
+    "description": "تنبيه فشل إنشاء النموذج"
+  },
+  "customModel.betaNotice": {
+    "message": "بيتا · الحد الأقصى 3 نماذج لكل تطبيق",
+    "description": "قيود نموذج الموسيقى المخصص في بيتا"
+  },
+  "customModel.empty": {
+    "message": "لا يوجد نموذج موسيقى مخصص بعد",
+    "description": "حالة قائمة النموذج الفارغة"
+  },
+  "customModel.use": {
+    "message": "استخدام",
+    "description": "زر استخدام النموذج المخصص"
+  },
+  "customModel.archive": {
+    "message": "أرشفة",
+    "description": "زر أرشفة النموذج"
+  },
+  "customModel.archiveConfirm": {
+    "message": "بعد الأرشفة، لن تتمكن من استخدامه مرة أخرى؛ لا يتم الالتزام حاليًا بإطلاق سعة النموذج.",
+    "description": "تنبيه تأكيد الأرشفة"
+  },
+  "customModel.archiveSuccess": {
+    "message": "تم أرشفة النموذج",
+    "description": "نجاح أرشفة النموذج"
+  },
+  "customModel.archiveFailed": {
+    "message": "فشل أرشفة النموذج",
+    "description": "فشل أرشفة النموذج"
+  },
+  "customModel.creditsOnly": {
+    "message": "النموذج المخصص يدعم حاليًا وضع الاعتمادات فقط",
+    "description": "قيود دفع النموذج المخصص"
+  },
+  "customModel.status.queued": {
+    "message": "قيد الانتظار",
+    "description": "حالة انتظار النموذج"
+  },
+  "customModel.status.uploading": {
+    "message": "جارٍ تحميل المواد",
+    "description": "حالة تحميل النموذج"
+  },
+  "customModel.status.training": {
+    "message": "جارٍ التدريب",
+    "description": "حالة تدريب النموذج"
+  },
+  "customModel.status.ready": {
+    "message": "جاهز للاستخدام",
+    "description": "حالة جاهزية النموذج"
+  },
+  "customModel.status.failed": {
+    "message": "فشل الإنشاء",
+    "description": "حالة فشل النموذج"
+  },
+  "customModel.status.archived": {
+    "message": "تم أرشفته",
+    "description": "حالة أرشفة النموذج"
   }
 }

--- a/src/i18n/de/suno.json
+++ b/src/i18n/de/suno.json
@@ -942,5 +942,129 @@
   "name.lyricsMode": {
     "message": "Lyrics-Modus",
     "description": "Label des Auswahlfeldes für den Lyrics-Modus (manuell / automatisch)"
+  },
+  "customModel.name": {
+    "message": "Exklusives Musikmodell",
+    "description": "Label für den Auswahlbereich exklusiver Musikmodelle"
+  },
+  "customModel.description": {
+    "message": "Erstellen Sie ein wiederverwendbares Musikmodell mit 6 bis 24 autorisierten Audios",
+    "description": "Beschreibung des exklusiven Musikmodells"
+  },
+  "customModel.manage": {
+    "message": "Modelle verwalten",
+    "description": "Button zur Verwaltung exklusiver Musikmodelle"
+  },
+  "customModel.placeholder": {
+    "message": "Wählen Sie ein bereitgestelltes exklusives Modell aus",
+    "description": "Platzhalter für die Auswahl exklusiver Modelle"
+  },
+  "customModel.title": {
+    "message": "Mein persönliches Musikmodell",
+    "description": "Titel für die Verwaltung des persönlichen Modells"
+  },
+  "customModel.createTitle": {
+    "message": "Exklusives Musikmodell erstellen",
+    "description": "Titel des Popups zur Erstellung eines Modells"
+  },
+  "customModel.modelName": {
+    "message": "Modellname",
+    "description": "Feld für den Modellnamen"
+  },
+  "customModel.namePlaceholder": {
+    "message": "Zum Beispiel: Mein Albumstil",
+    "description": "Platzhalter für den Modellnamen"
+  },
+  "customModel.audioUrls": {
+    "message": "Autorisierte Audio-URLs (jeweils eine pro Zeile)",
+    "description": "Feld für die Audio-URLs zum Trainieren"
+  },
+  "customModel.urlsPlaceholder": {
+    "message": "Geben Sie 6 bis 24 einzigartige HTTPS-Audio-URLs ein, jede in einer neuen Zeile",
+    "description": "Platzhalter für Trainingsaudio-URLs"
+  },
+  "customModel.urlCount": {
+    "message": "Aktuell {count} von 6 bis 24 erlaubt",
+    "description": "Anzahl der Trainingsaudio"
+  },
+  "customModel.rightsNotice": {
+    "message": "Die Erstellung ist eine kostenpflichtige Langzeitaufgabe. Reichen Sie nur Audio ein, für das Sie Nutzungsrechte besitzen und das für die Modellerstellung genehmigt ist.",
+    "description": "Hinweis zu den Rechten des Modells"
+  },
+  "customModel.rightsConfirm": {
+    "message": "Ich bestätige, dass ich die Rechte zur Erstellung und Generierung dieses Modells mit diesen Audios besitze",
+    "description": "Bestätigung der Audio-Rechte"
+  },
+  "customModel.createPrice": {
+    "message": "Die Erstellung des Modells kostet 5,6 Credits; bei einem Fehler fallen keine Kosten an.",
+    "description": "Hinweis zu den Kosten der Modell-Erstellung"
+  },
+  "customModel.create": {
+    "message": "Modell erstellen",
+    "description": "Button zum Erstellen eines Modells"
+  },
+  "customModel.createAccepted": {
+    "message": "Modell-Erstellungsauftrag wurde eingereicht",
+    "description": "Benachrichtigung, dass die Modell-Erstellung akzeptiert wurde"
+  },
+  "customModel.createFailed": {
+    "message": "Modell-Erstellung fehlgeschlagen",
+    "description": "Benachrichtigung über die fehlgeschlagene Modell-Erstellung"
+  },
+  "customModel.betaNotice": {
+    "message": "Beta · Maximal 3 Modelle pro Anwendung",
+    "description": "Einschränkung für exklusive Modelle in der Beta-Phase"
+  },
+  "customModel.empty": {
+    "message": "Es gibt noch kein exklusives Musikmodell",
+    "description": "Leerer Zustand der Modellliste"
+  },
+  "customModel.use": {
+    "message": "Verwenden",
+    "description": "Schaltfläche zum Verwenden des persönlichen Modells"
+  },
+  "customModel.archive": {
+    "message": "Archivieren",
+    "description": "Button zum Archivieren des Modells"
+  },
+  "customModel.archiveConfirm": {
+    "message": "Nach dem Archivieren kann das Modell nicht mehr verwendet werden; derzeit wird keine Freigabe von Modellkapazitäten zugesichert.",
+    "description": "Bestätigungsnachricht für das Archivieren"
+  },
+  "customModel.archiveSuccess": {
+    "message": "Modell wurde archiviert",
+    "description": "Erfolgsmeldung für die erfolgreiche Archivierung des Modells"
+  },
+  "customModel.archiveFailed": {
+    "message": "Archivierung des Modells fehlgeschlagen",
+    "description": "Fehlermeldung für die fehlgeschlagene Archivierung des Modells"
+  },
+  "customModel.creditsOnly": {
+    "message": "Exklusive Modelle unterstützen derzeit nur das Credits-Modell",
+    "description": "Zahlungseinschränkung für exklusive Modelle"
+  },
+  "customModel.status.queued": {
+    "message": "In der Warteschlange",
+    "description": "Wartestatus des Modells"
+  },
+  "customModel.status.uploading": {
+    "message": "Hochladen von Materialien",
+    "description": "Uploadstatus des Modells"
+  },
+  "customModel.status.training": {
+    "message": "Wird trainiert",
+    "description": "Trainingsstatus des Modells"
+  },
+  "customModel.status.ready": {
+    "message": "Verfügbar",
+    "description": "Bereitstellungsstatus des Modells"
+  },
+  "customModel.status.failed": {
+    "message": "Erstellung fehlgeschlagen",
+    "description": "Fehlerstatus des Modells"
+  },
+  "customModel.status.archived": {
+    "message": "Archiviert",
+    "description": "Archivierungsstatus des Modells"
   }
 }

--- a/src/i18n/en/suno.json
+++ b/src/i18n/en/suno.json
@@ -942,5 +942,129 @@
   "name.lyricsMode": {
     "message": "Lyrics Mode",
     "description": "Label for the lyrics mode selector (Manual / Automatic)"
+  },
+  "customModel.name": {
+    "message": "Custom music model",
+    "description": "Custom music model selector label"
+  },
+  "customModel.description": {
+    "message": "Create a reusable music model from 6–24 authorized audio files",
+    "description": "Custom music model description"
+  },
+  "customModel.manage": {
+    "message": "Manage models",
+    "description": "Manage custom models button"
+  },
+  "customModel.placeholder": {
+    "message": "Select a ready custom model",
+    "description": "Custom model placeholder"
+  },
+  "customModel.title": {
+    "message": "My custom music models",
+    "description": "Custom model manager title"
+  },
+  "customModel.createTitle": {
+    "message": "Create custom music model",
+    "description": "Create model dialog title"
+  },
+  "customModel.modelName": {
+    "message": "Model name",
+    "description": "Model name field"
+  },
+  "customModel.namePlaceholder": {
+    "message": "For example: My album sound",
+    "description": "Model name placeholder"
+  },
+  "customModel.audioUrls": {
+    "message": "Authorized audio URLs (one per line)",
+    "description": "Training audio URL field"
+  },
+  "customModel.urlsPlaceholder": {
+    "message": "Enter 6–24 distinct HTTPS audio URLs, one per line",
+    "description": "Training audio URL placeholder"
+  },
+  "customModel.urlCount": {
+    "message": "{count} entered; 6–24 required",
+    "description": "Training audio count"
+  },
+  "customModel.rightsNotice": {
+    "message": "Creation is a paid, long-running task. Submit only audio authorized for model creation.",
+    "description": "Model rights notice"
+  },
+  "customModel.rightsConfirm": {
+    "message": "I confirm I have model-creation and generation rights for these audio files",
+    "description": "Audio rights confirmation"
+  },
+  "customModel.createPrice": {
+    "message": "5.6 Credits after successful creation; failures are not charged.",
+    "description": "Model creation price"
+  },
+  "customModel.create": {
+    "message": "Create model",
+    "description": "Create model button"
+  },
+  "customModel.createAccepted": {
+    "message": "Model creation task submitted",
+    "description": "Model creation accepted"
+  },
+  "customModel.createFailed": {
+    "message": "Model creation failed",
+    "description": "Model creation failed"
+  },
+  "customModel.betaNotice": {
+    "message": "Beta · Up to 3 models per application",
+    "description": "Custom model Beta limit"
+  },
+  "customModel.empty": {
+    "message": "No custom music models yet",
+    "description": "Empty custom model list"
+  },
+  "customModel.use": {
+    "message": "Use",
+    "description": "Use custom model button"
+  },
+  "customModel.archive": {
+    "message": "Archive",
+    "description": "Archive model button"
+  },
+  "customModel.archiveConfirm": {
+    "message": "Archived models cannot be used. Capacity release is not guaranteed.",
+    "description": "Archive confirmation"
+  },
+  "customModel.archiveSuccess": {
+    "message": "Model archived",
+    "description": "Model archived success"
+  },
+  "customModel.archiveFailed": {
+    "message": "Failed to archive model",
+    "description": "Model archive failure"
+  },
+  "customModel.creditsOnly": {
+    "message": "Custom models currently require Credits mode",
+    "description": "Custom model payment limitation"
+  },
+  "customModel.status.queued": {
+    "message": "Queued",
+    "description": "Model queued status"
+  },
+  "customModel.status.uploading": {
+    "message": "Uploading sources",
+    "description": "Model uploading status"
+  },
+  "customModel.status.training": {
+    "message": "Training",
+    "description": "Model training status"
+  },
+  "customModel.status.ready": {
+    "message": "Ready",
+    "description": "Model ready status"
+  },
+  "customModel.status.failed": {
+    "message": "Creation failed",
+    "description": "Model failed status"
+  },
+  "customModel.status.archived": {
+    "message": "Archived",
+    "description": "Model archived status"
   }
 }

--- a/src/i18n/es/suno.json
+++ b/src/i18n/es/suno.json
@@ -942,5 +942,129 @@
   "name.lyricsMode": {
     "message": "Modo de letras",
     "description": "Etiqueta del selector de modo de letras (manual / automático)"
+  },
+  "customModel.name": {
+    "message": "Modelo de música exclusivo",
+    "description": "Etiqueta del selector de modelo de música exclusivo"
+  },
+  "customModel.description": {
+    "message": "Crea un modelo de música reutilizable utilizando de 6 a 24 pistas de audio autorizadas",
+    "description": "Descripción del modelo de música exclusivo"
+  },
+  "customModel.manage": {
+    "message": "Gestionar modelo",
+    "description": "Botón para gestionar modelos de música exclusivos"
+  },
+  "customModel.placeholder": {
+    "message": "Selecciona un modelo exclusivo listo",
+    "description": "Placeholder para la selección de modelos exclusivos"
+  },
+  "customModel.title": {
+    "message": "Mi modelo de música exclusivo",
+    "description": "Título de gestión del modelo exclusivo"
+  },
+  "customModel.createTitle": {
+    "message": "Crear modelo de música exclusivo",
+    "description": "Título del cuadro de diálogo para crear un modelo"
+  },
+  "customModel.modelName": {
+    "message": "Nombre del modelo",
+    "description": "Campo para el nombre del modelo"
+  },
+  "customModel.namePlaceholder": {
+    "message": "Por ejemplo: Estilo de mi álbum",
+    "description": "Placeholder para el nombre del modelo"
+  },
+  "customModel.audioUrls": {
+    "message": "URLs de audio autorizadas (una por línea)",
+    "description": "Campo para las URLs de audio de entrenamiento"
+  },
+  "customModel.urlsPlaceholder": {
+    "message": "Ingresa de 6 a 24 direcciones de audio HTTPS únicas, una por línea",
+    "description": "Marcador de posición para las URL de audio de entrenamiento"
+  },
+  "customModel.urlCount": {
+    "message": "Actualmente {count} , se permiten de 6 a 24",
+    "description": "Cantidad de audios de entrenamiento"
+  },
+  "customModel.rightsNotice": {
+    "message": "La creación es una tarea larga y de pago. Solo envíe audios que tenga derechos de uso y que estén autorizados para la creación de modelos.",
+    "description": "Mensaje sobre derechos de modelo"
+  },
+  "customModel.rightsConfirm": {
+    "message": "Confirmo que tengo la autorización para crear y generar modelos con estos audios",
+    "description": "Confirmación de derechos de audio"
+  },
+  "customModel.createPrice": {
+    "message": "Se consumen 5.6 Créditos tras la creación exitosa del modelo; no se cobran si falla.",
+    "description": "Mensaje sobre el costo de creación del modelo"
+  },
+  "customModel.create": {
+    "message": "Crear modelo",
+    "description": "Botón para crear un modelo"
+  },
+  "customModel.createAccepted": {
+    "message": "Tarea de creación de modelo enviada",
+    "description": "Mensaje de aceptación de creación de modelo"
+  },
+  "customModel.createFailed": {
+    "message": "Error al crear el modelo",
+    "description": "Mensaje de error al crear el modelo"
+  },
+  "customModel.betaNotice": {
+    "message": "Beta · Máximo 3 modelos por aplicación",
+    "description": "Restricción de modelos exclusivos en Beta"
+  },
+  "customModel.empty": {
+    "message": "No hay modelos de música exclusivos aún",
+    "description": "Estado vacío de la lista de modelos"
+  },
+  "customModel.use": {
+    "message": "Usar",
+    "description": "Botón para usar el modelo exclusivo"
+  },
+  "customModel.archive": {
+    "message": "Archivar",
+    "description": "Botón para archivar el modelo"
+  },
+  "customModel.archiveConfirm": {
+    "message": "Después de archivar, no se podrá seguir utilizando; actualmente no se garantiza la liberación de la capacidad del modelo.",
+    "description": "Mensaje de confirmación para archivar"
+  },
+  "customModel.archiveSuccess": {
+    "message": "Modelo archivado",
+    "description": "Éxito al archivar el modelo"
+  },
+  "customModel.archiveFailed": {
+    "message": "Error al archivar el modelo",
+    "description": "Error al archivar el modelo"
+  },
+  "customModel.creditsOnly": {
+    "message": "El modelo exclusivo actualmente solo admite el modo Créditos",
+    "description": "Restricción de pago para modelos exclusivos"
+  },
+  "customModel.status.queued": {
+    "message": "En cola",
+    "description": "Estado de cola del modelo"
+  },
+  "customModel.status.uploading": {
+    "message": "Subiendo materiales",
+    "description": "Estado de subida del modelo"
+  },
+  "customModel.status.training": {
+    "message": "Entrenando",
+    "description": "Estado de entrenamiento del modelo"
+  },
+  "customModel.status.ready": {
+    "message": "Disponible",
+    "description": "Estado de preparación del modelo"
+  },
+  "customModel.status.failed": {
+    "message": "Creación fallida",
+    "description": "Estado de fallo del modelo"
+  },
+  "customModel.status.archived": {
+    "message": "Archivado",
+    "description": "Estado de archivo del modelo"
   }
 }

--- a/src/i18n/fr/suno.json
+++ b/src/i18n/fr/suno.json
@@ -942,5 +942,129 @@
   "name.lyricsMode": {
     "message": "Mode paroles",
     "description": "Étiquette du sélecteur de mode paroles (manuel / automatique)"
+  },
+  "customModel.name": {
+    "message": "Modèle musical exclusif",
+    "description": "Étiquette du sélecteur de modèle musical exclusif"
+  },
+  "customModel.description": {
+    "message": "Utilisez de 6 à 24 pistes audio autorisées pour créer un modèle musical réutilisable",
+    "description": "Description du modèle musical exclusif"
+  },
+  "customModel.manage": {
+    "message": "Gérer le modèle",
+    "description": "Bouton pour gérer le modèle musical exclusif"
+  },
+  "customModel.placeholder": {
+    "message": "Sélectionnez un modèle exclusif prêt",
+    "description": "Espace réservé pour la sélection de modèle exclusif"
+  },
+  "customModel.title": {
+    "message": "Mon modèle de musique personnalisé",
+    "description": "Titre de gestion du modèle personnalisé"
+  },
+  "customModel.createTitle": {
+    "message": "Créer un modèle musical exclusif",
+    "description": "Titre de la fenêtre contextuelle de création de modèle"
+  },
+  "customModel.modelName": {
+    "message": "Nom du modèle",
+    "description": "Champ pour le nom du modèle"
+  },
+  "customModel.namePlaceholder": {
+    "message": "Par exemple : Mon style d'album",
+    "description": "Espace réservé pour le nom du modèle"
+  },
+  "customModel.audioUrls": {
+    "message": "URLs audio autorisées (une par ligne)",
+    "description": "Champ pour les URLs audio d'entraînement"
+  },
+  "customModel.urlsPlaceholder": {
+    "message": "Entrez de 6 à 24 adresses audio HTTPS uniques, une par ligne",
+    "description": "Placeholder pour les URL audio d'entraînement"
+  },
+  "customModel.urlCount": {
+    "message": "Actuellement {count}, autorisé de 6 à 24",
+    "description": "Nombre d'audios d'entraînement"
+  },
+  "customModel.rightsNotice": {
+    "message": "La création est une tâche longue et payante. Soumettez uniquement les audio dont vous détenez les droits d'utilisation et qui sont autorisés pour la création de modèles.",
+    "description": "Alerte sur les droits du modèle"
+  },
+  "customModel.rightsConfirm": {
+    "message": "Je confirme que j'ai l'autorisation de créer et de générer des modèles avec ces audio",
+    "description": "Confirmation des droits audio"
+  },
+  "customModel.createPrice": {
+    "message": "La création du modèle consomme 5,6 crédits ; aucun frais en cas d'échec.",
+    "description": "Alerte de prix pour la création de modèle"
+  },
+  "customModel.create": {
+    "message": "Créer un modèle",
+    "description": "Bouton pour créer un modèle"
+  },
+  "customModel.createAccepted": {
+    "message": "Tâche de création de modèle soumise",
+    "description": "Alerte d'acceptation de création de modèle"
+  },
+  "customModel.createFailed": {
+    "message": "Échec de la création du modèle",
+    "description": "Alerte d'échec de création de modèle"
+  },
+  "customModel.betaNotice": {
+    "message": "Beta · Maximum de 3 modèles par application",
+    "description": "Limite pour les modèles exclusifs en Beta"
+  },
+  "customModel.empty": {
+    "message": "Aucun modèle musical exclusif pour le moment",
+    "description": "État de la liste des modèles vide"
+  },
+  "customModel.use": {
+    "message": "Utiliser",
+    "description": "Bouton pour utiliser le modèle personnalisé"
+  },
+  "customModel.archive": {
+    "message": "Archiver",
+    "description": "Bouton pour archiver le modèle"
+  },
+  "customModel.archiveConfirm": {
+    "message": "Une fois archivé, il ne pourra plus être utilisé ; aucune promesse actuelle de libérer la capacité du modèle.",
+    "description": "Alerte de confirmation d'archivage"
+  },
+  "customModel.archiveSuccess": {
+    "message": "Modèle archivé",
+    "description": "Succès de l'archivage du modèle"
+  },
+  "customModel.archiveFailed": {
+    "message": "Échec de l'archivage du modèle",
+    "description": "Échec de l'archivage du modèle"
+  },
+  "customModel.creditsOnly": {
+    "message": "Le modèle exclusif prend actuellement uniquement en charge le mode crédits",
+    "description": "Restriction de paiement pour le modèle exclusif"
+  },
+  "customModel.status.queued": {
+    "message": "En attente",
+    "description": "État de la file d'attente du modèle"
+  },
+  "customModel.status.uploading": {
+    "message": "Téléchargement des ressources",
+    "description": "État du téléchargement du modèle"
+  },
+  "customModel.status.training": {
+    "message": "En cours d'entraînement",
+    "description": "État de l'entraînement du modèle"
+  },
+  "customModel.status.ready": {
+    "message": "Prêt à l'utilisation",
+    "description": "État du modèle prêt"
+  },
+  "customModel.status.failed": {
+    "message": "Échec de la création",
+    "description": "État d'échec du modèle"
+  },
+  "customModel.status.archived": {
+    "message": "Archivé",
+    "description": "État du modèle archivé"
   }
 }

--- a/src/i18n/it/suno.json
+++ b/src/i18n/it/suno.json
@@ -942,5 +942,129 @@
   "name.lyricsMode": {
     "message": "Modalità testi",
     "description": "Etichetta del selettore della modalità testi (manuale / automatica)"
+  },
+  "customModel.name": {
+    "message": "Modello musicale personalizzato",
+    "description": "Etichetta del selettore del modello musicale personalizzato"
+  },
+  "customModel.description": {
+    "message": "Crea modelli musicali riutilizzabili utilizzando da 6 a 24 tracce audio autorizzate",
+    "description": "Descrizione del modello musicale personalizzato"
+  },
+  "customModel.manage": {
+    "message": "Gestisci modello",
+    "description": "Pulsante per gestire il modello musicale personalizzato"
+  },
+  "customModel.placeholder": {
+    "message": "Seleziona un modello personalizzato pronto",
+    "description": "Segnaposto per la selezione del modello personalizzato"
+  },
+  "customModel.title": {
+    "message": "I miei modelli musicali personalizzati",
+    "description": "Titolo della gestione del modello personalizzato"
+  },
+  "customModel.createTitle": {
+    "message": "Crea un modello musicale personalizzato",
+    "description": "Titolo della finestra pop-up per la creazione del modello"
+  },
+  "customModel.modelName": {
+    "message": "Nome del modello",
+    "description": "Campo per il nome del modello"
+  },
+  "customModel.namePlaceholder": {
+    "message": "Ad esempio: il mio stile album",
+    "description": "Segnaposto per il nome del modello"
+  },
+  "customModel.audioUrls": {
+    "message": "URL audio autorizzati (uno per riga)",
+    "description": "Campo per gli URL audio di addestramento"
+  },
+  "customModel.urlsPlaceholder": {
+    "message": "Inserisci da 6 a 24 indirizzi audio HTTPS univoci, uno per riga",
+    "description": "Segnaposto per gli URL audio di addestramento"
+  },
+  "customModel.urlCount": {
+    "message": "Attualmente {count} elementi, consentiti da 6 a 24",
+    "description": "Numero di audio di addestramento"
+  },
+  "customModel.rightsNotice": {
+    "message": "La creazione è un'attività a pagamento. Invia solo audio di cui possiedi i diritti e che sono autorizzati per la creazione del modello.",
+    "description": "Avviso sui diritti del modello"
+  },
+  "customModel.rightsConfirm": {
+    "message": "Confermo di avere l'autorizzazione per la creazione e generazione del modello di questi audio",
+    "description": "Conferma dei diritti audio"
+  },
+  "customModel.createPrice": {
+    "message": "La creazione del modello consuma 5.6 Crediti; in caso di fallimento non verranno addebitati costi.",
+    "description": "Avviso sul prezzo di creazione del modello"
+  },
+  "customModel.create": {
+    "message": "Crea modello",
+    "description": "Pulsante per creare il modello"
+  },
+  "customModel.createAccepted": {
+    "message": "Compito di creazione del modello inviato",
+    "description": "Avviso di accettazione della creazione del modello"
+  },
+  "customModel.createFailed": {
+    "message": "Creazione del modello fallita",
+    "description": "Avviso di fallimento della creazione del modello"
+  },
+  "customModel.betaNotice": {
+    "message": "Beta · Massimo 3 modelli per applicazione",
+    "description": "Limitazione Beta per il modello personalizzato"
+  },
+  "customModel.empty": {
+    "message": "Non ci sono ancora modelli musicali personalizzati",
+    "description": "Stato vuoto della lista dei modelli"
+  },
+  "customModel.use": {
+    "message": "Usa",
+    "description": "Pulsante per utilizzare il modello personalizzato"
+  },
+  "customModel.archive": {
+    "message": "Archivia",
+    "description": "Pulsante per archiviare il modello"
+  },
+  "customModel.archiveConfirm": {
+    "message": "Dopo l'archiviazione non sarà possibile continuare a utilizzare; attualmente non ci si impegna a liberare la capacità del modello.",
+    "description": "Avviso di conferma dell'archiviazione"
+  },
+  "customModel.archiveSuccess": {
+    "message": "Modello archiviato",
+    "description": "Successo dell'archiviazione del modello"
+  },
+  "customModel.archiveFailed": {
+    "message": "Archiviazione del modello fallita",
+    "description": "Fallimento dell'archiviazione del modello"
+  },
+  "customModel.creditsOnly": {
+    "message": "Attualmente il modello personalizzato supporta solo la modalità Crediti",
+    "description": "Limitazione di pagamento per il modello personalizzato"
+  },
+  "customModel.status.queued": {
+    "message": "In coda",
+    "description": "Stato in coda del modello"
+  },
+  "customModel.status.uploading": {
+    "message": "Caricamento in corso",
+    "description": "Stato di caricamento del modello"
+  },
+  "customModel.status.training": {
+    "message": "In fase di addestramento",
+    "description": "Stato di addestramento del modello"
+  },
+  "customModel.status.ready": {
+    "message": "Pronto all'uso",
+    "description": "Stato di prontezza del modello"
+  },
+  "customModel.status.failed": {
+    "message": "Creazione fallita",
+    "description": "Stato di fallimento del modello"
+  },
+  "customModel.status.archived": {
+    "message": "Archiviato",
+    "description": "Stato di archiviazione del modello"
   }
 }

--- a/src/i18n/ja/suno.json
+++ b/src/i18n/ja/suno.json
@@ -942,5 +942,129 @@
   "name.lyricsMode": {
     "message": "歌詞モード",
     "description": "歌詞モード選択器のラベル（手動 / 自動）"
+  },
+  "customModel.name": {
+    "message": "専用音楽モデル",
+    "description": "専用音楽モデル選択ラベル"
+  },
+  "customModel.description": {
+    "message": "6〜24曲のライセンス音声を使用して再利用可能な音楽モデルを作成",
+    "description": "専用音楽モデルの説明"
+  },
+  "customModel.manage": {
+    "message": "モデルを管理",
+    "description": "専用音楽モデル管理ボタン"
+  },
+  "customModel.placeholder": {
+    "message": "準備ができた専用モデルを選択",
+    "description": "専用モデル選択プレースホルダー"
+  },
+  "customModel.title": {
+    "message": "私の専用音楽モデル",
+    "description": "専用モデル管理タイトル"
+  },
+  "customModel.createTitle": {
+    "message": "専用音楽モデルを作成",
+    "description": "モデル作成ポップアップタイトル"
+  },
+  "customModel.modelName": {
+    "message": "モデル名",
+    "description": "モデル名フィールド"
+  },
+  "customModel.namePlaceholder": {
+    "message": "例：私のアルバムスタイル",
+    "description": "モデル名プレースホルダー"
+  },
+  "customModel.audioUrls": {
+    "message": "ライセンス音声のURL（1行1つ）",
+    "description": "トレーニング音声URLフィールド"
+  },
+  "customModel.urlsPlaceholder": {
+    "message": "6〜24個の重複しないHTTPS音声アドレスを入力、1行1つ",
+    "description": "トレーニング音声URLプレースホルダー"
+  },
+  "customModel.urlCount": {
+    "message": "現在{count}個、6〜24個を許可",
+    "description": "トレーニング音声の数量"
+  },
+  "customModel.rightsNotice": {
+    "message": "作成は有料の長いタスクです。使用権があり、モデル作成に許可された音声のみを提出してください。",
+    "description": "モデル権利通知"
+  },
+  "customModel.rightsConfirm": {
+    "message": "これらの音声のモデル作成および生成権を持っていることを確認します",
+    "description": "音声権利確認"
+  },
+  "customModel.createPrice": {
+    "message": "モデル作成成功後に5.6クレジット消費；失敗時は料金は発生しません。",
+    "description": "モデル作成価格通知"
+  },
+  "customModel.create": {
+    "message": "モデルを作成",
+    "description": "モデル作成ボタン"
+  },
+  "customModel.createAccepted": {
+    "message": "モデル作成タスクが提出されました",
+    "description": "モデル作成受理通知"
+  },
+  "customModel.createFailed": {
+    "message": "モデル作成に失敗しました",
+    "description": "モデル作成失敗通知"
+  },
+  "customModel.betaNotice": {
+    "message": "ベータ · 各アプリ最大3モデル",
+    "description": "専用モデルベータ制限"
+  },
+  "customModel.empty": {
+    "message": "専用音楽モデルはまだありません",
+    "description": "モデルリスト空状態"
+  },
+  "customModel.use": {
+    "message": "使用する",
+    "description": "専用モデル使用ボタン"
+  },
+  "customModel.archive": {
+    "message": "アーカイブ",
+    "description": "モデルアーカイブボタン"
+  },
+  "customModel.archiveConfirm": {
+    "message": "アーカイブ後は使用できなくなります；現在モデル容量の解放を約束しません。",
+    "description": "アーカイブ確認通知"
+  },
+  "customModel.archiveSuccess": {
+    "message": "モデルがアーカイブされました",
+    "description": "モデルアーカイブ成功"
+  },
+  "customModel.archiveFailed": {
+    "message": "モデルアーカイブに失敗しました",
+    "description": "モデルアーカイブ失敗"
+  },
+  "customModel.creditsOnly": {
+    "message": "専用モデルは現在クレジットモードのみサポートしています",
+    "description": "専用モデル支払い制限"
+  },
+  "customModel.status.queued": {
+    "message": "キュー中",
+    "description": "モデルキュー状態"
+  },
+  "customModel.status.uploading": {
+    "message": "素材をアップロード中",
+    "description": "モデルアップロード状態"
+  },
+  "customModel.status.training": {
+    "message": "トレーニング中",
+    "description": "モデルトレーニング状態"
+  },
+  "customModel.status.ready": {
+    "message": "使用可能",
+    "description": "モデル準備状態"
+  },
+  "customModel.status.failed": {
+    "message": "作成に失敗しました",
+    "description": "モデル失敗状態"
+  },
+  "customModel.status.archived": {
+    "message": "アーカイブ済み",
+    "description": "モデルアーカイブ状態"
   }
 }

--- a/src/i18n/ko/suno.json
+++ b/src/i18n/ko/suno.json
@@ -942,5 +942,129 @@
   "name.lyricsMode": {
     "message": "가사 모드",
     "description": "가사 모드 선택기 레이블(수동 / 자동)"
+  },
+  "customModel.name": {
+    "message": "전용 음악 모델",
+    "description": "전용 음악 모델 선택기 레이블"
+  },
+  "customModel.description": {
+    "message": "6에서 24개의 승인된 오디오를 사용하여 재사용 가능한 음악 모델을 생성합니다.",
+    "description": "전용 음악 모델 설명"
+  },
+  "customModel.manage": {
+    "message": "모델 관리",
+    "description": "전용 음악 모델 관리 버튼"
+  },
+  "customModel.placeholder": {
+    "message": "준비된 전용 모델 선택",
+    "description": "전용 모델 선택 자리 표시자"
+  },
+  "customModel.title": {
+    "message": "내 전용 음악 모델",
+    "description": "전용 모델 관리 제목"
+  },
+  "customModel.createTitle": {
+    "message": "전용 음악 모델 생성",
+    "description": "모델 생성 팝업 제목"
+  },
+  "customModel.modelName": {
+    "message": "모델 이름",
+    "description": "모델 이름 필드"
+  },
+  "customModel.namePlaceholder": {
+    "message": "예: 내 앨범 스타일",
+    "description": "모델 이름 자리 표시자"
+  },
+  "customModel.audioUrls": {
+    "message": "승인된 오디오 URL (각 줄마다 하나)",
+    "description": "훈련 오디오 URL 필드"
+  },
+  "customModel.urlsPlaceholder": {
+    "message": "6에서 24개의 중복되지 않는 HTTPS 오디오 주소를 입력하세요. 각 줄마다 하나",
+    "description": "훈련 오디오 URL 자리 표시자"
+  },
+  "customModel.urlCount": {
+    "message": "현재 {count}개, 6에서 24개 허용",
+    "description": "훈련 오디오 수"
+  },
+  "customModel.rightsNotice": {
+    "message": "생성은 유료의 긴 작업입니다. 모델 생성에 사용 권한이 있고 허가된 오디오만 제출하세요.",
+    "description": "모델 권리 알림"
+  },
+  "customModel.rightsConfirm": {
+    "message": "이 오디오의 모델 생성 및 생성 권한이 있음을 확인합니다.",
+    "description": "오디오 권리 확인"
+  },
+  "customModel.createPrice": {
+    "message": "모델 생성 성공 후 5.6 크레딧 소모; 실패 시 비용 없음.",
+    "description": "모델 생성 가격 알림"
+  },
+  "customModel.create": {
+    "message": "모델 생성",
+    "description": "모델 생성 버튼"
+  },
+  "customModel.createAccepted": {
+    "message": "모델 생성 작업이 제출되었습니다.",
+    "description": "모델 생성 수락 알림"
+  },
+  "customModel.createFailed": {
+    "message": "모델 생성 실패",
+    "description": "모델 생성 실패 알림"
+  },
+  "customModel.betaNotice": {
+    "message": "베타 · 각 애플리케이션당 최대 3개 모델",
+    "description": "전용 모델 베타 제한"
+  },
+  "customModel.empty": {
+    "message": "아직 전용 음악 모델이 없습니다.",
+    "description": "모델 목록 비어 있는 상태"
+  },
+  "customModel.use": {
+    "message": "사용",
+    "description": "전용 모델 사용 버튼"
+  },
+  "customModel.archive": {
+    "message": "보관",
+    "description": "모델 보관 버튼"
+  },
+  "customModel.archiveConfirm": {
+    "message": "보관 후에는 계속 사용할 수 없습니다; 현재 모델 용량 해제를 약속하지 않습니다.",
+    "description": "보관 확인 알림"
+  },
+  "customModel.archiveSuccess": {
+    "message": "모델이 보관되었습니다.",
+    "description": "모델 보관 성공"
+  },
+  "customModel.archiveFailed": {
+    "message": "모델 보관 실패",
+    "description": "모델 보관 실패"
+  },
+  "customModel.creditsOnly": {
+    "message": "전용 모델은 현재 크레딧 모드만 지원합니다.",
+    "description": "전용 모델 결제 제한"
+  },
+  "customModel.status.queued": {
+    "message": "대기 중",
+    "description": "모델 대기 상태"
+  },
+  "customModel.status.uploading": {
+    "message": "자료 업로드 중",
+    "description": "모델 업로드 상태"
+  },
+  "customModel.status.training": {
+    "message": "훈련 중",
+    "description": "모델 훈련 상태"
+  },
+  "customModel.status.ready": {
+    "message": "사용 가능",
+    "description": "모델 준비 상태"
+  },
+  "customModel.status.failed": {
+    "message": "생성 실패",
+    "description": "모델 실패 상태"
+  },
+  "customModel.status.archived": {
+    "message": "보관됨",
+    "description": "모델 보관 상태"
   }
 }

--- a/src/i18n/pt/suno.json
+++ b/src/i18n/pt/suno.json
@@ -942,5 +942,129 @@
   "name.lyricsMode": {
     "message": "Modo de Letras",
     "description": "Rótulo do seletor de modo de letras (manual / automático)"
+  },
+  "customModel.name": {
+    "message": "Modelo de música exclusivo",
+    "description": "Rótulo do seletor de modelo de música exclusivo"
+  },
+  "customModel.description": {
+    "message": "Use de 6 a 24 faixas de áudio autorizadas para criar um modelo de música reutilizável",
+    "description": "Descrição do modelo de música exclusivo"
+  },
+  "customModel.manage": {
+    "message": "Gerenciar modelo",
+    "description": "Botão para gerenciar modelos de música exclusivos"
+  },
+  "customModel.placeholder": {
+    "message": "Selecione um modelo exclusivo pronto",
+    "description": "Placeholder para seleção de modelo exclusivo"
+  },
+  "customModel.title": {
+    "message": "Meu modelo de música exclusivo",
+    "description": "Título para gerenciamento de modelos exclusivos"
+  },
+  "customModel.createTitle": {
+    "message": "Criar modelo de música exclusivo",
+    "description": "Título da janela de criação do modelo"
+  },
+  "customModel.modelName": {
+    "message": "Nome do modelo",
+    "description": "Campo para o nome do modelo"
+  },
+  "customModel.namePlaceholder": {
+    "message": "Por exemplo: meu estilo de álbum",
+    "description": "Placeholder para o nome do modelo"
+  },
+  "customModel.audioUrls": {
+    "message": "URLs de áudio autorizadas (uma por linha)",
+    "description": "Campo para URLs de áudio de treinamento"
+  },
+  "customModel.urlsPlaceholder": {
+    "message": "Insira de 6 a 24 endereços de áudio HTTPS únicos, um por linha",
+    "description": "Placeholder para URLs de áudio para treinamento"
+  },
+  "customModel.urlCount": {
+    "message": "Atualmente {count} itens, permitido de 6 a 24",
+    "description": "Quantidade de áudios para treinamento"
+  },
+  "customModel.rightsNotice": {
+    "message": "A criação é uma tarefa longa e paga. Apenas envie áudios que você possui direitos de uso e que estão autorizados para criação de modelos.",
+    "description": "Mensagem sobre direitos do modelo"
+  },
+  "customModel.rightsConfirm": {
+    "message": "Confirmo que possuo a autorização para criar e gerar modelos com esses áudios",
+    "description": "Confirmação de direitos de áudio"
+  },
+  "customModel.createPrice": {
+    "message": "A criação do modelo consome 5,6 Créditos; falhas não geram cobrança.",
+    "description": "Mensagem sobre o preço da criação do modelo"
+  },
+  "customModel.create": {
+    "message": "Criar modelo",
+    "description": "Botão para criar um modelo"
+  },
+  "customModel.createAccepted": {
+    "message": "Tarefa de criação do modelo foi enviada",
+    "description": "Mensagem de aceitação da criação do modelo"
+  },
+  "customModel.createFailed": {
+    "message": "Falha ao criar o modelo",
+    "description": "Mensagem de falha na criação do modelo"
+  },
+  "customModel.betaNotice": {
+    "message": "Beta · Máximo de 3 modelos por aplicativo",
+    "description": "Limitação de modelos exclusivos em Beta"
+  },
+  "customModel.empty": {
+    "message": "Ainda não há modelos de música exclusivos",
+    "description": "Estado vazio da lista de modelos"
+  },
+  "customModel.use": {
+    "message": "Usar",
+    "description": "Botão para usar o modelo exclusivo"
+  },
+  "customModel.archive": {
+    "message": "Arquivar",
+    "description": "Botão para arquivar o modelo"
+  },
+  "customModel.archiveConfirm": {
+    "message": "Após arquivar, não será possível continuar usando; atualmente não há compromisso de liberar a capacidade do modelo.",
+    "description": "Mensagem de confirmação para arquivamento"
+  },
+  "customModel.archiveSuccess": {
+    "message": "Modelo arquivado com sucesso",
+    "description": "Mensagem de sucesso ao arquivar o modelo"
+  },
+  "customModel.archiveFailed": {
+    "message": "Falha ao arquivar o modelo",
+    "description": "Mensagem de falha ao arquivar o modelo"
+  },
+  "customModel.creditsOnly": {
+    "message": "Modelos exclusivos atualmente suportam apenas o modo Créditos",
+    "description": "Limitação de pagamento para modelos exclusivos"
+  },
+  "customModel.status.queued": {
+    "message": "Em fila",
+    "description": "Estado de fila do modelo"
+  },
+  "customModel.status.uploading": {
+    "message": "Carregando material",
+    "description": "Estado de upload do modelo"
+  },
+  "customModel.status.training": {
+    "message": "Treinando",
+    "description": "Estado de treinamento do modelo"
+  },
+  "customModel.status.ready": {
+    "message": "Disponível",
+    "description": "Estado de prontidão do modelo"
+  },
+  "customModel.status.failed": {
+    "message": "Criação falhou",
+    "description": "Estado de falha do modelo"
+  },
+  "customModel.status.archived": {
+    "message": "Arquivado",
+    "description": "Estado de arquivamento do modelo"
   }
 }

--- a/src/i18n/ru/suno.json
+++ b/src/i18n/ru/suno.json
@@ -942,5 +942,129 @@
   "name.lyricsMode": {
     "message": "Режим текста",
     "description": "Метка селектора режима текста (ручной / автоматический)"
+  },
+  "customModel.name": {
+    "message": "Индивидуальная музыкальная модель",
+    "description": "Метка выбора индивидуальной музыкальной модели"
+  },
+  "customModel.description": {
+    "message": "Создайте многоразовую музыкальную модель, используя от 6 до 24 авторизованных аудио",
+    "description": "Описание индивидуальной музыкальной модели"
+  },
+  "customModel.manage": {
+    "message": "Управлять моделью",
+    "description": "Кнопка управления индивидуальной музыкальной моделью"
+  },
+  "customModel.placeholder": {
+    "message": "Выберите готовую индивидуальную модель",
+    "description": "Заполнитель выбора индивидуальной модели"
+  },
+  "customModel.title": {
+    "message": "Мои индивидуальные музыкальные модели",
+    "description": "Заголовок управления индивидуальными моделями"
+  },
+  "customModel.createTitle": {
+    "message": "Создать индивидуальную музыкальную модель",
+    "description": "Заголовок всплывающего окна создания модели"
+  },
+  "customModel.modelName": {
+    "message": "Название модели",
+    "description": "Поле названия модели"
+  },
+  "customModel.namePlaceholder": {
+    "message": "Например: мой стиль альбома",
+    "description": "Заполнитель названия модели"
+  },
+  "customModel.audioUrls": {
+    "message": "URL авторизованного аудио (по одному на строку)",
+    "description": "Поле URL обучающего аудио"
+  },
+  "customModel.urlsPlaceholder": {
+    "message": "Введите от 6 до 24 уникальных HTTPS аудио адресов, по одному на строку",
+    "description": "Заполнитель URL обучающего аудио"
+  },
+  "customModel.urlCount": {
+    "message": "Текущие {count} штук, разрешено от 6 до 24",
+    "description": "Количество обучающего аудио"
+  },
+  "customModel.rightsNotice": {
+    "message": "Создание является платной длительной задачей. Пожалуйста, отправляйте только аудио, на которые у вас есть права и разрешение на использование для создания модели.",
+    "description": "Уведомление о правах модели"
+  },
+  "customModel.rightsConfirm": {
+    "message": "Я подтверждаю, что обладаю правами на создание и генерацию модели с использованием этих аудио",
+    "description": "Подтверждение прав на аудио"
+  },
+  "customModel.createPrice": {
+    "message": "Создание модели стоит 5.6 кредитов; в случае неудачи плата не взимается.",
+    "description": "Уведомление о цене создания модели"
+  },
+  "customModel.create": {
+    "message": "Создать модель",
+    "description": "Кнопка создания модели"
+  },
+  "customModel.createAccepted": {
+    "message": "Задача на создание модели принята",
+    "description": "Уведомление о принятии создания модели"
+  },
+  "customModel.createFailed": {
+    "message": "Создание модели не удалось",
+    "description": "Уведомление о неудаче создания модели"
+  },
+  "customModel.betaNotice": {
+    "message": "Бета · Максимум 3 модели на приложение",
+    "description": "Ограничение бета-версии индивидуальной модели"
+  },
+  "customModel.empty": {
+    "message": "Пока нет индивидуальных музыкальных моделей",
+    "description": "Состояние пустого списка моделей"
+  },
+  "customModel.use": {
+    "message": "Использовать",
+    "description": "Кнопка использования индивидуальной модели"
+  },
+  "customModel.archive": {
+    "message": "Архивировать",
+    "description": "Кнопка архивирования модели"
+  },
+  "customModel.archiveConfirm": {
+    "message": "После архивирования модель нельзя будет использовать; в данный момент нет обязательств по освобождению объема модели.",
+    "description": "Подтверждение архивирования"
+  },
+  "customModel.archiveSuccess": {
+    "message": "Модель архивирована",
+    "description": "Успешное архивирование модели"
+  },
+  "customModel.archiveFailed": {
+    "message": "Архивирование модели не удалось",
+    "description": "Неудача архивирования модели"
+  },
+  "customModel.creditsOnly": {
+    "message": "Индивидуальные модели в настоящее время поддерживают только режим кредитов",
+    "description": "Ограничение платежа для индивидуальных моделей"
+  },
+  "customModel.status.queued": {
+    "message": "В очереди",
+    "description": "Статус очереди модели"
+  },
+  "customModel.status.uploading": {
+    "message": "Загрузка материалов",
+    "description": "Статус загрузки модели"
+  },
+  "customModel.status.training": {
+    "message": "Обучение",
+    "description": "Статус обучения модели"
+  },
+  "customModel.status.ready": {
+    "message": "Готово к использованию",
+    "description": "Статус готовности модели"
+  },
+  "customModel.status.failed": {
+    "message": "Создание не удалось",
+    "description": "Статус неудачи модели"
+  },
+  "customModel.status.archived": {
+    "message": "Архивировано",
+    "description": "Статус архивирования модели"
   }
 }

--- a/src/i18n/zh-CN/suno.json
+++ b/src/i18n/zh-CN/suno.json
@@ -942,5 +942,129 @@
   "name.lyricsMode": {
     "message": "歌词模式",
     "description": "歌词模式选择器的标签（手动 / 自动）"
+  },
+  "customModel.name": {
+    "message": "专属音乐模型",
+    "description": "专属音乐模型选择器标签"
+  },
+  "customModel.description": {
+    "message": "使用 6 至 24 首授权音频创建可复用的音乐模型",
+    "description": "专属音乐模型说明"
+  },
+  "customModel.manage": {
+    "message": "管理模型",
+    "description": "管理专属音乐模型按钮"
+  },
+  "customModel.placeholder": {
+    "message": "选择已就绪的专属模型",
+    "description": "专属模型选择占位符"
+  },
+  "customModel.title": {
+    "message": "我的专属音乐模型",
+    "description": "专属模型管理标题"
+  },
+  "customModel.createTitle": {
+    "message": "创建专属音乐模型",
+    "description": "创建模型弹窗标题"
+  },
+  "customModel.modelName": {
+    "message": "模型名称",
+    "description": "模型名称字段"
+  },
+  "customModel.namePlaceholder": {
+    "message": "例如：我的专辑风格",
+    "description": "模型名称占位符"
+  },
+  "customModel.audioUrls": {
+    "message": "授权音频 URL（每行一个）",
+    "description": "训练音频 URL 字段"
+  },
+  "customModel.urlsPlaceholder": {
+    "message": "输入 6 至 24 个互不重复的 HTTPS 音频地址，每行一个",
+    "description": "训练音频 URL 占位符"
+  },
+  "customModel.urlCount": {
+    "message": "当前 {count} 个，允许 6 至 24 个",
+    "description": "训练音频数量"
+  },
+  "customModel.rightsNotice": {
+    "message": "创建是付费的长任务。仅提交您拥有使用权并获准用于模型创建的音频。",
+    "description": "模型权利提示"
+  },
+  "customModel.rightsConfirm": {
+    "message": "我确认拥有这些音频的模型创建与生成授权",
+    "description": "音频权利确认"
+  },
+  "customModel.createPrice": {
+    "message": "模型创建成功后消耗 5.6 Credits；失败不扣费。",
+    "description": "模型创建价格提示"
+  },
+  "customModel.create": {
+    "message": "创建模型",
+    "description": "创建模型按钮"
+  },
+  "customModel.createAccepted": {
+    "message": "模型创建任务已提交",
+    "description": "模型创建已接受提示"
+  },
+  "customModel.createFailed": {
+    "message": "模型创建失败",
+    "description": "模型创建失败提示"
+  },
+  "customModel.betaNotice": {
+    "message": "Beta · 每个应用最多 3 个模型",
+    "description": "专属模型 Beta 限制"
+  },
+  "customModel.empty": {
+    "message": "还没有专属音乐模型",
+    "description": "模型列表空状态"
+  },
+  "customModel.use": {
+    "message": "使用",
+    "description": "使用专属模型按钮"
+  },
+  "customModel.archive": {
+    "message": "归档",
+    "description": "归档模型按钮"
+  },
+  "customModel.archiveConfirm": {
+    "message": "归档后将不能继续使用；当前不承诺释放模型容量。",
+    "description": "归档确认提示"
+  },
+  "customModel.archiveSuccess": {
+    "message": "模型已归档",
+    "description": "模型归档成功"
+  },
+  "customModel.archiveFailed": {
+    "message": "模型归档失败",
+    "description": "模型归档失败"
+  },
+  "customModel.creditsOnly": {
+    "message": "专属模型当前仅支持 Credits 模式",
+    "description": "专属模型支付限制"
+  },
+  "customModel.status.queued": {
+    "message": "排队中",
+    "description": "模型排队状态"
+  },
+  "customModel.status.uploading": {
+    "message": "上传素材中",
+    "description": "模型上传状态"
+  },
+  "customModel.status.training": {
+    "message": "训练中",
+    "description": "模型训练状态"
+  },
+  "customModel.status.ready": {
+    "message": "可使用",
+    "description": "模型就绪状态"
+  },
+  "customModel.status.failed": {
+    "message": "创建失败",
+    "description": "模型失败状态"
+  },
+  "customModel.status.archived": {
+    "message": "已归档",
+    "description": "模型归档状态"
   }
 }

--- a/src/i18n/zh-TW/suno.json
+++ b/src/i18n/zh-TW/suno.json
@@ -942,5 +942,129 @@
   "name.lyricsMode": {
     "message": "歌詞模式",
     "description": "歌詞模式選擇器的標籤（手動 / 自動）"
+  },
+  "customModel.name": {
+    "message": "專屬音樂模型",
+    "description": "專屬音樂模型選擇器標籤"
+  },
+  "customModel.description": {
+    "message": "使用 6 至 24 首授權音頻創建可重用的音樂模型",
+    "description": "專屬音樂模型說明"
+  },
+  "customModel.manage": {
+    "message": "管理模型",
+    "description": "管理專屬音樂模型按鈕"
+  },
+  "customModel.placeholder": {
+    "message": "選擇已就緒的專屬模型",
+    "description": "專屬模型選擇佔位符"
+  },
+  "customModel.title": {
+    "message": "我的專屬音樂模型",
+    "description": "專屬模型管理標題"
+  },
+  "customModel.createTitle": {
+    "message": "創建專屬音樂模型",
+    "description": "創建模型彈窗標題"
+  },
+  "customModel.modelName": {
+    "message": "模型名稱",
+    "description": "模型名稱欄位"
+  },
+  "customModel.namePlaceholder": {
+    "message": "例如：我的專輯風格",
+    "description": "模型名稱佔位符"
+  },
+  "customModel.audioUrls": {
+    "message": "授權音頻 URL（每行一個）",
+    "description": "訓練音頻 URL 欄位"
+  },
+  "customModel.urlsPlaceholder": {
+    "message": "輸入 6 至 24 個互不重複的 HTTPS 音頻地址，每行一個",
+    "description": "訓練音頻 URL 占位符"
+  },
+  "customModel.urlCount": {
+    "message": "當前 {count} 個，允許 6 至 24 個",
+    "description": "訓練音頻數量"
+  },
+  "customModel.rightsNotice": {
+    "message": "創建是付費的長任務。僅提交您擁有使用權並獲准用於模型創建的音頻。",
+    "description": "模型權利提示"
+  },
+  "customModel.rightsConfirm": {
+    "message": "我確認擁有這些音頻的模型創建與生成授權",
+    "description": "音頻權利確認"
+  },
+  "customModel.createPrice": {
+    "message": "模型創建成功後消耗 5.6 Credits；失敗不扣費。",
+    "description": "模型創建價格提示"
+  },
+  "customModel.create": {
+    "message": "創建模型",
+    "description": "創建模型按鈕"
+  },
+  "customModel.createAccepted": {
+    "message": "模型創建任務已提交",
+    "description": "模型創建已接受提示"
+  },
+  "customModel.createFailed": {
+    "message": "模型創建失敗",
+    "description": "模型創建失敗提示"
+  },
+  "customModel.betaNotice": {
+    "message": "Beta · 每個應用最多 3 個模型",
+    "description": "專屬模型 Beta 限制"
+  },
+  "customModel.empty": {
+    "message": "還沒有專屬音樂模型",
+    "description": "模型列表空狀態"
+  },
+  "customModel.use": {
+    "message": "使用",
+    "description": "使用專屬模型按鈕"
+  },
+  "customModel.archive": {
+    "message": "歸檔",
+    "description": "歸檔模型按鈕"
+  },
+  "customModel.archiveConfirm": {
+    "message": "歸檔後將不能繼續使用；當前不承諾釋放模型容量。",
+    "description": "歸檔確認提示"
+  },
+  "customModel.archiveSuccess": {
+    "message": "模型已歸檔",
+    "description": "模型歸檔成功"
+  },
+  "customModel.archiveFailed": {
+    "message": "模型歸檔失敗",
+    "description": "模型歸檔失敗"
+  },
+  "customModel.creditsOnly": {
+    "message": "專屬模型當前僅支持 Credits 模式",
+    "description": "專屬模型支付限制"
+  },
+  "customModel.status.queued": {
+    "message": "排隊中",
+    "description": "模型排隊狀態"
+  },
+  "customModel.status.uploading": {
+    "message": "上傳素材中",
+    "description": "模型上傳狀態"
+  },
+  "customModel.status.training": {
+    "message": "訓練中",
+    "description": "模型訓練狀態"
+  },
+  "customModel.status.ready": {
+    "message": "可使用",
+    "description": "模型就緒狀態"
+  },
+  "customModel.status.failed": {
+    "message": "創建失敗",
+    "description": "模型失敗狀態"
+  },
+  "customModel.status.archived": {
+    "message": "已歸檔",
+    "description": "模型歸檔狀態"
   }
 }

--- a/src/models/suno.ts
+++ b/src/models/suno.ts
@@ -77,6 +77,7 @@ export interface ISunoConfig {
   audio_weight?: number;
   duration?: number;
   persona_id?: string;
+  custom_model_id?: string;
   replace_section_start?: number;
   replace_section_end?: number;
   overpainting_start?: number;
@@ -305,4 +306,46 @@ export type ISunoTaskResponse = ISunoTask;
 export interface ISunoTasksResponse {
   count: number;
   items: ISunoTask[];
+}
+
+export type SunoCustomModelStatus = 'queued' | 'uploading' | 'training' | 'ready' | 'failed' | 'archived';
+
+export interface ISunoCustomModel {
+  id: string;
+  task_id?: string;
+  name: string;
+  status: SunoCustomModelStatus;
+  source_count: number;
+  progress?: { stage?: string; uploaded?: number; total?: number };
+  created_at: number;
+  updated_at: number;
+}
+
+export interface ISunoCustomModelCreateRequest {
+  action: 'create';
+  name: string;
+  audio_urls: string[];
+  callback_url?: string;
+}
+
+export interface ISunoCustomModelGenerateRequest {
+  action: 'generate';
+  id: string;
+  lyric?: string;
+  lyric_prompt?: string;
+  style?: string;
+  negative_tags?: string;
+  title?: string;
+  instrumental?: boolean;
+  vocal_gender?: string;
+  weirdness?: number;
+  style_influence?: number;
+  duration?: number;
+  async?: boolean;
+  callback_url?: string;
+}
+
+export interface ISunoCustomModelsResponse {
+  success: boolean;
+  data: { items: ISunoCustomModel[]; count: number };
 }

--- a/src/operators/suno.ts
+++ b/src/operators/suno.ts
@@ -23,6 +23,11 @@ import {
   ISunoMashupLyricsRequest,
   ISunoMashupLyricsResponse,
   ISunoPersonasListResponse,
+  ISunoCustomModelCreateRequest,
+  ISunoCustomModelGenerateRequest,
+  ISunoCustomModelsResponse,
+  ISunoCustomModel,
+  ISunoAudio,
   ISunoConfig
 } from '@/models';
 import { BASE_URL_API, BASE_URL_X402 } from '@/constants';
@@ -32,7 +37,10 @@ const HEADERS = { 'content-type': 'application/json', accept: 'application/json'
 const TASK_HEADERS = { ...HEADERS, 'x-record-exempt': 'true' };
 
 export function buildSunoAudioRequest(config?: ISunoConfig): ISunoAudioRequest {
-  const request = { ...(config || {}), audio: undefined, async: true } as ISunoAudioRequest;
+  const request = { ...(config || {}), audio: undefined, async: true } as ISunoAudioRequest & {
+    custom_model_id?: string;
+  };
+  delete request.custom_model_id;
   if (typeof request.prompt === 'string') request.prompt = request.prompt.trim();
   return request;
 }
@@ -253,6 +261,72 @@ class SunoOperator {
       },
       baseURL: BASE_URL_API
     });
+  }
+
+  async createCustomModel(
+    data: ISunoCustomModelCreateRequest,
+    options: { token: string; idempotencyKey: string }
+  ): Promise<AxiosResponse<{ success: boolean; id: string; task_id: string; status: string }>> {
+    return axios.post('/suno/custom-models', data, {
+      headers: {
+        ...HEADERS,
+        authorization: `Bearer ${options.token}`,
+        'Idempotency-Key': options.idempotencyKey
+      },
+      baseURL: BASE_URL_API
+    });
+  }
+
+  async generateWithCustomModel(
+    data: ISunoCustomModelGenerateRequest,
+    options: { token: string }
+  ): Promise<AxiosResponse<{ success?: boolean; task_id?: string; data?: ISunoAudio[] }>> {
+    return axios.post('/suno/custom-models', data, {
+      headers: { ...HEADERS, authorization: `Bearer ${options.token}` },
+      baseURL: BASE_URL_API
+    });
+  }
+
+  async customModelsList(
+    data: { status?: string; limit?: number; offset?: number },
+    options: { token: string }
+  ): Promise<AxiosResponse<ISunoCustomModelsResponse>> {
+    return axios.post(
+      '/suno/custom-models',
+      { action: 'retrieve_batch', ...data },
+      {
+        headers: { ...HEADERS, authorization: `Bearer ${options.token}`, 'x-record-exempt': 'true' },
+        baseURL: BASE_URL_API
+      }
+    );
+  }
+
+  async customModelRetrieve(
+    id: string,
+    options: { token: string }
+  ): Promise<AxiosResponse<{ success: boolean; data: ISunoCustomModel }>> {
+    return axios.post(
+      '/suno/custom-models',
+      { action: 'retrieve', id },
+      {
+        headers: { ...HEADERS, authorization: `Bearer ${options.token}`, 'x-record-exempt': 'true' },
+        baseURL: BASE_URL_API
+      }
+    );
+  }
+
+  async customModelArchive(
+    id: string,
+    options: { token: string }
+  ): Promise<AxiosResponse<{ success: boolean; data: { id: string; status: 'archived'; capacity_released: false } }>> {
+    return axios.post(
+      '/suno/custom-models',
+      { action: 'delete', id },
+      {
+        headers: { ...HEADERS, authorization: `Bearer ${options.token}`, 'x-record-exempt': 'true' },
+        baseURL: BASE_URL_API
+      }
+    );
   }
 
   // GET /suno/persona - list user personas

--- a/src/operators/sunoCustomModels.test.ts
+++ b/src/operators/sunoCustomModels.test.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { buildSunoAudioRequest } from './suno';
+
+const source = (path: string) => readFileSync(resolve(process.cwd(), 'src', path), 'utf8');
+
+describe('Suno custom model integration contract', () => {
+  it('keeps custom_model_id out of the standard audio endpoint payload', () => {
+    const request = buildSunoAudioRequest({
+      custom: true,
+      custom_model_id: 'model-id',
+      lyric: 'hello',
+      continue_at: 0
+    });
+
+    expect(request).not.toHaveProperty('custom_model_id');
+    expect(request.lyric).toBe('hello');
+  });
+
+  it('routes only active custom-mode generation and forwards supported controls', () => {
+    const page = source('pages/suno/Index.vue');
+    const panel = source('components/suno/ConfigPanel.vue');
+
+    expect(page).toContain('!!this.config?.custom && !!customModelId');
+    expect(page).toContain("!this.config?.action || this.config.action === 'generate'");
+    for (const field of ['vocal_gender', 'weirdness', 'style_influence', 'duration']) {
+      expect(page).toContain(`${field}: request.${field}`);
+    }
+    expect(panel).toContain('const pricingConfig = this.usesCustomModel');
+  });
+
+  it('reuses an idempotency key for the same failed submission and rotates it after edits', () => {
+    const dialog = source('components/suno/model/CustomModelCreateDialog.vue');
+
+    expect(dialog).toContain('if (fingerprint !== this.submittedFingerprint)');
+    expect(dialog).toContain('this.idempotencyKey = crypto.randomUUID()');
+    expect(dialog).toContain('idempotencyKey: this.idempotencyKey');
+    expect(dialog.match(/crypto\.randomUUID\(\)/g)).toHaveLength(1);
+  });
+});

--- a/src/pages/suno/Index.vue
+++ b/src/pages/suno/Index.vue
@@ -275,7 +275,12 @@ export default defineComponent({
       if (this.hasText(request.prompt)) {
         request.prompt = request.prompt.trim();
       }
-      const operation = this.createPaymentOperation((options) => sunoOperator.audio(request, options));
+      const customModelId = this.config?.custom_model_id;
+      const usesCustomModel =
+        !!this.config?.custom && !!customModelId && (!this.config?.action || this.config.action === 'generate');
+      const operation = usesCustomModel
+        ? this.createCustomModelOperation(customModelId, request)
+        : this.createPaymentOperation((options) => sunoOperator.audio(request, options));
       if (!operation) return;
       ElMessage.info(this.$t('suno.message.startingTask'));
       try {
@@ -292,6 +297,33 @@ export default defineComponent({
           await this.onScrollDown();
         }, 1000);
       }
+    },
+    createCustomModelOperation(customModelId: string, request: ISunoAudioRequest): Promise<any> | undefined {
+      if (this.walletMode) {
+        ElMessage.error(this.$t('suno.customModel.creditsOnly'));
+        return undefined;
+      }
+      if (!ensureLoggedIn()) return undefined;
+      const token = this.credential?.token;
+      if (!token) return undefined;
+      return sunoOperator.generateWithCustomModel(
+        {
+          action: 'generate',
+          id: customModelId,
+          lyric: request.lyric,
+          lyric_prompt: request.lyric_prompt,
+          style: request.style,
+          negative_tags: request.negative_tags,
+          title: request.title,
+          instrumental: request.instrumental,
+          vocal_gender: request.vocal_gender,
+          weirdness: request.weirdness,
+          style_influence: request.style_influence,
+          duration: request.duration,
+          async: true
+        },
+        { token }
+      );
     },
     createPaymentOperation(submit: (options: OperatorRequestOptions) => Promise<any>): Promise<any> | undefined {
       if (!this.walletMode) {

--- a/src/store/suno/actions.ts
+++ b/src/store/suno/actions.ts
@@ -2,7 +2,7 @@ import { applicationOperator, sunoOperator, serviceOperator, credentialOperator 
 import { ISunoState } from './models';
 import { ActionContext } from 'vuex';
 import { IRootState } from '../common/models';
-import { IApplication, ICredential, ISunoConfig, ISunoPersona, ISunoTask, IService } from '@/models';
+import { IApplication, ICredential, ISunoConfig, ISunoPersona, ISunoCustomModel, ISunoTask, IService } from '@/models';
 import { Status } from '@/models/common';
 import { SUNO_SERVICE_ID } from '@/constants';
 import { mergeAndSortLists } from '@/utils/merge';
@@ -236,6 +236,38 @@ export const deletePersona = async (
   }
 };
 
+export const getCustomModels = async ({
+  commit,
+  state
+}: ActionContext<ISunoState, IRootState>): Promise<ISunoCustomModel[]> => {
+  const token = state.credential?.token;
+  if (!token) return [];
+  try {
+    const { data } = await sunoOperator.customModelsList({}, { token });
+    commit('setCustomModels', data.data.items || []);
+    return data.data.items || [];
+  } catch (error) {
+    console.error('get custom models failed', error);
+    return [];
+  }
+};
+
+export const archiveCustomModel = async (
+  { state, dispatch }: ActionContext<ISunoState, IRootState>,
+  id: string
+): Promise<boolean> => {
+  const token = state.credential?.token;
+  if (!token) return false;
+  try {
+    await sunoOperator.customModelArchive(id, { token });
+    await dispatch('getCustomModels');
+    return true;
+  } catch (error) {
+    console.error('archive custom model failed', error);
+    return false;
+  }
+};
+
 export const refreshPendingTasks = async (
   { commit, state }: ActionContext<ISunoState, IRootState>,
   args: { mode?: 'credits' | 'x402' } = {}
@@ -269,6 +301,8 @@ export default {
   getTasks,
   setAudio,
   getPersonas,
+  getCustomModels,
+  archiveCustomModel,
   deletePersona,
   createCredential
 };

--- a/src/store/suno/models.ts
+++ b/src/store/suno/models.ts
@@ -1,4 +1,4 @@
-import { IApplication, ICredential, IService, ISunoAudio, ISunoPersona, Status } from '@/models';
+import { IApplication, ICredential, IService, ISunoAudio, ISunoPersona, ISunoCustomModel, Status } from '@/models';
 import { ISunoConfig, ISunoTask } from '@/models';
 
 export interface ISunoState {
@@ -16,6 +16,7 @@ export interface ISunoState {
     | undefined;
   audio: ISunoAudio | undefined;
   personas: ISunoPersona[] | undefined;
+  customModels: ISunoCustomModel[] | undefined;
   favoritePersonaIds: string[];
   status: {
     getService: Status;

--- a/src/store/suno/mutations.ts
+++ b/src/store/suno/mutations.ts
@@ -1,4 +1,4 @@
-import { IApplication, ICredential, ISunoConfig, ISunoPersona, ISunoTask, IService } from '@/models';
+import { IApplication, ICredential, ISunoConfig, ISunoPersona, ISunoCustomModel, ISunoTask, IService } from '@/models';
 import { ISunoState } from './models';
 
 export const resetAll = (state: ISunoState): void => {
@@ -9,6 +9,7 @@ export const resetAll = (state: ISunoState): void => {
   state.credential = undefined;
   state.tasks = undefined;
   state.personas = undefined;
+  state.customModels = undefined;
 };
 
 export const setApplications = (state: ISunoState, payload: IApplication[]): void => {
@@ -63,6 +64,10 @@ export const setTasks = (state: ISunoState, payload: any): void => {
   state.tasks = payload;
 };
 
+export const setCustomModels = (state: ISunoState, payload: ISunoCustomModel[]): void => {
+  state.customModels = payload;
+};
+
 export const setPersonas = (state: ISunoState, payload: ISunoPersona[]): void => {
   state.personas = payload;
 };
@@ -92,6 +97,7 @@ export default {
   setTasksTotal,
   setAudio,
   setPersonas,
+  setCustomModels,
   togglePersonaFavorite,
   resetAll
 };

--- a/src/store/suno/state.ts
+++ b/src/store/suno/state.ts
@@ -13,6 +13,7 @@ export default (): ISunoState => {
     credential: undefined,
     config: undefined,
     personas: undefined,
+    customModels: undefined,
     favoritePersonaIds: [],
     status: {
       getService: Status.None,


### PR DESCRIPTION
## Summary
- add a Credits-only Suno custom model manager for creating, listing, selecting, and archiving models
- route selected ready models through `POST /suno/custom-models` with the full supported generation controls
- preserve create idempotency across network retries, add responsive UI, and localize all 11 locales

## Dependency
- Runtime/API contract is already live via PlatformService https://github.com/AceDataCloud/PlatformService/pull/2268 and PlatformBackend https://github.com/AceDataCloud/PlatformBackend/pull/1695.

## Validation
- `npx vitest run src/operators/sunoCustomModels.test.ts` — 3 passed
- `python3 scripts/check_i18n_coverage.py` — 11 locales × 50 namespaces, no placeholders
- `npm run lint:check` — 0 errors (2 pre-existing warnings)
- `npm run build:web` — passed
- `git diff --check` — passed

## Rollout / rollback
- Standard Suno flows remain unchanged unless a ready custom model is explicitly selected in Custom mode.
- Revert this PR to remove the UI surface; the live API remains independently usable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
