### PR TITLE
feat: configure per-site GitHub OAuth apps

### DIFF
--- a/change/site-github-oauth-app.json
+++ b/change/site-github-oauth-app.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Let site administrators configure a dedicated GitHub OAuth App for tenant sign-in.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/setting/Auth.vue
+++ b/src/components/setting/Auth.vue
@@ -79,6 +79,7 @@
       </div>
     </section>
 
+    <site-github-o-auth-app v-if="site?.id" :site-id="site.id" :provider-enabled="isProviderEnabled('github')" />
     <site-email-transport v-if="site?.id" :site-id="site.id" :provider-enabled="isProviderEnabled('email')" />
     <site-phone-delivery v-if="site?.id" :site-id="site.id" :provider-enabled="isProviderEnabled('phone')" />
   </div>
@@ -89,6 +90,7 @@ import { defineComponent } from 'vue';
 import { ElMessage, ElOption, ElSelect, ElSwitch } from 'element-plus';
 import SectionNotice from '@/components/setting/SectionNotice.vue';
 import SiteEmailTransport from '@/components/setting/SiteEmailTransport.vue';
+import SiteGithubOAuthApp from '@/components/setting/SiteGithubOAuthApp.vue';
 import SitePhoneDelivery from '@/components/setting/SitePhoneDelivery.vue';
 import { siteOperator } from '@/operators';
 import type { ISiteAuth, ISiteAuthProvider } from '@/models';
