### PR TITLE
fix(pricing): preserve fractional credit precision

### DIFF
--- a/change/seedream-pricing-precision.json
+++ b/change/seedream-pricing-precision.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Preserve exact fractional Credit prices in service pricing displays.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/utils/servicePricing.test.ts
+++ b/src/utils/servicePricing.test.ts
@@ -204,6 +204,7 @@ describe('formatCredits', () => {
     [0.00001, '<0.0001'],
     [0.005, '0.0050'],
     [0.14, '0.14'],
+    [0.255, '0.255'],
     [2, '2.00']
   ])('formats %s as %s', (value, expected) => {
     expect(formatCredits(value)).toBe(expected);

--- a/src/utils/servicePricing.ts
+++ b/src/utils/servicePricing.ts
@@ -130,7 +130,7 @@ function applyRemarkOverrides(conditions: PricingCondition[], remark: IServiceCo
 export function formatCredits(value: number): string {
   if (value > 0 && value < 0.0001) return '<0.0001';
   if (value < 0.01) return value.toFixed(4);
-  return value.toFixed(2);
+  return value.toFixed(4).replace(/0{1,2}$/, '');
 }
 
 export function normalizeServicePricing(rules: unknown): ServicePricingRow[] {


### PR DESCRIPTION
## Summary

- preserve up to four decimal places for fractional Credit prices while keeping at least two decimals
- display the Seedream 5.0 Pro layer price as 0.255 Credits instead of rounding it to 0.26
- retain existing formatting for values such as 0.14, 2.00, 0.0050, and values below 0.0001

## Context

The standard cost rows in https://github.com/AceDataCloud/PlatformBackend/pull/1735 allow the Studio pricing dialog to render explicit Seedream 5.0 Pro tiers without custom pricing metadata. The parser already retains the exact 0.255 amount; this change fixes only its final display formatting.

## Verification

- `npm run test:run` — 2,023 tests passed
- `npm run lint:check` — 0 errors, 2 pre-existing warnings
- `npm run build:web` — passed
- `npm run verify` — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)