### PR TITLE
fix(chat): load scheduled templates on deep links

### DIFF
--- a/change/scheduled-template-wizard-initial-load.json
+++ b/change/scheduled-template-wizard-initial-load.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Load scheduled templates after chat credentials become available on deep links.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/scheduledTemplates/ScheduledTemplateWizard.test.ts
+++ b/src/components/scheduledTemplates/ScheduledTemplateWizard.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { shallowMount } from '@vue/test-utils';
 import { ElMessage } from 'element-plus';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { scheduledTasksOperator } from '@/operators/scheduledTasks';
 import ScheduledTemplateWizard from './ScheduledTemplateWizard.vue';
@@ -37,9 +37,12 @@ const disabledTask = {
   updated_at: 1
 };
 
-const mountWizard = (translate: (key: string) => string = (key) => key) =>
+const mountWizard = (
+  translate: (key: string) => string = (key) => key,
+  props: { modelValue?: boolean; token?: string; initialCategory?: string } = {}
+) =>
   shallowMount(ScheduledTemplateWizard, {
-    props: { modelValue: true, token: 'tok' },
+    props: { modelValue: true, token: 'tok', ...props },
     global: {
       mocks: { $t: translate },
       stubs: {
@@ -52,7 +55,49 @@ const mountWizard = (translate: (key: string) => string = (key) => key) =>
   });
 
 describe('ScheduledTemplateWizard', () => {
+  beforeEach(() => {
+    vi.spyOn(scheduledTasksOperator, 'listTemplates').mockResolvedValue({ items: [], categories: [] });
+  });
   afterEach(() => vi.restoreAllMocks());
+
+  it('loads templates once when mounted open with an initial category', async () => {
+    const listTemplates = vi.mocked(scheduledTasksOperator.listTemplates);
+    mountWizard(undefined, { initialCategory: 'sales' });
+
+    await vi.waitFor(() => expect(listTemplates).toHaveBeenCalledTimes(1));
+    expect(listTemplates).toHaveBeenCalledWith('tok', { category: 'sales', query: '' });
+  });
+
+  it('does not load templates while closed', async () => {
+    const listTemplates = vi.mocked(scheduledTasksOperator.listTemplates);
+    mountWizard(undefined, { modelValue: false });
+
+    await Promise.resolve();
+    expect(listTemplates).not.toHaveBeenCalled();
+  });
+
+  it('loads after a token arrives while visible', async () => {
+    const listTemplates = vi.mocked(scheduledTasksOperator.listTemplates);
+    const wrapper = mountWizard(undefined, { token: '' });
+    expect(listTemplates).not.toHaveBeenCalled();
+
+    await wrapper.setProps({ token: 'later-token' });
+
+    await vi.waitFor(() => expect(listTemplates).toHaveBeenCalledTimes(1));
+    expect(listTemplates).toHaveBeenCalledWith('later-token', { category: '', query: '' });
+  });
+
+  it('does not repeat a successful initial load when reopened', async () => {
+    const listTemplates = vi.mocked(scheduledTasksOperator.listTemplates);
+    const wrapper = mountWizard();
+    await vi.waitFor(() => expect(listTemplates).toHaveBeenCalledTimes(1));
+
+    await wrapper.setProps({ modelValue: false });
+    await wrapper.setProps({ modelValue: true });
+    await Promise.resolve();
+
+    expect(listTemplates).toHaveBeenCalledTimes(1);
+  });
 
   it('keeps backend categories dynamic and localizes known values with a slug fallback', async () => {
     vi.spyOn(scheduledTasksOperator, 'listTemplates').mockResolvedValue({

--- a/src/components/scheduledTemplates/ScheduledTemplateWizard.vue
+++ b/src/components/scheduledTemplates/ScheduledTemplateWizard.vue
@@ -234,6 +234,7 @@ export default defineComponent({
       visible: this.modelValue,
       step: 0,
       loading: false,
+      templatesLoaded: false,
       working: false,
       templates: [] as IScheduledTaskTemplateDefinition[],
       categories: [] as string[],
@@ -261,13 +262,23 @@ export default defineComponent({
   watch: {
     modelValue(value: boolean) {
       this.visible = value;
-      if (value) void this.loadTemplates();
+      if (value) void this.ensureTemplatesLoaded();
+    },
+    token: {
+      immediate: true,
+      handler() {
+        void this.ensureTemplatesLoaded();
+      }
     },
     visible(value: boolean) {
       this.$emit('update:modelValue', value);
     }
   },
   methods: {
+    async ensureTemplatesLoaded() {
+      if (!this.visible || !this.token || this.loading || this.templatesLoaded) return;
+      await this.loadTemplates();
+    },
     async loadTemplates() {
       this.loading = true;
       try {
@@ -277,6 +288,7 @@ export default defineComponent({
         });
         this.templates = data.items;
         this.categories = data.categories;
+        this.templatesLoaded = true;
         if (this.selected) this.selected = data.items.find((item) => item.id === this.selected?.id) ?? this.selected;
       } catch {
         ElMessage.error(this.$t('chat.scheduledTemplates.loadError') as string);


### PR DESCRIPTION
Fixes wizard not loading templates when opened via deep link before chat credentials arrive.

## Changes
- Add `templatesLoaded` flag to prevent repeated initial loads
- Add `ensureTemplatesLoaded()` guard checking visibility, token, loading state
- Watch `token` to trigger load when it becomes available while visible
- Preserve existing category filter and search behavior

## Testing
- ✅ Loads once when mounted open with initial category
- ✅ Does not load while closed
- ✅ Loads after token arrives while visible  
- ✅ Does not repeat successful initial load when reopened
- ✅ Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)