@@ -117,6 +119,7 @@ export default defineComponent({
     ElSwitch,
     SectionNotice,
     SiteEmailTransport,
+    SiteGithubOAuthApp,
     SitePhoneDelivery
   },
   computed: {

--- a/src/components/setting/SiteGithubOAuthApp.vue
+++ b/src/components/setting/SiteGithubOAuthApp.vue
@@ -1,0 +1,190 @@
+<template>
+  <section class="settings-item github-oauth">
+    <div class="settings-label">
+      <p class="settings-title">{{ $t('site.field.authGithubOAuthApp') }}</p>
+      <p class="settings-tip">{{ $t('site.message.authGithubOAuthAppTip') }}</p>
+    </div>
+    <div v-loading="loading" class="settings-content github-oauth__content">
+      <el-alert
+        v-if="!providerEnabled"
+        :title="$t('site.message.authGithubOAuthProviderDisabled')"
+        type="info"
+        :closable="false"
+      />
+      <el-alert
+        :title="
+          config.using_platform_default
+            ? $t('site.message.authGithubOAuthUsingPlatform')
+            : $t('site.message.authGithubOAuthUsingCustom')
+        "
+        :type="config.using_platform_default ? 'info' : 'success'"
+        :closable="false"
+      />
+      <el-form label-position="top" class="github-oauth__form">
+        <el-form-item :label="$t('site.field.authGithubOAuthClientId')">
+          <el-input v-model.trim="draft.clientId" autocomplete="off" />
+        </el-form-item>
+        <el-form-item :label="$t('site.field.authGithubOAuthClientSecret')">
+          <el-input
+            v-model="draft.clientSecret"
+            type="password"
+            show-password
+            autocomplete="new-password"
+            :placeholder="$t('site.placeholder.authGithubOAuthClientSecret')"
+          />
+          <span v-if="config.client_secret_configured" class="github-oauth__hint">
+            {{ $t('site.message.authGithubOAuthSecretConfigured') }}
+          </span>
+        </el-form-item>
+        <el-form-item :label="$t('site.field.authGithubOAuthCallbackUrl')">
+          <div class="github-oauth__callback">
+            <el-input :model-value="callbackUrl" readonly />
+            <copy-to-clipboard :content="callbackUrl" />
+          </div>
+          <span class="github-oauth__hint">{{ $t('site.message.authGithubOAuthCallbackTip') }}</span>
+        </el-form-item>
+      </el-form>
+      <div class="github-oauth__actions">
+        <el-button type="primary" :loading="saving" :disabled="!canSave" @click="save">
+          {{ $t('common.button.save') }}
+        </el-button>
+        <el-button v-if="!config.using_platform_default" type="danger" plain :loading="deleting" @click="reset">
+          {{ $t('site.button.authGithubOAuthRestoreDefault') }}
+        </el-button>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElAlert, ElButton, ElForm, ElFormItem, ElInput, ElMessage, ElMessageBox } from 'element-plus';
+import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
+import { getBaseUrlAuth } from '@/utils';
+import { type ISiteGithubOAuthApp, siteGithubOAuthOperator } from '@/operators/siteGithubOAuth';
+
+const CALLBACK_URL = `${getBaseUrlAuth().replace(/\/$/, '')}/oauth/callback/github`;
+const emptyConfig = (): ISiteGithubOAuthApp => ({
+  client_id: null,
+  client_secret_configured: false,
+  using_platform_default: true
+});
+
+export default defineComponent({
+  name: 'SiteGithubOAuthApp',
+  components: { CopyToClipboard, ElAlert, ElButton, ElForm, ElFormItem, ElInput },
+  props: {
+    siteId: { type: String, required: true },
+    providerEnabled: { type: Boolean, required: true }
+  },
+  data() {
+    return {
+      config: emptyConfig(),
+      draft: { clientId: '', clientSecret: '' },
+      callbackUrl: CALLBACK_URL,
+      loading: false,
+      saving: false,
+      deleting: false
+    };
+  },
+  computed: {
+    canSave(): boolean {
+      return Boolean(!this.loading && !this.saving && this.draft.clientId && this.draft.clientSecret);
+    }
+  },
+  async mounted() {
+    await this.load();
+  },
+  methods: {
+    apply(config: ISiteGithubOAuthApp): void {
+      this.config = config;
+      this.draft = { clientId: config.client_id || '', clientSecret: '' };
+    },
+    async load(): Promise<void> {
+      this.loading = true;
+      try {
+        const { data } = await siteGithubOAuthOperator.get(this.siteId);
+        this.apply(data);
+      } catch {
+        ElMessage.error(this.$t('site.error.authGithubOAuthLoad'));
+      } finally {
+        this.loading = false;
+      }
+    },
+    async save(): Promise<void> {
+      if (!this.canSave) return;
+      this.saving = true;
+      try {
+        const payload = {
+          client_id: this.draft.clientId,
+          ...(this.draft.clientSecret ? { client_secret: this.draft.clientSecret } : {})
+        };
+        const { data } = await siteGithubOAuthOperator.update(this.siteId, payload);
+        this.apply(data);
+        ElMessage.success(this.$t('site.message.authGithubOAuthSaved'));
+      } catch {
+        ElMessage.error(this.$t('site.error.authGithubOAuthSave'));
+      } finally {
+        this.saving = false;
+      }
+    },
+    async reset(): Promise<void> {
+      try {
+        await ElMessageBox.confirm(
+          this.$t('site.message.authGithubOAuthDeleteConfirm'),
+          this.$t('site.field.authGithubOAuthDeleteTitle'),
+          { type: 'warning' }
+        );
+      } catch {
+        return;
+      }
+      this.deleting = true;
+      try {
+        await siteGithubOAuthOperator.remove(this.siteId);
+        this.apply(emptyConfig());
+        ElMessage.success(this.$t('site.message.authGithubOAuthDeleted'));
+      } catch {
+        ElMessage.error(this.$t('site.error.authGithubOAuthDelete'));
+      } finally {
+        this.deleting = false;
+      }
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.github-oauth__content,
+.github-oauth__form {
+  display: flex;
+  width: 100%;
+  max-width: 420px;
+  flex-direction: column;
+  gap: 12px;
+  align-items: stretch;
+  text-align: left;
+}
+.github-oauth__callback {
+  display: flex;
+  width: 100%;
+  gap: 8px;
+}
+.github-oauth__hint {
+  display: block;
+  margin-top: 6px;
+  color: var(--el-text-color-secondary);
+  font-size: 12px;
+  line-height: 1.5;
+}
+.github-oauth__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+@container auth-settings (max-width: 560px) {
+  .github-oauth__actions .el-button {
+    flex: 1 1 auto;
+    margin-left: 0;
+  }
+}
+</style>

--- a/src/i18n/ar/site.json
+++ b/src/i18n/ar/site.json
@@ -1525,5 +1525,81 @@
   "message.referralEntryEnabledTip": {
     "message": "بعد الإيقاف، لن يتمكن المستخدمون العاديون والزوار غير المسجلين من رؤية مدخل التسويق بالعمولة أو محتوى الترويج في هذا الموقع؛ وسيظل بإمكان مسؤولي الموقع الاطلاع عليه وإعادة تفعيله. لا يتأثر إسناد الدعوات أو العمولات.",
     "description": "نص توضيحي لمفتاح مدخل التسويق بالعمولة"
+  },
+  "field.authGithubOAuthApp": {
+    "message": "GitHub OAuth App",
+    "description": "Title for per-site GitHub OAuth App settings"
+  },
+  "message.authGithubOAuthAppTip": {
+    "message": "استخدم إعدادات المنصة الافتراضية لتسجيل الدخول إلى هذا الموقع، أو أدخل تطبيق GitHub OAuth الخاص بك.",
+    "description": "شرح إعداد GitHub OAuth للموقع"
+  },
+  "message.authGithubOAuthProviderDisabled": {
+    "message": "تسجيل الدخول عبر GitHub مغلق حاليًا، ولكن يمكنك إعداد تطبيق OAuth مسبقًا ثم تفعيله لاحقًا.",
+    "description": "تنبيه إغلاق تسجيل الدخول عبر GitHub"
+  },
+  "message.authGithubOAuthUsingPlatform": {
+    "message": "يستخدم هذا الموقع تطبيق GitHub OAuth الافتراضي للمنصة.",
+    "description": "حالة الإعداد الافتراضي للمنصة"
+  },
+  "message.authGithubOAuthUsingCustom": {
+    "message": "يستخدم هذا الموقع تطبيق GitHub OAuth مخصصًا.",
+    "description": "حالة الإعداد المخصص"
+  },
+  "field.authGithubOAuthClientId": {
+    "message": "Client ID",
+    "description": "GitHub OAuth App client ID label"
+  },
+  "field.authGithubOAuthClientSecret": {
+    "message": "Client Secret",
+    "description": "GitHub OAuth App client secret label"
+  },
+  "placeholder.authGithubOAuthClientSecret": {
+    "message": "اتركه فارغًا للإبقاء على المفتاح السري المحفوظ",
+    "description": "نص إرشادي لحقل Client Secret فقط"
+  },
+  "message.authGithubOAuthSecretConfigured": {
+    "message": "تم حفظ Client Secret، واتركه فارغًا للإبقاء عليه دون تغيير.",
+    "description": "تنبيه حفظ المفتاح السري"
+  },
+  "field.authGithubOAuthCallbackUrl": {
+    "message": "Authorization callback URL",
+    "description": "GitHub OAuth callback URL label"
+  },
+  "message.authGithubOAuthCallbackTip": {
+    "message": "أضف هذا العنوان الكامل إلى إعدادات الاستدعاء في تطبيق GitHub OAuth.",
+    "description": "تنبيه إعداد استدعاء GitHub"
+  },
+  "button.authGithubOAuthRestoreDefault": {
+    "message": "استعادة إعدادات المنصة الافتراضية",
+    "description": "زر حذف تطبيق GitHub OAuth المخصص"
+  },
+  "message.authGithubOAuthSaved": {
+    "message": "تم حفظ تطبيق GitHub OAuth",
+    "description": "رسالة نجاح الحفظ"
+  },
+  "error.authGithubOAuthSave": {
+    "message": "تعذّر حفظ تطبيق GitHub OAuth",
+    "description": "رسالة فشل الحفظ"
+  },
+  "error.authGithubOAuthLoad": {
+    "message": "تعذّر تحميل تطبيق GitHub OAuth",
+    "description": "رسالة فشل التحميل"
+  },
+  "field.authGithubOAuthDeleteTitle": {
+    "message": "هل تريد استعادة تطبيق GitHub OAuth الافتراضي للمنصة؟",
+    "description": "عنوان تأكيد استعادة الإعدادات الافتراضية"
+  },
+  "message.authGithubOAuthDeleteConfirm": {
+    "message": "سيتم حذف Client ID وClient Secret المحفوظَين نهائيًا.",
+    "description": "محتوى تأكيد استعادة الإعدادات الافتراضية"
+  },
+  "message.authGithubOAuthDeleted": {
+    "message": "تمت استعادة تطبيق GitHub OAuth الافتراضي للمنصة",
+    "description": "رسالة نجاح استعادة الإعدادات الافتراضية"
+  },
+  "error.authGithubOAuthDelete": {
+    "message": "تعذّرت استعادة تطبيق GitHub OAuth الافتراضي للمنصة",
+    "description": "رسالة فشل استعادة الإعدادات الافتراضية"
   }
 }

--- a/src/i18n/de/site.json
+++ b/src/i18n/de/site.json
@@ -1525,5 +1525,81 @@
   "message.referralEntryEnabledTip": {
     "message": "Nach dem Deaktivieren sehen normale Nutzer und nicht angemeldete Besucher den Affiliate-Bereich und die Werbeinhalte dieser Website nicht mehr. Website-Administratoren können sie weiterhin anzeigen und wiederherstellen. Die Zuordnung von Einladungen und Provisionsauszahlungen bleibt davon unberührt.",
     "description": "Hinweistext zum Schalter für den Affiliate-Bereich"
+  },
+  "field.authGithubOAuthApp": {
+    "message": "GitHub OAuth App",
+    "description": "Title for per-site GitHub OAuth App settings"
+  },
+  "message.authGithubOAuthAppTip": {
+    "message": "Verwende für die Anmeldung auf dieser Website die Plattformstandards oder gib deine eigene GitHub-OAuth-App ein.",
+    "description": "Hinweis zur GitHub-OAuth-Konfiguration der Website"
+  },
+  "message.authGithubOAuthProviderDisabled": {
+    "message": "Die GitHub-Anmeldung ist derzeit deaktiviert. Du kannst die OAuth-App trotzdem vorab konfigurieren und sie später aktivieren.",
+    "description": "Hinweis zur Deaktivierung der GitHub-Anmeldung"
+  },
+  "message.authGithubOAuthUsingPlatform": {
+    "message": "Diese Website verwendet die standardmäßige GitHub-OAuth-App der Plattform.",
+    "description": "Status der Plattformstandardkonfiguration"
+  },
+  "message.authGithubOAuthUsingCustom": {
+    "message": "Diese Website verwendet eine benutzerdefinierte GitHub-OAuth-App.",
+    "description": "Status der benutzerdefinierten Konfiguration"
+  },
+  "field.authGithubOAuthClientId": {
+    "message": "Client ID",
+    "description": "GitHub OAuth App client ID label"
+  },
+  "field.authGithubOAuthClientSecret": {
+    "message": "Client Secret",
+    "description": "GitHub OAuth App client secret label"
+  },
+  "placeholder.authGithubOAuthClientSecret": {
+    "message": "Leer lassen, um das gespeicherte Secret beizubehalten",
+    "description": "Platzhalterhinweis für das Feld „Client-Secret“"
+  },
+  "message.authGithubOAuthSecretConfigured": {
+    "message": "Client-Secret gespeichert. Lass das Feld leer, um es unverändert zu lassen.",
+    "description": "Hinweis, dass das Secret bereits gespeichert ist"
+  },
+  "field.authGithubOAuthCallbackUrl": {
+    "message": "Authorization callback URL",
+    "description": "GitHub OAuth callback URL label"
+  },
+  "message.authGithubOAuthCallbackTip": {
+    "message": "Füge diese vollständige Adresse zu den Callback-Einstellungen der GitHub-OAuth-App hinzu.",
+    "description": "Hinweis zur Konfiguration des GitHub-Callbacks"
+  },
+  "button.authGithubOAuthRestoreDefault": {
+    "message": "Plattformstandard wiederherstellen",
+    "description": "Schaltfläche zum Löschen der benutzerdefinierten GitHub-OAuth-App"
+  },
+  "message.authGithubOAuthSaved": {
+    "message": "GitHub-OAuth-App gespeichert",
+    "description": "Erfolgshinweis zum Speichern"
+  },
+  "error.authGithubOAuthSave": {
+    "message": "Speichern der GitHub-OAuth-App fehlgeschlagen",
+    "description": "Hinweis auf einen Speicherfehler"
+  },
+  "error.authGithubOAuthLoad": {
+    "message": "Laden der GitHub-OAuth-App fehlgeschlagen",
+    "description": "Hinweis auf einen Ladefehler"
+  },
+  "field.authGithubOAuthDeleteTitle": {
+    "message": "Standardmäßige GitHub-OAuth-App der Plattform wiederherstellen?",
+    "description": "Titel der Bestätigung zur Wiederherstellung des Standards"
+  },
+  "message.authGithubOAuthDeleteConfirm": {
+    "message": "Die gespeicherte Client-ID und das Client-Secret werden dauerhaft gelöscht.",
+    "description": "Inhalt der Bestätigung zur Wiederherstellung des Standards"
+  },
+  "message.authGithubOAuthDeleted": {
+    "message": "Standardmäßige GitHub-OAuth-App der Plattform wiederhergestellt",
+    "description": "Erfolgshinweis zur Wiederherstellung des Standards"
+  },
+  "error.authGithubOAuthDelete": {
+    "message": "Wiederherstellung der standardmäßigen GitHub-OAuth-App der Plattform fehlgeschlagen",
+    "description": "Hinweis auf eine fehlgeschlagene Wiederherstellung"
   }
 }

--- a/src/i18n/en/site.json
+++ b/src/i18n/en/site.json
@@ -1526,5 +1526,81 @@
   "error.authDeliverySave": {
     "message": "Failed to save the delivery configuration",
     "description": "Custom delivery configuration save failure."
+  },
+  "field.authGithubOAuthApp": {
+    "message": "GitHub OAuth App",
+    "description": "Title for per-site GitHub OAuth App settings"
+  },
+  "message.authGithubOAuthAppTip": {
+    "message": "Use the platform app or your own GitHub OAuth App for sign-in on this site.",
+    "description": "Explains per-site GitHub OAuth configuration"
+  },
+  "message.authGithubOAuthProviderDisabled": {
+    "message": "GitHub sign-in is disabled. You can still configure the OAuth App before enabling it.",
+    "description": "Shown when the GitHub login provider is disabled"
+  },
+  "message.authGithubOAuthUsingPlatform": {
+    "message": "This site uses the platform GitHub OAuth App.",
+    "description": "Platform OAuth App status"
+  },
+  "message.authGithubOAuthUsingCustom": {
+    "message": "This site uses its own GitHub OAuth App.",
+    "description": "Custom OAuth App status"
+  },
+  "field.authGithubOAuthClientId": {
+    "message": "Client ID",
+    "description": "GitHub OAuth App client ID label"
+  },
+  "field.authGithubOAuthClientSecret": {
+    "message": "Client Secret",
+    "description": "GitHub OAuth App client secret label"
+  },
+  "placeholder.authGithubOAuthClientSecret": {
+    "message": "Leave blank to keep the saved secret",
+    "description": "Write-only Client Secret placeholder"
+  },
+  "message.authGithubOAuthSecretConfigured": {
+    "message": "A Client Secret is saved. Leave this field blank to keep it.",
+    "description": "Saved secret hint"
+  },
+  "field.authGithubOAuthCallbackUrl": {
+    "message": "Authorization callback URL",
+    "description": "GitHub OAuth callback URL label"
+  },
+  "message.authGithubOAuthCallbackTip": {
+    "message": "Add this exact URL to the OAuth App settings on GitHub.",
+    "description": "GitHub callback setup hint"
+  },
+  "button.authGithubOAuthRestoreDefault": {
+    "message": "Restore platform default",
+    "description": "Delete custom GitHub OAuth App button"
+  },
+  "message.authGithubOAuthSaved": {
+    "message": "GitHub OAuth App saved",
+    "description": "Save success message"
+  },
+  "error.authGithubOAuthSave": {
+    "message": "Failed to save the GitHub OAuth App",
+    "description": "Save failure message"
+  },
+  "error.authGithubOAuthLoad": {
+    "message": "Failed to load the GitHub OAuth App",
+    "description": "Load failure message"
+  },
+  "field.authGithubOAuthDeleteTitle": {
+    "message": "Restore the platform GitHub OAuth App?",
+    "description": "Reset confirmation title"
+  },
+  "message.authGithubOAuthDeleteConfirm": {
+    "message": "The saved Client ID and Client Secret will be permanently deleted.",
+    "description": "Reset confirmation body"
+  },
+  "message.authGithubOAuthDeleted": {
+    "message": "Platform GitHub OAuth App restored",
+    "description": "Reset success message"
+  },
+  "error.authGithubOAuthDelete": {
+    "message": "Failed to restore the platform GitHub OAuth App",
+    "description": "Reset failure message"
   }
 }

--- a/src/i18n/es/site.json
+++ b/src/i18n/es/site.json
@@ -1526,5 +1526,81 @@
   "message.referralEntryEnabledTip": {
     "message": "Al desactivarlo, los usuarios habituales y los visitantes que no hayan iniciado sesión no podrán ver el acceso de afiliados ni el contenido promocional del sitio; los administradores del sitio podrán seguir viéndolos y restaurarlos. La atribución de invitaciones y las comisiones no se ven afectadas.",
     "description": "Texto explicativo del interruptor del acceso de afiliados"
+  },
+  "field.authGithubOAuthApp": {
+    "message": "GitHub OAuth App",
+    "description": "Title for per-site GitHub OAuth App settings"
+  },
+  "message.authGithubOAuthAppTip": {
+    "message": "Usa la configuración predeterminada de la plataforma para iniciar sesión en este sitio o introduce tu propia aplicación OAuth de GitHub.",
+    "description": "Instrucciones sobre la configuración OAuth de GitHub del sitio"
+  },
+  "message.authGithubOAuthProviderDisabled": {
+    "message": "El inicio de sesión con GitHub está desactivado. Aun así, puedes configurar previamente una aplicación OAuth y activarlo más adelante.",
+    "description": "Aviso de que el inicio de sesión con GitHub está desactivado"
+  },
+  "message.authGithubOAuthUsingPlatform": {
+    "message": "Este sitio está utilizando la aplicación OAuth predeterminada de GitHub de la plataforma.",
+    "description": "Estado de la configuración predeterminada de la plataforma"
+  },
+  "message.authGithubOAuthUsingCustom": {
+    "message": "Este sitio está utilizando una aplicación OAuth personalizada de GitHub.",
+    "description": "Estado de la configuración personalizada"
+  },
+  "field.authGithubOAuthClientId": {
+    "message": "Client ID",
+    "description": "GitHub OAuth App client ID label"
+  },
+  "field.authGithubOAuthClientSecret": {
+    "message": "Client Secret",
+    "description": "GitHub OAuth App client secret label"
+  },
+  "placeholder.authGithubOAuthClientSecret": {
+    "message": "Déjalo en blanco para conservar el secreto guardado",
+    "description": "Texto de ayuda del campo Client Secret"
+  },
+  "message.authGithubOAuthSecretConfigured": {
+    "message": "El Client Secret se guardó. Déjalo en blanco para conservarlo sin cambios.",
+    "description": "Aviso de que el secreto ya está guardado"
+  },
+  "field.authGithubOAuthCallbackUrl": {
+    "message": "Authorization callback URL",
+    "description": "GitHub OAuth callback URL label"
+  },
+  "message.authGithubOAuthCallbackTip": {
+    "message": "Añade esta dirección completa a la configuración de callbacks de la aplicación OAuth de GitHub.",
+    "description": "Instrucciones para configurar el callback de GitHub"
+  },
+  "button.authGithubOAuthRestoreDefault": {
+    "message": "Restaurar configuración predeterminada de la plataforma",
+    "description": "Botón para eliminar la aplicación OAuth personalizada de GitHub"
+  },
+  "message.authGithubOAuthSaved": {
+    "message": "Se guardó la aplicación OAuth de GitHub",
+    "description": "Mensaje de éxito al guardar la configuración"
+  },
+  "error.authGithubOAuthSave": {
+    "message": "No se pudo guardar la aplicación OAuth de GitHub",
+    "description": "Mensaje de error al guardar la configuración"
+  },
+  "error.authGithubOAuthLoad": {
+    "message": "No se pudo cargar la aplicación OAuth de GitHub",
+    "description": "Mensaje de error al cargar la configuración"
+  },
+  "field.authGithubOAuthDeleteTitle": {
+    "message": "¿Restaurar la aplicación OAuth predeterminada de GitHub?",
+    "description": "Título de confirmación para restaurar la configuración predeterminada"
+  },
+  "message.authGithubOAuthDeleteConfirm": {
+    "message": "El Client ID y el Client Secret guardados se eliminarán permanentemente.",
+    "description": "Contenido de confirmación para restaurar la configuración predeterminada"
+  },
+  "message.authGithubOAuthDeleted": {
+    "message": "Se restauró la aplicación OAuth predeterminada de GitHub",
+    "description": "Mensaje de éxito al restaurar la configuración predeterminada"
+  },
+  "error.authGithubOAuthDelete": {
+    "message": "No se pudo restaurar la aplicación OAuth predeterminada de GitHub",
+    "description": "Mensaje de error al restaurar la configuración predeterminada"
   }
 }

--- a/src/i18n/fr/site.json
+++ b/src/i18n/fr/site.json
@@ -1528,5 +1528,81 @@
   "message.referralEntryEnabledTip": {
     "message": "Après désactivation, les utilisateurs standard et les visiteurs non connectés ne verront plus l’accès à l’affiliation ni les contenus promotionnels du site. Les administrateurs du site peuvent toujours les consulter et les réactiver. L’attribution des invitations et les commissions ne sont pas affectées.",
     "description": "Texte explicatif du bouton d’activation de l’accès à l’affiliation"
+  },
+  "field.authGithubOAuthApp": {
+    "message": "GitHub OAuth App",
+    "description": "Title for per-site GitHub OAuth App settings"
+  },
+  "message.authGithubOAuthAppTip": {
+    "message": "Utilisez la configuration par défaut de la plateforme pour la connexion à ce site, ou renseignez votre propre application GitHub OAuth.",
+    "description": "Explication de la configuration GitHub OAuth du site"
+  },
+  "message.authGithubOAuthProviderDisabled": {
+    "message": "La connexion avec GitHub est actuellement désactivée. Vous pouvez néanmoins configurer à l’avance une application OAuth, puis l’activer ultérieurement.",
+    "description": "Message indiquant que la connexion avec GitHub est désactivée"
+  },
+  "message.authGithubOAuthUsingPlatform": {
+    "message": "Ce site utilise l’application GitHub OAuth par défaut de la plateforme.",
+    "description": "État de la configuration par défaut de la plateforme"
+  },
+  "message.authGithubOAuthUsingCustom": {
+    "message": "Ce site utilise une application GitHub OAuth personnalisée.",
+    "description": "État de la configuration personnalisée"
+  },
+  "field.authGithubOAuthClientId": {
+    "message": "Client ID",
+    "description": "GitHub OAuth App client ID label"
+  },
+  "field.authGithubOAuthClientSecret": {
+    "message": "Client Secret",
+    "description": "GitHub OAuth App client secret label"
+  },
+  "placeholder.authGithubOAuthClientSecret": {
+    "message": "Laissez vide pour conserver le secret enregistré",
+    "description": "Indication d’espace réservé pour le champ Client Secret"
+  },
+  "message.authGithubOAuthSecretConfigured": {
+    "message": "Le Client Secret a été enregistré. Laissez ce champ vide pour le conserver.",
+    "description": "Indication signalant que le secret a été enregistré"
+  },
+  "field.authGithubOAuthCallbackUrl": {
+    "message": "Authorization callback URL",
+    "description": "GitHub OAuth callback URL label"
+  },
+  "message.authGithubOAuthCallbackTip": {
+    "message": "Ajoutez cette adresse complète aux paramètres de rappel de l’application GitHub OAuth.",
+    "description": "Indication de configuration du rappel GitHub"
+  },
+  "button.authGithubOAuthRestoreDefault": {
+    "message": "Rétablir la configuration par défaut de la plateforme",
+    "description": "Bouton permettant de supprimer l’application GitHub OAuth personnalisée"
+  },
+  "message.authGithubOAuthSaved": {
+    "message": "L’application GitHub OAuth a été enregistrée",
+    "description": "Message de réussite de l’enregistrement"
+  },
+  "error.authGithubOAuthSave": {
+    "message": "Échec de l’enregistrement de l’application GitHub OAuth",
+    "description": "Message d’échec de l’enregistrement"
+  },
+  "error.authGithubOAuthLoad": {
+    "message": "Échec du chargement de l’application GitHub OAuth",
+    "description": "Message d’échec du chargement"
+  },
+  "field.authGithubOAuthDeleteTitle": {
+    "message": "Rétablir l’application GitHub OAuth par défaut de la plateforme ?",
+    "description": "Titre de confirmation du rétablissement de la configuration par défaut"
+  },
+  "message.authGithubOAuthDeleteConfirm": {
+    "message": "Le Client ID et le Client Secret enregistrés seront définitivement supprimés.",
+    "description": "Contenu de la confirmation du rétablissement de la configuration par défaut"
+  },
+  "message.authGithubOAuthDeleted": {
+    "message": "L’application GitHub OAuth par défaut de la plateforme a été rétablie",
+    "description": "Message de réussite du rétablissement de la configuration par défaut"
+  },
+  "error.authGithubOAuthDelete": {
+    "message": "Échec du rétablissement de l’application GitHub OAuth par défaut de la plateforme",
+    "description": "Message d’échec du rétablissement de la configuration par défaut"
   }
 }

