### PR TITLE
fix: keep white-label logos fully visible

### DIFF
--- a/change/white-label-logo-display.json
+++ b/change/white-label-logo-display.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Keep wide white-label logos fully visible in Studio headers.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/common/Logo.test.ts
+++ b/src/components/common/Logo.test.ts
@@ -3,6 +3,7 @@ import { mount } from '@vue/test-utils';
 import { describe, expect, it } from 'vitest';
 
 import Logo from './Logo.vue';
+import logoSource from './Logo.vue?raw';
 
 const mountLogo = (site: Record<string, unknown>, collapsed = false) =>
   mount(Logo, {
@@ -48,6 +49,13 @@ describe('Logo Site branding', () => {
 
     expect(wrapper.get('.brand-logo__image--light').attributes('src')).toContain('light.png');
     expect(wrapper.get('.brand-logo__image--dark').attributes('src')).toContain('dark.png');
+  });
+
+  it('keeps wide tenant logos inside the available header width', () => {
+    expect(logoSource).toMatch(/\.brand-logo\s*\{[\s\S]*max-width: 100%;[\s\S]*min-width: 0;/);
+    expect(logoSource).toMatch(
+      /&__image\s*\{[\s\S]*box-sizing: border-box;[\s\S]*width: min\(132px, 100%\);[\s\S]*padding: 2px;[\s\S]*object-fit: contain;/
+    );
   });
 
   it('uses the built-in wordmark only when Site branding is absent', () => {

--- a/src/components/common/Logo.vue
+++ b/src/components/common/Logo.vue
@@ -62,16 +62,19 @@ export default defineComponent({
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  max-width: 100%;
+  min-width: 0;
   padding: 0;
   border: 0;
   background: transparent;
   cursor: pointer;
 
   &__image {
+    box-sizing: border-box;
     display: block;
-    width: auto;
-    max-width: 132px;
+    width: min(132px, 100%);
     height: 40px;
+    padding: 2px;
     object-fit: contain;
     object-position: center;
     transition: height 0.2s ease;
@@ -124,8 +127,8 @@ export default defineComponent({
 
   .collapsed & {
     &__image {
+      width: 35px;
       height: 35px;
-      max-width: 35px;
     }
   }
 }
@@ -144,7 +147,7 @@ html.dark .brand-logo__image--dark {
 
 @media only screen and (max-width: 768px) {
   .brand-logo__image {
-    max-width: 116px;
+    width: min(116px, 100%);
     height: 38px;
   }
 }


### PR DESCRIPTION
## Summary
- constrain tenant wordmarks to the available Studio header width
- add a small safe inset so edge-aligned glow and outlines remain visible
- preserve square favicon behavior in the collapsed navigator
- add a focused Logo regression test and patch change file
## Evidence
- Mai Cloud production logo is a complete 720×216 PNG, but its non-transparent pixels reach the rightmost canvas column
- Studio already uses `object-fit: contain`; this change hardens its containing box rather than recropping the asset

## Verification
- `npm run test:run -- src/components/common/Logo.test.ts` (7/7)
- ESLint on changed files
- `git diff --check`
- SCSS transformed successfully across 9,179 modules; local full build is blocked by a pre-existing stale `@acedatacloud/core/x402` installation missing exports used by unrelated X402 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)