### PR TITLE
fix(android): stage Play policy review uploads

### DIFF
--- a/.github/workflows/release-android.yaml
+++ b/.github/workflows/release-android.yaml
@@ -350,6 +350,9 @@ jobs:
           releaseFiles: android/app/build/outputs/bundle/playRelease/app-play-release.aab
           tracks: ${{ needs.preflight.outputs.track }}
           status: completed
+          # Policy-rejected apps cannot commit review submission through the API.
+          # Stage the edit; Play Console is the deliberate review boundary.
+          changesNotSentForReview: true
 
   promote:
     name: Promote to Production

--- a/change/play-review-staging.json
+++ b/change/play-review-staging.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Stage Google Play uploads for manual review while the policy hold is active.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/docs/android-release.md
+++ b/docs/android-release.md
@@ -13,7 +13,7 @@ the pipeline end-to-end on **2026-05-23 (run [26324168813][run-3351])**.
 
 ## Google Play policy hold
 
-Automatic Play production promotion is currently fail-closed while the AI-generated content policy remediation is under review. Remediation builds may be uploaded only to an internal or testing track and are left unsent for review. Set the repository variable `ANDROID_POLICY_HOLD=cleared` only after the Play Console policy case is cleared for the new version code; production submission remains a deliberate manual action.
+Automatic Play production promotion is currently fail-closed while the AI-generated content policy remediation is under review. Play uploads set `changesNotSentForReview: true` because Google rejects automatic review submission while a policy case is open; submit the staged edit manually in Play Console. Remediation builds may be uploaded only to an internal or testing track and are left unsent for review. Set the repository variable `ANDROID_POLICY_HOLD=cleared` only after the Play Console policy case is cleared for the new version code; production submission remains a deliberate manual action.
 
 The Google Play bundle compiles out Nano Banana navigation, routes, home cards, and showcases until its provider safety contract is deterministic. Web, iOS, desktop, and the full sideload Android APK remain unchanged.
 

--- a/scripts/check_release_workflows.py
+++ b/scripts/check_release_workflows.py
@@ -65,7 +65,7 @@ def main() -> None:
     ios = read("release-ios.yaml")
     require("workflow_call:" in android, "Android release must be reusable")
     require("workflow_call:" in ios, "iOS release must be reusable")
-    require("changesNotSentForReview" not in android, "obsolete Google Play review parameter returned")
+    require("changesNotSentForReview: true" in android, "Play uploads must remain staged during policy remediation")
     require("VITE_PLAY_BUILD: 'true'" in android, "Play web bundle must compile out unqualified AI surfaces")
     require("vars.ANDROID_POLICY_HOLD == 'cleared'" in android, "Play promotion must require explicit policy clearance")
     require("Block direct production upload during policy remediation" in android, "direct Play production upload must remain blocked")


### PR DESCRIPTION
## Summary
- set `changesNotSentForReview: true` on Play uploads while policy remediation is active
- keep production promotion gated by `ANDROID_POLICY_HOLD=cleared`
- update the release workflow contract and runbook

## Evidence
Google rejected the internal upload with: `Changes cannot be sent for review automatically. Please set the query parameter changesNotSentForReview to true.`

## Validation
- `python3 scripts/check_release_workflows.py` — passed
- `git diff --check` — passed

## Rollout
After merge, rerun the Android internal upload. Submit the staged edit manually in Play Console only after verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)