--- a/src/i18n/it/site.json
+++ b/src/i18n/it/site.json
@@ -1525,5 +1525,81 @@
   "message.referralEntryEnabledTip": {
     "message": "Dopo la disattivazione, gli utenti standard e i visitatori non autenticati non vedranno più l'accesso al programma di affiliazione né i contenuti promozionali del sito; gli amministratori del sito potranno comunque visualizzarli e ripristinarli. L'attribuzione degli inviti e le commissioni non saranno interessate.",
     "description": "Testo descrittivo dell'interruttore per l'accesso al programma di affiliazione"
+  },
+  "field.authGithubOAuthApp": {
+    "message": "GitHub OAuth App",
+    "description": "Title for per-site GitHub OAuth App settings"
+  },
+  "message.authGithubOAuthAppTip": {
+    "message": "Usa la configurazione predefinita della piattaforma per accedere a questo sito oppure inserisci la tua app GitHub OAuth.",
+    "description": "Descrizione della configurazione GitHub OAuth del sito"
+  },
+  "message.authGithubOAuthProviderDisabled": {
+    "message": "L'accesso con GitHub è attualmente disabilitato; puoi comunque configurare in anticipo un'app OAuth e abilitarlo in seguito.",
+    "description": "Avviso che l'accesso con GitHub è disabilitato"
+  },
+  "message.authGithubOAuthUsingPlatform": {
+    "message": "Questo sito sta utilizzando l'app GitHub OAuth predefinita della piattaforma.",
+    "description": "Stato della configurazione predefinita della piattaforma"
+  },
+  "message.authGithubOAuthUsingCustom": {
+    "message": "Questo sito sta utilizzando un'app GitHub OAuth personalizzata.",
+    "description": "Stato della configurazione personalizzata"
+  },
+  "field.authGithubOAuthClientId": {
+    "message": "Client ID",
+    "description": "GitHub OAuth App client ID label"
+  },
+  "field.authGithubOAuthClientSecret": {
+    "message": "Client Secret",
+    "description": "GitHub OAuth App client secret label"
+  },
+  "placeholder.authGithubOAuthClientSecret": {
+    "message": "Lascia vuoto per mantenere il segreto salvato",
+    "description": "Testo segnaposto per il campo Client Secret"
+  },
+  "message.authGithubOAuthSecretConfigured": {
+    "message": "Il Client Secret è stato salvato; lascia vuoto il campo per mantenerlo invariato.",
+    "description": "Avviso che il segreto è già stato salvato"
+  },
+  "field.authGithubOAuthCallbackUrl": {
+    "message": "Authorization callback URL",
+    "description": "GitHub OAuth callback URL label"
+  },
+  "message.authGithubOAuthCallbackTip": {
+    "message": "Aggiungi questo indirizzo completo alle impostazioni di callback dell'app GitHub OAuth.",
+    "description": "Istruzione per configurare il callback GitHub"
+  },
+  "button.authGithubOAuthRestoreDefault": {
+    "message": "Ripristina configurazione predefinita della piattaforma",
+    "description": "Pulsante per eliminare l'app GitHub OAuth personalizzata"
+  },
+  "message.authGithubOAuthSaved": {
+    "message": "App GitHub OAuth salvata",
+    "description": "Messaggio di successo del salvataggio"
+  },
+  "error.authGithubOAuthSave": {
+    "message": "Impossibile salvare l'app GitHub OAuth",
+    "description": "Messaggio di errore durante il salvataggio"
+  },
+  "error.authGithubOAuthLoad": {
+    "message": "Impossibile caricare l'app GitHub OAuth",
+    "description": "Messaggio di errore durante il caricamento"
+  },
+  "field.authGithubOAuthDeleteTitle": {
+    "message": "Ripristinare l'app GitHub OAuth predefinita della piattaforma?",
+    "description": "Titolo della conferma del ripristino della configurazione predefinita"
+  },
+  "message.authGithubOAuthDeleteConfirm": {
+    "message": "Il Client ID e il Client Secret salvati verranno eliminati definitivamente.",
+    "description": "Contenuto della conferma del ripristino della configurazione predefinita"
+  },
+  "message.authGithubOAuthDeleted": {
+    "message": "App GitHub OAuth predefinita della piattaforma ripristinata",
+    "description": "Messaggio di successo del ripristino della configurazione predefinita"
+  },
+  "error.authGithubOAuthDelete": {
+    "message": "Impossibile ripristinare l'app GitHub OAuth predefinita della piattaforma",
+    "description": "Messaggio di errore durante il ripristino della configurazione predefinita"
   }
 }

