### PR TITLE
feat(ace): 增加 Holder Center 与专属内容

### DIFF
--- a/change/ace-holder-center.json
+++ b/change/ace-holder-center.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add ACE Holder Center, holder-only showcases, and Operator applications",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   ],
   "scripts": {
     "dev": "vite --host",
+    "prebuild": "node --test scripts/check_ace_holder_center.mjs",
     "build": "npm run build:web",
     "build:web": "cross-env VITE_SURFACE=web vue-tsc -b && vite build",
     "build:android": "cross-env VITE_SURFACE=android vite build",

--- a/scripts/check_ace_holder_center.mjs
+++ b/scripts/check_ace_holder_center.mjs
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { test } from 'node:test';
+
+const read = (path) => readFileSync(new URL(`../${path}`, import.meta.url), 'utf8');
+
+test('holder center uses backend entitlement contracts', () => {
+  const page = read('src/pages/console/holder/Index.vue');
+  const operator = read('src/operators/ace.ts');
+  assert.match(page, /aceOperator\.summary\(\)/);
+  assert.match(page, /aceOperator\.operatorProfile\(\)/);
+  assert.match(page, /aceOperator\.applyOperator/);
+  assert.match(operator, /get\('\/coin-wallet\/summary\/'/);
+  assert.match(operator, /post\('\/ace-operator\/'/);
+  assert.match(operator, /patch\('\/ace-operator\/'/);
+});
+
+test('holder showcase requests are identity-scoped and separated on home', () => {
+  const showcase = read('src/operators/showcase.ts');
+  const home = read('src/pages/home/Index.vue');
+  assert.match(showcase, /store\.getters\.authenticated \? optionalHttpClient : publicClient/);
+  assert.match(showcase, /const key = `\$\{identity\}:/);
+  assert.match(home, /visibleHolderShowcases/);
+  assert.match(home, /minimumAceTier/);
+  assert.match(home, /coin\.holderLab\.title/);
+  assert.match(read('src/components/common/ShowcaseGrid.vue'), /item\.operator\.display_name/);
+});
+
+test('translation JSON mode names JSON in the user prompt', () => {
+  const translator = read('scripts/translate_i18n.py');
+  assert.match(translator, /user_prompt = "Translate this JSON object and return JSON only:/);
+});
+
+test('holder center is limited to the official site and native apps', () => {
+  const route = read('src/router/console.ts');
+  const sidePanel = read('src/components/console/SidePanel.vue');
+  const userCenter = read('src/components/user/Center.vue');
+  assert.match(route, /isMainOfficial\(\) \|\| isNative\(\)/);
+  assert.match(sidePanel, /isMainOfficial\(\) \|\| isNative\(\)/);
+  assert.match(userCenter, /this\.isMainOfficialHost \|\| this\.isNative/);
+});
+
+test('operator copy never promises featured placement', () => {
+  const zh = JSON.parse(read('src/i18n/zh-CN/coin.json'));
+  const en = JSON.parse(read('src/i18n/en/coin.json'));
+  assert.match(zh['operator.description'].message, /不保证 Featured/);
+  assert.match(en['operator.description'].message, /does not guarantee Featured/);
+});

--- a/scripts/translate_i18n.py
+++ b/scripts/translate_i18n.py
@@ -254,7 +254,7 @@ def translate_batch(
         }
 
     sys_prompt = SYSTEM_PROMPT_TEMPLATE.format(language=LANGUAGE_NAMES[locale])
-    user_prompt = json.dumps(payload_in, ensure_ascii=False)
+    user_prompt = "Translate this JSON object and return JSON only:\n" + json.dumps(payload_in, ensure_ascii=False)
 
     raw = chat_completion(
         api_key,

--- a/src/components/common/ShowcaseGrid.test.ts
+++ b/src/components/common/ShowcaseGrid.test.ts
@@ -82,6 +82,27 @@ describe('ShowcaseGrid', () => {
     expect(wrapper.find('.detail-trigger').exists()).toBe(false);
   });
 
+  it('shows only server-approved operator attribution', () => {
+    const operatorItems = [
+      {
+        ...items[0],
+        operator: { display_name: 'Studio Builder', bio: 'Curated workflows', featured: true }
+      },
+      items[1]
+    ];
+    vi.stubGlobal('matchMedia', () => ({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() }));
+    const wrapper = mount(ShowcaseGrid, {
+      props: { items: operatorItems },
+      global: {
+        stubs: { RouterLink: { props: ['to'], template: '<a class="router-link"><slot /></a>' } },
+        mocks: { $t: (key: string) => key }
+      }
+    });
+    expect(wrapper.findAll('.operator-attribution')).toHaveLength(1);
+    expect(wrapper.get('.operator-attribution').text()).toContain('Studio Builder');
+    expect(wrapper.get('.operator-featured').text()).toBe('coin.operator.featuredBadge');
+  });
+
   it('uses a native button to select a card for detail preview', async () => {
     const { wrapper } = mountGrid(false, true);
     const triggers = wrapper.findAll('button.detail-trigger');

--- a/src/components/common/ShowcaseGrid.vue
+++ b/src/components/common/ShowcaseGrid.vue
@@ -66,6 +66,10 @@
             {{ item.name }}
           </span>
           <strong>{{ item.title }}</strong>
+          <span v-if="item.operator" class="operator-attribution">
+            {{ item.operator.display_name }}
+            <span v-if="item.operator.featured" class="operator-featured">{{ $t('coin.operator.featuredBadge') }}</span>
+          </span>
           <p>{{ item.description }}</p>
           <router-link :to="{ name: item.routeName, query: { showcase: item.id } }" class="create-link">
             {{ $t('intro.home.showcase.createSimilar') }} <span aria-hidden="true">→</span>
@@ -415,6 +419,22 @@ defineExpose({ playingId, loadedMediaIds, startPreview, stopPreview, togglePrevi
     -webkit-box-orient: vertical;
     -webkit-line-clamp: 2;
   }
+}
+
+.operator-attribution {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 5px;
+  color: rgba(255, 255, 255, 0.82);
+  font-size: 11px;
+}
+
+.operator-featured {
+  padding: 2px 6px;
+  border: 1px solid rgba(255, 255, 255, 0.36);
+  border-radius: 999px;
+  font-weight: 700;
 }
 
 .capability {

--- a/src/components/console/SidePanel.vue
+++ b/src/components/console/SidePanel.vue
@@ -29,6 +29,7 @@
 import {
   ApplicationIcon,
   ConnectionIcon,
+  CreditsIcon,
   DesktopIcon,
   ExternalLinkIcon,
   HistoryIcon,
@@ -37,6 +38,7 @@ import {
 } from '@acedatacloud/core/icons/components';
 import { defineComponent, type Component } from 'vue';
 import {
+  ROUTE_CONSOLE_ACE_HOLDER,
   ROUTE_CONSOLE_APPLICATION_LIST,
   ROUTE_CONSOLE_BROWSER_DEVICES,
   ROUTE_CONSOLE_CONNECTORS,
@@ -45,7 +47,8 @@ import {
   ROUTE_CONSOLE_USAGE_LIST,
   ROUTE_INDEX
 } from '@/router';
-import { isOfficial } from '@/utils';
+import { isMainOfficial } from '@/utils';
+import { isNative } from '@/utils/surface';
 
 interface ILink {
   key: string;
@@ -62,8 +65,8 @@ export default defineComponent({
     ExternalLinkIcon
   },
   computed: {
-    isOfficial() {
-      return isOfficial();
+    showAceHolder() {
+      return isMainOfficial() || isNative();
     },
     active() {
       return this.$route.matched[0].path;
@@ -110,6 +113,15 @@ export default defineComponent({
           icon: DesktopIcon
         }
       ];
+
+      if (this.showAceHolder) {
+        links.splice(5, 0, {
+          key: 'ace-holder',
+          text: this.$t('coin.holderCenter.nav'),
+          name: ROUTE_CONSOLE_ACE_HOLDER,
+          icon: CreditsIcon
+        });
+      }
 
       // Order history stays visible on iOS — purchases now happen in-app via
       // Apple IAP, so users should see their orders.

--- a/src/components/user/Center.vue
+++ b/src/components/user/Center.vue
@@ -20,6 +20,10 @@
             <settings-icon class="mr-2" :size="'1em' as any" aria-hidden="true" focusable="false" />
             {{ $t('common.nav.setting') }}
           </el-dropdown-item>
+          <el-dropdown-item v-if="authenticated && showAceHolder" class="py-2" @click="onHolder">
+            <credits-icon class="mr-2" :size="'1em' as any" aria-hidden="true" focusable="false" />
+            {{ $t('coin.holderCenter.nav') }}
+          </el-dropdown-item>
           <el-dropdown-item class="py-2" @click="onDistribution">
             <credits-icon class="mr-2" :size="'1em' as any" aria-hidden="true" focusable="false" />
             {{ $t('common.nav.distribution') }}
@@ -59,7 +63,7 @@ import { defineComponent } from 'vue';
 import UserAvatar from '@/components/user/Avatar.vue';
 import UserSetting from '@/components/user/Setting.vue';
 import DeleteAccountDialog from '@/components/user/DeleteAccountDialog.vue';
-import { ROUTE_CONSOLE_ROOT, ROUTE_DISTRIBUTION_INDEX, ROUTE_DOWNLOAD } from '@/router';
+import { ROUTE_CONSOLE_ACE_HOLDER, ROUTE_CONSOLE_ROOT, ROUTE_DISTRIBUTION_INDEX, ROUTE_DOWNLOAD } from '@/router';
 import { isIOS as isIOSSurface, isNative as isNativeSurface } from '@/utils/surface';
 import { isMainOfficial } from '@/utils';
 import { ElDivider } from 'element-plus';
@@ -105,6 +109,9 @@ export default defineComponent({
     isMainOfficialHost() {
       return isMainOfficial();
     },
+    showAceHolder() {
+      return this.isMainOfficialHost || this.isNative;
+    },
     isIOS() {
       return isIOSSurface();
     }
@@ -148,6 +155,9 @@ export default defineComponent({
     },
     onConsole() {
       this.$router.push({ name: ROUTE_CONSOLE_ROOT });
+    },
+    onHolder() {
+      this.$router.push({ name: ROUTE_CONSOLE_ACE_HOLDER });
     },
     onDistribution() {
       this.$router.push({

--- a/src/i18n/ar/coin.json
+++ b/src/i18n/ar/coin.json
@@ -6,5 +6,209 @@
   "message.connectError": {
     "message": "فشل في الاتصال بالمحفظة.",
     "description": "رسالة الخطأ المعروضة عند فشل الاتصال بالمحفظة."
+  },
+  "holderCenter.nav": {
+    "message": "ACE Holder",
+    "description": "Navigation label for the ACE holder center."
+  },
+  "holderCenter.eyebrow": {
+    "message": "مزايا حاملي ACE",
+    "description": "تسمية رأس صفحة مركز المزايا."
+  },
+  "holderCenter.title": {
+    "message": "مزايا حامل ACE الخاصة بك",
+    "description": "العنوان الرئيسي لمركز المزايا."
+  },
+  "holderCenter.description": {
+    "message": "اطّلع على مستواك الحالي، والمزايا المُفعّلة، والمحتوى الحصري، وحالة طلب Operator.",
+    "description": "وصف مركز المزايا."
+  },
+  "holderCenter.manageWallet": {
+    "message": "إدارة محفظة التحقق",
+    "description": "زر للانتقال إلى صفحة محفظة المزايا على المنصة."
+  },
+  "holderCenter.connectPrompt": {
+    "message": "يرجى الانتقال أولًا إلى API Platform لربط محفظة Solana التي تحتوي على ACE والتحقق منها.",
+    "description": "تنبيه بشأن عدم ربط المحفظة."
+  },
+  "holderCenter.currentTier": {
+    "message": "المستوى الحالي",
+    "description": "تسمية مستوى ACE الحالي."
+  },
+  "holderCenter.holder": {
+    "message": "مزايا حامل ACE سارية",
+    "description": "حالة من بلغ حد حيازة التوكنات."
+  },
+  "holderCenter.notQualified": {
+    "message": "لم تبلغ حد 100,000 ACE بعد",
+    "description": "حالة من لم يبلغ المستوى الأول بعد."
+  },
+  "holderCenter.toNext": {
+    "message": "متبقي {amount} ACE للوصول إلى {tier}",
+    "description": "وصف التقدم نحو المستوى التالي."
+  },
+  "holderCenter.maxTier": {
+    "message": "لقد بلغت أعلى مستوى.",
+    "description": "تنبيه بلوغ أعلى مستوى."
+  },
+  "holderCenter.monthlySavings": {
+    "message": "التوفير في API هذا الشهر",
+    "description": "تسمية التوفير الشهري في Credits."
+  },
+  "holderCenter.benefitsEyebrow": {
+    "message": "مزايا تم التحقق منها",
+    "description": "تسمية قائمة المزايا."
+  },
+  "holderCenter.benefits": {
+    "message": "المزايا المتاحة حاليًا",
+    "description": "عنوان قائمة المزايا."
+  },
+  "holderCenter.loadError": {
+    "message": "تعذّر تحميل مزايا ACE. يرجى المحاولة مرة أخرى لاحقًا.",
+    "description": "فشل تحميل مركز المزايا."
+  },
+  "holderLab.eyebrow": {
+    "message": "Holder Lab",
+    "description": "Holder-only showcase eyebrow."
+  },
+  "holderLab.title": {
+    "message": "إلهام حصري لحاملي ACE",
+    "description": "عنوان Showcase الحصري لحاملي ACE."
+  },
+  "holderLab.description": {
+    "message": "قوالب وسير عمل مختارة متاحة للمستوى الحالي.",
+    "description": "وصف Showcase الحصري لحاملي ACE."
+  },
+  "benefitStatus.active": {
+    "message": "سارية",
+    "description": "حالة سريان الميزة."
+  },
+  "benefitStatus.eligible": {
+    "message": "متاحة للاستخدام",
+    "description": "حالة إتاحة الميزة للاستخدام."
+  },
+  "benefitStatus.coming_soon": {
+    "message": "قريبًا",
+    "description": "حالة ميزة ستتاح قريبًا."
+  },
+  "benefitStatus.locked": {
+    "message": "غير مُفعّلة",
+    "description": "حالة الميزة غير المُفعّلة."
+  },
+  "benefit.api_discount.title": {
+    "message": "خصم على استدعاءات API",
+    "description": "عنوان ميزة خصم ACE API."
+  },
+  "benefit.api_discount.description": {
+    "message": "يُطبَّق الخصم الساري تلقائيًا على واجهات Credits API المدعومة واستدعاءات x402 التي يمكنها تحديد هوية الحساب.",
+    "description": "شرح ميزة خصم ACE API."
+  },
+  "benefit.early_access.title": {
+    "message": "الوصول المبكر",
+    "description": "عنوان ميزة الوصول المبكر من ACE."
+  },
+  "benefit.early_access.description": {
+    "message": "يمكن تجربة نماذج وميزات محددة قبل إتاحتها رسميًا بـ72 ساعة.",
+    "description": "شرح ميزة الوصول المبكر من ACE."
+  },
+  "benefit.referral_bonus.title": {
+    "message": "زيادة عمولة الإحالة",
+    "description": "عنوان مكافأة الإحالة الإضافية من ACE."
+  },
+  "benefit.referral_bonus.description": {
+    "message": "إضافة نقاط مئوية إلى نسبة الإحالة الأساسية بناءً على حيازة التوكنات، لتصل النسبة النهائية إلى 30% كحد أقصى.",
+    "description": "شرح مكافأة الإحالة الإضافية من ACE."
+  },
+  "benefit.nexior_holder_lab.title": {
+    "message": "Holder Lab",
+    "description": "Nexior Holder Lab benefit title."
+  },
+  "benefit.nexior_holder_lab.description": {
+    "message": "الوصول إلى القوالب ومسارات العمل والميزات المختارة لحاملي Holder.",
+    "description": "شرح ميزة Nexior Holder Lab."
+  },
+  "benefit.ace_operator.title": {
+    "message": "ACE Operator",
+    "description": "ACE Operator benefit title."
+  },
+  "benefit.ace_operator.description": {
+    "message": "يمكن التقديم بدءًا من المستوى 4؛ ولا يزال العرض العام وFeatured يتطلبان المراجعة.",
+    "description": "شرح ميزة ACE Operator."
+  },
+  "operator.eyebrow": {
+    "message": "Operator",
+    "description": "Operator section eyebrow."
+  },
+  "operator.title": {
+    "message": "التقدم بطلب ACE Operator",
+    "description": "عنوان قسم Operator."
+  },
+  "operator.description": {
+    "message": "أرسل نبذتك العامة للمراجعة. يمنح امتلاك العملات أهلية التقديم فقط، ولا يضمن الظهور ضمن Featured أو الحصول على انتشار.",
+    "description": "وصف طلب Operator."
+  },
+  "operator.tierRequired": {
+    "message": "يمكنك التقدم بطلب ACE Operator بعد الوصول إلى Tier 4.",
+    "description": "إشعار بمتطلبات مستوى Operator."
+  },
+  "operator.displayName": {
+    "message": "الاسم العام",
+    "description": "حقل الاسم العام لـ Operator."
+  },
+  "operator.bio": {
+    "message": "النبذة العامة",
+    "description": "حقل النبذة العامة لـ Operator."
+  },
+  "operator.public": {
+    "message": "عرض الملف علنًا بعد اجتياز المراجعة",
+    "description": "وصف مفتاح العرض العام لـ Operator."
+  },
+  "operator.apply": {
+    "message": "إرسال الطلب",
+    "description": "زر إرسال طلب Operator."
+  },
+  "operator.save": {
+    "message": "حفظ الملف",
+    "description": "زر حفظ ملف Operator."
+  },
+  "operator.applied": {
+    "message": "تم إرسال الطلب، وهو في انتظار المراجعة.",
+    "description": "إشعار بنجاح تقديم طلب Operator."
+  },
+  "operator.saved": {
+    "message": "تم حفظ ملف Operator.",
+    "description": "إشعار بنجاح حفظ Operator."
+  },
+  "operator.saveError": {
+    "message": "تعذر حفظ ملف Operator، يرجى المحاولة لاحقًا.",
+    "description": "إشعار بفشل حفظ Operator."
+  },
+  "operator.nameRequired": {
+    "message": "يرجى إدخال اسم عام.",
+    "description": "إشعار يفيد بأن اسم Operator فارغ."
+  },
+  "operator.featuredEligible": {
+    "message": "يمكن لمستواك الحالي المشاركة في مراجعة Featured",
+    "description": "إشعار أهلية الترشح لـ Featured."
+  },
+  "operator.featured": {
+    "message": "تم تعيينه Featured من قِبل المنصة",
+    "description": "حالة مراجعة Featured المكتملة."
+  },
+  "operator.featuredBadge": {
+    "message": "مميّز",
+    "description": "شارة «مميّز» التي تمّت مراجعتها والمُستخدمة في بطاقة Showcase."
+  },
+  "operator.status.pending": {
+    "message": "قيد المراجعة",
+    "description": "حالة Operator قيد المراجعة."
+  },
+  "operator.status.approved": {
+    "message": "تمت الموافقة",
+    "description": "حالة اجتياز مراجعة Operator."
+  },
+  "operator.status.suspended": {
+    "message": "متوقف مؤقتًا",
+    "description": "حالة إيقاف Operator مؤقتًا."
   }
 }

--- a/src/i18n/de/coin.json
+++ b/src/i18n/de/coin.json
@@ -6,5 +6,209 @@
   "message.connectError": {
     "message": "Fehler beim Verbinden der Brieftasche.",
     "description": "Fehlermeldung, die angezeigt wird, wenn die Verbindung zur Brieftasche fehlschlägt."
+  },
+  "holderCenter.nav": {
+    "message": "ACE Holder",
+    "description": "Navigation label for the ACE holder center."
+  },
+  "holderCenter.eyebrow": {
+    "message": "ACE-Holder-Vorteile",
+    "description": "Label im Kopfbereich der Vorteilscenter-Seite."
+  },
+  "holderCenter.title": {
+    "message": "Deine ACE-Holder-Vorteile",
+    "description": "Haupttitel des Vorteilscenters."
+  },
+  "holderCenter.description": {
+    "message": "Sieh dir dein aktuelles Tier, freigeschaltete Vorteile, exklusive Inhalte und den Status deines Operator-Antrags an.",
+    "description": "Beschreibung des Vorteilscenters."
+  },
+  "holderCenter.manageWallet": {
+    "message": "Verifiziertes Wallet verwalten",
+    "description": "Schaltfläche zur Vorteilsseite für Wallets auf der Plattform."
+  },
+  "holderCenter.connectPrompt": {
+    "message": "Bitte verbinde und verifiziere zuerst ein Solana-Wallet mit ACE-Bestand auf der API Platform.",
+    "description": "Hinweis für ein nicht verbundenes Wallet."
+  },
+  "holderCenter.currentTier": {
+    "message": "Aktuelles Tier",
+    "description": "Label für das aktuelle ACE-Tier."
+  },
+  "holderCenter.holder": {
+    "message": "ACE-Holder-Vorteile sind aktiv",
+    "description": "Status für das Erreichen der erforderlichen Token-Menge."
+  },
+  "holderCenter.notQualified": {
+    "message": "Die Schwelle von 100.000 ACE ist noch nicht erreicht",
+    "description": "Status bei Nichterreichen der ersten Stufe."
+  },
+  "holderCenter.toNext": {
+    "message": "Noch {amount} ACE bis {tier}",
+    "description": "Fortschrittsanzeige bis zur nächsten Stufe."
+  },
+  "holderCenter.maxTier": {
+    "message": "Höchstes Tier erreicht.",
+    "description": "Hinweis zum Erreichen des höchsten Tiers."
+  },
+  "holderCenter.monthlySavings": {
+    "message": "Diesen Monat bei der API gespart",
+    "description": "Label für die monatlichen Einsparungen bei Credits."
+  },
+  "holderCenter.benefitsEyebrow": {
+    "message": "Verifizierte Vorteile",
+    "description": "Label der Vorteilsliste."
+  },
+  "holderCenter.benefits": {
+    "message": "Derzeit verfügbare Vorteile",
+    "description": "Titel der Vorteilsliste."
+  },
+  "holderCenter.loadError": {
+    "message": "ACE-Vorteile konnten nicht geladen werden. Bitte versuche es später erneut.",
+    "description": "Fehler beim Laden des Vorteilscenters."
+  },
+  "holderLab.eyebrow": {
+    "message": "Holder Lab",
+    "description": "Holder-only showcase eyebrow."
+  },
+  "holderLab.title": {
+    "message": "Exklusive Inspiration für ACE Holder",
+    "description": "Titel des exklusiven Holder-Showcase."
+  },
+  "holderLab.description": {
+    "message": "Ausgewählte Vorlagen und Workflows, die für die aktuelle Stufe verfügbar sind.",
+    "description": "Beschreibung des exklusiven Holder-Showcase."
+  },
+  "benefitStatus.active": {
+    "message": "Aktiv",
+    "description": "Status eines bereits aktivierten Vorteils."
+  },
+  "benefitStatus.eligible": {
+    "message": "Nutzbar",
+    "description": "Status eines nutzbaren Vorteils."
+  },
+  "benefitStatus.coming_soon": {
+    "message": "Demnächst verfügbar",
+    "description": "Status eines in Kürze verfügbaren Vorteils."
+  },
+  "benefitStatus.locked": {
+    "message": "Nicht freigeschaltet",
+    "description": "Status eines nicht freigeschalteten Vorteils."
+  },
+  "benefit.api_discount.title": {
+    "message": "API-Rabatt",
+    "description": "Titel des ACE-API-Rabattvorteils."
+  },
+  "benefit.api_discount.description": {
+    "message": "Für unterstützte Credits-API- und x402-Aufrufe mit erkennbarer Kontoidentität wird der gültige Rabatt automatisch angewendet.",
+    "description": "Beschreibung des ACE-API-Rabattvorteils."
+  },
+  "benefit.early_access.title": {
+    "message": "Früher Zugriff",
+    "description": "Titel des ACE-Vorteils für frühen Zugriff."
+  },
+  "benefit.early_access.description": {
+    "message": "Ausgewählte Modelle und Funktionen können 72 Stunden vor der offiziellen Freigabe getestet werden.",
+    "description": "Beschreibung des ACE-Vorteils für frühen Zugriff."
+  },
+  "benefit.referral_bonus.title": {
+    "message": "Empfehlungsprovisionsbonus",
+    "description": "Titel des ACE-Empfehlungsbonus."
+  },
+  "benefit.referral_bonus.description": {
+    "message": "Zusätzliche Prozentpunkte auf die Basis-Empfehlungsrate durch das Halten von Tokens; die endgültige Rate beträgt höchstens 30 %.",
+    "description": "Beschreibung des ACE-Empfehlungsbonus."
+  },
+  "benefit.nexior_holder_lab.title": {
+    "message": "Holder Lab",
+    "description": "Nexior Holder Lab benefit title."
+  },
+  "benefit.nexior_holder_lab.description": {
+    "message": "Zugriff auf für Holder kuratierte Vorlagen, Workflows und Funktionen.",
+    "description": "Beschreibung des Vorteils von Nexior Holder Lab."
+  },
+  "benefit.ace_operator.title": {
+    "message": "ACE Operator",
+    "description": "ACE Operator benefit title."
+  },
+  "benefit.ace_operator.description": {
+    "message": "Ab Tier 4 kann ein Antrag gestellt werden; die öffentliche Anzeige und Featured erfordern weiterhin eine Prüfung.",
+    "description": "Beschreibung des ACE-Operator-Vorteils."
+  },
+  "operator.eyebrow": {
+    "message": "Operator",
+    "description": "Operator section eyebrow."
+  },
+  "operator.title": {
+    "message": "Als ACE Operator bewerben",
+    "description": "Titel des Operator-Bereichs."
+  },
+  "operator.description": {
+    "message": "Reiche deine öffentliche Vorstellung zur Prüfung ein. Das Halten von ACE berechtigt nur zur Antragstellung und garantiert weder eine Aufnahme als Featured noch zusätzliche Sichtbarkeit.",
+    "description": "Beschreibung des Operator-Antrags."
+  },
+  "operator.tierRequired": {
+    "message": "Ab Tier 4 kannst du dich als ACE Operator bewerben.",
+    "description": "Hinweis zur erforderlichen Operator-Stufe."
+  },
+  "operator.displayName": {
+    "message": "Öffentlicher Name",
+    "description": "Feld für den öffentlichen Namen des Operators."
+  },
+  "operator.bio": {
+    "message": "Öffentliche Vorstellung",
+    "description": "Feld für die öffentliche Vorstellung des Operators."
+  },
+  "operator.public": {
+    "message": "Profil nach erfolgreicher Prüfung öffentlich anzeigen",
+    "description": "Beschreibung des Schalters für die öffentliche Anzeige des Operators."
+  },
+  "operator.apply": {
+    "message": "Antrag einreichen",
+    "description": "Schaltfläche zum Einreichen des Operator-Antrags."
+  },
+  "operator.save": {
+    "message": "Profil speichern",
+    "description": "Schaltfläche zum Speichern des Operator-Profils."
+  },
+  "operator.applied": {
+    "message": "Antrag eingereicht. Warten auf Prüfung.",
+    "description": "Erfolgsmeldung für den Operator-Antrag."
+  },
+  "operator.saved": {
+    "message": "Das Operator-Profil wurde gespeichert.",
+    "description": "Erfolgsmeldung beim Speichern des Operators."
+  },
+  "operator.saveError": {
+    "message": "Das Operator-Profil konnte nicht gespeichert werden. Bitte versuche es später erneut.",
+    "description": "Fehlermeldung beim Speichern des Operators."
+  },
+  "operator.nameRequired": {
+    "message": "Bitte gib einen öffentlichen Namen ein.",
+    "description": "Hinweis, wenn der Operator-Name leer ist."
+  },
+  "operator.featuredEligible": {
+    "message": "Die aktuelle Stufe berechtigt zur Teilnahme an der Featured-Prüfung",
+    "description": "Hinweis zur Featured-Kandidatur."
+  },
+  "operator.featured": {
+    "message": "Von der Plattform als Featured ausgewählt",
+    "description": "Status nach erfolgreicher Featured-Prüfung."
+  },
+  "operator.featuredBadge": {
+    "message": "Hervorgehoben",
+    "description": "Geprüftes „Hervorgehoben“-Label in der Showcase-Karte."
+  },
+  "operator.status.pending": {
+    "message": "Ausstehende Prüfung",
+    "description": "Status eines Operators, dessen Antrag noch geprüft wird."
+  },
+  "operator.status.approved": {
+    "message": "Genehmigt",
+    "description": "Status eines genehmigten Operator-Antrags."
+  },
+  "operator.status.suspended": {
+    "message": "Pausiert",
+    "description": "Status eines pausierten Operators."
   }
 }

--- a/src/i18n/en/coin.json
+++ b/src/i18n/en/coin.json
@@ -5,6 +5,210 @@
   },
   "message.connectError": {
     "message": "Wallet connection failed.",
-    "description": "Error message displayed when the wallet connection fails."
+    "description": "Error message displayed when wallet connection fails."
+  },
+  "holderCenter.nav": {
+    "message": "ACE Holder",
+    "description": "Navigation label for the ACE holder center."
+  },
+  "holderCenter.eyebrow": {
+    "message": "ACE holder benefits",
+    "description": "Eyebrow for the holder center."
+  },
+  "holderCenter.title": {
+    "message": "Your ACE Holder Benefits",
+    "description": "Main title for the holder center."
+  },
+  "holderCenter.description": {
+    "message": "See your tier, active benefits, holder content, and Operator application status.",
+    "description": "Holder center description."
+  },
+  "holderCenter.manageWallet": {
+    "message": "Manage Verified Wallet",
+    "description": "Link to the platform wallet benefits page."
+  },
+  "holderCenter.connectPrompt": {
+    "message": "Connect and verify the Solana wallet holding ACE in API Platform first.",
+    "description": "Prompt shown when no wallet is bound."
+  },
+  "holderCenter.currentTier": {
+    "message": "Current tier",
+    "description": "Current ACE tier label."
+  },
+  "holderCenter.holder": {
+    "message": "ACE Holder benefits are active",
+    "description": "State shown when the holder threshold is met."
+  },
+  "holderCenter.notQualified": {
+    "message": "The 100,000 ACE threshold has not been reached",
+    "description": "State shown below the first tier."
+  },
+  "holderCenter.toNext": {
+    "message": "Hold {amount} more ACE to reach {tier}",
+    "description": "Progress toward the next tier."
+  },
+  "holderCenter.maxTier": {
+    "message": "You have reached the highest tier.",
+    "description": "Highest tier message."
+  },
+  "holderCenter.monthlySavings": {
+    "message": "API savings this month",
+    "description": "Monthly Credits savings label."
+  },
+  "holderCenter.benefitsEyebrow": {
+    "message": "Verified benefits",
+    "description": "Benefits section eyebrow."
+  },
+  "holderCenter.benefits": {
+    "message": "Benefits available now",
+    "description": "Benefits section title."
+  },
+  "holderCenter.loadError": {
+    "message": "ACE benefits could not be loaded. Try again later.",
+    "description": "Holder center load error."
+  },
+  "holderLab.eyebrow": {
+    "message": "Holder Lab",
+    "description": "Holder-only showcase eyebrow."
+  },
+  "holderLab.title": {
+    "message": "Ideas for ACE Holders",
+    "description": "Holder-only showcase title."
+  },
+  "holderLab.description": {
+    "message": "Curated templates and workflows available to your current tier.",
+    "description": "Holder-only showcase description."
+  },
+  "benefitStatus.active": {
+    "message": "Active",
+    "description": "Active benefit status."
+  },
+  "benefitStatus.eligible": {
+    "message": "Available",
+    "description": "Eligible benefit status."
+  },
+  "benefitStatus.coming_soon": {
+    "message": "Coming soon",
+    "description": "Upcoming benefit status."
+  },
+  "benefitStatus.locked": {
+    "message": "Locked",
+    "description": "Locked benefit status."
+  },
+  "benefit.api_discount.title": {
+    "message": "API usage discount",
+    "description": "ACE API discount title."
+  },
+  "benefit.api_discount.description": {
+    "message": "Supported Credits APIs and identified x402 calls automatically use your valid discount.",
+    "description": "ACE API discount description."
+  },
+  "benefit.early_access.title": {
+    "message": "Early access",
+    "description": "ACE early-access title."
+  },
+  "benefit.early_access.description": {
+    "message": "Use selected models and features 72 hours before general availability.",
+    "description": "ACE early-access description."
+  },
+  "benefit.referral_bonus.title": {
+    "message": "Referral bonus",
+    "description": "ACE referral bonus title."
+  },
+  "benefit.referral_bonus.description": {
+    "message": "Add holder percentage points to your base referral rate, capped at 30% total.",
+    "description": "ACE referral bonus description."
+  },
+  "benefit.nexior_holder_lab.title": {
+    "message": "Holder Lab",
+    "description": "Nexior Holder Lab benefit title."
+  },
+  "benefit.nexior_holder_lab.description": {
+    "message": "Access templates, workflows, and features curated for holders.",
+    "description": "Nexior Holder Lab benefit description."
+  },
+  "benefit.ace_operator.title": {
+    "message": "ACE Operator",
+    "description": "ACE Operator benefit title."
+  },
+  "benefit.ace_operator.description": {
+    "message": "Apply from Tier 4; public placement and Featured status still require review.",
+    "description": "ACE Operator benefit description."
+  },
+  "operator.eyebrow": {
+    "message": "Operator",
+    "description": "Operator section eyebrow."
+  },
+  "operator.title": {
+    "message": "Apply to Be an ACE Operator",
+    "description": "Operator section title."
+  },
+  "operator.description": {
+    "message": "Submit a public introduction for review. Holding ACE makes you eligible to apply; it does not guarantee Featured placement or traffic.",
+    "description": "Operator application explanation."
+  },
+  "operator.tierRequired": {
+    "message": "Reach Tier 4 to apply as an ACE Operator.",
+    "description": "Operator tier requirement."
+  },
+  "operator.displayName": {
+    "message": "Public name",
+    "description": "Operator public display name field."
+  },
+  "operator.bio": {
+    "message": "Public introduction",
+    "description": "Operator public bio field."
+  },
+  "operator.public": {
+    "message": "Show my profile after approval",
+    "description": "Operator profile visibility control."
+  },
+  "operator.apply": {
+    "message": "Submit Application",
+    "description": "Operator application action."
+  },
+  "operator.save": {
+    "message": "Save Profile",
+    "description": "Save Operator profile action."
+  },
+  "operator.applied": {
+    "message": "Application submitted for review.",
+    "description": "Operator application success message."
+  },
+  "operator.saved": {
+    "message": "Operator profile saved.",
+    "description": "Operator profile save success message."
+  },
+  "operator.saveError": {
+    "message": "The Operator profile could not be saved. Try again later.",
+    "description": "Operator profile save error."
+  },
+  "operator.nameRequired": {
+    "message": "Enter a public name.",
+    "description": "Operator display name validation."
+  },
+  "operator.featuredEligible": {
+    "message": "Your current tier is eligible for Featured review",
+    "description": "Featured eligibility message."
+  },
+  "operator.featured": {
+    "message": "Featured by the platform",
+    "description": "Approved Featured status."
+  },
+  "operator.featuredBadge": {
+    "message": "Featured",
+    "description": "Reviewed Featured badge shown on a Showcase card."
+  },
+  "operator.status.pending": {
+    "message": "Pending review",
+    "description": "Pending Operator status."
+  },
+  "operator.status.approved": {
+    "message": "Approved",
+    "description": "Approved Operator status."
+  },
+  "operator.status.suspended": {
+    "message": "Suspended",
+    "description": "Suspended Operator status."
   }
 }

--- a/src/i18n/es/coin.json
+++ b/src/i18n/es/coin.json
@@ -6,5 +6,209 @@
   "message.connectError": {
     "message": "Error al conectar la billetera.",
     "description": "Mensaje de error que se muestra cuando falla la conexión con la billetera."
+  },
+  "holderCenter.nav": {
+    "message": "ACE Holder",
+    "description": "Navigation label for the ACE holder center."
+  },
+  "holderCenter.eyebrow": {
+    "message": "Beneficios por tener ACE",
+    "description": "Etiqueta del encabezado del centro de beneficios."
+  },
+  "holderCenter.title": {
+    "message": "Tus beneficios de ACE Holder",
+    "description": "Título principal del centro de beneficios."
+  },
+  "holderCenter.description": {
+    "message": "Consulta tu nivel actual, los beneficios desbloqueados, el contenido exclusivo y el estado de tu solicitud de Operator.",
+    "description": "Descripción del centro de beneficios."
+  },
+  "holderCenter.manageWallet": {
+    "message": "Gestionar wallet verificada",
+    "description": "Botón que lleva a la página de wallets y beneficios de la plataforma."
+  },
+  "holderCenter.connectPrompt": {
+    "message": "Ve primero a API Platform para conectar y verificar tu wallet de Solana con ACE.",
+    "description": "Aviso que indica que no hay ninguna wallet vinculada."
+  },
+  "holderCenter.currentTier": {
+    "message": "Nivel actual",
+    "description": "Etiqueta del nivel actual de ACE."
+  },
+  "holderCenter.holder": {
+    "message": "Los beneficios de ACE Holder están activos",
+    "description": "Estado que indica que se ha alcanzado el umbral de tenencia."
+  },
+  "holderCenter.notQualified": {
+    "message": "Aún no has alcanzado el umbral de 100,000 ACE",
+    "description": "Estado que se muestra cuando no se ha alcanzado el primer nivel."
+  },
+  "holderCenter.toNext": {
+    "message": "Faltan {amount} ACE para alcanzar {tier}",
+    "description": "Descripción del progreso hacia el siguiente nivel."
+  },
+  "holderCenter.maxTier": {
+    "message": "Has alcanzado el nivel máximo.",
+    "description": "Aviso que indica que se ha alcanzado el nivel máximo."
+  },
+  "holderCenter.monthlySavings": {
+    "message": "Ahorro de API este mes",
+    "description": "Etiqueta del ahorro mensual en Credits."
+  },
+  "holderCenter.benefitsEyebrow": {
+    "message": "Beneficios verificados",
+    "description": "Etiqueta de la lista de beneficios."
+  },
+  "holderCenter.benefits": {
+    "message": "Beneficios disponibles actualmente",
+    "description": "Título de la lista de beneficios."
+  },
+  "holderCenter.loadError": {
+    "message": "No se pueden cargar los beneficios de ACE. Inténtalo de nuevo más tarde.",
+    "description": "Error de carga del centro de beneficios."
+  },
+  "holderLab.eyebrow": {
+    "message": "Holder Lab",
+    "description": "Holder-only showcase eyebrow."
+  },
+  "holderLab.title": {
+    "message": "Inspiración exclusiva para Holders de ACE",
+    "description": "Título del Showcase exclusivo para Holders."
+  },
+  "holderLab.description": {
+    "message": "Plantillas y flujos de trabajo seleccionados disponibles para el nivel actual.",
+    "description": "Descripción del Showcase exclusivo para Holders."
+  },
+  "benefitStatus.active": {
+    "message": "Activo",
+    "description": "Estado que indica que el beneficio está activo."
+  },
+  "benefitStatus.eligible": {
+    "message": "Disponible",
+    "description": "Estado que indica que el beneficio está disponible para su uso."
+  },
+  "benefitStatus.coming_soon": {
+    "message": "Próximamente",
+    "description": "Estado que indica que el beneficio estará disponible próximamente."
+  },
+  "benefitStatus.locked": {
+    "message": "Bloqueado",
+    "description": "Estado que indica que el beneficio está bloqueado."
+  },
+  "benefit.api_discount.title": {
+    "message": "Descuento en llamadas API",
+    "description": "Título del beneficio de descuento de ACE API."
+  },
+  "benefit.api_discount.description": {
+    "message": "Los descuentos válidos se aplican automáticamente a las Credits API compatibles y a las llamadas x402 con una cuenta identificable.",
+    "description": "Descripción del beneficio de descuento de ACE API."
+  },
+  "benefit.early_access.title": {
+    "message": "Acceso anticipado",
+    "description": "Título del beneficio de acceso anticipado de ACE."
+  },
+  "benefit.early_access.description": {
+    "message": "Prueba modelos y funciones seleccionados 72 horas antes de su lanzamiento oficial.",
+    "description": "Descripción del beneficio de acceso anticipado de ACE."
+  },
+  "benefit.referral_bonus.title": {
+    "message": "Bono de comisión por referidos",
+    "description": "Título del bono de referidos de ACE."
+  },
+  "benefit.referral_bonus.description": {
+    "message": "Añade puntos porcentuales de tenencia a la tasa de referidos básica, hasta un máximo del 30%.",
+    "description": "Descripción del bono de referidos de ACE."
+  },
+  "benefit.nexior_holder_lab.title": {
+    "message": "Holder Lab",
+    "description": "Nexior Holder Lab benefit title."
+  },
+  "benefit.nexior_holder_lab.description": {
+    "message": "Accede a plantillas, flujos de trabajo y funciones seleccionados para Holders.",
+    "description": "Descripción del beneficio de Nexior Holder Lab."
+  },
+  "benefit.ace_operator.title": {
+    "message": "ACE Operator",
+    "description": "ACE Operator benefit title."
+  },
+  "benefit.ace_operator.description": {
+    "message": "Se puede solicitar a partir del nivel 4; la publicación y Featured aún requieren revisión.",
+    "description": "Descripción de los beneficios de ACE Operator."
+  },
+  "operator.eyebrow": {
+    "message": "Operator",
+    "description": "Operator section eyebrow."
+  },
+  "operator.title": {
+    "message": "Solicitar ser ACE Operator",
+    "description": "Título de la sección de Operator."
+  },
+  "operator.description": {
+    "message": "Envía tu presentación pública para su revisión. Tener tokens solo da derecho a solicitarlo y no garantiza aparecer en Featured ni obtener exposición.",
+    "description": "Descripción de la solicitud de Operator."
+  },
+  "operator.tierRequired": {
+    "message": "Puedes solicitar ser ACE Operator al alcanzar el Tier 4.",
+    "description": "Aviso del requisito de nivel para Operator."
+  },
+  "operator.displayName": {
+    "message": "Nombre público",
+    "description": "Campo del nombre público del Operator."
+  },
+  "operator.bio": {
+    "message": "Presentación pública",
+    "description": "Campo de presentación pública del Operator."
+  },
+  "operator.public": {
+    "message": "Mostrar públicamente el perfil tras su aprobación",
+    "description": "Descripción del interruptor de visibilidad pública del Operator."
+  },
+  "operator.apply": {
+    "message": "Enviar solicitud",
+    "description": "Botón para enviar la solicitud de Operator."
+  },
+  "operator.save": {
+    "message": "Guardar perfil",
+    "description": "Botón para guardar el perfil del Operator."
+  },
+  "operator.applied": {
+    "message": "Solicitud enviada. Pendiente de revisión.",
+    "description": "Aviso de solicitud de Operator enviada correctamente."
+  },
+  "operator.saved": {
+    "message": "Perfil del Operator guardado.",
+    "description": "Aviso de perfil del Operator guardado correctamente."
+  },
+  "operator.saveError": {
+    "message": "No se puede guardar el perfil del Operator. Inténtalo de nuevo más tarde.",
+    "description": "Aviso de error al guardar el perfil del Operator."
+  },
+  "operator.nameRequired": {
+    "message": "Introduce un nombre público.",
+    "description": "Aviso de nombre de Operator vacío."
+  },
+  "operator.featuredEligible": {
+    "message": "El nivel actual permite participar en la evaluación de Featured",
+    "description": "Aviso de candidato para Featured."
+  },
+  "operator.featured": {
+    "message": "Featured por la plataforma",
+    "description": "Estado de Featured aprobado."
+  },
+  "operator.featuredBadge": {
+    "message": "Destacado",
+    "description": "Distintivo «Destacado» revisado que aparece en las tarjetas de Showcase."
+  },
+  "operator.status.pending": {
+    "message": "Pendiente de revisión",
+    "description": "Estado de solicitud de Operator pendiente de revisión."
+  },
+  "operator.status.approved": {
+    "message": "Aprobado",
+    "description": "Estado de solicitud de Operator aprobada."
+  },
+  "operator.status.suspended": {
+    "message": "Suspendido",
+    "description": "Estado de Operator suspendido."
   }
 }

--- a/src/i18n/fr/coin.json
+++ b/src/i18n/fr/coin.json
@@ -6,5 +6,209 @@
   "message.connectError": {
     "message": "Échec de la connexion au portefeuille.",
     "description": "Message d'erreur affiché lorsque la connexion au portefeuille échoue."
+  },
+  "holderCenter.nav": {
+    "message": "ACE Holder",
+    "description": "Navigation label for the ACE holder center."
+  },
+  "holderCenter.eyebrow": {
+    "message": "Avantages liés à la détention d’ACE",
+    "description": "Libellé d’en-tête du centre des avantages."
+  },
+  "holderCenter.title": {
+    "message": "Vos avantages ACE Holder",
+    "description": "Titre principal du centre des avantages."
+  },
+  "holderCenter.description": {
+    "message": "Consultez votre niveau actuel, les avantages déverrouillés, le contenu exclusif et le statut de votre demande Operator.",
+    "description": "Description du centre des avantages."
+  },
+  "holderCenter.manageWallet": {
+    "message": "Gérer le portefeuille vérifié",
+    "description": "Bouton redirigeant vers la page de gestion du portefeuille et des avantages sur la plateforme."
+  },
+  "holderCenter.connectPrompt": {
+    "message": "Accédez d’abord à API Platform pour connecter et vérifier le portefeuille Solana détenant des ACE.",
+    "description": "Invite indiquant qu’aucun portefeuille n’est associé."
+  },
+  "holderCenter.currentTier": {
+    "message": "Niveau actuel",
+    "description": "Libellé du niveau ACE actuel."
+  },
+  "holderCenter.holder": {
+    "message": "Avantages ACE Holder actifs",
+    "description": "Statut indiquant que le seuil de détention est atteint."
+  },
+  "holderCenter.notQualified": {
+    "message": "Le seuil de 100 000 ACE n’est pas encore atteint",
+    "description": "Statut affiché lorsque le premier niveau n’est pas atteint."
+  },
+  "holderCenter.toNext": {
+    "message": "Encore {amount} ACE avant le niveau {tier}",
+    "description": "Indication de progression vers le niveau suivant."
+  },
+  "holderCenter.maxTier": {
+    "message": "Vous avez atteint le niveau maximal.",
+    "description": "Message indiquant que le niveau maximal est atteint."
+  },
+  "holderCenter.monthlySavings": {
+    "message": "Économies API réalisées ce mois-ci",
+    "description": "Libellé des économies mensuelles en Credits."
+  },
+  "holderCenter.benefitsEyebrow": {
+    "message": "Avantages vérifiés",
+    "description": "Libellé de la liste des avantages."
+  },
+  "holderCenter.benefits": {
+    "message": "Avantages actuellement disponibles",
+    "description": "Titre de la liste des avantages."
+  },
+  "holderCenter.loadError": {
+    "message": "Impossible de charger les avantages ACE. Veuillez réessayer plus tard.",
+    "description": "Échec du chargement du centre des avantages."
+  },
+  "holderLab.eyebrow": {
+    "message": "Holder Lab",
+    "description": "Holder-only showcase eyebrow."
+  },
+  "holderLab.title": {
+    "message": "Inspiration exclusive pour les Holders ACE",
+    "description": "Titre du Showcase réservé aux Holders."
+  },
+  "holderLab.description": {
+    "message": "Sélection de modèles et de workflows disponibles pour le niveau actuel.",
+    "description": "Description du Showcase réservé aux Holders."
+  },
+  "benefitStatus.active": {
+    "message": "Actif",
+    "description": "Statut indiquant que l’avantage est actif."
+  },
+  "benefitStatus.eligible": {
+    "message": "Disponible",
+    "description": "Statut indiquant que l’avantage peut être utilisé."
+  },
+  "benefitStatus.coming_soon": {
+    "message": "Bientôt disponible",
+    "description": "Statut indiquant que l’avantage sera bientôt disponible."
+  },
+  "benefitStatus.locked": {
+    "message": "Verrouillé",
+    "description": "Statut indiquant que l’avantage n’est pas déverrouillé."
+  },
+  "benefit.api_discount.title": {
+    "message": "Remise sur les appels API",
+    "description": "Titre de l’avantage de remise API ACE."
+  },
+  "benefit.api_discount.description": {
+    "message": "Une remise applicable est automatiquement accordée pour les API Credits prises en charge et les appels x402 pouvant identifier le compte.",
+    "description": "Description de l’avantage de remise API ACE."
+  },
+  "benefit.early_access.title": {
+    "message": "Accès anticipé",
+    "description": "Titre de l’avantage d’accès anticipé ACE."
+  },
+  "benefit.early_access.description": {
+    "message": "Découvrez certains modèles et fonctionnalités 72 heures avant leur ouverture officielle.",
+    "description": "Description de l’avantage d’accès anticipé ACE."
+  },
+  "benefit.referral_bonus.title": {
+    "message": "Bonus de commission de parrainage",
+    "description": "Titre du bonus de parrainage ACE."
+  },
+  "benefit.referral_bonus.description": {
+    "message": "Augmentation en points de pourcentage du taux de parrainage de base, jusqu’à un taux final de 30 %.",
+    "description": "Description du bonus de parrainage ACE."
+  },
+  "benefit.nexior_holder_lab.title": {
+    "message": "Holder Lab",
+    "description": "Nexior Holder Lab benefit title."
+  },
+  "benefit.nexior_holder_lab.description": {
+    "message": "Accédez aux modèles, workflows et fonctionnalités sélectionnés pour les Holders.",
+    "description": "Description de l’avantage Nexior Holder Lab."
+  },
+  "benefit.ace_operator.title": {
+    "message": "ACE Operator",
+    "description": "ACE Operator benefit title."
+  },
+  "benefit.ace_operator.description": {
+    "message": "Demande possible à partir du niveau 4 ; l’affichage public et le statut Featured restent soumis à approbation.",
+    "description": "Description des avantages ACE Operator."
+  },
+  "operator.eyebrow": {
+    "message": "Operator",
+    "description": "Operator section eyebrow."
+  },
+  "operator.title": {
+    "message": "Postuler comme ACE Operator",
+    "description": "Titre de la section Operator."
+  },
+  "operator.description": {
+    "message": "Soumettez votre présentation publique pour examen. Détenir des tokens donne uniquement le droit de postuler et ne garantit ni la mise en avant dans Featured ni une visibilité accrue.",
+    "description": "Description de la candidature Operator."
+  },
+  "operator.tierRequired": {
+    "message": "Atteignez le niveau Tier 4 pour pouvoir postuler comme ACE Operator.",
+    "description": "Indication du niveau requis pour devenir Operator."
+  },
+  "operator.displayName": {
+    "message": "Nom public",
+    "description": "Champ du nom public de l’Operator."
+  },
+  "operator.bio": {
+    "message": "Présentation publique",
+    "description": "Champ de présentation publique de l’Operator."
+  },
+  "operator.public": {
+    "message": "Profil affiché publiquement après approbation",
+    "description": "Description de l’option de visibilité publique de l’Operator."
+  },
+  "operator.apply": {
+    "message": "Envoyer la candidature",
+    "description": "Bouton d’envoi de la candidature Operator."
+  },
+  "operator.save": {
+    "message": "Enregistrer le profil",
+    "description": "Bouton d’enregistrement du profil Operator."
+  },
+  "operator.applied": {
+    "message": "Candidature envoyée, en attente d’examen.",
+    "description": "Message de confirmation de candidature Operator."
+  },
+  "operator.saved": {
+    "message": "Le profil Operator a été enregistré.",
+    "description": "Message de confirmation de l’enregistrement de l’Operator."
+  },
+  "operator.saveError": {
+    "message": "Impossible d’enregistrer le profil Operator. Veuillez réessayer plus tard.",
+    "description": "Message d’échec de l’enregistrement de l’Operator."
+  },
+  "operator.nameRequired": {
+    "message": "Veuillez saisir un nom public.",
+    "description": "Message affiché lorsque le nom de l’Operator est vide."
+  },
+  "operator.featuredEligible": {
+    "message": "Votre niveau actuel vous permet de participer à l’examen Featured",
+    "description": "Indication d’éligibilité à Featured."
+  },
+  "operator.featured": {
+    "message": "Défini comme Featured par la plateforme",
+    "description": "Statut Featured après examen."
+  },
+  "operator.featuredBadge": {
+    "message": "À la une",
+    "description": "Badge « À la une » vérifié dans la carte Showcase."
+  },
+  "operator.status.pending": {
+    "message": "En attente d’examen",
+    "description": "Statut de candidature Operator en attente d’examen."
+  },
+  "operator.status.approved": {
+    "message": "Approuvé",
+    "description": "Statut de candidature Operator approuvée."
+  },
+  "operator.status.suspended": {
+    "message": "Suspendu",
+    "description": "Statut Operator suspendu."
   }
 }

--- a/src/i18n/it/coin.json
+++ b/src/i18n/it/coin.json
@@ -6,5 +6,209 @@
   "message.connectError": {
     "message": "Errore di connessione del portafoglio.",
     "description": "Messaggio di errore visualizzato quando la connessione al portafoglio fallisce."
+  },
+  "holderCenter.nav": {
+    "message": "ACE Holder",
+    "description": "Navigation label for the ACE holder center."
+  },
+  "holderCenter.eyebrow": {
+    "message": "Vantaggi per i detentori di ACE",
+    "description": "Etichetta dell'intestazione del centro vantaggi."
+  },
+  "holderCenter.title": {
+    "message": "I tuoi vantaggi ACE Holder",
+    "description": "Titolo principale del centro vantaggi."
+  },
+  "holderCenter.description": {
+    "message": "Visualizza il livello attuale, i vantaggi sbloccati, i contenuti esclusivi e lo stato della richiesta Operator.",
+    "description": "Descrizione del centro vantaggi."
+  },
+  "holderCenter.manageWallet": {
+    "message": "Gestisci il wallet verificato",
+    "description": "Pulsante che reindirizza alla pagina dei vantaggi del wallet sulla piattaforma."
+  },
+  "holderCenter.connectPrompt": {
+    "message": "Vai prima su API Platform per connettere e verificare il wallet Solana che detiene ACE.",
+    "description": "Messaggio che invita a collegare un wallet."
+  },
+  "holderCenter.currentTier": {
+    "message": "Livello attuale",
+    "description": "Etichetta del livello ACE attuale."
+  },
+  "holderCenter.holder": {
+    "message": "Vantaggi ACE Holder attivi",
+    "description": "Stato che indica il raggiungimento della soglia di possesso."
+  },
+  "holderCenter.notQualified": {
+    "message": "Non hai ancora raggiunto la soglia di 100.000 ACE",
+    "description": "Stato visualizzato quando non è stata raggiunta la prima soglia."
+  },
+  "holderCenter.toNext": {
+    "message": "Mancano {amount} ACE per raggiungere {tier}",
+    "description": "Descrizione dei progressi verso il livello successivo."
+  },
+  "holderCenter.maxTier": {
+    "message": "Hai raggiunto il livello massimo.",
+    "description": "Messaggio relativo al raggiungimento del livello massimo."
+  },
+  "holderCenter.monthlySavings": {
+    "message": "Risparmi API di questo mese",
+    "description": "Etichetta dei risparmi mensili in Credits."
+  },
+  "holderCenter.benefitsEyebrow": {
+    "message": "Vantaggi verificati",
+    "description": "Etichetta dell'elenco dei vantaggi."
+  },
+  "holderCenter.benefits": {
+    "message": "Vantaggi attualmente disponibili",
+    "description": "Titolo dell'elenco dei vantaggi."
+  },
+  "holderCenter.loadError": {
+    "message": "Impossibile caricare i vantaggi ACE. Riprova più tardi.",
+    "description": "Errore di caricamento del centro vantaggi."
+  },
+  "holderLab.eyebrow": {
+    "message": "Holder Lab",
+    "description": "Holder-only showcase eyebrow."
+  },
+  "holderLab.title": {
+    "message": "Ispirazione esclusiva per Holder ACE",
+    "description": "Titolo dello Showcase esclusivo per Holder."
+  },
+  "holderLab.description": {
+    "message": "Template e workflow selezionati disponibili per il livello attuale.",
+    "description": "Descrizione dello Showcase esclusivo per Holder."
+  },
+  "benefitStatus.active": {
+    "message": "Attivo",
+    "description": "Stato che indica che il vantaggio è attivo."
+  },
+  "benefitStatus.eligible": {
+    "message": "Disponibile",
+    "description": "Stato che indica che il vantaggio è disponibile per l'uso."
+  },
+  "benefitStatus.coming_soon": {
+    "message": "Disponibile a breve",
+    "description": "Stato che indica che il vantaggio sarà disponibile a breve."
+  },
+  "benefitStatus.locked": {
+    "message": "Bloccato",
+    "description": "Stato che indica che il vantaggio non è ancora sbloccato."
+  },
+  "benefit.api_discount.title": {
+    "message": "Sconto sulle chiamate API",
+    "description": "Titolo dei vantaggi dello sconto API ACE."
+  },
+  "benefit.api_discount.description": {
+    "message": "Gli sconti validi vengono applicati automaticamente alle Credits API supportate e alle chiamate x402 con identità dell'account riconoscibile.",
+    "description": "Descrizione dei vantaggi dello sconto API ACE."
+  },
+  "benefit.early_access.title": {
+    "message": "Accesso anticipato",
+    "description": "Titolo dei vantaggi di accesso anticipato ACE."
+  },
+  "benefit.early_access.description": {
+    "message": "Prova modelli e funzionalità selezionati 72 ore prima dell'apertura ufficiale.",
+    "description": "Descrizione dei vantaggi di accesso anticipato ACE."
+  },
+  "benefit.referral_bonus.title": {
+    "message": "Bonus sulle commissioni referral",
+    "description": "Titolo del bonus referral ACE."
+  },
+  "benefit.referral_bonus.description": {
+    "message": "Aumento percentuale per il possesso di token rispetto alla percentuale base di referral, fino a un massimo del 30%.",
+    "description": "Descrizione del bonus referral ACE."
+  },
+  "benefit.nexior_holder_lab.title": {
+    "message": "Holder Lab",
+    "description": "Nexior Holder Lab benefit title."
+  },
+  "benefit.nexior_holder_lab.description": {
+    "message": "Accedi a template, workflow e funzionalità selezionati per gli Holder.",
+    "description": "Descrizione dei vantaggi di Nexior Holder Lab."
+  },
+  "benefit.ace_operator.title": {
+    "message": "ACE Operator",
+    "description": "ACE Operator benefit title."
+  },
+  "benefit.ace_operator.description": {
+    "message": "A partire dal livello 4 è possibile fare richiesta; la pubblicazione pubblica e la sezione Featured richiedono comunque l'approvazione.",
+    "description": "Descrizione dei vantaggi ACE Operator."
+  },
+  "operator.eyebrow": {
+    "message": "Operator",
+    "description": "Operator section eyebrow."
+  },
+  "operator.title": {
+    "message": "Candidati come ACE Operator",
+    "description": "Titolo della sezione Operator."
+  },
+  "operator.description": {
+    "message": "Invia la tua presentazione pubblica per la revisione. Il possesso di token dà solo diritto a candidarsi e non garantisce l'inserimento tra i Featured né visibilità.",
+    "description": "Descrizione della candidatura Operator."
+  },
+  "operator.tierRequired": {
+    "message": "Raggiungi il Tier 4 per candidarti come ACE Operator.",
+    "description": "Avviso relativo al requisito di livello per l'Operator."
+  },
+  "operator.displayName": {
+    "message": "Nome pubblico",
+    "description": "Campo per il nome pubblico dell'Operator."
+  },
+  "operator.bio": {
+    "message": "Presentazione pubblica",
+    "description": "Campo per la presentazione pubblica dell'Operator."
+  },
+  "operator.public": {
+    "message": "Profilo pubblico dopo l'approvazione",
+    "description": "Descrizione dell'opzione per rendere pubblico il profilo dell'Operator."
+  },
+  "operator.apply": {
+    "message": "Invia candidatura",
+    "description": "Pulsante per inviare la candidatura Operator."
+  },
+  "operator.save": {
+    "message": "Salva profilo",
+    "description": "Pulsante per salvare il profilo dell'Operator."
+  },
+  "operator.applied": {
+    "message": "Candidatura inviata, in attesa di revisione.",
+    "description": "Messaggio di conferma dell'invio della candidatura Operator."
+  },
+  "operator.saved": {
+    "message": "Profilo Operator salvato.",
+    "description": "Messaggio di conferma del salvataggio del profilo Operator."
+  },
+  "operator.saveError": {
+    "message": "Impossibile salvare il profilo dell'Operator. Riprova più tardi.",
+    "description": "Messaggio di errore durante il salvataggio del profilo Operator."
+  },
+  "operator.nameRequired": {
+    "message": "Inserisci un nome pubblico.",
+    "description": "Avviso mostrato quando il nome dell'Operator è vuoto."
+  },
+  "operator.featuredEligible": {
+    "message": "Il livello attuale consente di partecipare alla valutazione Featured",
+    "description": "Avviso relativo all'idoneità come candidato Featured."
+  },
+  "operator.featured": {
+    "message": "Impostato dalla piattaforma come Featured",
+    "description": "Stato di approvazione come Featured."
+  },
+  "operator.featuredBadge": {
+    "message": "In evidenza",
+    "description": "Il contrassegno “In evidenza” approvato nella scheda Showcase."
+  },
+  "operator.status.pending": {
+    "message": "In attesa di revisione",
+    "description": "Stato dell'Operator in attesa di revisione."
+  },
+  "operator.status.approved": {
+    "message": "Approvato",
+    "description": "Stato di approvazione dell'Operator."
+  },
+  "operator.status.suspended": {
+    "message": "Sospeso",
+    "description": "Stato di sospensione dell'Operator."
   }
 }

--- a/src/i18n/ja/coin.json
+++ b/src/i18n/ja/coin.json
@@ -6,5 +6,209 @@
   "message.connectError": {
     "message": "ウォレットの接続に失敗しました。",
     "description": "ウォレットの接続に失敗した際に表示されるエラーメッセージ。"
+  },
+  "holderCenter.nav": {
+    "message": "ACE Holder",
+    "description": "Navigation label for the ACE holder center."
+  },
+  "holderCenter.eyebrow": {
+    "message": "ACE保有者特典",
+    "description": "特典センターヘッダーのラベル。"
+  },
+  "holderCenter.title": {
+    "message": "あなたのACE Holder特典",
+    "description": "特典センターのメインタイトル。"
+  },
+  "holderCenter.description": {
+    "message": "現在のティア、解除済みの特典、限定コンテンツ、Operator申請状況を確認できます。",
+    "description": "特典センターの説明。"
+  },
+  "holderCenter.manageWallet": {
+    "message": "認証済みウォレットを管理",
+    "description": "プラットフォームのウォレット特典ページへ移動するボタン。"
+  },
+  "holderCenter.connectPrompt": {
+    "message": "まずAPI Platformに移動し、ACEを保有するSolanaウォレットを接続して認証してください。",
+    "description": "ウォレット未連携時の案内。"
+  },
+  "holderCenter.currentTier": {
+    "message": "現在のティア",
+    "description": "現在のACEティアのラベル。"
+  },
+  "holderCenter.holder": {
+    "message": "ACE Holder特典が有効です",
+    "description": "保有量の基準を満たしている状態。"
+  },
+  "holderCenter.notQualified": {
+    "message": "まだ100,000 ACEの基準に達していません",
+    "description": "最初のティアに達していない場合の状態。"
+  },
+  "holderCenter.toNext": {
+    "message": "{tier}まであと{amount} ACE",
+    "description": "次のレベルまでの進捗説明。"
+  },
+  "holderCenter.maxTier": {
+    "message": "最高ティアに到達しています。",
+    "description": "最高ティアに到達したことを示す案内。"
+  },
+  "holderCenter.monthlySavings": {
+    "message": "今月のAPI節約額",
+    "description": "当月のCredits節約額のラベル。"
+  },
+  "holderCenter.benefitsEyebrow": {
+    "message": "認証済み特典",
+    "description": "特典一覧のラベル。"
+  },
+  "holderCenter.benefits": {
+    "message": "現在利用可能な特典",
+    "description": "特典一覧のタイトル。"
+  },
+  "holderCenter.loadError": {
+    "message": "ACE特典を読み込めません。しばらくしてからもう一度お試しください。",
+    "description": "特典センターの読み込みに失敗した状態。"
+  },
+  "holderLab.eyebrow": {
+    "message": "Holder Lab",
+    "description": "Holder-only showcase eyebrow."
+  },
+  "holderLab.title": {
+    "message": "ACE Holder専用インスピレーション",
+    "description": "Holder専用ショーケースのタイトル。"
+  },
+  "holderLab.description": {
+    "message": "現在のレベルで利用できる厳選テンプレートとワークフロー。",
+    "description": "Holder専用ショーケースの説明。"
+  },
+  "benefitStatus.active": {
+    "message": "有効",
+    "description": "特典が有効になっている状態。"
+  },
+  "benefitStatus.eligible": {
+    "message": "利用可能",
+    "description": "特典を利用できる状態。"
+  },
+  "benefitStatus.coming_soon": {
+    "message": "近日公開",
+    "description": "特典が近日公開される状態。"
+  },
+  "benefitStatus.locked": {
+    "message": "未解除",
+    "description": "特典が解除されていない状態。"
+  },
+  "benefit.api_discount.title": {
+    "message": "API呼び出し割引",
+    "description": "ACE API割引特典のタイトル。"
+  },
+  "benefit.api_discount.description": {
+    "message": "対象のCredits APIおよびアカウントIDを識別できるx402呼び出しに、有効な割引が自動適用されます。",
+    "description": "ACE API割引特典の説明。"
+  },
+  "benefit.early_access.title": {
+    "message": "先行体験",
+    "description": "ACE早期アクセス特典のタイトル。"
+  },
+  "benefit.early_access.description": {
+    "message": "対象モデルと機能を正式公開の72時間前から体験できます。",
+    "description": "ACE早期アクセス特典の説明。"
+  },
+  "benefit.referral_bonus.title": {
+    "message": "紹介報酬ボーナス",
+    "description": "ACE紹介ボーナスのタイトル。"
+  },
+  "benefit.referral_bonus.description": {
+    "message": "基本紹介率に保有量に応じたポイントが加算され、最終紹介率は最大30%です。",
+    "description": "ACE紹介ボーナスの説明。"
+  },
+  "benefit.nexior_holder_lab.title": {
+    "message": "Holder Lab",
+    "description": "Nexior Holder Lab benefit title."
+  },
+  "benefit.nexior_holder_lab.description": {
+    "message": "Holder向けに厳選されたテンプレート、ワークフロー、機能にアクセスできます。",
+    "description": "Nexior Holder Lab特典の説明。"
+  },
+  "benefit.ace_operator.title": {
+    "message": "ACE Operator",
+    "description": "ACE Operator benefit title."
+  },
+  "benefit.ace_operator.description": {
+    "message": "Tier 4以上から申請可能。公開掲載とFeaturedには引き続き審査が必要です。",
+    "description": "ACE Operator特典の説明。"
+  },
+  "operator.eyebrow": {
+    "message": "Operator",
+    "description": "Operator section eyebrow."
+  },
+  "operator.title": {
+    "message": "ACE Operatorに申請",
+    "description": "Operatorセクションのタイトル。"
+  },
+  "operator.description": {
+    "message": "審査のため、公開プロフィールを送信してください。保有資格は申請資格を提供するだけで、Featuredやトラフィック露出を保証するものではありません。",
+    "description": "Operator申請の説明。"
+  },
+  "operator.tierRequired": {
+    "message": "Tier 4に到達するとACE Operatorに申請できます。",
+    "description": "Operatorのレベル要件に関する通知。"
+  },
+  "operator.displayName": {
+    "message": "公開名",
+    "description": "Operatorの公開名欄。"
+  },
+  "operator.bio": {
+    "message": "公開プロフィール",
+    "description": "Operatorの公開プロフィール欄。"
+  },
+  "operator.public": {
+    "message": "審査承認後にプロフィールを公開表示",
+    "description": "Operator公開設定の説明。"
+  },
+  "operator.apply": {
+    "message": "申請を送信",
+    "description": "Operator申請を送信するボタン。"
+  },
+  "operator.save": {
+    "message": "プロフィールを保存",
+    "description": "Operatorプロフィールを保存するボタン。"
+  },
+  "operator.applied": {
+    "message": "申請を送信しました。審査をお待ちください。",
+    "description": "Operator申請の成功通知。"
+  },
+  "operator.saved": {
+    "message": "Operatorプロフィールを保存しました。",
+    "description": "Operatorの保存成功通知。"
+  },
+  "operator.saveError": {
+    "message": "Operatorプロフィールを保存できません。後でもう一度お試しください。",
+    "description": "Operatorの保存失敗通知。"
+  },
+  "operator.nameRequired": {
+    "message": "公開名を入力してください。",
+    "description": "Operator名が空の場合の通知。"
+  },
+  "operator.featuredEligible": {
+    "message": "現在のレベルではFeatured審査に参加できます",
+    "description": "Featured候補であることを示す通知。"
+  },
+  "operator.featured": {
+    "message": "プラットフォームによりFeaturedに設定済み",
+    "description": "Featuredの審査済みステータス。"
+  },
+  "operator.featuredBadge": {
+    "message": "注目",
+    "description": "Showcaseカード内の審査済み「注目」バッジ。"
+  },
+  "operator.status.pending": {
+    "message": "審査待ち",
+    "description": "Operatorの審査待ちステータス。"
+  },
+  "operator.status.approved": {
+    "message": "承認済み",
+    "description": "Operatorの審査承認ステータス。"
+  },
+  "operator.status.suspended": {
+    "message": "停止中",
+    "description": "Operatorの停止ステータス。"
   }
 }

--- a/src/i18n/ko/coin.json
+++ b/src/i18n/ko/coin.json
@@ -6,5 +6,209 @@
   "message.connectError": {
     "message": "지갑 연결에 실패했습니다.",
     "description": "지갑 연결 실패 시 표시되는 오류 메시지입니다."
+  },
+  "holderCenter.nav": {
+    "message": "ACE Holder",
+    "description": "Navigation label for the ACE holder center."
+  },
+  "holderCenter.eyebrow": {
+    "message": "ACE 보유자 혜택",
+    "description": "혜택 센터 헤더 레이블."
+  },
+  "holderCenter.title": {
+    "message": "나의 ACE Holder 혜택",
+    "description": "혜택 센터 기본 제목."
+  },
+  "holderCenter.description": {
+    "message": "현재 등급, 잠금 해제된 혜택, 전용 콘텐츠 및 Operator 신청 상태를 확인하세요.",
+    "description": "혜택 센터 설명."
+  },
+  "holderCenter.manageWallet": {
+    "message": "인증 지갑 관리",
+    "description": "플랫폼의 지갑 혜택 페이지로 이동하는 버튼."
+  },
+  "holderCenter.connectPrompt": {
+    "message": "먼저 API Platform으로 이동하여 ACE를 보유한 Solana 지갑을 연결하고 인증하세요.",
+    "description": "지갑이 연결되지 않은 경우 표시되는 안내."
+  },
+  "holderCenter.currentTier": {
+    "message": "현재 등급",
+    "description": "현재 ACE 등급 레이블."
+  },
+  "holderCenter.holder": {
+    "message": "ACE Holder 혜택 적용됨",
+    "description": "보유량 기준을 충족한 상태."
+  },
+  "holderCenter.notQualified": {
+    "message": "아직 100,000 ACE 기준을 충족하지 않았습니다",
+    "description": "첫 번째 등급 기준을 충족하지 못한 상태."
+  },
+  "holderCenter.toNext": {
+    "message": "{tier}까지 {amount} ACE 남음",
+    "description": "다음 등급까지의 진행 상황을 설명합니다."
+  },
+  "holderCenter.maxTier": {
+    "message": "최고 등급에 도달했습니다.",
+    "description": "최고 등급 안내."
+  },
+  "holderCenter.monthlySavings": {
+    "message": "이번 달 API 절약 금액",
+    "description": "이번 달 Credits 절약 금액 레이블."
+  },
+  "holderCenter.benefitsEyebrow": {
+    "message": "검증된 혜택",
+    "description": "혜택 목록 레이블."
+  },
+  "holderCenter.benefits": {
+    "message": "현재 사용 가능한 혜택",
+    "description": "혜택 목록 제목."
+  },
+  "holderCenter.loadError": {
+    "message": "ACE 혜택을 불러올 수 없습니다. 잠시 후 다시 시도하세요.",
+    "description": "혜택 센터 로드 실패 상태."
+  },
+  "holderLab.eyebrow": {
+    "message": "Holder Lab",
+    "description": "Holder-only showcase eyebrow."
+  },
+  "holderLab.title": {
+    "message": "ACE Holder 전용 영감",
+    "description": "Holder 전용 Showcase 제목입니다."
+  },
+  "holderLab.description": {
+    "message": "현재 등급에 공개된 엄선된 템플릿과 워크플로",
+    "description": "Holder 전용 Showcase 설명입니다."
+  },
+  "benefitStatus.active": {
+    "message": "적용됨",
+    "description": "혜택이 적용된 상태."
+  },
+  "benefitStatus.eligible": {
+    "message": "사용 가능",
+    "description": "혜택을 사용할 수 있는 상태."
+  },
+  "benefitStatus.coming_soon": {
+    "message": "곧 제공",
+    "description": "혜택이 곧 제공될 상태."
+  },
+  "benefitStatus.locked": {
+    "message": "잠김",
+    "description": "혜택이 잠금 해제되지 않은 상태."
+  },
+  "benefit.api_discount.title": {
+    "message": "API 호출 할인",
+    "description": "ACE API 할인 혜택 제목."
+  },
+  "benefit.api_discount.description": {
+    "message": "지원되는 Credits API 및 계정 신원을 식별할 수 있는 x402 호출에 유효한 할인이 자동 적용됩니다.",
+    "description": "ACE API 할인 혜택 설명."
+  },
+  "benefit.early_access.title": {
+    "message": "사전 체험",
+    "description": "ACE 얼리 액세스 혜택 제목."
+  },
+  "benefit.early_access.description": {
+    "message": "지정된 모델과 기능을 정식 공개 72시간 전부터 이용할 수 있습니다.",
+    "description": "ACE 얼리 액세스 혜택 설명."
+  },
+  "benefit.referral_bonus.title": {
+    "message": "추천 커미션 보너스",
+    "description": "ACE 추천 보너스 제목."
+  },
+  "benefit.referral_bonus.description": {
+    "message": "기본 추천 비율에 보유량 기반 퍼센트포인트가 추가되며, 최종 비율은 최대 30%입니다.",
+    "description": "ACE 추천 보너스 설명."
+  },
+  "benefit.nexior_holder_lab.title": {
+    "message": "Holder Lab",
+    "description": "Nexior Holder Lab benefit title."
+  },
+  "benefit.nexior_holder_lab.description": {
+    "message": "Holder를 위해 엄선된 템플릿, 워크플로 및 기능에 액세스할 수 있습니다.",
+    "description": "Nexior Holder Lab 혜택 설명."
+  },
+  "benefit.ace_operator.title": {
+    "message": "ACE Operator",
+    "description": "ACE Operator benefit title."
+  },
+  "benefit.ace_operator.description": {
+    "message": "Tier 4부터 신청할 수 있으며, 공개 표시 및 Featured는 여전히 심사가 필요합니다.",
+    "description": "ACE Operator 혜택 설명."
+  },
+  "operator.eyebrow": {
+    "message": "Operator",
+    "description": "Operator section eyebrow."
+  },
+  "operator.title": {
+    "message": "ACE Operator 신청",
+    "description": "Operator 영역 제목입니다."
+  },
+  "operator.description": {
+    "message": "심사를 위해 공개 소개를 제출하세요. 보유만으로 신청 자격이 주어지며 Featured 선정이나 트래픽 노출이 보장되지는 않습니다.",
+    "description": "Operator 신청 안내입니다."
+  },
+  "operator.tierRequired": {
+    "message": "Tier 4에 도달하면 ACE Operator를 신청할 수 있습니다.",
+    "description": "Operator 등급 요건 안내입니다."
+  },
+  "operator.displayName": {
+    "message": "공개 이름",
+    "description": "Operator 공개 이름 입력란입니다."
+  },
+  "operator.bio": {
+    "message": "공개 소개",
+    "description": "Operator 공개 소개 입력란입니다."
+  },
+  "operator.public": {
+    "message": "심사 통과 후 프로필을 공개적으로 표시합니다.",
+    "description": "Operator 공개 설정 안내입니다."
+  },
+  "operator.apply": {
+    "message": "신청 제출",
+    "description": "Operator 신청 제출 버튼입니다."
+  },
+  "operator.save": {
+    "message": "프로필 저장",
+    "description": "Operator 프로필 저장 버튼입니다."
+  },
+  "operator.applied": {
+    "message": "신청이 제출되었으며 심사를 기다리고 있습니다.",
+    "description": "Operator 신청 성공 알림입니다."
+  },
+  "operator.saved": {
+    "message": "Operator 프로필이 저장되었습니다.",
+    "description": "Operator 저장 성공 알림입니다."
+  },
+  "operator.saveError": {
+    "message": "Operator 프로필을 저장할 수 없습니다. 잠시 후 다시 시도하세요.",
+    "description": "Operator 저장 실패 알림입니다."
+  },
+  "operator.nameRequired": {
+    "message": "공개 이름을 입력하세요.",
+    "description": "Operator 이름이 비어 있을 때 표시되는 안내입니다."
+  },
+  "operator.featuredEligible": {
+    "message": "현재 등급에서 Featured 심사에 참여할 수 있습니다.",
+    "description": "Featured 후보 자격 안내입니다."
+  },
+  "operator.featured": {
+    "message": "플랫폼에서 Featured로 선정됨",
+    "description": "Featured 심사 완료 상태입니다."
+  },
+  "operator.featuredBadge": {
+    "message": "추천",
+    "description": "Showcase 카드에 검토가 완료된 추천(Featured) 배지를 표시합니다."
+  },
+  "operator.status.pending": {
+    "message": "심사 대기 중",
+    "description": "Operator 심사 대기 상태입니다."
+  },
+  "operator.status.approved": {
+    "message": "승인됨",
+    "description": "Operator 심사 승인 상태입니다."
+  },
+  "operator.status.suspended": {
+    "message": "일시 중지됨",
+    "description": "Operator 일시 중지 상태입니다."
   }
 }

--- a/src/i18n/pt/coin.json
+++ b/src/i18n/pt/coin.json
@@ -6,5 +6,209 @@
   "message.connectError": {
     "message": "Falha na conexão da carteira.",
     "description": "Mensagem de erro exibida quando a conexão da carteira falha."
+  },
+  "holderCenter.nav": {
+    "message": "ACE Holder",
+    "description": "Navigation label for the ACE holder center."
+  },
+  "holderCenter.eyebrow": {
+    "message": "Benefícios de Holder do ACE",
+    "description": "Rótulo do cabeçalho da página de benefícios."
+  },
+  "holderCenter.title": {
+    "message": "Seus benefícios de ACE Holder",
+    "description": "Título principal do centro de benefícios."
+  },
+  "holderCenter.description": {
+    "message": "Veja seu nível atual, os benefícios desbloqueados, o conteúdo exclusivo e o status da solicitação de Operator.",
+    "description": "Descrição do centro de benefícios."
+  },
+  "holderCenter.manageWallet": {
+    "message": "Gerenciar carteira verificada",
+    "description": "Botão que leva à página de benefícios da carteira na plataforma."
+  },
+  "holderCenter.connectPrompt": {
+    "message": "Acesse primeiro a API Platform para conectar e verificar sua carteira Solana com ACE.",
+    "description": "Aviso de carteira não vinculada."
+  },
+  "holderCenter.currentTier": {
+    "message": "Nível atual",
+    "description": "Rótulo do nível atual do ACE."
+  },
+  "holderCenter.holder": {
+    "message": "Benefícios de ACE Holder ativos",
+    "description": "Status de quem atingiu o limite mínimo de posse."
+  },
+  "holderCenter.notQualified": {
+    "message": "Ainda não atingiu o limite de 100.000 ACE",
+    "description": "Status de quem ainda não atingiu o primeiro nível."
+  },
+  "holderCenter.toNext": {
+    "message": "Faltam {amount} ACE para {tier}",
+    "description": "Descrição do progresso até o próximo nível."
+  },
+  "holderCenter.maxTier": {
+    "message": "Você atingiu o nível máximo.",
+    "description": "Aviso de nível máximo."
+  },
+  "holderCenter.monthlySavings": {
+    "message": "Economia de API neste mês",
+    "description": "Rótulo da economia mensal em Credits."
+  },
+  "holderCenter.benefitsEyebrow": {
+    "message": "Benefícios verificados",
+    "description": "Rótulo da lista de benefícios."
+  },
+  "holderCenter.benefits": {
+    "message": "Benefícios disponíveis atualmente",
+    "description": "Título da lista de benefícios."
+  },
+  "holderCenter.loadError": {
+    "message": "Não foi possível carregar os benefícios do ACE. Tente novamente mais tarde.",
+    "description": "Falha ao carregar o centro de benefícios."
+  },
+  "holderLab.eyebrow": {
+    "message": "Holder Lab",
+    "description": "Holder-only showcase eyebrow."
+  },
+  "holderLab.title": {
+    "message": "Inspiração exclusiva para Holders de ACE",
+    "description": "Título do Showcase exclusivo para Holders."
+  },
+  "holderLab.description": {
+    "message": "Modelos e fluxos de trabalho selecionados, disponíveis para o nível atual.",
+    "description": "Descrição do Showcase exclusivo para Holders."
+  },
+  "benefitStatus.active": {
+    "message": "Ativo",
+    "description": "Status de benefício ativo."
+  },
+  "benefitStatus.eligible": {
+    "message": "Disponível",
+    "description": "Status de benefício disponível para uso."
+  },
+  "benefitStatus.coming_soon": {
+    "message": "Em breve",
+    "description": "Status de benefício que será disponibilizado em breve."
+  },
+  "benefitStatus.locked": {
+    "message": "Bloqueado",
+    "description": "Status de benefício ainda não desbloqueado."
+  },
+  "benefit.api_discount.title": {
+    "message": "Desconto nas chamadas de API",
+    "description": "Título dos benefícios de desconto de API do ACE."
+  },
+  "benefit.api_discount.description": {
+    "message": "Descontos válidos são aplicados automaticamente às APIs de Credits compatíveis e às chamadas x402 com identidade de conta reconhecível.",
+    "description": "Descrição dos benefícios de desconto de API do ACE."
+  },
+  "benefit.early_access.title": {
+    "message": "Acesso antecipado",
+    "description": "Título dos benefícios de acesso antecipado do ACE."
+  },
+  "benefit.early_access.description": {
+    "message": "Experimente modelos e recursos selecionados 72 horas antes da abertura oficial.",
+    "description": "Descrição dos benefícios de acesso antecipado do ACE."
+  },
+  "benefit.referral_bonus.title": {
+    "message": "Bônus de comissão por indicação",
+    "description": "Título do bônus de indicação do ACE."
+  },
+  "benefit.referral_bonus.description": {
+    "message": "Adiciona pontos percentuais à taxa básica de indicação, com uma taxa final de até 30%.",
+    "description": "Descrição do bônus de indicação do ACE."
+  },
+  "benefit.nexior_holder_lab.title": {
+    "message": "Holder Lab",
+    "description": "Nexior Holder Lab benefit title."
+  },
+  "benefit.nexior_holder_lab.description": {
+    "message": "Acesse modelos, fluxos de trabalho e recursos selecionados para Holders.",
+    "description": "Descrição dos benefícios do Nexior Holder Lab."
+  },
+  "benefit.ace_operator.title": {
+    "message": "ACE Operator",
+    "description": "ACE Operator benefit title."
+  },
+  "benefit.ace_operator.description": {
+    "message": "A partir do nível 4, é possível solicitar; a exibição pública e o destaque ainda estão sujeitos a aprovação.",
+    "description": "Descrição dos benefícios do ACE Operator."
+  },
+  "operator.eyebrow": {
+    "message": "Operator",
+    "description": "Operator section eyebrow."
+  },
+  "operator.title": {
+    "message": "Candidatar-se a ACE Operator",
+    "description": "Título da seção de Operator."
+  },
+  "operator.description": {
+    "message": "Envie sua apresentação pública para análise. Ter tokens apenas dá direito a se candidatar; não garante destaque como Featured nem exposição ou tráfego.",
+    "description": "Descrição da candidatura a Operator."
+  },
+  "operator.tierRequired": {
+    "message": "Você pode se candidatar a ACE Operator após alcançar o Tier 4.",
+    "description": "Aviso sobre o requisito de nível para Operator."
+  },
+  "operator.displayName": {
+    "message": "Nome público",
+    "description": "Campo de nome público do Operator."
+  },
+  "operator.bio": {
+    "message": "Apresentação pública",
+    "description": "Campo de apresentação pública do Operator."
+  },
+  "operator.public": {
+    "message": "Perfil exibido publicamente após aprovação",
+    "description": "Descrição da opção de exibição pública do Operator."
+  },
+  "operator.apply": {
+    "message": "Enviar candidatura",
+    "description": "Botão para enviar a candidatura a Operator."
+  },
+  "operator.save": {
+    "message": "Salvar perfil",
+    "description": "Botão para salvar o perfil do Operator."
+  },
+  "operator.applied": {
+    "message": "Candidatura enviada. Aguardando análise.",
+    "description": "Aviso de candidatura enviada com sucesso para Operator."
+  },
+  "operator.saved": {
+    "message": "Perfil do Operator salvo.",
+    "description": "Aviso de perfil do Operator salvo com sucesso."
+  },
+  "operator.saveError": {
+    "message": "Não foi possível salvar o perfil do Operator. Tente novamente mais tarde.",
+    "description": "Aviso de falha ao salvar o perfil do Operator."
+  },
+  "operator.nameRequired": {
+    "message": "Preencha o nome público.",
+    "description": "Aviso exibido quando o nome do Operator está vazio."
+  },
+  "operator.featuredEligible": {
+    "message": "O nível atual permite participar da avaliação para Featured",
+    "description": "Aviso de elegibilidade para Featured."
+  },
+  "operator.featured": {
+    "message": "Definido como Featured pela plataforma",
+    "description": "Status de aprovação como Featured."
+  },
+  "operator.featuredBadge": {
+    "message": "Em destaque",
+    "description": "Selo “Em destaque” aprovado exibido nos cartões do Showcase."
+  },
+  "operator.status.pending": {
+    "message": "Pendente de análise",
+    "description": "Status de candidatura do Operator aguardando análise."
+  },
+  "operator.status.approved": {
+    "message": "Aprovado",
+    "description": "Status de candidatura do Operator aprovada."
+  },
+  "operator.status.suspended": {
+    "message": "Suspenso",
+    "description": "Status de Operator suspenso."
   }
 }

--- a/src/i18n/ru/coin.json
+++ b/src/i18n/ru/coin.json
@@ -6,5 +6,209 @@
   "message.connectError": {
     "message": "Ошибка подключения кошелька.",
     "description": "Сообщение об ошибке, отображаемое при неудачном подключении кошелька."
+  },
+  "holderCenter.nav": {
+    "message": "ACE Holder",
+    "description": "Navigation label for the ACE holder center."
+  },
+  "holderCenter.eyebrow": {
+    "message": "Привилегии держателя ACE",
+    "description": "Метка в заголовке страницы центра привилегий."
+  },
+  "holderCenter.title": {
+    "message": "Ваши привилегии ACE Holder",
+    "description": "Основной заголовок центра привилегий."
+  },
+  "holderCenter.description": {
+    "message": "Просматривайте текущий уровень, разблокированные привилегии, эксклюзивный контент и статус заявки Operator.",
+    "description": "Описание центра привилегий."
+  },
+  "holderCenter.manageWallet": {
+    "message": "Управление подтверждённым кошельком",
+    "description": "Кнопка перехода на страницу управления кошельком и привилегиями на платформе."
+  },
+  "holderCenter.connectPrompt": {
+    "message": "Сначала перейдите на API Platform, чтобы подключить и подтвердить Solana-кошелёк с ACE.",
+    "description": "Подсказка о неподключённом кошельке."
+  },
+  "holderCenter.currentTier": {
+    "message": "Текущий уровень",
+    "description": "Метка текущего уровня ACE."
+  },
+  "holderCenter.holder": {
+    "message": "Привилегии ACE Holder активированы",
+    "description": "Статус достижения порога владения токенами."
+  },
+  "holderCenter.notQualified": {
+    "message": "Порог в 100 000 ACE ещё не достигнут",
+    "description": "Статус при недостижении первого уровня."
+  },
+  "holderCenter.toNext": {
+    "message": "До {tier} осталось {amount} ACE",
+    "description": "Описание прогресса до следующего уровня."
+  },
+  "holderCenter.maxTier": {
+    "message": "Достигнут максимальный уровень.",
+    "description": "Уведомление о достижении максимального уровня."
+  },
+  "holderCenter.monthlySavings": {
+    "message": "Экономия на API за этот месяц",
+    "description": "Метка экономии Credits за текущий месяц."
+  },
+  "holderCenter.benefitsEyebrow": {
+    "message": "Подтверждённые привилегии",
+    "description": "Метка списка привилегий."
+  },
+  "holderCenter.benefits": {
+    "message": "Доступные привилегии",
+    "description": "Заголовок списка привилегий."
+  },
+  "holderCenter.loadError": {
+    "message": "Не удалось загрузить привилегии ACE. Повторите попытку позже.",
+    "description": "Ошибка загрузки центра привилегий."
+  },
+  "holderLab.eyebrow": {
+    "message": "Holder Lab",
+    "description": "Holder-only showcase eyebrow."
+  },
+  "holderLab.title": {
+    "message": "Эксклюзивное вдохновение для ACE Holder",
+    "description": "Заголовок эксклюзивного Showcase для Holder."
+  },
+  "holderLab.description": {
+    "message": "Избранные шаблоны и рабочие процессы, доступные на текущем уровне.",
+    "description": "Описание эксклюзивного Showcase для Holder."
+  },
+  "benefitStatus.active": {
+    "message": "Активна",
+    "description": "Статус активированной привилегии."
+  },
+  "benefitStatus.eligible": {
+    "message": "Доступна",
+    "description": "Статус доступной привилегии."
+  },
+  "benefitStatus.coming_soon": {
+    "message": "Скоро доступна",
+    "description": "Статус привилегии, которая скоро станет доступна."
+  },
+  "benefitStatus.locked": {
+    "message": "Не разблокирована",
+    "description": "Статус заблокированной привилегии."
+  },
+  "benefit.api_discount.title": {
+    "message": "Скидка на вызовы API",
+    "description": "Заголовок привилегии ACE API Discount."
+  },
+  "benefit.api_discount.description": {
+    "message": "Действующая скидка автоматически применяется к поддерживаемым вызовам Credits API и x402, если можно идентифицировать аккаунт.",
+    "description": "Описание привилегии ACE API Discount."
+  },
+  "benefit.early_access.title": {
+    "message": "Ранний доступ",
+    "description": "Заголовок привилегии ACE Early Access."
+  },
+  "benefit.early_access.description": {
+    "message": "Доступ к выбранным моделям и функциям за 72 часа до официального запуска.",
+    "description": "Описание привилегии ACE Early Access."
+  },
+  "benefit.referral_bonus.title": {
+    "message": "Бонус к реферальной комиссии",
+    "description": "Заголовок бонуса ACE за рекомендации."
+  },
+  "benefit.referral_bonus.description": {
+    "message": "Дополнительные процентные пункты за владение токенами к базовой ставке реферальной программы; итоговая ставка — до 30%.",
+    "description": "Описание бонуса ACE за рекомендации."
+  },
+  "benefit.nexior_holder_lab.title": {
+    "message": "Holder Lab",
+    "description": "Nexior Holder Lab benefit title."
+  },
+  "benefit.nexior_holder_lab.description": {
+    "message": "Доступ к шаблонам, рабочим процессам и функциям, отобранным для Holder.",
+    "description": "Описание привилегии Nexior Holder Lab."
+  },
+  "benefit.ace_operator.title": {
+    "message": "ACE Operator",
+    "description": "ACE Operator benefit title."
+  },
+  "benefit.ace_operator.description": {
+    "message": "Подача заявки доступна начиная с 4-го уровня; публичное размещение и статус Featured по-прежнему требуют проверки.",
+    "description": "Описание привилегии ACE Operator."
+  },
+  "operator.eyebrow": {
+    "message": "Operator",
+    "description": "Operator section eyebrow."
+  },
+  "operator.title": {
+    "message": "Подать заявку на ACE Operator",
+    "description": "Заголовок раздела Operator."
+  },
+  "operator.description": {
+    "message": "Отправьте своё публичное описание на проверку. Владение токенами даёт право подать заявку, но не гарантирует статус Featured или продвижение.",
+    "description": "Описание заявки Operator."
+  },
+  "operator.tierRequired": {
+    "message": "Подать заявку на ACE Operator можно после достижения Tier 4.",
+    "description": "Уведомление о требуемом уровне для Operator."
+  },
+  "operator.displayName": {
+    "message": "Публичное имя",
+    "description": "Поле публичного имени Operator."
+  },
+  "operator.bio": {
+    "message": "Публичное описание",
+    "description": "Поле публичного описания Operator."
+  },
+  "operator.public": {
+    "message": "Профиль будет опубликован после одобрения",
+    "description": "Описание настройки публичности Operator."
+  },
+  "operator.apply": {
+    "message": "Подать заявку",
+    "description": "Кнопка подачи заявки Operator."
+  },
+  "operator.save": {
+    "message": "Сохранить профиль",
+    "description": "Кнопка сохранения профиля Operator."
+  },
+  "operator.applied": {
+    "message": "Заявка отправлена и ожидает проверки.",
+    "description": "Уведомление об успешной подаче заявки Operator."
+  },
+  "operator.saved": {
+    "message": "Профиль Operator сохранён.",
+    "description": "Уведомление об успешном сохранении профиля Operator."
+  },
+  "operator.saveError": {
+    "message": "Не удалось сохранить профиль Operator. Повторите попытку позже.",
+    "description": "Уведомление об ошибке сохранения профиля Operator."
+  },
+  "operator.nameRequired": {
+    "message": "Укажите публичное имя.",
+    "description": "Уведомление о пустом имени Operator."
+  },
+  "operator.featuredEligible": {
+    "message": "Текущий уровень позволяет участвовать в отборе Featured",
+    "description": "Уведомление о возможности стать кандидатом на Featured."
+  },
+  "operator.featured": {
+    "message": "Платформа присвоила статус Featured",
+    "description": "Статус после одобрения Featured."
+  },
+  "operator.featuredBadge": {
+    "message": "Избранное",
+    "description": "Проверенный значок «Избранное» в карточках Showcase."
+  },
+  "operator.status.pending": {
+    "message": "На проверке",
+    "description": "Статус заявки Operator, ожидающей проверки."
+  },
+  "operator.status.approved": {
+    "message": "Одобрено",
+    "description": "Статус одобренной заявки Operator."
+  },
+  "operator.status.suspended": {
+    "message": "Приостановлено",
+    "description": "Статус приостановленного Operator."
   }
 }

--- a/src/i18n/zh-CN/coin.json
+++ b/src/i18n/zh-CN/coin.json
@@ -6,6 +6,209 @@
   "message.connectError": {
     "message": "钱包连接失败。",
     "description": "连接钱包失败时显示的错误提示。"
+  },
+  "holderCenter.nav": {
+    "message": "ACE Holder",
+    "description": "ACE 持币权益中心导航名称。"
+  },
+  "holderCenter.eyebrow": {
+    "message": "ACE 持币权益",
+    "description": "权益中心页眉标签。"
+  },
+  "holderCenter.title": {
+    "message": "你的 ACE Holder 权益",
+    "description": "权益中心主标题。"
+  },
+  "holderCenter.description": {
+    "message": "查看当前等级、已解锁权益、专属内容和 Operator 申请状态。",
+    "description": "权益中心说明。"
+  },
+  "holderCenter.manageWallet": {
+    "message": "管理验证钱包",
+    "description": "跳转平台钱包权益页的按钮。"
+  },
+  "holderCenter.connectPrompt": {
+    "message": "请先前往 API Platform 连接并验证持有 ACE 的 Solana 钱包。",
+    "description": "未绑定钱包提示。"
+  },
+  "holderCenter.currentTier": {
+    "message": "当前等级",
+    "description": "当前 ACE 等级标签。"
+  },
+  "holderCenter.holder": {
+    "message": "ACE Holder 权益已生效",
+    "description": "已达到持币门槛的状态。"
+  },
+  "holderCenter.notQualified": {
+    "message": "尚未达到 100,000 ACE 门槛",
+    "description": "未达到首档时的状态。"
+  },
+  "holderCenter.toNext": {
+    "message": "距离 {tier} 还需 {amount} ACE",
+    "description": "下一等级进度说明。"
+  },
+  "holderCenter.maxTier": {
+    "message": "已达到最高等级。",
+    "description": "最高等级提示。"
+  },
+  "holderCenter.monthlySavings": {
+    "message": "本月 API 已节省",
+    "description": "当月 Credits 节省标签。"
+  },
+  "holderCenter.benefitsEyebrow": {
+    "message": "已验证权益",
+    "description": "权益列表标签。"
+  },
+  "holderCenter.benefits": {
+    "message": "当前可用权益",
+    "description": "权益列表标题。"
+  },
+  "holderCenter.loadError": {
+    "message": "无法加载 ACE 权益，请稍后重试。",
+    "description": "权益中心加载失败。"
+  },
+  "holderLab.eyebrow": {
+    "message": "Holder Lab",
+    "description": "Holder 专属内容区标签。"
+  },
+  "holderLab.title": {
+    "message": "ACE Holder 专属灵感",
+    "description": "Holder 专属 Showcase 标题。"
+  },
+  "holderLab.description": {
+    "message": "为当前等级开放的精选模板和工作流。",
+    "description": "Holder 专属 Showcase 说明。"
+  },
+  "benefitStatus.active": {
+    "message": "已生效",
+    "description": "权益已生效状态。"
+  },
+  "benefitStatus.eligible": {
+    "message": "可使用",
+    "description": "权益可使用状态。"
+  },
+  "benefitStatus.coming_soon": {
+    "message": "即将开放",
+    "description": "权益即将开放状态。"
+  },
+  "benefitStatus.locked": {
+    "message": "未解锁",
+    "description": "权益未解锁状态。"
+  },
+  "benefit.api_discount.title": {
+    "message": "API 调用折扣",
+    "description": "ACE API 折扣权益标题。"
+  },
+  "benefit.api_discount.description": {
+    "message": "支持的 Credits API 与可识别账户身份的 x402 调用自动应用有效折扣。",
+    "description": "ACE API 折扣权益说明。"
+  },
+  "benefit.early_access.title": {
+    "message": "提前体验",
+    "description": "ACE 早鸟权益标题。"
+  },
+  "benefit.early_access.description": {
+    "message": "指定模型和功能可在正式开放前 72 小时体验。",
+    "description": "ACE 早鸟权益说明。"
+  },
+  "benefit.referral_bonus.title": {
+    "message": "推荐佣金加成",
+    "description": "ACE 推荐加成标题。"
+  },
+  "benefit.referral_bonus.description": {
+    "message": "在基础推荐比例上增加持币百分点，最终比例最高 30%。",
+    "description": "ACE 推荐加成说明。"
+  },
+  "benefit.nexior_holder_lab.title": {
+    "message": "Holder Lab",
+    "description": "Nexior Holder Lab 权益标题。"
+  },
+  "benefit.nexior_holder_lab.description": {
+    "message": "访问为 Holder 精选的模板、工作流和功能。",
+    "description": "Nexior Holder Lab 权益说明。"
+  },
+  "benefit.ace_operator.title": {
+    "message": "ACE Operator",
+    "description": "ACE Operator 权益标题。"
+  },
+  "benefit.ace_operator.description": {
+    "message": "Tier 4 起可申请；公开展示和 Featured 仍需审核。",
+    "description": "ACE Operator 权益说明。"
+  },
+  "operator.eyebrow": {
+    "message": "Operator",
+    "description": "Operator 区域标签。"
+  },
+  "operator.title": {
+    "message": "申请 ACE Operator",
+    "description": "Operator 区域标题。"
+  },
+  "operator.description": {
+    "message": "提交你的公开介绍供审核。持币只提供申请资格，不保证 Featured 或流量曝光。",
+    "description": "Operator 申请说明。"
+  },
+  "operator.tierRequired": {
+    "message": "达到 Tier 4 后可以申请 ACE Operator。",
+    "description": "Operator 等级门槛提示。"
+  },
+  "operator.displayName": {
+    "message": "公开名称",
+    "description": "Operator 公开名称字段。"
+  },
+  "operator.bio": {
+    "message": "公开介绍",
+    "description": "Operator 公开介绍字段。"
+  },
+  "operator.public": {
+    "message": "审核通过后公开展示资料",
+    "description": "Operator 公开开关说明。"
+  },
+  "operator.apply": {
+    "message": "提交申请",
+    "description": "提交 Operator 申请按钮。"
+  },
+  "operator.save": {
+    "message": "保存资料",
+    "description": "保存 Operator 资料按钮。"
+  },
+  "operator.applied": {
+    "message": "申请已提交，等待审核。",
+    "description": "Operator 申请成功提示。"
+  },
+  "operator.saved": {
+    "message": "Operator 资料已保存。",
+    "description": "Operator 保存成功提示。"
+  },
+  "operator.saveError": {
+    "message": "无法保存 Operator 资料，请稍后重试。",
+    "description": "Operator 保存失败提示。"
+  },
+  "operator.nameRequired": {
+    "message": "请填写公开名称。",
+    "description": "Operator 名称为空提示。"
+  },
+  "operator.featuredEligible": {
+    "message": "当前等级可参与 Featured 评审",
+    "description": "Featured 候选提示。"
+  },
+  "operator.featured": {
+    "message": "已由平台设为 Featured",
+    "description": "Featured 已审核状态。"
+  },
+  "operator.featuredBadge": {
+    "message": "精选",
+    "description": "Showcase 卡片中的已审核 Featured 标记。"
+  },
+  "operator.status.pending": {
+    "message": "待审核",
+    "description": "Operator 待审核状态。"
+  },
+  "operator.status.approved": {
+    "message": "已通过",
+    "description": "Operator 审核通过状态。"
+  },
+  "operator.status.suspended": {
+    "message": "已暂停",
+    "description": "Operator 暂停状态。"
   }
 }
-

--- a/src/i18n/zh-TW/coin.json
+++ b/src/i18n/zh-TW/coin.json
@@ -6,5 +6,209 @@
   "message.connectError": {
     "message": "錢包連線失敗。",
     "description": "連線錢包失敗時顯示的錯誤提示。"
+  },
+  "holderCenter.nav": {
+    "message": "ACE Holder",
+    "description": "Navigation label for the ACE holder center."
+  },
+  "holderCenter.eyebrow": {
+    "message": "ACE 持幣權益",
+    "description": "權益中心頁首標籤。"
+  },
+  "holderCenter.title": {
+    "message": "你的 ACE Holder 權益",
+    "description": "權益中心主標題。"
+  },
+  "holderCenter.description": {
+    "message": "查看目前等級、已解鎖權益、專屬內容和 Operator 申請狀態。",
+    "description": "權益中心說明。"
+  },
+  "holderCenter.manageWallet": {
+    "message": "管理驗證錢包",
+    "description": "跳轉至平台錢包權益頁面的按鈕。"
+  },
+  "holderCenter.connectPrompt": {
+    "message": "請先前往 API Platform 連線並驗證持有 ACE 的 Solana 錢包。",
+    "description": "未綁定錢包提示。"
+  },
+  "holderCenter.currentTier": {
+    "message": "目前等級",
+    "description": "目前 ACE 等級標籤。"
+  },
+  "holderCenter.holder": {
+    "message": "ACE Holder 權益已生效",
+    "description": "已達到持幣門檻的狀態。"
+  },
+  "holderCenter.notQualified": {
+    "message": "尚未達到 100,000 ACE 門檻",
+    "description": "未達到首檔時的狀態。"
+  },
+  "holderCenter.toNext": {
+    "message": "距離 {tier} 還需 {amount} ACE",
+    "description": "下一等級進度說明。"
+  },
+  "holderCenter.maxTier": {
+    "message": "已達到最高等級。",
+    "description": "最高等級提示。"
+  },
+  "holderCenter.monthlySavings": {
+    "message": "本月 API 已節省",
+    "description": "當月 Credits 節省標籤。"
+  },
+  "holderCenter.benefitsEyebrow": {
+    "message": "已驗證權益",
+    "description": "權益清單標籤。"
+  },
+  "holderCenter.benefits": {
+    "message": "目前可用權益",
+    "description": "權益清單標題。"
+  },
+  "holderCenter.loadError": {
+    "message": "無法載入 ACE 權益，請稍後再試。",
+    "description": "權益中心載入失敗。"
+  },
+  "holderLab.eyebrow": {
+    "message": "Holder Lab",
+    "description": "Holder-only showcase eyebrow."
+  },
+  "holderLab.title": {
+    "message": "ACE Holder 專屬靈感",
+    "description": "Holder 專屬 Showcase 標題。"
+  },
+  "holderLab.description": {
+    "message": "為當前等級開放的精選範本和工作流程。",
+    "description": "Holder 專屬 Showcase 說明。"
+  },
+  "benefitStatus.active": {
+    "message": "已生效",
+    "description": "權益已生效狀態。"
+  },
+  "benefitStatus.eligible": {
+    "message": "可使用",
+    "description": "權益可使用狀態。"
+  },
+  "benefitStatus.coming_soon": {
+    "message": "即將開放",
+    "description": "權益即將開放狀態。"
+  },
+  "benefitStatus.locked": {
+    "message": "未解鎖",
+    "description": "權益未解鎖狀態。"
+  },
+  "benefit.api_discount.title": {
+    "message": "API 呼叫折扣",
+    "description": "ACE API 折扣權益標題。"
+  },
+  "benefit.api_discount.description": {
+    "message": "支援的 Credits API 與可識別帳戶身分的 x402 呼叫會自動套用有效折扣。",
+    "description": "ACE API 折扣權益說明。"
+  },
+  "benefit.early_access.title": {
+    "message": "提前體驗",
+    "description": "ACE 早鳥權益標題。"
+  },
+  "benefit.early_access.description": {
+    "message": "指定模型和功能可在正式開放前 72 小時體驗。",
+    "description": "ACE 早鳥權益說明。"
+  },
+  "benefit.referral_bonus.title": {
+    "message": "推薦佣金加成",
+    "description": "ACE 推薦加成標題。"
+  },
+  "benefit.referral_bonus.description": {
+    "message": "在基礎推薦比例上增加持幣百分點，最終比例最高 30%。",
+    "description": "ACE 推薦加成說明。"
+  },
+  "benefit.nexior_holder_lab.title": {
+    "message": "Holder Lab",
+    "description": "Nexior Holder Lab benefit title."
+  },
+  "benefit.nexior_holder_lab.description": {
+    "message": "存取為 Holder 精選的範本、工作流程和功能。",
+    "description": "Nexior Holder Lab 權益說明。"
+  },
+  "benefit.ace_operator.title": {
+    "message": "ACE Operator",
+    "description": "ACE Operator benefit title."
+  },
+  "benefit.ace_operator.description": {
+    "message": "Tier 4 起即可申請；公開展示和 Featured 仍需審核。",
+    "description": "ACE Operator 權益說明。"
+  },
+  "operator.eyebrow": {
+    "message": "Operator",
+    "description": "Operator section eyebrow."
+  },
+  "operator.title": {
+    "message": "申請 ACE Operator",
+    "description": "Operator 區域標題。"
+  },
+  "operator.description": {
+    "message": "提交你的公開介紹供審核。持幣只提供申請資格，不保證 Featured 或流量曝光。",
+    "description": "Operator 申請說明。"
+  },
+  "operator.tierRequired": {
+    "message": "達到 Tier 4 後可以申請 ACE Operator。",
+    "description": "Operator 等級門檻提示。"
+  },
+  "operator.displayName": {
+    "message": "公開名稱",
+    "description": "Operator 公開名稱欄位。"
+  },
+  "operator.bio": {
+    "message": "公開介紹",
+    "description": "Operator 公開介紹欄位。"
+  },
+  "operator.public": {
+    "message": "審核通過後公開展示資料",
+    "description": "Operator 公開開關說明。"
+  },
+  "operator.apply": {
+    "message": "提交申請",
+    "description": "提交 Operator 申請按鈕。"
+  },
+  "operator.save": {
+    "message": "儲存資料",
+    "description": "儲存 Operator 資料按鈕。"
+  },
+  "operator.applied": {
+    "message": "申請已提交，等待審核。",
+    "description": "Operator 申請成功提示。"
+  },
+  "operator.saved": {
+    "message": "Operator 資料已儲存。",
+    "description": "Operator 儲存成功提示。"
+  },
+  "operator.saveError": {
+    "message": "無法儲存 Operator 資料，請稍後重試。",
+    "description": "Operator 儲存失敗提示。"
+  },
+  "operator.nameRequired": {
+    "message": "請填寫公開名稱。",
+    "description": "Operator 名稱為空提示。"
+  },
+  "operator.featuredEligible": {
+    "message": "當前等級可參與 Featured 評審",
+    "description": "Featured 候選提示。"
+  },
+  "operator.featured": {
+    "message": "已由平台設為 Featured",
+    "description": "Featured 已審核狀態。"
+  },
+  "operator.featuredBadge": {
+    "message": "精選",
+    "description": "Showcase 卡片中的已審核 Featured 標記。"
+  },
+  "operator.status.pending": {
+    "message": "待審核",
+    "description": "Operator 待審核狀態。"
+  },
+  "operator.status.approved": {
+    "message": "已通過",
+    "description": "Operator 審核通過狀態。"
+  },
+  "operator.status.suspended": {
+    "message": "已暫停",
+    "description": "Operator 暫停狀態。"
   }
 }

--- a/src/layouts/consoleLayout.test.ts
+++ b/src/layouts/consoleLayout.test.ts
@@ -98,7 +98,7 @@ describe('console layout contract', () => {
     // renders no panel.
     const children = routes.slice(routes.indexOf('children:'));
     const entries = children.match(/{\s*path: '[^']*',[\s\S]*?component:/g) || [];
-    expect(entries.length).toBe(9);
+    expect(entries.length).toBe(10);
     const undeclared = entries.filter((entry) => !/meta:\s*(DOCUMENT|WORKSPACE)/.test(entry));
     expect(undeclared).toEqual([]);
   });

--- a/src/models/showcase.ts
+++ b/src/models/showcase.ts
@@ -25,6 +25,12 @@ export interface IShowcase {
   service: string;
   task_id: string | null;
   data: IShowcaseTaskData;
+  minimum_ace_tier?: number | null;
+  operator?: {
+    display_name: string;
+    bio: string;
+    featured: boolean;
+  } | null;
 }
 
 export interface ResolvedShowcase {
@@ -45,4 +51,6 @@ export interface ResolvedShowcase {
   prompt: string;
   model: string;
   parameters: Array<{ key: string; value: string }>;
+  minimumAceTier?: number | null;
+  operator?: IShowcase['operator'];
 }

--- a/src/operators/ace.ts
+++ b/src/operators/ace.ts
@@ -1,0 +1,81 @@
+import type { AxiosResponse } from 'axios';
+import { httpClient } from './common';
+
+export interface AceTier {
+  tier: number;
+  code: string;
+  name: string;
+  threshold: number;
+  discount: number;
+}
+
+export interface AceBenefit {
+  code: 'api_discount' | 'early_access' | 'referral_bonus' | 'nexior_holder_lab' | 'ace_operator';
+  status: 'active' | 'eligible' | 'coming_soon' | 'locked';
+  minimum_tier: number;
+}
+
+export interface AceHolderSummary {
+  wallet?: {
+    address?: string | null;
+    balance?: number;
+    verification_status?: 'legacy_unverified' | 'verified' | 'revoked';
+    balance_checked_at?: string | null;
+    public_holder_status?: boolean;
+  } | null;
+  balance_fresh: boolean;
+  holder_status?: 'holder' | 'not_qualified';
+  current_tier?: AceTier;
+  next_tier?: AceTier & { remaining: number; progress: number };
+  benefits?: AceBenefit[];
+  monthly_savings?: {
+    calls: number;
+    saved_credits: number;
+  };
+}
+
+export interface AceOperatorProfile {
+  id: string;
+  display_name: string;
+  bio: string;
+  status: 'pending' | 'approved' | 'suspended';
+  public: boolean;
+  featured: boolean;
+  current_tier: number;
+  eligible: boolean;
+  featured_eligible: boolean;
+}
+
+export interface AceOperatorState {
+  profile: AceOperatorProfile | null;
+  current_tier?: number;
+  eligible?: boolean;
+  featured_eligible?: boolean;
+  minimum_tier: number;
+}
+
+class AceOperator {
+  summary(): Promise<AxiosResponse<AceHolderSummary>> {
+    return httpClient.get('/coin-wallet/summary/');
+  }
+
+  operatorProfile(): Promise<AxiosResponse<AceOperatorState>> {
+    return httpClient.get('/ace-operator/');
+  }
+
+  applyOperator(data: {
+    display_name: string;
+    bio: string;
+    public: boolean;
+  }): Promise<AxiosResponse<AceOperatorState>> {
+    return httpClient.post('/ace-operator/', data);
+  }
+
+  updateOperator(
+    data: Partial<{ display_name: string; bio: string; public: boolean }>
+  ): Promise<AxiosResponse<AceOperatorState>> {
+    return httpClient.patch('/ace-operator/', data);
+  }
+}
+
+export const aceOperator = new AceOperator();

--- a/src/operators/config.ts
+++ b/src/operators/config.ts
@@ -1,12 +1,12 @@
 import { AxiosResponse } from 'axios';
-import { anonymousHttpClient } from './common';
+import { optionalHttpClient } from './common';
 import { IConfigResponse } from '@/models';
 
 class ConfigService {
   key = 'config';
 
   async get(): Promise<AxiosResponse<IConfigResponse>> {
-    return await anonymousHttpClient.get(`/${this.key}/`);
+    return await optionalHttpClient.get(`/${this.key}/`);
   }
 }
 

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -52,3 +52,4 @@ export * from './appVersion';
 export * from './codingBridge';
 export * from './contentReport';
 export * from './showcase';
+export * from './ace';

--- a/src/operators/showcase.test.ts
+++ b/src/operators/showcase.test.ts
@@ -1,15 +1,31 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import axios from 'axios';
 
-const get = vi.fn();
-vi.mock('axios', () => ({ default: { create: vi.fn(() => ({ get })) } }));
+const publicGet = vi.fn();
+const optionalGet = vi.fn();
+const authState = { authenticated: false, user: undefined as { id: string } | undefined };
+vi.mock('axios', () => ({ default: { create: vi.fn(() => ({ get: publicGet })) } }));
 vi.mock('@/utils/baseUrl', () => ({ getBaseUrlPlatform: () => 'https://platform.example.com' }));
+vi.mock('@/store', () => ({
+  default: {
+    getters: new Proxy(
+      {},
+      {
+        get: (_target, key) => authState[key as keyof typeof authState]
+      }
+    )
+  }
+}));
+vi.mock('./common', () => ({ optionalHttpClient: { get: optionalGet } }));
 
 const { showcaseOperator } = await import('./showcase');
 
 describe('showcaseOperator', () => {
   beforeEach(() => {
-    get.mockReset();
+    publicGet.mockReset();
+    optionalGet.mockReset();
+    authState.authenticated = false;
+    authState.user = undefined;
     showcaseOperator.clearCache();
   });
 
@@ -18,49 +34,63 @@ describe('showcaseOperator', () => {
   });
 
   it('loads the complete list or exact service filter', async () => {
-    get.mockResolvedValue({ data: [] });
+    publicGet.mockResolvedValue({ data: [] });
     await showcaseOperator.list();
-    expect(get).toHaveBeenCalledWith('/showcases/', { headers: { 'Accept-Language': 'en' }, params: undefined });
+    expect(publicGet).toHaveBeenCalledWith('/showcases/', {
+      headers: { 'Accept-Language': 'en' },
+      params: undefined
+    });
     showcaseOperator.clearCache();
     await showcaseOperator.list('seedance', 'zh-CN');
-    expect(get).toHaveBeenLastCalledWith('/showcases/', {
+    expect(publicGet).toHaveBeenLastCalledWith('/showcases/', {
       headers: { 'Accept-Language': 'zh-cn' },
       params: { service: 'seedance' }
     });
   });
 
-  it('isolates cache entries by locale', async () => {
-    get.mockResolvedValue({ data: [] });
+  it('isolates cache entries by locale and authenticated identity', async () => {
+    publicGet.mockResolvedValue({ data: [] });
+    optionalGet.mockResolvedValue({ data: [] });
     await showcaseOperator.list('seedance', 'en');
     await showcaseOperator.list('seedance', 'zh-CN');
     await showcaseOperator.list('seedance', 'en');
-    expect(get).toHaveBeenCalledTimes(2);
+    expect(publicGet).toHaveBeenCalledTimes(2);
+
+    authState.authenticated = true;
+    authState.user = { id: 'holder-1' };
+    await showcaseOperator.list('seedance', 'en');
+    await showcaseOperator.list('seedance', 'en');
+    expect(optionalGet).toHaveBeenCalledTimes(1);
+
+    authState.user = { id: 'holder-2' };
+    await showcaseOperator.list('seedance', 'en');
+    expect(optionalGet).toHaveBeenCalledTimes(2);
   });
 
   it('expires successful cache entries after the server cache window', async () => {
     vi.useFakeTimers();
-    get.mockResolvedValue({ data: [] });
+    publicGet.mockResolvedValue({ data: [] });
     await showcaseOperator.list('seedance');
     await showcaseOperator.list('seedance');
-    expect(get).toHaveBeenCalledTimes(1);
+    expect(publicGet).toHaveBeenCalledTimes(1);
     vi.advanceTimersByTime(60_001);
     await showcaseOperator.list('seedance');
-    expect(get).toHaveBeenCalledTimes(2);
+    expect(publicGet).toHaveBeenCalledTimes(2);
     vi.useRealTimers();
   });
 
   it('deduplicates identical list requests and clears failed promises', async () => {
-    get.mockResolvedValue({ data: [] });
+    publicGet.mockResolvedValue({ data: [] });
     const first = showcaseOperator.list('nano-banana');
     const second = showcaseOperator.list('nano-banana');
     expect(first).toBe(second);
     await first;
-    expect(get).toHaveBeenCalledTimes(1);
+    expect(publicGet).toHaveBeenCalledTimes(1);
 
     showcaseOperator.clearCache();
-    get.mockRejectedValueOnce(new Error('offline')).mockResolvedValueOnce({ data: [] });
+    publicGet.mockRejectedValueOnce(new Error('offline')).mockResolvedValueOnce({ data: [] });
     await showcaseOperator.list('seedance').catch(() => undefined);
     await showcaseOperator.list('seedance');
-    expect(get).toHaveBeenCalledTimes(3);
+    expect(publicGet).toHaveBeenCalledTimes(3);
   });
 });

--- a/src/operators/showcase.ts
+++ b/src/operators/showcase.ts
@@ -1,6 +1,8 @@
 import axios, { type AxiosInstance, type AxiosResponse } from 'axios';
 import type { IShowcase } from '@/models';
 import { getBaseUrlPlatform } from '@/utils/baseUrl';
+import store from '@/store';
+import { optionalHttpClient } from './common';
 
 const CACHE_TTL_MS = 60_000;
 const publicClient: AxiosInstance = axios.create({
@@ -18,11 +20,13 @@ class ShowcaseOperator {
 
   list(service?: string, locale = 'en'): Promise<AxiosResponse<IShowcase[]>> {
     const normalizedLocale = locale.trim().toLowerCase() || 'en';
-    const key = `${normalizedLocale}:${service || '*'}`;
+    const identity = store.getters.authenticated ? String(store.getters.user?.id || 'authenticated') : 'anonymous';
+    const key = `${identity}:${normalizedLocale}:${service || '*'}`;
     const now = Date.now();
     const cached = this.cache.get(key);
     if (cached && cached.expiresAt > now) return cached.request;
-    const request = publicClient.get<IShowcase[]>('/showcases/', {
+    const client = store.getters.authenticated ? optionalHttpClient : publicClient;
+    const request = client.get<IShowcase[]>('/showcases/', {
       headers: { 'Accept-Language': normalizedLocale },
       params: service ? { service } : undefined
     });

--- a/src/pages/console/holder/Index.vue
+++ b/src/pages/console/holder/Index.vue
@@ -1,0 +1,336 @@
+<template>
+  <main v-loading="loading" class="holder-page">
+    <section class="holder-hero">
+      <div>
+        <p class="eyebrow">{{ $t('coin.holderCenter.eyebrow') }}</p>
+        <h1>{{ $t('coin.holderCenter.title') }}</h1>
+        <p>{{ $t('coin.holderCenter.description') }}</p>
+      </div>
+      <a :href="platformBenefitsUrl" target="_blank" rel="noopener noreferrer" class="platform-link">
+        {{ $t('coin.holderCenter.manageWallet') }}
+      </a>
+    </section>
+
+    <el-alert
+      v-if="!summary?.wallet?.address"
+      type="info"
+      :closable="false"
+      show-icon
+      :title="$t('coin.holderCenter.connectPrompt')"
+    />
+
+    <section class="tier-card">
+      <div class="tier-mark">
+        <span>{{ $t('coin.holderCenter.currentTier') }}</span>
+        <strong>{{ currentTier ? `T${currentTier}` : 'T0' }}</strong>
+      </div>
+      <div class="tier-copy">
+        <h2>{{ currentTier ? $t('coin.holderCenter.holder') : $t('coin.holderCenter.notQualified') }}</h2>
+        <p v-if="summary?.next_tier">
+          {{
+            $t('coin.holderCenter.toNext', {
+              amount: formatNumber(summary.next_tier.remaining),
+              tier: summary.next_tier.code
+            })
+          }}
+        </p>
+        <p v-else>{{ $t('coin.holderCenter.maxTier') }}</p>
+      </div>
+      <div class="tier-savings">
+        <span>{{ $t('coin.holderCenter.monthlySavings') }}</span>
+        <strong>{{ formatCredits(summary?.monthly_savings?.saved_credits) }}</strong>
+      </div>
+    </section>
+
+    <section v-if="summary?.benefits?.length" class="benefits-panel">
+      <header>
+        <p class="eyebrow">{{ $t('coin.holderCenter.benefitsEyebrow') }}</p>
+        <h2>{{ $t('coin.holderCenter.benefits') }}</h2>
+      </header>
+      <div class="benefit-list">
+        <article v-for="benefit in summary.benefits" :key="benefit.code">
+          <div>
+            <strong>{{ $t(`coin.benefit.${benefit.code}.title`) }}</strong>
+            <p>{{ $t(`coin.benefit.${benefit.code}.description`) }}</p>
+          </div>
+          <el-tag
+            :type="benefit.status === 'active' ? 'success' : benefit.status === 'coming_soon' ? 'warning' : 'info'"
+            effect="plain"
+            round
+          >
+            {{ $t(`coin.benefitStatus.${benefit.status}`) }}
+          </el-tag>
+        </article>
+      </div>
+    </section>
+
+    <section class="operator-panel">
+      <header>
+        <p class="eyebrow">{{ $t('coin.operator.eyebrow') }}</p>
+        <h2>{{ $t('coin.operator.title') }}</h2>
+        <p>{{ $t('coin.operator.description') }}</p>
+      </header>
+      <el-alert
+        v-if="!operatorState?.profile && !operatorState?.eligible"
+        type="info"
+        :closable="false"
+        :title="$t('coin.operator.tierRequired')"
+      />
+      <el-form v-else label-position="top" class="operator-form" @submit.prevent>
+        <el-form-item :label="$t('coin.operator.displayName')">
+          <el-input v-model="operatorForm.display_name" :maxlength="80" show-word-limit />
+        </el-form-item>
+        <el-form-item :label="$t('coin.operator.bio')">
+          <el-input v-model="operatorForm.bio" type="textarea" :rows="4" />
+        </el-form-item>
+        <div class="operator-form__footer">
+          <div>
+            <el-switch v-model="operatorForm.public" :disabled="operatorState?.profile?.status !== 'approved'" />
+            <span>{{ $t('coin.operator.public') }}</span>
+          </div>
+          <el-button type="primary" :loading="saving" @click="saveOperator">
+            {{ operatorState?.profile ? $t('coin.operator.save') : $t('coin.operator.apply') }}
+          </el-button>
+        </div>
+      </el-form>
+      <div v-if="operatorState?.profile" class="operator-status">
+        <el-tag effect="plain">{{ $t(`coin.operator.status.${operatorState.profile.status}`) }}</el-tag>
+        <span v-if="operatorState.profile.featured_eligible">{{ $t('coin.operator.featuredEligible') }}</span>
+        <span v-if="operatorState.profile.featured">{{ $t('coin.operator.featured') }}</span>
+      </div>
+    </section>
+  </main>
+</template>
+
+<script setup lang="ts">
+import { computed, getCurrentInstance, onMounted, reactive, ref } from 'vue';
+import { ElAlert, ElButton, ElForm, ElFormItem, ElInput, ElMessage, ElSwitch, ElTag } from 'element-plus';
+import { aceOperator, type AceHolderSummary, type AceOperatorState } from '@/operators';
+import { getBaseUrlPlatform } from '@/utils/baseUrl';
+import { captureError } from '@/plugins/telemetry';
+
+const vm = getCurrentInstance()!.proxy as any;
+const loading = ref(true);
+const saving = ref(false);
+const summary = ref<AceHolderSummary>();
+const operatorState = ref<AceOperatorState>();
+const operatorForm = reactive({ display_name: '', bio: '', public: false });
+const platformBenefitsUrl = `${getBaseUrlPlatform()}/console/coin`;
+const currentTier = computed(() => Number(summary.value?.current_tier?.tier || 0));
+
+async function load() {
+  loading.value = true;
+  try {
+    const [summaryResponse, operatorResponse] = await Promise.all([
+      aceOperator.summary(),
+      aceOperator.operatorProfile()
+    ]);
+    summary.value = summaryResponse.data;
+    operatorState.value = operatorResponse.data;
+    if (operatorState.value.profile) {
+      operatorForm.display_name = operatorState.value.profile.display_name;
+      operatorForm.bio = operatorState.value.profile.bio;
+      operatorForm.public = operatorState.value.profile.public;
+    }
+  } catch (error) {
+    captureError(error, { source: 'ace-holder', action: 'load' });
+    ElMessage.error(vm.$t('coin.holderCenter.loadError'));
+  } finally {
+    loading.value = false;
+  }
+}
+
+async function saveOperator() {
+  if (!operatorForm.display_name.trim()) {
+    ElMessage.warning(vm.$t('coin.operator.nameRequired'));
+    return;
+  }
+  saving.value = true;
+  try {
+    const payload = {
+      display_name: operatorForm.display_name.trim(),
+      bio: operatorForm.bio.trim(),
+      public: operatorForm.public
+    };
+    const response = operatorState.value?.profile
+      ? await aceOperator.updateOperator(payload)
+      : await aceOperator.applyOperator(payload);
+    operatorState.value = { ...operatorState.value, ...response.data } as AceOperatorState;
+    ElMessage.success(
+      vm.$t(operatorState.value.profile?.status === 'pending' ? 'coin.operator.applied' : 'coin.operator.saved')
+    );
+  } catch (error) {
+    captureError(error, { source: 'ace-holder', action: 'saveOperator' });
+    ElMessage.error(vm.$t('coin.operator.saveError'));
+  } finally {
+    saving.value = false;
+  }
+}
+
+const formatNumber = (value?: number | null) =>
+  Number(value || 0).toLocaleString(undefined, { maximumFractionDigits: 0 });
+const formatCredits = (value?: number | null) =>
+  `${Number(value || 0).toLocaleString(undefined, { maximumFractionDigits: 2 })} Credits`;
+
+onMounted(load);
+</script>
+
+<style scoped lang="scss">
+.holder-page {
+  display: grid;
+  gap: 18px;
+  max-width: 1040px;
+  margin: 0 auto;
+}
+.holder-hero,
+.tier-card,
+.benefits-panel,
+.operator-panel {
+  border: 1px solid var(--app-border-subtle);
+  border-radius: 18px;
+  background: var(--el-bg-color);
+}
+.holder-hero {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 28px;
+}
+.holder-hero h1,
+.holder-hero p,
+.operator-panel h2,
+.operator-panel p {
+  margin: 0;
+}
+.holder-hero h1 {
+  margin-bottom: 8px;
+  font-size: 28px;
+}
+.holder-hero p,
+.operator-panel p,
+.benefit-list p {
+  color: var(--el-text-color-secondary);
+  line-height: 1.6;
+}
+.eyebrow {
+  margin: 0 0 6px;
+  color: var(--el-color-primary);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.platform-link {
+  flex: none;
+  padding: 10px 16px;
+  border: 1px solid var(--el-color-primary);
+  border-radius: 999px;
+  color: var(--el-color-primary);
+  text-decoration: none;
+}
+.tier-card {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 22px;
+  padding: 22px;
+}
+.tier-mark {
+  display: grid;
+  place-items: center;
+  width: 96px;
+  height: 96px;
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--el-color-primary) 12%, var(--el-bg-color));
+}
+.tier-mark span,
+.tier-savings span {
+  color: var(--el-text-color-secondary);
+  font-size: 12px;
+}
+.tier-mark strong {
+  color: var(--el-color-primary);
+  font-size: 30px;
+}
+.tier-copy h2,
+.tier-copy p,
+.tier-savings span,
+.tier-savings strong {
+  margin: 0;
+}
+.tier-copy p {
+  margin-top: 5px;
+  color: var(--el-text-color-secondary);
+}
+.tier-savings {
+  display: grid;
+  justify-items: end;
+  gap: 5px;
+}
+.tier-savings strong {
+  font-size: 20px;
+}
+.benefits-panel,
+.operator-panel {
+  padding: 24px;
+}
+.benefit-list {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+  margin-top: 18px;
+}
+.benefit-list article {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 15px;
+  border: 1px solid var(--app-border-subtle);
+  border-radius: 13px;
+}
+.benefit-list p {
+  margin: 5px 0 0;
+}
+.operator-form {
+  margin-top: 18px;
+}
+.operator-form__footer,
+.operator-status {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+.operator-form__footer > div,
+.operator-status {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+}
+.operator-status {
+  justify-content: flex-start;
+  margin-top: 16px;
+}
+@media (max-width: 720px) {
+  .holder-hero,
+  .tier-card {
+    align-items: flex-start;
+    grid-template-columns: 1fr;
+  }
+  .holder-hero {
+    flex-direction: column;
+  }
+  .tier-savings {
+    justify-items: start;
+  }
+  .benefit-list {
+    grid-template-columns: 1fr;
+  }
+  .operator-form__footer {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}
+</style>

--- a/src/pages/home/Index.test.ts
+++ b/src/pages/home/Index.test.ts
@@ -105,6 +105,17 @@ describe('Studio workbench home', () => {
     expect(wrapper.getComponent({ name: 'ShowcaseGrid' }).props('items')[0].capability).toBe('seedance');
   });
 
+  it('separates holder-only showcases from the public gallery', async () => {
+    vi.mocked(showcaseOperator.list).mockResolvedValue({
+      data: [showcase, { ...showcase, id: 'holder-item', minimum_ace_tier: 1 }]
+    } as any);
+    const wrapper = mountHome({ id: 'studio', features: { seedance: { enabled: true } } });
+    await vi.waitFor(() => expect(wrapper.findAllComponents({ name: 'ShowcaseGrid' })).toHaveLength(2));
+    const galleries = wrapper.findAllComponents({ name: 'ShowcaseGrid' });
+    expect(galleries[0].props('items').map((item: any) => item.id)).toEqual(['holder-item']);
+    expect(galleries[1].props('items').map((item: any) => item.id)).toEqual([showcase.id]);
+  });
+
   it('renders Showcases in twelve-item batches with an accessible fallback button', async () => {
     const feed = Array.from({ length: 30 }, (_, index) => ({ ...showcase, id: `showcase-${index}` }));
     vi.mocked(showcaseOperator.list).mockResolvedValue({ data: feed } as any);

--- a/src/pages/home/Index.vue
+++ b/src/pages/home/Index.vue
@@ -9,6 +9,17 @@
         @icon-error="onIconError"
       />
       <showcase-grid
+        v-if="visibleHolderShowcases.length"
+        :items="visibleHolderShowcases"
+        :eyebrow="$t('coin.holderLab.eyebrow')"
+        :title="$t('coin.holderLab.title')"
+        :subtitle="$t('coin.holderLab.description')"
+        :aria-label="$t('coin.holderLab.title')"
+        detail-preview
+        @select="selectedShowcase = $event"
+        @icon-error="onShowcaseIconError"
+      />
+      <showcase-grid
         v-if="visibleShowcases.length"
         :items="visibleShowcases"
         :eyebrow="$t('intro.home.showcase.eyebrow')"
@@ -155,11 +166,20 @@ export default defineComponent({
           icon: this.failedIcons[item.capability] ? item.defaultIcon : item.icon
         }));
     },
+    holderShowcases(): ResolvedShowcase[] {
+      return this.resolvedShowcases.filter((item) => Number(item.minimumAceTier || 0) > 0);
+    },
+    publicShowcases(): ResolvedShowcase[] {
+      return this.resolvedShowcases.filter((item) => !item.minimumAceTier);
+    },
+    visibleHolderShowcases(): ResolvedShowcase[] {
+      return this.holderShowcases.slice(0, SHOWCASE_BATCH_SIZE);
+    },
     visibleShowcases(): ResolvedShowcase[] {
-      return this.resolvedShowcases.slice(0, this.visibleShowcaseCount);
+      return this.publicShowcases.slice(0, this.visibleShowcaseCount);
     },
     hasMoreShowcases(): boolean {
-      return this.visibleShowcaseCount < this.resolvedShowcases.length;
+      return this.visibleShowcaseCount < this.publicShowcases.length;
     }
   },
   watch: {

--- a/src/router/console.ts
+++ b/src/router/console.ts
@@ -1,4 +1,5 @@
 import {
+  ROUTE_CONSOLE_ACE_HOLDER,
   ROUTE_CONSOLE_APPLICATION_EXTRA,
   ROUTE_CONSOLE_APPLICATION_LIST,
   ROUTE_CONSOLE_APPLICATION_SUBSCRIBE,
@@ -10,6 +11,8 @@ import {
   ROUTE_CONSOLE_SKILLS,
   ROUTE_CONSOLE_USAGE_LIST
 } from './constants';
+import { isMainOfficial } from '@/utils';
+import { isNative } from '@/utils/surface';
 
 // Which shape of `.panel` the layout gives a page. There is no single mode
 // that serves both: `document` lets the panel scroll (a workspace page would
@@ -94,6 +97,13 @@ export default {
       name: ROUTE_CONSOLE_BROWSER_DEVICES,
       meta: DOCUMENT,
       component: () => import('@/pages/console/browserDevices/Index.vue')
+    },
+    {
+      path: 'holder',
+      name: ROUTE_CONSOLE_ACE_HOLDER,
+      meta: DOCUMENT,
+      beforeEnter: () => (isMainOfficial() || isNative() ? true : { name: ROUTE_CONSOLE_ROOT }),
+      component: () => import('@/pages/console/holder/Index.vue')
     }
   ]
 };

--- a/src/router/constants.ts
+++ b/src/router/constants.ts
@@ -105,5 +105,6 @@ export const ROUTE_CONSOLE_USAGE_LIST = 'console-usage-list';
 export const ROUTE_CONSOLE_CONNECTORS = 'console-connectors';
 export const ROUTE_CONSOLE_SKILLS = 'console-skills';
 export const ROUTE_CONSOLE_BROWSER_DEVICES = 'console-browser-devices';
+export const ROUTE_CONSOLE_ACE_HOLDER = 'console-ace-holder';
 
 export const ROUTE_NOT_FOUND = 'not-found';

--- a/src/utils/showcase.ts
+++ b/src/utils/showcase.ts
@@ -237,6 +237,8 @@ export function resolveShowcase(item: IShowcase, site: ISite): ResolvedShowcase 
     prompt,
     model: stringValue(request.model, result.model),
     parameters: deriveParameters(request),
+    minimumAceTier: item.minimum_ace_tier,
+    operator: item.operator,
     ...media
   };
 }


### PR DESCRIPTION
## 背景

后端依赖：

- Holder/Tier API：https://github.com/AceDataCloud/PlatformBackend/pull/1758
- Early Access：https://github.com/AceDataCloud/PlatformBackend/pull/1759
- Holder Showcase / Operator API：https://github.com/AceDataCloud/PlatformBackend/pull/1762

本 PR 将 ACE 持币权益接入 Nexior，但不复制钱包签名逻辑。钱包绑定、换绑和余额同步仍由 API Platform 的权益中心负责；Nexior 只消费服务端返回的 Tier 与权益状态。

## 具体改动

### Holder Center

新增 `/console/holder`：

- 当前 `ACE Holder · Tier N` / T0；
- 下一档与所需 ACE；
- 本月 API 节省 Credits；
- 已生效、即将开放和未解锁权益；
- 跳转 API Platform 管理验证钱包；
- T4+ Operator 申请/资料维护；
- T7+ 仅显示可参与 Featured 评审，不保证曝光。

入口只在 `studio.acedata.cloud` 或官方 iOS/Android App 显示；白牌 Web 站隐藏，直接 URL 也回到 Console 首页。

### Holder Lab

- Showcase 请求在登录时使用 optional-auth client，后端可返回当前 Tier 有权查看的内容。
- 缓存键加入用户身份，匿名缓存不会遮挡登录后的 Holder 内容，用户之间也不复用个性化响应。
- 首页将 `minimum_ace_tier` 内容单独展示为 Holder Lab，普通 Showcase 保持原分页。
- 经后端审核且公开的 Operator 可显示名称；Featured 标签只展示后端已审核结果，不展示 user_id、钱包或余额。

### Feature Flag

`configOperator` 改为 optional-auth，使 `targeting.min_ace_tier` 能针对登录用户返回真实结果；匿名用户仍正常获取公共配置。

### i18n / 发布

- zh-CN/en 手工维护，其他 10 个 locale 通过 backfill + `translate_i18n.py --repair` 生成。
- 修复翻译脚本 JSON mode 兼容：user prompt 显式包含 JSON。
- 增加 beachball minor change。

## 验证

- i18n coverage：**11 locale × 50 namespace，无缺键/英文占位**。
- ESLint：0 error（仅 2 条既有 test warning）。
- `vue-tsc --noEmit`：通过。
- Showcase/Home 相关 Vitest：**32 passed**。
- ACE contract：**5 passed**。
- `npm run build:web`：成功。
- `npm run build:android`：成功。
- `npm run build:ios`：成功。

构建仅出现第三方 Sass / Rolldown pure annotation 既有 warning。

## 上线与回滚

1. 先部署 Backend #1758、#1759、#1762。
2. 再部署 Nexior。
3. 后端未配置 Holder-only Showcase 时 Holder Lab 自动不显示，不影响现有首页。
4. 回滚本 PR 只移除 Nexior 展示与调用；Backend 权益和 API 不受影响。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
