### PR TITLE
fix: make auth settings responsive

### DIFF
--- a/change/fix-auth-settings-responsive.json
+++ b/change/fix-auth-settings-responsive.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Make the site authentication settings responsive so labels and delivery controls stay readable at desktop, tablet, and mobile widths.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/setting/Auth.vue
+++ b/src/components/setting/Auth.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="settings-list">
+  <div class="settings-list auth-settings">
     <section-notice tone="admin" :text="$t('common.settings.adminOnlyHint')" />
 
     <!--
@@ -247,47 +247,33 @@ export default defineComponent({
 </script>
 
 <style lang="scss" scoped>
-// The settings row uses ``display:flex; justify-content:space-between``
-// from the parent ``user/Setting.vue`` (``:deep(.settings-item)``). Its
-// ``.settings-label`` ships without ``min-width: 0``, so when an inner
-// ``.settings-tip`` carries ``max-width: 440px`` the label's flex
-// preferred size resolves to ~440px. On the 50%-dialog the available
-// content width can be as little as ~400px, which pushes the right
-// switch column past the gutter and visually overlaps the tip text
-// with the provider labels (邮箱 / Google / GitHub / 手机号 / 微信).
-//
-// Force the label column to share the row by:
-//   * letting it grow into all remaining space (``flex: 1 1 0``)
-//   * unlocking flex-shrink below intrinsic min-content (``min-width:0``)
-//
-// And lock the right column to its content size so it never gets
-// squeezed below the toggle width either.
-:deep(.settings-item) {
-  .settings-label {
-    flex: 1 1 0;
+.auth-settings {
+  container: auth-settings / inline-size;
+}
+
+// Auth controls have intrinsic widths, so size these rows against the content pane rather than the viewport.
+.auth-settings :deep(.settings-item) {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+
+  .settings-label,
+  .settings-content {
     min-width: 0;
+  }
+
+  .settings-content {
+    width: 100%;
   }
 }
 
-.auth-providers-content {
-  // Let the switch list stretch the full content column so each
-  // row aligns its label and toggle in a single visual gutter, and
-  // pin the column to its intrinsic width so it never collides with
-  // the tip text on narrow viewports.
-  align-items: stretch;
-  flex: 0 0 auto;
-}
-
 .auth-providers-list {
+  width: min(100%, 220px);
+  min-width: 0;
   list-style: none;
   padding: 0;
   margin: 0;
   display: flex;
   flex-direction: column;
-  // 220px is enough to render the longest provider label (``GitHub``)
-  // plus the el-switch comfortably; the earlier 240px was wide enough
-  // to monopolise the row on a 50%-width dialog and starve the tip.
-  min-width: 220px;
 }
 
 .auth-providers-row {
@@ -307,7 +293,8 @@ export default defineComponent({
 }
 
 .auth-default-provider-select {
-  min-width: 240px;
+  width: min(100%, 240px);
+  min-width: 0;
 }
 
 .auth-sms-content {
@@ -369,5 +356,16 @@ export default defineComponent({
   line-height: 1.6;
   white-space: pre-wrap;
   word-break: break-word;
+}
+
+@container auth-settings (max-width: 560px) {
+  .auth-settings :deep(.settings-item) {
+    grid-template-columns: minmax(0, 1fr);
+
+    .settings-content {
+      align-items: flex-start;
+      text-align: left;
+    }
+  }
 }
 </style>

--- a/src/components/user/Setting.test.ts
+++ b/src/components/user/Setting.test.ts
@@ -86,6 +86,18 @@ describe('user/Setting layout', () => {
     const aside = wrapper.find('aside');
     expect(aside.classes()).toEqual(expect.arrayContaining(['h-full', 'min-h-0', 'overflow-y-auto']));
   });
+
+  it('opens Auth at the wide desktop width and keeps the mobile width priority', async () => {
+    vi.stubEnv('VITE_SURFACE', 'web');
+    const wrapper = mountSetting();
+    await wrapper.setData({ activeTab: 'auth' });
+
+    expect(wrapper.findComponent(AuthSetting).exists()).toBe(true);
+    expect((wrapper.vm as unknown as { dialogWidth: string }).dialogWidth).toBe('min(900px, 94vw)');
+
+    await wrapper.setData({ mobile: true });
+    expect((wrapper.vm as unknown as { dialogWidth: string }).dialogWidth).toBe('94vw');
+  });
 });
 
 describe('user/Setting surface gating', () => {

--- a/src/components/user/Setting.vue
+++ b/src/components/user/Setting.vue
@@ -366,6 +366,7 @@ export default defineComponent({
       return this.currentTab === SETTING_TAB_API_KEY ||
         this.currentTab === SETTING_TAB_SITE_SERVICES ||
         this.currentTab === SETTING_TAB_BANNERS ||
+        this.currentTab === SETTING_TAB_AUTH ||
         this.currentTab === SETTING_TAB_SUBSITES
         ? 'min(900px, 94vw)'
         : '50%';


### PR DESCRIPTION
## Summary

- open the Auth settings tab at the existing wide dialog size on desktop
- size Auth rows against their actual content pane and switch to one column when that pane is narrow
- let provider and select controls shrink without collapsing labels or overflowing
- cover desktop and mobile dialog-width decisions with a regression test

## Verification

- `npm run test:run -- src/components/user/Setting.test.ts` (13 passed)
- `npm run build`
- `npm run lint` (0 errors; 2 existing warnings in `src/utils/dropUploadMixin.test.ts`)
- `python3 scripts/check_i18n_coverage.py`
- `npx beachball check --branch origin/main`
- release workflow, Studio deployment, and release asset contract checks
- Chromium viewport matrix: 1440, 1024, 800, 768, 767, 641, 640, 390, and 320 px; no body/Auth/row horizontal overflow and all Auth titles remain readable
- Chromium SMTP + webhook expanded state at 800 px; 19 editor controls rendered with no horizontal overflow or console errors

## Local environment notes

- the full Vitest run has one pre-existing timeout in `ScheduledTasks.test.ts:1802`; it reproduces in isolation and neither the test nor implementation is changed by this PR
- `deploy/test-compatible-images.sh studio-frontend` could not complete locally because Docker Desktop timed out fetching/building `nginx:stable-alpine` twice

🤖 Generated with [Claude Code](https://claude.com/claude-code)