--- a/src/i18n/ja/site.json
+++ b/src/i18n/ja/site.json
@@ -1525,5 +1525,81 @@
   "message.referralEntryEnabledTip": {
     "message": "無効にすると、一般ユーザーと未ログインの訪問者には、本サイトのアフィリエイト入口とプロモーションコンテンツが表示されなくなります。サイト管理者は引き続き確認・復元できます。招待のアトリビューションと紹介報酬には影響しません。",
     "description": "アフィリエイト入口スイッチの説明文"
+  },
+  "field.authGithubOAuthApp": {
+    "message": "GitHub OAuth App",
+    "description": "Title for per-site GitHub OAuth App settings"
+  },
+  "message.authGithubOAuthAppTip": {
+    "message": "このサイトへのログインにプラットフォームのデフォルト設定を使用するか、独自の GitHub OAuth App を入力してください。",
+    "description": "サイトの GitHub OAuth 設定に関する説明"
+  },
+  "message.authGithubOAuthProviderDisabled": {
+    "message": "現在、GitHub ログインは無効です。OAuth App を事前に設定しておけば、後から有効にできます。",
+    "description": "GitHub ログインが無効であることを示す案内"
+  },
+  "message.authGithubOAuthUsingPlatform": {
+    "message": "このサイトではプラットフォームのデフォルト GitHub OAuth App を使用しています。",
+    "description": "プラットフォームのデフォルト設定の状態"
+  },
+  "message.authGithubOAuthUsingCustom": {
+    "message": "このサイトではカスタム GitHub OAuth App を使用しています。",
+    "description": "カスタム設定の状態"
+  },
+  "field.authGithubOAuthClientId": {
+    "message": "Client ID",
+    "description": "GitHub OAuth App client ID label"
+  },
+  "field.authGithubOAuthClientSecret": {
+    "message": "Client Secret",
+    "description": "GitHub OAuth App client secret label"
+  },
+  "placeholder.authGithubOAuthClientSecret": {
+    "message": "空欄にすると保存済みの秘密鍵を保持します",
+    "description": "Client Secret のみを入力する欄のプレースホルダー案内"
+  },
+  "message.authGithubOAuthSecretConfigured": {
+    "message": "Client Secret は保存済みです。空欄にすると変更されません。",
+    "description": "秘密鍵が保存済みであることを示す案内"
+  },
+  "field.authGithubOAuthCallbackUrl": {
+    "message": "Authorization callback URL",
+    "description": "GitHub OAuth callback URL label"
+  },
+  "message.authGithubOAuthCallbackTip": {
+    "message": "この完全な URL を GitHub OAuth App のコールバック設定に追加してください。",
+    "description": "GitHub のコールバック設定に関する案内"
+  },
+  "button.authGithubOAuthRestoreDefault": {
+    "message": "プラットフォームのデフォルト設定に戻す",
+    "description": "カスタム GitHub OAuth App を削除するボタン"
+  },
+  "message.authGithubOAuthSaved": {
+    "message": "GitHub OAuth App を保存しました",
+    "description": "保存に成功したことを示すメッセージ"
+  },
+  "error.authGithubOAuthSave": {
+    "message": "GitHub OAuth App の保存に失敗しました",
+    "description": "保存に失敗したことを示すメッセージ"
+  },
+  "error.authGithubOAuthLoad": {
+    "message": "GitHub OAuth App の読み込みに失敗しました",
+    "description": "読み込みに失敗したことを示すメッセージ"
+  },
+  "field.authGithubOAuthDeleteTitle": {
+    "message": "プラットフォームのデフォルト GitHub OAuth App に戻しますか？",
+    "description": "デフォルト設定への復元を確認するタイトル"
+  },
+  "message.authGithubOAuthDeleteConfirm": {
+    "message": "保存済みの Client ID と Client Secret は完全に削除されます。",
+    "description": "デフォルト設定への復元を確認する内容"
+  },
+  "message.authGithubOAuthDeleted": {
+    "message": "プラットフォームのデフォルト GitHub OAuth App に戻しました",
+    "description": "デフォルト設定への復元に成功したことを示すメッセージ"
+  },
+  "error.authGithubOAuthDelete": {
+    "message": "プラットフォームのデフォルト GitHub OAuth App に戻せませんでした",
+    "description": "デフォルト設定への復元に失敗したことを示すメッセージ"
   }
 }

