### PR TITLE
feat(chat): localize scheduled sales categories

### DIFF
--- a/change/scheduled-marketing-categories.json
+++ b/change/scheduled-marketing-categories.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Localize sales and customer scheduled-template categories and preserve category deep links.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/scheduledTemplates/ScheduledTemplateWizard.test.ts
+++ b/src/components/scheduledTemplates/ScheduledTemplateWizard.test.ts
@@ -37,11 +37,11 @@ const disabledTask = {
   updated_at: 1
 };
 
-const mountWizard = () =>
+const mountWizard = (translate: (key: string) => string = (key) => key) =>
   shallowMount(ScheduledTemplateWizard, {
     props: { modelValue: true, token: 'tok' },
     global: {
-      mocks: { $t: (key: string) => key },
+      mocks: { $t: translate },
       stubs: {
         BrowseConnectors: true,
         ElDialog: { template: '<div><slot /><slot name="footer" /></div>' },
@@ -53,6 +53,30 @@ const mountWizard = () =>
 
 describe('ScheduledTemplateWizard', () => {
   afterEach(() => vi.restoreAllMocks());
+
+  it('keeps backend categories dynamic and localizes known values with a slug fallback', async () => {
+    vi.spyOn(scheduledTasksOperator, 'listTemplates').mockResolvedValue({
+      items: [template],
+      categories: ['marketing', 'sales', 'customer', 'partner-ops']
+    });
+    const labels: Record<string, string> = {
+      'chat.scheduledTemplates.category.sales': 'Sales & leads',
+      'chat.scheduledTemplates.category.customer': 'Customer success'
+    };
+    const wrapper = mountWizard((key) => labels[key] ?? key);
+    const vm = wrapper.vm as unknown as {
+      categories: string[];
+      loadTemplates: () => Promise<void>;
+      categoryLabel: (category: string) => string;
+    };
+
+    await vm.loadTemplates();
+
+    expect(vm.categories).toEqual(['marketing', 'sales', 'customer', 'partner-ops']);
+    expect(vm.categoryLabel('sales')).toBe('Sales & leads');
+    expect(vm.categoryLabel('customer')).toBe('Customer success');
+    expect(vm.categoryLabel('partner-ops')).toBe('partner-ops');
+  });
 
   it('renders only the choose, configure, and connect steps', () => {
     const wrapper = mountWizard();

--- a/src/i18n/ar/chat.json
+++ b/src/i18n/ar/chat.json
@@ -1726,6 +1726,14 @@
     "message": "مساعد شخصي",
     "description": "نسخة مركز قوالب المهام المجدولة"
   },
+  "scheduledTemplates.category.sales": {
+    "message": "المبيعات والعملاء المحتملون",
+    "description": "نص مركز قوالب المهام المجدولة"
+  },
+  "scheduledTemplates.category.customer": {
+    "message": "إدارة العملاء",
+    "description": "نص مركز قوالب المهام المجدولة"
+  },
   "actionConfirmation.tiktok.music": {
     "message": "نشر يعني أنك توافق على \"تأكيد استخدام الموسيقى\" من TikTok",
     "description": "تأكيد نشر TikTok: بيان استخدام الموسيقى"

--- a/src/i18n/de/chat.json
+++ b/src/i18n/de/chat.json
@@ -1726,6 +1726,14 @@
     "message": "Persönlicher Assistent",
     "description": "Kopie des Vorlagenzentrums für geplante Aufgaben"
   },
+  "scheduledTemplates.category.sales": {
+    "message": "Vertrieb und Leads",
+    "description": "Text für das Vorlagenzentrum für geplante Aufgaben"
+  },
+  "scheduledTemplates.category.customer": {
+    "message": "Kundenmanagement",
+    "description": "Text für das Vorlagenzentrum für geplante Aufgaben"
+  },
   "actionConfirmation.tiktok.music": {
     "message": "Mit der Veröffentlichung stimmen Sie der TikTok „Musiknutzungsbestätigung“ zu",
     "description": "Bestätigungsfeld für TikTok: Erklärung zur Musiknutzung"

--- a/src/i18n/en/chat.json
+++ b/src/i18n/en/chat.json
@@ -1664,6 +1664,14 @@
     "message": "Personal assistant",
     "description": "Scheduled task template center copy"
   },
+  "scheduledTemplates.category.sales": {
+    "message": "Sales & leads",
+    "description": "Scheduled task template center copy"
+  },
+  "scheduledTemplates.category.customer": {
+    "message": "Customer success",
+    "description": "Scheduled task template center copy"
+  },
   "scheduledTemplates.previous": {
     "message": "Previous",
     "description": "Scheduled template wizard navigation and connection guidance"

--- a/src/i18n/es/chat.json
+++ b/src/i18n/es/chat.json
@@ -1727,6 +1727,14 @@
     "message": "Asistente personal",
     "description": "Texto del centro de plantillas de tareas programadas"
   },
+  "scheduledTemplates.category.sales": {
+    "message": "Ventas y leads",
+    "description": "Texto del centro de plantillas de tareas programadas"
+  },
+  "scheduledTemplates.category.customer": {
+    "message": "Gestión de clientes",
+    "description": "Texto del centro de plantillas de tareas programadas"
+  },
   "actionConfirmation.tiktok.music": {
     "message": "Publicar significa que aceptas el 'Acuerdo de uso de música' de TikTok",
     "description": "Confirmación de publicación de TikTok: declaración sobre el uso de música"

--- a/src/i18n/fr/chat.json
+++ b/src/i18n/fr/chat.json
@@ -1735,6 +1735,14 @@
     "message": "Assistant personnel",
     "description": "Copie du centre de modèles de tâches planifiées"
   },
+  "scheduledTemplates.category.sales": {
+    "message": "Ventes et prospects",
+    "description": "Texte du centre de modèles de tâches planifiées"
+  },
+  "scheduledTemplates.category.customer": {
+    "message": "Gestion des clients",
+    "description": "Texte du centre de modèles de tâches planifiées"
+  },
   "scheduledTemplates.previous": {
     "message": "Précédent",
     "description": "Navigation dans l'assistant de modèle programmé et conseils de connexion"

--- a/src/i18n/it/chat.json
+++ b/src/i18n/it/chat.json
@@ -1726,6 +1726,14 @@
     "message": "Assistente personale",
     "description": "Testo del centro modelli per attività programmate"
   },
+  "scheduledTemplates.category.sales": {
+    "message": "Vendite e lead",
+    "description": "Testo del centro modelli di attività pianificate"
+  },
+  "scheduledTemplates.category.customer": {
+    "message": "Gestione clienti",
+    "description": "Testo del centro modelli di attività pianificate"
+  },
   "actionConfirmation.tiktok.music": {
     "message": "Pubblicando, accetti la 'Conferma di utilizzo della musica' di TikTok",
     "description": "Conferma di pubblicazione TikTok: dichiarazione sull'uso della musica"

--- a/src/i18n/ja/chat.json
+++ b/src/i18n/ja/chat.json
@@ -1687,6 +1687,14 @@
     "message": "パーソナルアシスタント",
     "description": "スケジュールされたタスクテンプレートセンターのコピー"
   },
+  "scheduledTemplates.category.sales": {
+    "message": "販売・リード",
+    "description": "スケジュールタスクテンプレートセンターの文言"
+  },
+  "scheduledTemplates.category.customer": {
+    "message": "顧客運用",
+    "description": "スケジュールタスクテンプレートセンターの文言"
+  },
   "model.claudeOpus47": {
     "message": "claude-opus-4.7",
     "description": "サービスのモデル名、すなわち Claude Opus 4.7"

--- a/src/i18n/ko/chat.json
+++ b/src/i18n/ko/chat.json
@@ -1726,6 +1726,14 @@
     "message": "개인 비서",
     "description": "예약된 작업 템플릿 센터 복사"
   },
+  "scheduledTemplates.category.sales": {
+    "message": "영업 및 리드",
+    "description": "예약 작업 템플릿 센터 문구"
+  },
+  "scheduledTemplates.category.customer": {
+    "message": "고객 운영",
+    "description": "예약 작업 템플릿 센터 문구"
+  },
   "actionConfirmation.tiktok.music": {
     "message": "게시함으로써 TikTok의 '음악 사용 확인'에 동의합니다.",
     "description": "TikTok 게시 확인: 음악 사용 선언"

--- a/src/i18n/pt/chat.json
+++ b/src/i18n/pt/chat.json
@@ -1726,6 +1726,14 @@
     "message": "Assistente Pessoal",
     "description": "Cópia do centro de modelos de tarefas agendadas"
   },
+  "scheduledTemplates.category.sales": {
+    "message": "Vendas e Leads",
+    "description": "Texto da central de modelos de tarefas agendadas"
+  },
+  "scheduledTemplates.category.customer": {
+    "message": "Operações de Clientes",
+    "description": "Texto da central de modelos de tarefas agendadas"
+  },
   "actionConfirmation.tiktok.music": {
     "message": "Publicar significa que você concorda com a 'Confirmação de uso de música' do TikTok",
     "description": "Confirmação de publicação do TikTok: declaração de uso de música."

--- a/src/i18n/ru/chat.json
+++ b/src/i18n/ru/chat.json
@@ -1726,6 +1726,14 @@
     "message": "Личный помощник",
     "description": "Центр шаблонов запланированных задач"
   },
+  "scheduledTemplates.category.sales": {
+    "message": "Продажи и лиды",
+    "description": "Текст для центра шаблонов запланированных задач"
+  },
+  "scheduledTemplates.category.customer": {
+    "message": "Работа с клиентами",
+    "description": "Текст для центра шаблонов запланированных задач"
+  },
   "actionConfirmation.tiktok.music": {
     "message": "Публикация означает, что вы соглашаетесь с «Подтверждением использования музыки» TikTok",
     "description": "Заявление о использовании музыки в подтверждении публикации TikTok"

--- a/src/i18n/zh-CN/chat.json
+++ b/src/i18n/zh-CN/chat.json
@@ -1732,6 +1732,14 @@
     "message": "个人助理",
     "description": "Scheduled task template center copy"
   },
+  "scheduledTemplates.category.sales": {
+    "message": "销售与线索",
+    "description": "Scheduled task template center copy"
+  },
+  "scheduledTemplates.category.customer": {
+    "message": "客户运营",
+    "description": "Scheduled task template center copy"
+  },
   "scheduledTemplates.previous": {
     "message": "上一步",
     "description": "Scheduled template wizard navigation and connection guidance"

--- a/src/i18n/zh-TW/chat.json
+++ b/src/i18n/zh-TW/chat.json
@@ -1687,6 +1687,14 @@
     "message": "個人助理",
     "description": "排程任務模板中心的文字"
   },
+  "scheduledTemplates.category.sales": {
+    "message": "銷售與潛在客戶",
+    "description": "排程任務範本中心文案"
+  },
+  "scheduledTemplates.category.customer": {
+    "message": "客戶營運",
+    "description": "排程任務範本中心文案"
+  },
   "actionConfirmation.tiktok.music": {
     "message": "發布即表示您同意 TikTok 的《音樂使用確認》",
     "description": "TikTok 發布確認：音樂使用聲明"

--- a/src/pages/chat/ScheduledTasks.test.ts
+++ b/src/pages/chat/ScheduledTasks.test.ts
@@ -246,24 +246,27 @@ describe('chat/ScheduledTasks — local execution', () => {
 describe('chat/ScheduledTasks', () => {
   afterEach(() => vi.restoreAllMocks());
 
-  it('opens the template wizard automatically for a categorized deep link', async () => {
-    vi.spyOn(scheduledTasksOperator, 'listTasks').mockResolvedValue([]);
-    const wrapper = shallowMount(ScheduledTasks, {
-      global: {
-        stubs: { ScheduledTemplateWizard: true },
-        mocks: {
-          $t: (key: string) => key,
-          $te: () => false,
-          $route: { query: { template_category: 'marketing' } },
-          $store: { state: { chat: { credential: { token: 'tok' } }, site: { features: {} } } }
+  it.each(['marketing', 'sales', 'customer'])(
+    'opens the template wizard automatically for a %s category deep link',
+    async (category) => {
+      vi.spyOn(scheduledTasksOperator, 'listTasks').mockResolvedValue([]);
+      const wrapper = shallowMount(ScheduledTasks, {
+        global: {
+          stubs: { ScheduledTemplateWizard: true },
+          mocks: {
+            $t: (key: string) => key,
+            $te: () => false,
+            $route: { query: { template_category: category } },
+            $store: { state: { chat: { credential: { token: 'tok' } }, site: { features: {} } } }
+          }
         }
-      }
-    });
-    await flushPromises();
-    const vm = wrapper.vm as unknown as { showTemplateWizard: boolean; templateInitialCategory: string };
-    expect(vm.showTemplateWizard).toBe(true);
-    expect(vm.templateInitialCategory).toBe('marketing');
-  });
+      });
+      await flushPromises();
+      const vm = wrapper.vm as unknown as { showTemplateWizard: boolean; templateInitialCategory: string };
+      expect(vm.showTemplateWizard).toBe(true);
+      expect(vm.templateInitialCategory).toBe(category);
+    }
+  );
   describe('template activation', () => {
     const templateTask: IScheduledTask = {
       ...editedTask,


### PR DESCRIPTION
## Summary

- localize the new `sales` and `customer` scheduled-template categories across all supported Studio locales
- preserve the backend-driven category list and unknown-category fallback
- cover marketing, sales, and customer category deep links

Depends on https://github.com/AceDataCloud/PlatformService/pull/2302 for the new backend category slugs. This frontend change remains backward-compatible if it deploys first.

## Verification

- focused scheduled-template tests — 86 passed
- full unit suite — 265 files, 2018 tests passed
- i18n coverage — 11 locales × 50 namespaces passed with no English placeholders
- `npm run lint:check` — 0 errors, 2 existing warnings
- `npm run build` — passed
- `npx beachball check --branch origin/main` — passed
- Prettier and `git diff --check` — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)