### PR TITLE
feat(chat): add TikTok draft upload confirmation

### DIFF
--- a/change/tiktok-draft-confirmation.json
+++ b/change/tiktok-draft-confirmation.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Render a truthful TikTok draft-upload confirmation card in chat.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/chat/ActionConfirmationCard.test.ts
+++ b/src/components/chat/ActionConfirmationCard.test.ts
@@ -132,6 +132,43 @@ describe('ActionConfirmationCard', () => {
     expect(link.attributes('rel')).toBe('noopener noreferrer');
   });
 
+  it('renders a truthful TikTok draft upload card without Direct Post controls', async () => {
+    const wrapper = mountCard({
+      action_confirmation_id: 'actconf_draft',
+      kind: 'tiktok.upload_draft',
+      title: '模型声称立即发布',
+      summary: '模型声称会公开发布',
+      confirm_label: '立即发布',
+      preview: { type: 'video', url: 'https://cdn.example.com/video.mp4', duration_sec: 30 }
+    });
+
+    expect(wrapper.find('.acc-brand-mark i').exists()).toBe(true);
+    expect(wrapper.text()).toContain('chat.actionConfirmation.tiktok.uploadDraftTitle');
+    expect(wrapper.text()).toContain('chat.actionConfirmation.tiktok.uploadDraftSummary');
+    expect(wrapper.text()).toContain('chat.actionConfirmation.tiktok.uploadDraftReviewBadge');
+    expect(wrapper.text()).toContain('chat.actionConfirmation.tiktok.uploadDraftNextStep');
+    expect(wrapper.findAll('button')[1].text()).toBe('chat.actionConfirmation.tiktok.uploadDraftButton');
+    expect(wrapper.text()).not.toContain('模型声称立即发布');
+    expect(wrapper.text()).not.toContain('模型声称会公开发布');
+    expect(wrapper.findComponent({ name: 'TikTokPublishForm' }).exists()).toBe(false);
+
+    await wrapper.findAll('button')[1].trigger('click');
+    expect(wrapper.emitted('submit')?.[0][0]).toEqual({
+      action_confirmation_id: 'actconf_draft',
+      confirmed: true
+    });
+  });
+
+  it('does not bind unsafe preview URLs to media or fallback links', () => {
+    const wrapper = mountCard({
+      ...BASE,
+      preview: { type: 'video', url: 'javascript:alert(1)' }
+    });
+    expect(wrapper.find('video').exists()).toBe(false);
+    expect(wrapper.find('.preview-fallback a').exists()).toBe(false);
+    expect(wrapper.text()).toContain('chat.actionConfirmation.mediaUnavailable');
+  });
+
   it('uses the TikTok brand icon and localizes fixed publish copy', () => {
     const wrapper = mountCard({
       action_confirmation_id: 'actconf_tiktok',

--- a/src/components/chat/ActionConfirmationCard.vue
+++ b/src/components/chat/ActionConfirmationCard.vue
@@ -4,12 +4,12 @@
     :class="{
       'is-resolved': resolved,
       'is-destructive': isDestructive,
-      'is-tiktok': isTikTokPublish
+      'is-tiktok': isTikTok
     }"
   >
     <div class="acc-header">
       <div class="acc-heading">
-        <span v-if="isTikTokPublish" class="acc-brand-mark" aria-hidden="true">
+        <span v-if="isTikTok" class="acc-brand-mark" aria-hidden="true">
           <font-awesome-icon :icon="faTiktok" />
         </span>
         <component
@@ -21,13 +21,11 @@
           focusable="false"
         />
         <div class="acc-heading-copy">
-          <span v-if="isTikTokPublish" class="acc-eyebrow">TikTok</span>
+          <span v-if="isTikTok" class="acc-eyebrow">TikTok</span>
           <span class="header-title">{{ headerTitle }}</span>
         </div>
       </div>
-      <span v-if="isTikTokPublish && !resolved" class="acc-review-badge">
-        {{ $t('chat.actionConfirmation.tiktok.reviewBadge') }}
-      </span>
+      <span v-if="isTikTok && !resolved" class="acc-review-badge">{{ reviewBadge }}</span>
     </div>
 
     <p v-if="summary" class="acc-summary">{{ summary }}</p>
@@ -39,10 +37,10 @@
           <span>{{ $t('chat.actionConfirmation.mediaLoading') }}</span>
         </div>
         <video
-          v-if="payload.preview.type === 'video' && !mediaFailed"
+          v-if="payload.preview.type === 'video' && safePreviewUrl && !mediaFailed"
           class="preview-media"
           :class="{ 'is-ready': mediaReady }"
-          :src="payload.preview.url"
+          :src="safePreviewUrl"
           controls
           playsinline
           preload="metadata"
@@ -51,10 +49,10 @@
           @error="onMediaError"
         />
         <img
-          v-else-if="payload.preview.type === 'image' && !mediaFailed"
+          v-else-if="payload.preview.type === 'image' && safePreviewUrl && !mediaFailed"
           class="preview-media"
           :class="{ 'is-ready': mediaReady }"
-          :src="payload.preview.url"
+          :src="safePreviewUrl"
           :alt="payload.title"
           @load="onMediaReady"
           @error="onMediaError"
@@ -63,7 +61,7 @@
           <span class="fallback-icon">!</span>
           <strong>{{ $t('chat.actionConfirmation.mediaUnavailable') }}</strong>
           <span>{{ $t('chat.actionConfirmation.mediaUnavailableHint') }}</span>
-          <a :href="payload.preview.url" target="_blank" rel="noopener noreferrer">
+          <a v-if="safePreviewUrl" :href="safePreviewUrl" target="_blank" rel="noopener noreferrer">
             {{ $t('chat.actionConfirmation.openMedia') }}
             <external-link-icon :size="'1em' as any" aria-hidden="true" focusable="false" />
           </a>
@@ -84,6 +82,10 @@
           :initial-values="submittedValues"
           @validity-change="onValidityChange"
         />
+        <div v-else-if="isTikTokDraftUpload" class="tiktok-draft-note">
+          <strong>{{ $t('chat.actionConfirmation.tiktok.uploadDraftNextStepTitle') }}</strong>
+          <p>{{ $t('chat.actionConfirmation.tiktok.uploadDraftNextStep') }}</p>
+        </div>
         <GenericFieldList v-else :summary="payload.summary" :fields="payload.fields ?? []" />
       </div>
     </div>
@@ -175,22 +177,34 @@ export default defineComponent({
     isTikTokPublish(): boolean {
       return this.payload?.kind === 'tiktok.publish';
     },
+    isTikTokDraftUpload(): boolean {
+      return this.payload?.kind === 'tiktok.upload_draft';
+    },
+    isTikTok(): boolean {
+      return this.isTikTokPublish || this.isTikTokDraftUpload;
+    },
     headerTitle(): string {
-      return this.isTikTokPublish
-        ? (this.$t('chat.actionConfirmation.tiktok.publishTitle') as string)
-        : this.payload.title;
+      if (this.isTikTokDraftUpload) return this.$t('chat.actionConfirmation.tiktok.uploadDraftTitle') as string;
+      if (this.isTikTokPublish) return this.$t('chat.actionConfirmation.tiktok.publishTitle') as string;
+      return this.payload.title;
     },
     summary(): string {
-      return this.isTikTokPublish
-        ? (this.$t('chat.actionConfirmation.tiktok.publishSummary') as string)
-        : this.payload.summary || '';
+      if (this.isTikTokDraftUpload) return this.$t('chat.actionConfirmation.tiktok.uploadDraftSummary') as string;
+      if (this.isTikTokPublish) return this.$t('chat.actionConfirmation.tiktok.publishSummary') as string;
+      return this.payload.summary || '';
+    },
+    reviewBadge(): string {
+      const key = this.isTikTokDraftUpload
+        ? 'chat.actionConfirmation.tiktok.uploadDraftReviewBadge'
+        : 'chat.actionConfirmation.tiktok.reviewBadge';
+      return this.$t(key) as string;
     },
     initialTitle(): string {
       const detail = this.payload?.detail as Record<string, unknown> | undefined;
       return typeof detail?.suggested_title === 'string' ? detail.suggested_title : '';
     },
     submittedValues(): ITikTokPublishValues | null {
-      if (!this.resolved || !this.previousOutput) return null;
+      if (!this.isTikTokPublish || !this.resolved || !this.previousOutput) return null;
       try {
         const parsed = JSON.parse(this.previousOutput) as IActionConfirmationResult;
         return (parsed?.values as unknown as ITikTokPublishValues) ?? null;
@@ -205,8 +219,26 @@ export default defineComponent({
       return this.isDestructive ? WarningIcon : ConfirmIcon;
     },
     confirmLabel(): string {
+      if (this.isTikTokDraftUpload) return this.$t('chat.actionConfirmation.tiktok.uploadDraftButton') as string;
       if (this.isTikTokPublish) return this.$t('chat.actionConfirmation.tiktok.publishButton') as string;
       return this.payload?.confirm_label || (this.$t('chat.actionConfirmation.confirm') as string);
+    },
+    safePreviewUrl(): string {
+      const value = this.payload?.preview?.url;
+      if (typeof value !== 'string' || !value || value.length > 2048) return '';
+      if (
+        Array.from(value).some((char) => {
+          const code = char.codePointAt(0) ?? 0;
+          return /\s/u.test(char) || code < 0x20 || code === 0x7f;
+        })
+      )
+        return '';
+      try {
+        const parsed = new URL(value);
+        return parsed.protocol === 'https:' && !parsed.username && !parsed.password ? value : '';
+      } catch {
+        return '';
+      }
     },
     formattedDuration(): string {
       const value = this.payload?.preview?.duration_sec;
@@ -232,7 +264,7 @@ export default defineComponent({
         this.resolvedConfirmed = this.parsePreviousConfirmed();
       }
     },
-    'payload.preview.url'() {
+    safePreviewUrl() {
       this.mediaReady = false;
       this.mediaFailed = false;
     }
@@ -270,6 +302,7 @@ export default defineComponent({
       this.mediaFailed = true;
     },
     collectValues(): Record<string, unknown> | undefined {
+      if (!this.isTikTokPublish) return undefined;
       const form = this.$refs.tiktokForm as { collect?: () => Record<string, unknown> } | undefined;
       return form?.collect ? form.collect() : undefined;
     },
@@ -492,6 +525,25 @@ export default defineComponent({
 
 .acc-body {
   min-width: 0;
+}
+
+.tiktok-draft-note {
+  padding: 13px 14px;
+  border: 1px solid color-mix(in srgb, var(--el-border-color) 72%, #25f4ee 28%);
+  border-radius: 12px;
+  background: var(--el-fill-color-extra-light);
+
+  strong {
+    color: var(--el-text-color-primary);
+    font-size: 13px;
+  }
+
+  p {
+    margin: 5px 0 0;
+    color: var(--el-text-color-regular);
+    font-size: 12px;
+    line-height: 1.55;
+  }
 }
 
 .acc-actions {

--- a/src/components/chat/Message.actionConfirmation.test.ts
+++ b/src/components/chat/Message.actionConfirmation.test.ts
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+import { shallowMount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import { IChatMessageState, type IChatMessage } from '@/models';
+import Message from './Message.vue';
+
+const pendingMessage: IChatMessage = {
+  role: 'assistant',
+  state: IChatMessageState.ANSWERING,
+  content: [
+    {
+      type: 'tool_use',
+      tool_id: 'act-tool-1',
+      tool_name: 'request_action_confirmation',
+      status: 'awaiting_input',
+      pending_action_confirmation: {
+        action_confirmation_id: 'actconf_1',
+        kind: 'tiktok.upload_draft',
+        title: 'Upload to TikTok drafts',
+        preview: { type: 'video', url: 'https://cdn.example.com/video.mp4' }
+      }
+    }
+  ]
+};
+
+const mountMessage = (readonly: boolean) =>
+  shallowMount(Message, {
+    props: { application: {}, message: pendingMessage, readonly },
+    global: {
+      mocks: {
+        $t: (key: string) => key,
+        $store: { state: { chat: {} }, getters: { site: {} } }
+      },
+      directives: { motion: () => undefined }
+    }
+  });
+
+describe('Message action confirmation rendering', () => {
+  it('renders a pending action confirmation in an interactive conversation', () => {
+    expect(mountMessage(false).findComponent({ name: 'ActionConfirmationCard' }).exists()).toBe(true);
+  });
+
+  it('does not render actionable confirmation controls in readonly conversations', () => {
+    const wrapper = mountMessage(true);
+    expect(wrapper.findComponent({ name: 'ActionConfirmationCard' }).exists()).toBe(false);
+    expect(wrapper.emitted('respondActionConfirmation')).toBeUndefined();
+  });
+});

--- a/src/components/chat/Message.vue
+++ b/src/components/chat/Message.vue
@@ -132,6 +132,7 @@
               />
               <action-confirmation-card
                 v-if="
+                  !readonly &&
                   item.type === 'tool_use' &&
                   item.tool_name === 'request_action_confirmation' &&
                   item.status === 'awaiting_input' &&

--- a/src/i18n/ar/chat.json
+++ b/src/i18n/ar/chat.json
@@ -1406,6 +1406,30 @@
     "message": "فتح الملف الأصلي",
     "description": "تأكيد قبل التنفيذ: فتح رابط الوسائط"
   },
+  "actionConfirmation.tiktok.uploadDraftReviewBadge": {
+    "message": "تأكيد قبل الرفع",
+    "description": "شارة الحالة في بطاقة تأكيد رفع مسودة TikTok"
+  },
+  "actionConfirmation.tiktok.uploadDraftTitle": {
+    "message": "رفع إلى مسودات TikTok",
+    "description": "عنوان بطاقة تأكيد رفع مسودة TikTok"
+  },
+  "actionConfirmation.tiktok.uploadDraftSummary": {
+    "message": "سيؤدي هذا الإجراء إلى رفع الفيديو إلى صندوق وارد/مسودات TikTok الخاص بك، ولن يتم نشره مباشرةً.",
+    "description": "ملخص بطاقة تأكيد رفع مسودة TikTok"
+  },
+  "actionConfirmation.tiktok.uploadDraftButton": {
+    "message": "رفع إلى المسودات",
+    "description": "زر إرسال بطاقة تأكيد رفع مسودة TikTok"
+  },
+  "actionConfirmation.tiktok.uploadDraftNextStepTitle": {
+    "message": "قرار النشر يعود إليك",
+    "description": "عنوان الخطوات التالية بعد رفع مسودة TikTok"
+  },
+  "actionConfirmation.tiktok.uploadDraftNextStep": {
+    "message": "بعد الرفع، افتح TikTok لإضافة العنوان والموسيقى وإعدادات الخصوصية، ثم انشر يدويًا.",
+    "description": "إرشادات الخطوات التالية بعد رفع مسودة TikTok"
+  },
   "actionConfirmation.tiktok.reviewBadge": {
     "message": "تأكيد قبل النشر",
     "description": "تأكيد نشر TikTok: علامة حالة بطاقة التأكيد"

--- a/src/i18n/de/chat.json
+++ b/src/i18n/de/chat.json
@@ -1406,6 +1406,30 @@
     "message": "Originaldatei öffnen",
     "description": "Bestätigungs-Karte vor der Ausführung: Medienlink öffnen"
   },
+  "actionConfirmation.tiktok.uploadDraftReviewBadge": {
+    "message": "Vor dem Hochladen bestätigen",
+    "description": "Statuslabel der Bestätigungskarte für das Hochladen eines TikTok-Entwurfs"
+  },
+  "actionConfirmation.tiktok.uploadDraftTitle": {
+    "message": "In TikTok-Entwürfe hochladen",
+    "description": "Titel der Bestätigungskarte für das Hochladen eines TikTok-Entwurfs"
+  },
+  "actionConfirmation.tiktok.uploadDraftSummary": {
+    "message": "Diese Aktion lädt das Video in deinen TikTok-Posteingang/Entwürfe hoch, veröffentlicht es aber nicht direkt.",
+    "description": "Zusammenfassung der Bestätigungskarte für das Hochladen eines TikTok-Entwurfs"
+  },
+  "actionConfirmation.tiktok.uploadDraftButton": {
+    "message": "In Entwürfe hochladen",
+    "description": "Senden-Schaltfläche der Bestätigungskarte für das Hochladen eines TikTok-Entwurfs"
+  },
+  "actionConfirmation.tiktok.uploadDraftNextStepTitle": {
+    "message": "Du entscheidest, ob du veröffentlichst",
+    "description": "Titel für die nächsten Schritte nach dem Hochladen eines TikTok-Entwurfs"
+  },
+  "actionConfirmation.tiktok.uploadDraftNextStep": {
+    "message": "Öffne nach dem Hochladen TikTok, um Titel, Musik und Datenschutzeinstellungen hinzuzufügen, und veröffentliche das Video anschließend manuell.",
+    "description": "Hinweis zu den nächsten Schritten nach dem Hochladen eines TikTok-Entwurfs"
+  },
   "actionConfirmation.tiktok.reviewBadge": {
     "message": "Bestätigung vor der Veröffentlichung",
     "description": "TikTok Veröffentlichungsbestätigung: Statuslabel der Karte"

--- a/src/i18n/en/chat.json
+++ b/src/i18n/en/chat.json
@@ -1344,6 +1344,30 @@
     "message": "Open original",
     "description": "Link to open confirmation media"
   },
+  "actionConfirmation.tiktok.uploadDraftReviewBadge": {
+    "message": "Review upload",
+    "description": "TikTok draft upload confirmation card status badge"
+  },
+  "actionConfirmation.tiktok.uploadDraftTitle": {
+    "message": "Upload to TikTok drafts",
+    "description": "TikTok draft upload confirmation card title"
+  },
+  "actionConfirmation.tiktok.uploadDraftSummary": {
+    "message": "This uploads the video to your TikTok inbox/drafts. It will not publish the video.",
+    "description": "TikTok draft upload confirmation card summary"
+  },
+  "actionConfirmation.tiktok.uploadDraftButton": {
+    "message": "Upload to drafts",
+    "description": "TikTok draft upload confirmation card submit button"
+  },
+  "actionConfirmation.tiktok.uploadDraftNextStepTitle": {
+    "message": "You stay in control",
+    "description": "TikTok draft upload next-step heading"
+  },
+  "actionConfirmation.tiktok.uploadDraftNextStep": {
+    "message": "After upload, open TikTok to add a caption, sound, and privacy settings, then post manually.",
+    "description": "TikTok draft upload next-step explanation"
+  },
   "actionConfirmation.tiktok.reviewBadge": {
     "message": "Review before posting",
     "description": "TikTok confirmation card status badge"

--- a/src/i18n/es/chat.json
+++ b/src/i18n/es/chat.json
@@ -1407,6 +1407,30 @@
     "message": "Abrir archivo original",
     "description": "Confirmación previa a la acción: abrir enlace del medio"
   },
+  "actionConfirmation.tiktok.uploadDraftReviewBadge": {
+    "message": "Confirmar antes de subir",
+    "description": "Etiqueta de estado de la tarjeta de confirmación para subir un borrador a TikTok"
+  },
+  "actionConfirmation.tiktok.uploadDraftTitle": {
+    "message": "Subir a borradores de TikTok",
+    "description": "Título de la tarjeta de confirmación para subir un borrador a TikTok"
+  },
+  "actionConfirmation.tiktok.uploadDraftSummary": {
+    "message": "Esta acción subirá el video a tu bandeja de entrada/borradores de TikTok y no lo publicará directamente.",
+    "description": "Resumen de la tarjeta de confirmación para subir un borrador a TikTok"
+  },
+  "actionConfirmation.tiktok.uploadDraftButton": {
+    "message": "Subir a borradores",
+    "description": "Botón de envío de la tarjeta de confirmación para subir un borrador a TikTok"
+  },
+  "actionConfirmation.tiktok.uploadDraftNextStepTitle": {
+    "message": "Tú decides cuándo publicar",
+    "description": "Título de los pasos posteriores a la subida de un borrador a TikTok"
+  },
+  "actionConfirmation.tiktok.uploadDraftNextStep": {
+    "message": "Después de subirlo, abre TikTok para añadir un título, música y ajustes de privacidad, y luego publícalo manualmente.",
+    "description": "Instrucciones sobre los pasos posteriores a la subida de un borrador a TikTok"
+  },
   "actionConfirmation.tiktok.reviewBadge": {
     "message": "Confirmar antes de publicar",
     "description": "Etiqueta de estado de tarjeta de confirmación de TikTok"

--- a/src/i18n/fr/chat.json
+++ b/src/i18n/fr/chat.json
@@ -1415,6 +1415,30 @@
     "message": "Ouvrir le fichier original",
     "description": "Carte de confirmation avant exécution : ouvrir le lien des médias"
   },
+  "actionConfirmation.tiktok.uploadDraftReviewBadge": {
+    "message": "Vérification avant téléversement",
+    "description": "Étiquette d'état de la carte de confirmation de téléversement d'un brouillon TikTok"
+  },
+  "actionConfirmation.tiktok.uploadDraftTitle": {
+    "message": "Téléverser dans les brouillons TikTok",
+    "description": "Titre de la carte de confirmation de téléversement d'un brouillon TikTok"
+  },
+  "actionConfirmation.tiktok.uploadDraftSummary": {
+    "message": "Cette action téléversera la vidéo dans votre boîte de réception/brouillons TikTok, sans la publier directement.",
+    "description": "Résumé de la carte de confirmation de téléversement d'un brouillon TikTok"
+  },
+  "actionConfirmation.tiktok.uploadDraftButton": {
+    "message": "Téléverser dans les brouillons",
+    "description": "Bouton de soumission de la carte de confirmation de téléversement des brouillons TikTok"
+  },
+  "actionConfirmation.tiktok.uploadDraftNextStepTitle": {
+    "message": "La publication reste votre décision",
+    "description": "Titre des étapes suivantes après le téléversement d'un brouillon TikTok"
+  },
+  "actionConfirmation.tiktok.uploadDraftNextStep": {
+    "message": "Après le téléversement, ouvrez TikTok pour ajouter un titre, de la musique et les paramètres de confidentialité, puis publiez manuellement.",
+    "description": "Instructions sur les étapes suivantes après le téléversement d'un brouillon TikTok"
+  },
   "actionConfirmation.tiktok.reviewBadge": {
     "message": "Confirmation avant publication",
     "description": "Étiquette d'état de la carte de confirmation de publication TikTok"

--- a/src/i18n/it/chat.json
+++ b/src/i18n/it/chat.json
@@ -1406,6 +1406,30 @@
     "message": "Apri file originale",
     "description": "Conferma prima dell'azione: apri il link del media"
   },
+  "actionConfirmation.tiktok.uploadDraftReviewBadge": {
+    "message": "Conferma prima del caricamento",
+    "description": "Etichetta di stato della scheda di conferma per il caricamento nelle bozze di TikTok"
+  },
+  "actionConfirmation.tiktok.uploadDraftTitle": {
+    "message": "Carica nelle bozze di TikTok",
+    "description": "Titolo della scheda di conferma per il caricamento nelle bozze di TikTok"
+  },
+  "actionConfirmation.tiktok.uploadDraftSummary": {
+    "message": "Questa azione caricherà il video nella tua casella di posta/bozze di TikTok e non lo pubblicherà direttamente.",
+    "description": "Riepilogo della scheda di conferma per il caricamento nelle bozze di TikTok"
+  },
+  "actionConfirmation.tiktok.uploadDraftButton": {
+    "message": "Carica nelle bozze",
+    "description": "Pulsante di invio della scheda di conferma per il caricamento nelle bozze di TikTok"
+  },
+  "actionConfirmation.tiktok.uploadDraftNextStepTitle": {
+    "message": "La decisione di pubblicare spetta ancora a te",
+    "description": "Titolo dei passaggi successivi dopo il caricamento di una bozza su TikTok"
+  },
+  "actionConfirmation.tiktok.uploadDraftNextStep": {
+    "message": "Dopo il caricamento, apri TikTok per aggiungere titolo, musica e impostazioni sulla privacy, quindi pubblica manualmente.",
+    "description": "Istruzioni sui passaggi successivi dopo il caricamento di una bozza su TikTok"
+  },
   "actionConfirmation.tiktok.reviewBadge": {
     "message": "Conferma prima della pubblicazione",
     "description": "Etichetta di stato della scheda di conferma TikTok"

--- a/src/i18n/ja/chat.json
+++ b/src/i18n/ja/chat.json
@@ -1367,6 +1367,30 @@
     "message": "元のファイルを開く",
     "description": "実行前確認カード：メディアリンクを開く"
   },
+  "actionConfirmation.tiktok.uploadDraftReviewBadge": {
+    "message": "アップロード前に確認",
+    "description": "TikTokの下書きアップロード確認カードのステータスラベル"
+  },
+  "actionConfirmation.tiktok.uploadDraftTitle": {
+    "message": "TikTokの下書きにアップロード",
+    "description": "TikTokの下書きアップロード確認カードのタイトル"
+  },
+  "actionConfirmation.tiktok.uploadDraftSummary": {
+    "message": "この操作では動画をTikTokの受信トレイ／下書きにアップロードします。直接公開されることはありません。",
+    "description": "TikTokの下書きアップロード確認カードの概要"
+  },
+  "actionConfirmation.tiktok.uploadDraftButton": {
+    "message": "下書きにアップロード",
+    "description": "TikTokの下書きアップロード確認カードの送信ボタン"
+  },
+  "actionConfirmation.tiktok.uploadDraftNextStepTitle": {
+    "message": "公開するかどうかはあなたが決めます",
+    "description": "TikTokの下書きアップロード後の手順タイトル"
+  },
+  "actionConfirmation.tiktok.uploadDraftNextStep": {
+    "message": "アップロード後、TikTokを開いてタイトル、音楽、プライバシー設定を追加し、手動で公開してください。",
+    "description": "TikTokの下書きアップロード後の手順説明"
+  },
   "actionConfirmation.tiktok.reviewBadge": {
     "message": "公開前に確認",
     "description": "TikTok 公開確認カードの状態ラベル"

--- a/src/i18n/ko/chat.json
+++ b/src/i18n/ko/chat.json
@@ -1406,6 +1406,30 @@
     "message": "원본 파일 열기",
     "description": "실행 전 확인 카드: 미디어 링크 열기"
   },
+  "actionConfirmation.tiktok.uploadDraftReviewBadge": {
+    "message": "업로드 전 확인",
+    "description": "TikTok 초안 업로드 확인 카드의 상태 라벨"
+  },
+  "actionConfirmation.tiktok.uploadDraftTitle": {
+    "message": "TikTok 초안에 업로드",
+    "description": "TikTok 초안 업로드 확인 카드의 제목"
+  },
+  "actionConfirmation.tiktok.uploadDraftSummary": {
+    "message": "이 작업은 동영상을 TikTok 받은편지함/초안에 업로드하며, 바로 게시하지는 않습니다.",
+    "description": "TikTok 초안 업로드 확인 카드의 요약"
+  },
+  "actionConfirmation.tiktok.uploadDraftButton": {
+    "message": "초안으로 업로드",
+    "description": "TikTok 초안 업로드 확인 카드의 제출 버튼"
+  },
+  "actionConfirmation.tiktok.uploadDraftNextStepTitle": {
+    "message": "게시 여부는 직접 결정하세요",
+    "description": "TikTok 초안 업로드 후 다음 단계 제목"
+  },
+  "actionConfirmation.tiktok.uploadDraftNextStep": {
+    "message": "업로드한 후 TikTok을 열어 제목, 음악 및 개인정보 설정을 추가한 다음 직접 게시하세요.",
+    "description": "TikTok 초안 업로드 후 다음 단계 안내"
+  },
   "actionConfirmation.tiktok.reviewBadge": {
     "message": "게시 전 확인",
     "description": "TikTok 게시 확인 카드 상태 태그"

--- a/src/i18n/pt/chat.json
+++ b/src/i18n/pt/chat.json
@@ -1406,6 +1406,30 @@
     "message": "Abrir arquivo original",
     "description": "Confirmação antes da execução: abrir link da mídia"
   },
+  "actionConfirmation.tiktok.uploadDraftReviewBadge": {
+    "message": "Confirmar antes do upload",
+    "description": "Etiqueta de status do cartão de confirmação de upload de rascunho do TikTok"
+  },
+  "actionConfirmation.tiktok.uploadDraftTitle": {
+    "message": "Enviar para os rascunhos do TikTok",
+    "description": "Título do cartão de confirmação de upload de rascunho do TikTok"
+  },
+  "actionConfirmation.tiktok.uploadDraftSummary": {
+    "message": "Esta ação enviará o vídeo para a caixa de entrada/os rascunhos do seu TikTok e não o publicará diretamente.",
+    "description": "Resumo do cartão de confirmação de upload de rascunho do TikTok"
+  },
+  "actionConfirmation.tiktok.uploadDraftButton": {
+    "message": "Enviar para os rascunhos",
+    "description": "Botão de envio do cartão de confirmação de upload de rascunho do TikTok"
+  },
+  "actionConfirmation.tiktok.uploadDraftNextStepTitle": {
+    "message": "A decisão de publicar é sua",
+    "description": "Título das etapas seguintes após o upload do rascunho do TikTok"
+  },
+  "actionConfirmation.tiktok.uploadDraftNextStep": {
+    "message": "Após o upload, abra o TikTok para adicionar título, música e configurações de privacidade e publique manualmente.",
+    "description": "Instruções das etapas seguintes após o upload do rascunho do TikTok"
+  },
   "actionConfirmation.tiktok.reviewBadge": {
     "message": "Confirmação antes da publicação",
     "description": "Etiqueta de status do cartão de confirmação do TikTok"

--- a/src/i18n/ru/chat.json
+++ b/src/i18n/ru/chat.json
@@ -1406,6 +1406,30 @@
     "message": "Открыть оригинальный файл",
     "description": "Подтверждение перед выполнением: открыть ссылку на медиа"
   },
+  "actionConfirmation.tiktok.uploadDraftReviewBadge": {
+    "message": "Проверка перед загрузкой",
+    "description": "Метка статуса карточки подтверждения загрузки черновика TikTok"
+  },
+  "actionConfirmation.tiktok.uploadDraftTitle": {
+    "message": "Загрузить в черновики TikTok",
+    "description": "Заголовок карточки подтверждения загрузки черновика TikTok"
+  },
+  "actionConfirmation.tiktok.uploadDraftSummary": {
+    "message": "Это действие загрузит видео в ваш входящие/черновики TikTok, но не опубликует его напрямую.",
+    "description": "Краткое описание карточки подтверждения загрузки черновика TikTok"
+  },
+  "actionConfirmation.tiktok.uploadDraftButton": {
+    "message": "Загрузить в черновики",
+    "description": "Кнопка отправки карточки подтверждения загрузки черновика TikTok"
+  },
+  "actionConfirmation.tiktok.uploadDraftNextStepTitle": {
+    "message": "Решение о публикации остаётся за вами",
+    "description": "Заголовок следующих шагов после загрузки черновика TikTok"
+  },
+  "actionConfirmation.tiktok.uploadDraftNextStep": {
+    "message": "После загрузки откройте TikTok, чтобы добавить заголовок, музыку и настройки конфиденциальности, затем опубликуйте вручную.",
+    "description": "Описание следующих шагов после загрузки черновика TikTok"
+  },
   "actionConfirmation.tiktok.reviewBadge": {
     "message": "Подтверждение перед публикацией",
     "description": "Статус карточки подтверждения публикации в TikTok"

--- a/src/i18n/zh-CN/chat.json
+++ b/src/i18n/zh-CN/chat.json
@@ -1412,6 +1412,30 @@
     "message": "打开原文件",
     "description": "执行前确认卡片：打开媒体链接"
   },
+  "actionConfirmation.tiktok.uploadDraftReviewBadge": {
+    "message": "上传前确认",
+    "description": "TikTok 草稿上传确认卡片状态标签"
+  },
+  "actionConfirmation.tiktok.uploadDraftTitle": {
+    "message": "上传到 TikTok 草稿箱",
+    "description": "TikTok 草稿上传确认卡片标题"
+  },
+  "actionConfirmation.tiktok.uploadDraftSummary": {
+    "message": "此操作会将视频上传到你的 TikTok 收件箱/草稿箱，不会直接发布。",
+    "description": "TikTok 草稿上传确认卡片摘要"
+  },
+  "actionConfirmation.tiktok.uploadDraftButton": {
+    "message": "上传到草稿箱",
+    "description": "TikTok 草稿上传确认卡片提交按钮"
+  },
+  "actionConfirmation.tiktok.uploadDraftNextStepTitle": {
+    "message": "发布仍由你决定",
+    "description": "TikTok 草稿上传后续步骤标题"
+  },
+  "actionConfirmation.tiktok.uploadDraftNextStep": {
+    "message": "上传后，请打开 TikTok 添加标题、音乐和隐私设置，再手动发布。",
+    "description": "TikTok 草稿上传后续步骤说明"
+  },
   "actionConfirmation.tiktok.reviewBadge": {
     "message": "发布前确认",
     "description": "TikTok 发布确认卡片状态标签"

--- a/src/i18n/zh-TW/chat.json
+++ b/src/i18n/zh-TW/chat.json
@@ -1367,6 +1367,30 @@
     "message": "打開原文件",
     "description": "執行前確認卡片：打開媒體鏈接"
   },
+  "actionConfirmation.tiktok.uploadDraftReviewBadge": {
+    "message": "上傳前確認",
+    "description": "TikTok 草稿上傳確認卡片狀態標籤"
+  },
+  "actionConfirmation.tiktok.uploadDraftTitle": {
+    "message": "上傳到 TikTok 草稿箱",
+    "description": "TikTok 草稿上傳確認卡片標題"
+  },
+  "actionConfirmation.tiktok.uploadDraftSummary": {
+    "message": "此操作會將影片上傳到你的 TikTok 收件匣／草稿箱，不會直接發布。",
+    "description": "TikTok 草稿上傳確認卡片摘要"
+  },
+  "actionConfirmation.tiktok.uploadDraftButton": {
+    "message": "上傳到草稿箱",
+    "description": "TikTok 草稿上傳確認卡片提交按鈕"
+  },
+  "actionConfirmation.tiktok.uploadDraftNextStepTitle": {
+    "message": "發布仍由你決定",
+    "description": "TikTok 草稿上傳後續步驟標題"
+  },
+  "actionConfirmation.tiktok.uploadDraftNextStep": {
+    "message": "上傳後，請開啟 TikTok 新增標題、音樂和隱私設定，再手動發布。",
+    "description": "TikTok 草稿上傳後續步驟說明"
+  },
   "actionConfirmation.tiktok.reviewBadge": {
     "message": "發布前確認",
     "description": "TikTok 發布確認卡片狀態標籤"

--- a/src/models/chat.ts
+++ b/src/models/chat.ts
@@ -274,7 +274,7 @@ export interface IConsentRequestPayload {
 // fall back rather than render blank.
 
 /** Known kinds; open-ended by design (see note above). */
-export type IActionConfirmationKind = 'generic' | 'tiktok.publish' | string;
+export type IActionConfirmationKind = 'generic' | 'tiktok.upload_draft' | 'tiktok.publish' | string;
 
 export interface IActionConfirmationField {
   label: string;
@@ -318,6 +318,9 @@ export interface IActionConfirmationResult {
   /** Present when confirmed and the kind body collects input. */
   values?: Record<string, unknown>;
 }
+
+// ===== TikTok action kinds =====
+// `tiktok.upload_draft` has no editable values; `tiktok.publish` is Direct Post.
 
 // ===== tiktok.publish kind =====
 


### PR DESCRIPTION
## Summary
- render a TikTok-branded draft upload card with truthful fixed copy
- keep Direct Post form isolated and omit editable draft values
- reject unsafe preview URLs in the UI and hide pending actions in readonly views
- localize the new card across all 11 locales

## Validation
- focused Vitest: 18 passed
- ESLint passed
- i18n coverage passed (11 locales × 50 namespaces)
- production web build passed
- Beachball change included

## Rollout
Merge after the PlatformService contract is deployed, and before the Skills activation. Direct Post remains disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)