--- a/src/i18n/ko/site.json
+++ b/src/i18n/ko/site.json
@@ -1525,5 +1525,81 @@
   "message.referralEntryEnabledTip": {
     "message": "끄면 일반 사용자와 로그인하지 않은 방문자는 이 사이트의 제휴 마케팅 메뉴와 홍보 콘텐츠를 볼 수 없습니다. 사이트 관리자는 계속 확인하고 복원할 수 있습니다. 초대 어트리뷰션과 커미션에는 영향을 주지 않습니다.",
     "description": "제휴 마케팅 메뉴 표시 설정에 대한 안내 문구"
+  },
+  "field.authGithubOAuthApp": {
+    "message": "GitHub OAuth App",
+    "description": "Title for per-site GitHub OAuth App settings"
+  },
+  "message.authGithubOAuthAppTip": {
+    "message": "사이트 로그인에 플랫폼 기본 설정을 사용하거나, 직접 GitHub OAuth App을 입력하세요.",
+    "description": "사이트 GitHub OAuth 설정 안내"
+  },
+  "message.authGithubOAuthProviderDisabled": {
+    "message": "현재 GitHub 로그인이 비활성화되어 있습니다. OAuth App을 미리 구성한 후 다시 활성화할 수 있습니다.",
+    "description": "GitHub 로그인 비활성화 안내"
+  },
+  "message.authGithubOAuthUsingPlatform": {
+    "message": "사이트에서 플랫폼 기본 GitHub OAuth App을 사용하고 있습니다.",
+    "description": "플랫폼 기본 설정 상태"
+  },
+  "message.authGithubOAuthUsingCustom": {
+    "message": "사이트에서 사용자 지정 GitHub OAuth App을 사용하고 있습니다.",
+    "description": "사용자 지정 설정 상태"
+  },
+  "field.authGithubOAuthClientId": {
+    "message": "Client ID",
+    "description": "GitHub OAuth App client ID label"
+  },
+  "field.authGithubOAuthClientSecret": {
+    "message": "Client Secret",
+    "description": "GitHub OAuth App client secret label"
+  },
+  "placeholder.authGithubOAuthClientSecret": {
+    "message": "비워 두면 저장된 키 유지",
+    "description": "Client Secret 전용 입력란 안내"
+  },
+  "message.authGithubOAuthSecretConfigured": {
+    "message": "Client Secret이 저장되었습니다. 변경하지 않으려면 비워 두세요.",
+    "description": "키 저장 안내"
+  },
+  "field.authGithubOAuthCallbackUrl": {
+    "message": "Authorization callback URL",
+    "description": "GitHub OAuth callback URL label"
+  },
+  "message.authGithubOAuthCallbackTip": {
+    "message": "이 전체 주소를 GitHub OAuth App의 콜백 설정에 추가하세요.",
+    "description": "GitHub 콜백 설정 안내"
+  },
+  "button.authGithubOAuthRestoreDefault": {
+    "message": "플랫폼 기본 설정으로 복원",
+    "description": "사용자 지정 GitHub OAuth App 삭제 버튼"
+  },
+  "message.authGithubOAuthSaved": {
+    "message": "GitHub OAuth App을 저장했습니다",
+    "description": "저장 성공 안내"
+  },
+  "error.authGithubOAuthSave": {
+    "message": "GitHub OAuth App을 저장하지 못했습니다",
+    "description": "저장 실패 안내"
+  },
+  "error.authGithubOAuthLoad": {
+    "message": "GitHub OAuth App을 불러오지 못했습니다",
+    "description": "불러오기 실패 안내"
+  },
+  "field.authGithubOAuthDeleteTitle": {
+    "message": "플랫폼 기본 GitHub OAuth App으로 복원하시겠습니까?",
+    "description": "기본 설정 복원 확인 제목"
+  },
+  "message.authGithubOAuthDeleteConfirm": {
+    "message": "저장된 Client ID와 Client Secret이 영구적으로 삭제됩니다.",
+    "description": "기본 설정 복원 확인 내용"
+  },
+  "message.authGithubOAuthDeleted": {
+    "message": "플랫폼 기본 GitHub OAuth App으로 복원했습니다",
+    "description": "기본 설정 복원 성공 안내"
+  },
+  "error.authGithubOAuthDelete": {
+    "message": "플랫폼 기본 GitHub OAuth App으로 복원하지 못했습니다",
+    "description": "기본 설정 복원 실패 안내"
   }
 }

--- a/src/i18n/pt/site.json
+++ b/src/i18n/pt/site.json
@@ -1525,5 +1525,81 @@
   "message.referralEntryEnabledTip": {
     "message": "Quando desativado, usuários comuns e visitantes não autenticados não poderão ver a entrada de afiliados nem o conteúdo promocional deste site; os administradores do site ainda poderão visualizar e reativar a opção. A atribuição de convites e as comissões não serão afetadas.",
     "description": "Texto explicativo da opção de entrada de afiliados"
+  },
+  "field.authGithubOAuthApp": {
+    "message": "GitHub OAuth App",
+    "description": "Title for per-site GitHub OAuth App settings"
+  },
+  "message.authGithubOAuthAppTip": {
+    "message": "Use a configuração padrão da plataforma para o login neste site ou preencha seu próprio GitHub OAuth App.",
+    "description": "Instrução sobre a configuração do GitHub OAuth no site"
+  },
+  "message.authGithubOAuthProviderDisabled": {
+    "message": "O login com GitHub está desativado no momento. Você ainda pode configurar previamente o OAuth App e ativá-lo depois.",
+    "description": "Aviso de que o login com GitHub está desativado"
+  },
+  "message.authGithubOAuthUsingPlatform": {
+    "message": "Este site está usando o GitHub OAuth App padrão da plataforma.",
+    "description": "Status da configuração padrão da plataforma"
+  },
+  "message.authGithubOAuthUsingCustom": {
+    "message": "Este site está usando um GitHub OAuth App personalizado.",
+    "description": "Status da configuração personalizada"
+  },
+  "field.authGithubOAuthClientId": {
+    "message": "Client ID",
+    "description": "GitHub OAuth App client ID label"
+  },
+  "field.authGithubOAuthClientSecret": {
+    "message": "Client Secret",
+    "description": "GitHub OAuth App client secret label"
+  },
+  "placeholder.authGithubOAuthClientSecret": {
+    "message": "Deixe em branco para manter o segredo salvo",
+    "description": "Texto de espaço reservado para o Client Secret"
+  },
+  "message.authGithubOAuthSecretConfigured": {
+    "message": "Client Secret salvo. Deixe em branco para mantê-lo inalterado.",
+    "description": "Aviso de que o segredo foi salvo"
+  },
+  "field.authGithubOAuthCallbackUrl": {
+    "message": "Authorization callback URL",
+    "description": "GitHub OAuth callback URL label"
+  },
+  "message.authGithubOAuthCallbackTip": {
+    "message": "Adicione este endereço completo às configurações de callback do GitHub OAuth App.",
+    "description": "Instrução para configurar o callback do GitHub"
+  },
+  "button.authGithubOAuthRestoreDefault": {
+    "message": "Restaurar configuração padrão da plataforma",
+    "description": "Botão para excluir o GitHub OAuth App personalizado"
+  },
+  "message.authGithubOAuthSaved": {
+    "message": "GitHub OAuth App salvo",
+    "description": "Mensagem de sucesso ao salvar"
+  },
+  "error.authGithubOAuthSave": {
+    "message": "Falha ao salvar o GitHub OAuth App",
+    "description": "Mensagem de falha ao salvar"
+  },
+  "error.authGithubOAuthLoad": {
+    "message": "Falha ao carregar o GitHub OAuth App",
+    "description": "Mensagem de falha ao carregar"
+  },
+  "field.authGithubOAuthDeleteTitle": {
+    "message": "Restaurar o GitHub OAuth App padrão da plataforma?",
+    "description": "Título da confirmação para restaurar o padrão"
+  },
+  "message.authGithubOAuthDeleteConfirm": {
+    "message": "O Client ID e o Client Secret salvos serão excluídos permanentemente.",
+    "description": "Conteúdo da confirmação para restaurar o padrão"
+  },
+  "message.authGithubOAuthDeleted": {
+    "message": "GitHub OAuth App padrão da plataforma restaurado",
+    "description": "Mensagem de sucesso ao restaurar o padrão"
+  },
+  "error.authGithubOAuthDelete": {
+    "message": "Falha ao restaurar o GitHub OAuth App padrão da plataforma",
+    "description": "Mensagem de falha ao restaurar o padrão"
   }
 }

--- a/src/i18n/ru/site.json
+++ b/src/i18n/ru/site.json
@@ -1525,5 +1525,81 @@
   "message.referralEntryEnabledTip": {
     "message": "После отключения обычные пользователи и неавторизованные гости не будут видеть вход в партнёрскую программу и рекламные материалы сайта; администратор сайта по-прежнему сможет просматривать их и восстановить доступ. Атрибуция приглашений и начисление вознаграждений не затрагиваются.",
     "description": "Текст-пояснение к переключателю входа в партнёрскую программу"
+  },
+  "field.authGithubOAuthApp": {
+    "message": "GitHub OAuth App",
+    "description": "Title for per-site GitHub OAuth App settings"
+  },
+  "message.authGithubOAuthAppTip": {
+    "message": "Используйте настройки платформы по умолчанию для входа на этот сайт или укажите собственный GitHub OAuth App.",
+    "description": "Описание настройки GitHub OAuth для сайта"
+  },
+  "message.authGithubOAuthProviderDisabled": {
+    "message": "Вход через GitHub сейчас отключён. Вы всё равно можете заранее настроить OAuth App и включить его позже.",
+    "description": "Сообщение об отключённом входе через GitHub"
+  },
+  "message.authGithubOAuthUsingPlatform": {
+    "message": "Этот сайт использует GitHub OAuth App платформы по умолчанию.",
+    "description": "Состояние конфигурации платформы по умолчанию"
+  },
+  "message.authGithubOAuthUsingCustom": {
+    "message": "Этот сайт использует пользовательский GitHub OAuth App.",
+    "description": "Состояние пользовательской конфигурации"
+  },
+  "field.authGithubOAuthClientId": {
+    "message": "Client ID",
+    "description": "GitHub OAuth App client ID label"
+  },
+  "field.authGithubOAuthClientSecret": {
+    "message": "Client Secret",
+    "description": "GitHub OAuth App client secret label"
+  },
+  "placeholder.authGithubOAuthClientSecret": {
+    "message": "Оставьте пустым, чтобы сохранить сохранённый секрет",
+    "description": "Подсказка в поле Client Secret"
+  },
+  "message.authGithubOAuthSecretConfigured": {
+    "message": "Client Secret сохранён. Оставьте поле пустым, чтобы сохранить текущее значение.",
+    "description": "Подсказка о сохранённом секрете"
+  },
+  "field.authGithubOAuthCallbackUrl": {
+    "message": "Authorization callback URL",
+    "description": "GitHub OAuth callback URL label"
+  },
+  "message.authGithubOAuthCallbackTip": {
+    "message": "Добавьте этот полный адрес в настройки обратного вызова GitHub OAuth App.",
+    "description": "Подсказка по настройке обратного вызова GitHub"
+  },
+  "button.authGithubOAuthRestoreDefault": {
+    "message": "Восстановить настройки платформы по умолчанию",
+    "description": "Кнопка удаления пользовательского GitHub OAuth App"
+  },
+  "message.authGithubOAuthSaved": {
+    "message": "GitHub OAuth App сохранён",
+    "description": "Сообщение об успешном сохранении"
+  },
+  "error.authGithubOAuthSave": {
+    "message": "Не удалось сохранить GitHub OAuth App",
+    "description": "Сообщение о сбое сохранения"
+  },
+  "error.authGithubOAuthLoad": {
+    "message": "Не удалось загрузить GitHub OAuth App",
+    "description": "Сообщение о сбое загрузки"
+  },
+  "field.authGithubOAuthDeleteTitle": {
+    "message": "Восстановить GitHub OAuth App платформы по умолчанию?",
+    "description": "Заголовок подтверждения восстановления настроек по умолчанию"
+  },
+  "message.authGithubOAuthDeleteConfirm": {
+    "message": "Сохранённые Client ID и Client Secret будут удалены навсегда.",
+    "description": "Текст подтверждения восстановления настроек по умолчанию"
+  },
+  "message.authGithubOAuthDeleted": {
+    "message": "Восстановлен GitHub OAuth App платформы по умолчанию",
+    "description": "Сообщение об успешном восстановлении настроек по умолчанию"
+  },
+  "error.authGithubOAuthDelete": {
+    "message": "Не удалось восстановить GitHub OAuth App платформы по умолчанию",
+    "description": "Сообщение о сбое восстановления настроек по умолчанию"
   }
 }

--- a/src/i18n/zh-CN/site.json
+++ b/src/i18n/zh-CN/site.json
@@ -1526,5 +1526,81 @@
   "error.authDeliverySave": {
     "message": "保存投递配置失败",
     "description": "自定义投递配置保存失败。"
+  },
+  "field.authGithubOAuthApp": {
+    "message": "GitHub OAuth App",
+    "description": "站点 GitHub OAuth App 配置标题"
+  },
+  "message.authGithubOAuthAppTip": {
+    "message": "为本站登录使用平台默认配置，或填写你自己的 GitHub OAuth App。",
+    "description": "站点 GitHub OAuth 配置说明"
+  },
+  "message.authGithubOAuthProviderDisabled": {
+    "message": "GitHub 登录当前已关闭，你仍可预先配置 OAuth App 后再启用。",
+    "description": "GitHub 登录关闭提示"
+  },
+  "message.authGithubOAuthUsingPlatform": {
+    "message": "本站正在使用平台默认 GitHub OAuth App。",
+    "description": "平台默认配置状态"
+  },
+  "message.authGithubOAuthUsingCustom": {
+    "message": "本站正在使用自定义 GitHub OAuth App。",
+    "description": "自定义配置状态"
+  },
+  "field.authGithubOAuthClientId": {
+    "message": "Client ID",
+    "description": "GitHub OAuth App Client ID 标签"
+  },
+  "field.authGithubOAuthClientSecret": {
+    "message": "Client Secret",
+    "description": "GitHub OAuth App Client Secret 标签"
+  },
+  "placeholder.authGithubOAuthClientSecret": {
+    "message": "留空则保留已保存的密钥",
+    "description": "只写 Client Secret 占位提示"
+  },
+  "message.authGithubOAuthSecretConfigured": {
+    "message": "Client Secret 已保存，留空即可保持不变。",
+    "description": "密钥已保存提示"
+  },
+  "field.authGithubOAuthCallbackUrl": {
+    "message": "Authorization callback URL",
+    "description": "GitHub OAuth 回调地址标签"
+  },
+  "message.authGithubOAuthCallbackTip": {
+    "message": "请将此完整地址添加到 GitHub OAuth App 的回调设置中。",
+    "description": "GitHub 回调配置提示"
+  },
+  "button.authGithubOAuthRestoreDefault": {
+    "message": "恢复平台默认配置",
+    "description": "删除自定义 GitHub OAuth App 按钮"
+  },
+  "message.authGithubOAuthSaved": {
+    "message": "GitHub OAuth App 已保存",
+    "description": "保存成功提示"
+  },
+  "error.authGithubOAuthSave": {
+    "message": "保存 GitHub OAuth App 失败",
+    "description": "保存失败提示"
+  },
+  "error.authGithubOAuthLoad": {
+    "message": "加载 GitHub OAuth App 失败",
+    "description": "加载失败提示"
+  },
+  "field.authGithubOAuthDeleteTitle": {
+    "message": "恢复平台默认 GitHub OAuth App？",
+    "description": "恢复默认确认标题"
+  },
+  "message.authGithubOAuthDeleteConfirm": {
+    "message": "已保存的 Client ID 和 Client Secret 将被永久删除。",
+    "description": "恢复默认确认内容"
+  },
+  "message.authGithubOAuthDeleted": {
+    "message": "已恢复平台默认 GitHub OAuth App",
+    "description": "恢复默认成功提示"
+  },
+  "error.authGithubOAuthDelete": {
+    "message": "恢复平台默认 GitHub OAuth App 失败",
+    "description": "恢复默认失败提示"
   }
 }

--- a/src/i18n/zh-TW/site.json
+++ b/src/i18n/zh-TW/site.json
@@ -1525,5 +1525,81 @@
   "message.referralEntryEnabledTip": {
     "message": "關閉後，一般使用者和未登入訪客將看不到本站的分銷入口和推廣內容；網站管理員仍可查看並恢復。邀請歸因與返傭不受影響。",
     "description": "分銷入口開關的說明文字"
+  },
+  "field.authGithubOAuthApp": {
+    "message": "GitHub OAuth App",
+    "description": "Title for per-site GitHub OAuth App settings"
+  },
+  "message.authGithubOAuthAppTip": {
+    "message": "為本站登入使用平台預設配置，或填寫你自己的 GitHub OAuth App。",
+    "description": "網站 GitHub OAuth 配置說明"
+  },
+  "message.authGithubOAuthProviderDisabled": {
+    "message": "GitHub 登入目前已關閉，你仍可預先配置 OAuth App 後再啟用。",
+    "description": "GitHub 登入關閉提示"
+  },
+  "message.authGithubOAuthUsingPlatform": {
+    "message": "本站正在使用平台預設 GitHub OAuth App。",
+    "description": "平台預設配置狀態"
+  },
+  "message.authGithubOAuthUsingCustom": {
+    "message": "本站正在使用自訂 GitHub OAuth App。",
+    "description": "自訂配置狀態"
+  },
+  "field.authGithubOAuthClientId": {
+    "message": "Client ID",
+    "description": "GitHub OAuth App client ID label"
+  },
+  "field.authGithubOAuthClientSecret": {
+    "message": "Client Secret",
+    "description": "GitHub OAuth App client secret label"
+  },
+  "placeholder.authGithubOAuthClientSecret": {
+    "message": "留白則保留已儲存的密鑰",
+    "description": "僅寫 Client Secret 佔位提示"
+  },
+  "message.authGithubOAuthSecretConfigured": {
+    "message": "Client Secret 已儲存，留白即可保持不變。",
+    "description": "密鑰已儲存提示"
+  },
+  "field.authGithubOAuthCallbackUrl": {
+    "message": "Authorization callback URL",
+    "description": "GitHub OAuth callback URL label"
+  },
+  "message.authGithubOAuthCallbackTip": {
+    "message": "請將此完整位址新增至 GitHub OAuth App 的回呼設定中。",
+    "description": "GitHub 回呼配置提示"
+  },
+  "button.authGithubOAuthRestoreDefault": {
+    "message": "恢復平台預設配置",
+    "description": "刪除自訂 GitHub OAuth App 按鈕"
+  },
+  "message.authGithubOAuthSaved": {
+    "message": "GitHub OAuth App 已儲存",
+    "description": "儲存成功提示"
+  },
+  "error.authGithubOAuthSave": {
+    "message": "儲存 GitHub OAuth App 失敗",
+    "description": "儲存失敗提示"
+  },
+  "error.authGithubOAuthLoad": {
+    "message": "載入 GitHub OAuth App 失敗",
+    "description": "載入失敗提示"
+  },
+  "field.authGithubOAuthDeleteTitle": {
+    "message": "恢復平台預設 GitHub OAuth App？",
+    "description": "恢復預設確認標題"
+  },
+  "message.authGithubOAuthDeleteConfirm": {
+    "message": "已儲存的 Client ID 和 Client Secret 將被永久刪除。",
+    "description": "恢復預設確認內容"
+  },
+  "message.authGithubOAuthDeleted": {
+    "message": "已恢復平台預設 GitHub OAuth App",
+    "description": "恢復預設成功提示"
+  },
+  "error.authGithubOAuthDelete": {
+    "message": "恢復平台預設 GitHub OAuth App 失敗",
+    "description": "恢復預設失敗提示"
   }
 }

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -30,6 +30,7 @@ export * from './siteServiceOverride';
 export * from './siteCapabilityOverride';
 export * from './site_domain';
 export * from './siteAuthDelivery';
+export * from './siteGithubOAuth';
 export * from './translation';
 export * from './suno';
 export * from './producer';

--- a/src/operators/siteGithubOAuth.test.ts
+++ b/src/operators/siteGithubOAuth.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('./common', () => ({
+  httpClient: {
+    get: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn()
+  }
+}));
+
+import { httpClient } from './common';
+import { siteGithubOAuthOperator } from './siteGithubOAuth';
+
+describe('siteGithubOAuthOperator', () => {
+  it('uses dedicated secret-safe endpoints', async () => {
+    await siteGithubOAuthOperator.get('site-id');
+    await siteGithubOAuthOperator.update('site-id', { client_id: 'client', client_secret: 'secret' });
+    await siteGithubOAuthOperator.remove('site-id');
+
+    expect(httpClient.get).toHaveBeenCalledWith('/sites/site-id/auth-providers/github/');
+    expect(httpClient.patch).toHaveBeenCalledWith('/sites/site-id/auth-providers/github/', {
+      client_id: 'client',
+      client_secret: 'secret'
+    });
+    expect(httpClient.delete).toHaveBeenCalledWith('/sites/site-id/auth-providers/github/');
+  });
+});

--- a/src/operators/siteGithubOAuth.ts
+++ b/src/operators/siteGithubOAuth.ts
@@ -1,0 +1,29 @@
+import type { AxiosResponse } from 'axios';
+import { httpClient } from './common';
+
+export interface ISiteGithubOAuthApp {
+  client_id: string | null;
+  client_secret_configured: boolean;
+  using_platform_default: boolean;
+}
+
+export interface ISiteGithubOAuthAppUpdate {
+  client_id: string;
+  client_secret?: string;
+}
+
+class SiteGithubOAuthOperator {
+  get(siteId: string): Promise<AxiosResponse<ISiteGithubOAuthApp>> {
+    return httpClient.get(`/sites/${siteId}/auth-providers/github/`);
+  }
+
+  update(siteId: string, payload: ISiteGithubOAuthAppUpdate): Promise<AxiosResponse<ISiteGithubOAuthApp>> {
+    return httpClient.patch(`/sites/${siteId}/auth-providers/github/`, payload);
+  }
+
+  remove(siteId: string): Promise<AxiosResponse<void>> {
+    return httpClient.delete(`/sites/${siteId}/auth-providers/github/`);
+  }
+}
+
+export const siteGithubOAuthOperator = new SiteGithubOAuthOperator();


### PR DESCRIPTION
## Summary
- add GitHub OAuth App configuration to Nexior's Site Authentication settings
- use the dedicated PlatformBackend endpoint without putting Client Secrets into Site/Vuex persistence
- show the environment-specific callback URL and platform/custom configuration state
- support explicit reset to the platform App with confirmation
- add complete translations and a Beachball minor change record

## Dependencies
- management API/storage: https://github.com/AceDataCloud/PlatformBackend/pull/1779
- runtime must deploy before exposing configuration: https://github.com/AceDataCloud/AuthBackend/pull/475
- authorization flow: https://github.com/AceDataCloud/AuthFrontend/pull/282

## Verification
- Vitest operator test: pass
- ESLint: pass (2 unrelated existing warnings)
- Web build: pass
- Electron build: pass
- Beachball check: pass
- i18n coverage: 11 locales × 50 namespaces, no English placeholders

## Security
Nexior continues to hand only Site context to AuthFrontend. It never receives or constructs OAuth credentials during login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)